### PR TITLE
Fix 175 python spec file formatting & Add 13 python packages

### DIFF
--- a/SPECS/pycairo/pycairo.spec
+++ b/SPECS/pycairo/pycairo.spec
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pycairo
+
+Name:           python-cairo
+Version:        1.29.0
+Release:        %autorelease
+Summary:        Python interface for cairo
+License:        LGPL-2.1-only OR MPL-1.1
+URL:            https://www.cairographics.org/pycairo
+VCS:            git:https://github.com/pygobject/pycairo.git
+#!RemoteAsset
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    meson
+
+BuildRequires:  gcc
+BuildRequires:  meson
+BuildRequires:  pkgconfig(cairo)
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(pytest)
+
+Provides:       python3-cairo
+Provides:       python3-cairo%{?_isa}
+%python_provide python3-cairo
+
+%description
+Python bindings for the cairo library.
+
+%package        devel
+Summary:        Development files for embedding pycairo
+Requires:       python3-cairo%{?_isa} = %{version}-%{release}
+
+%description    devel
+This package contains files required to embed pycairo support
+in other Python modules.
+
+%files
+%doc README.rst
+%license COPYING*
+%{python3_sitearch}/cairo/
+%{python3_sitearch}/pycairo*.dist-info
+
+%files devel
+%dir %{_includedir}/pycairo
+%{_includedir}/pycairo/py3cairo.h
+%{_libdir}/pkgconfig/py3cairo.pc
+
+%changelog
+%{?autochangelog}

--- a/SPECS/python-PyMySQL/python-PyMySQL.spec
+++ b/SPECS/python-PyMySQL/python-PyMySQL.spec
@@ -19,7 +19,7 @@ BuildSystem:    pyproject
 
 BuildOption(install):  %{srcname}
 
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)

--- a/SPECS/python-PyQt-builder/python-PyQt-builder.spec
+++ b/SPECS/python-PyQt-builder/python-PyQt-builder.spec
@@ -16,17 +16,20 @@ License:        BSD-2-Clause
 URL:            https://www.riverbankcomputing.com/software/pyqt/
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/p/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 # not support dynamic version.
 Patch0:         0001-fix-version.patch
+
 BuildOption(install):  -l pyqtbuild
 
+BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-pip
-BuildRequires:  python3-sip
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-wheel
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(sip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(setuptools-scm) >= 8
 
 Provides:       python3-%{srcname}

--- a/SPECS/python-appdirs/python-appdirs.spec
+++ b/SPECS/python-appdirs/python-appdirs.spec
@@ -9,29 +9,31 @@
 Name:           python-%{srcname}
 Version:        1.4.4
 Release:        %autorelease
+Summary:        Determine platform-specific dirs, e.g. a "user data dir"
 License:        MIT
 URL:            https://github.com/ActiveState/appdirs
-Summary:        Determine platform-specific dirs, e.g. a "user data dir"
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname} +auto
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
-BuildSystem:    pyproject
-BuildOption(install): -l %{srcname} +auto
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 %description
 A small Python module for determining appropriate " + " platform-specific
 directories, e.g. a "user data dir".
-
 
 %generate_buildrequires
 %pyproject_buildrequires
 
 %files -f %{pyproject_files}
-%doc  README.rst CHANGES.rst
+%doc README.rst CHANGES.rst
 
 %changelog
 %{?autochangelog}

--- a/SPECS/python-asgiref/python-asgiref.spec
+++ b/SPECS/python-asgiref/python-asgiref.spec
@@ -9,24 +9,21 @@
 Name:           python-%{srcname}
 Version:        3.8.1
 Release:        %autorelease
-# bundled async-timeout is Apache-2.0
-License:        BSD-3-Clause AND Apache-2.0
-URL:            https://github.com/django/asgiref/
 Summary:        ASGI specs, helper code, and adapters
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
+License:        BSD-3-Clause AND Apache-2.0
+URL:            https://github.com/django/asgiref
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
-BuildRequires:  pyproject-rpm-macros
 BuildSystem:    pyproject
-BuildOption(install): -l %{srcname} +auto
 
-# https://github.com/django/asgiref/commit/9c6df6e02700092eb19adefff3552d44388f69b8
-# This code is modified and probably cannot be unvendored.
-Provides:       bundled(python3dist(async-timeout)) == 3.0.1
+BuildOption(install):  -l %{srcname} +auto
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
 
 %description
 ASGI is a standard for Python asynchronous web apps and servers to

--- a/SPECS/python-attrs/python-attrs.spec
+++ b/SPECS/python-attrs/python-attrs.spec
@@ -9,23 +9,26 @@
 Name:           python-%{srcname}
 Version:        25.4.0
 Release:        %autorelease
-License:        MIT
-URL:            https://github.com/python-attrs/attrs/
 Summary:        Attributes without boilerplate
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
+License:        MIT
+URL:            https://github.com/python-attrs/attrs
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
 BuildSystem:    pyproject
-BuildOption(install): -l attr %{srcname} +auto
+
+BuildOption(install):  -l attr %{srcname} +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 %description
 attrs is an MIT-licensed Python package with class decorators that
 ease the chores of implementing the most common attribute-related
 object protocols.
-
 
 %generate_buildrequires
 %pyproject_buildrequires

--- a/SPECS/python-bcrypt/python-bcrypt.spec
+++ b/SPECS/python-bcrypt/python-bcrypt.spec
@@ -9,19 +9,18 @@
 Name:           python-%{srcname}
 Version:        3.2.2
 Release:        %autorelease
-License:        ASL2.0
-URL:            https://github.com/pyca/bcrypt/
 Summary:        Modern password hashing library
+License:        Apache-2.0
+URL:            https://github.com/pyca/bcrypt
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/b/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildSystem:    pyproject
 
-BuildOption(install): -l %{srcname} +auto
+BuildOption(install):  -l %{srcname} +auto
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pytest
-BuildRequires:  python3-devel
-
+BuildRequires:  pkgconfig(python3)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-bitarray/python-bitarray.spec
+++ b/SPECS/python-bitarray/python-bitarray.spec
@@ -16,11 +16,11 @@ URL:            https://github.com/ilanschnell/bitarray
 Source0:        https://files.pythonhosted.org/packages/source/b/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildSystem:    pyproject
 
-BuildOption(install): -l %{srcname}
+BuildOption(install):  -l %{srcname}
 
 BuildRequires:  gcc
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(pip) >= 19
 BuildRequires:  python3dist(setuptools) >= 42
 

--- a/SPECS/python-blivet/python-blivet.spec
+++ b/SPECS/python-blivet/python-blivet.spec
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname blivet
+
+Name:           python-blivet
+Version:        3.13.1
+Release:        %autorelease
+Summary:        Blivet is a python module for system storage configuration.
+License:        LGPL-2.1-or-later
+URL:            https://github.com/storaged-project/blivet
+#!RemoteAsset
+Source0:        https://files.pythonhosted.org/packages/source/b/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    autotools
+
+BuildRequires:  make
+BuildRequires:  systemd
+BuildRequires:  gettext
+BuildRequires:  pkgconfig(python3)
+
+Requires:       parted
+Requires:       python3-blockdev
+Requires:       python3-bytesize
+Requires:       python3dist(dasbus)
+Requires:       python3-libmount
+Requires:       python3dist(pygobject)
+Requires:       python3dist(pyparted)
+Requires:       python3dist(pyudev)
+Requires:       python3dist(selinux)
+Requires:       util-linux
+Requires:       lsof
+Requires:       systemd-udev
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
+%description
+The python-blivet package is a python module for examining and modifying
+storage configuration.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+# No configure
+%conf
+
+%install -a
+# TODO: Avoid illegal package names
+rm -rf %{buildroot}%{_datadir}/locale/*@*
+rm -rf %{buildroot}%{_datadir}/locale/en_GB/
+%find_lang %{srcname} --generate-subpackages
+
+# TODO: check needs ton of other dependencies - 251
+%check
+
+%files
+%doc README.md ChangeLog examples
+%license COPYING
+%{python3_sitelib}/*
+%{_sysconfdir}/dbus-1/system.d/*
+%{_datadir}/dbus-1/system-services/*
+%{_libexecdir}/*
+%{_unitdir}/*
+
+%changelog
+%{?autochangelog}

--- a/SPECS/python-boolean-py/python-boolean-py.spec
+++ b/SPECS/python-boolean-py/python-boolean-py.spec
@@ -9,18 +9,22 @@
 Name:           python-boolean-py
 Version:        5.0
 Release:        %autorelease
+Summary:        Boolean algebra in one Python module
 License:        BSD-2-clause
 URL:            https://github.com/bastikr/boolean.py
-Summary:        Boolean algebra in one Python module
-Provides:       python3-boolean-py
-%python_provide python3-boolean-py
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/b/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
 BuildSystem:    pyproject
-BuildOption(install): -l boolean +auto
+
+BuildOption(install):  -l boolean +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-boolean-py
+%python_provide python3-boolean-py
+
 %description
 This is a small Python library that implements boolean algebra.
 It defines two base elements, @code{TRUE} and @code{FALSE}, and a

--- a/SPECS/python-build/python-build.spec
+++ b/SPECS/python-build/python-build.spec
@@ -9,19 +9,21 @@
 Name:           python-%{srcname}
 Version:        1.3.0
 Release:        %autorelease
+Summary:        Simple Python PEP 517 package builder
 License:        MIT
 URL:            https://pypa-build.readthedocs.io/en/latest/
-Summary:        Simple Python PEP 517 package builder
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/b/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
-BuildRequires:  pyproject-rpm-macros
 BuildSystem:    pyproject
-BuildOption(install): build +auto
+
+BuildOption(install):  build +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
 %description
 The @command{build} command invokes the PEP 517 hooks to
 build a distribution package.  It is a simple build tool and does not perform
@@ -34,5 +36,6 @@ order to make bootstrapping easier.
 %files -f %{pyproject_files}
 %doc README*
 %license LICENSE
+
 %changelog
 %{?autochangelog}

--- a/SPECS/python-cachetools/python-cachetools.spec
+++ b/SPECS/python-cachetools/python-cachetools.spec
@@ -17,10 +17,10 @@ Source0:        https://files.pythonhosted.org/packages/source/c/%{srcname}/%{sr
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): -l %{srcname}
+BuildOption(install):  -l %{srcname}
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-certifi/python-certifi.spec
+++ b/SPECS/python-certifi/python-certifi.spec
@@ -11,25 +11,28 @@ Version:        2025.11.12
 Release:        %autorelease
 Summary:        Python CA certificate bundle
 License:        MIT
-URL:            https://certifi.io/
+URL:            https://certifi.io
 #!RemoteAsset:  sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316
 Source0:        https://files.pythonhosted.org/packages/source/c/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}
 
-BuildRequires:  python3-devel
-BuildRequires:  python3-pip
-BuildRequires:  python3-setuptools
-BuildSystem:    pyproject
-BuildOption(install): -l %{srcname}
 %description
 Certifi is a Python library that contains a CA certificate bundle, which
 is used by the Requests library to verify HTTPS requests.
 
 %generate_buildrequires
 %pyproject_buildrequires
-
 
 %files -f %{pyproject_files}
 %license LICENSE

--- a/SPECS/python-cffi/python-cffi.spec
+++ b/SPECS/python-cffi/python-cffi.spec
@@ -14,15 +14,19 @@ License:        MIT
 URL:            https://cffi.readthedocs.io/
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/c/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
 
-BuildRequires:  python3-devel
-BuildRequires:  libffi-devel
+BuildOption(install):  _cffi_backend cffi
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pkgconfig(libffi)
 BuildRequires:  pkg-config
 BuildRequires:  gcc
-BuildSystem:    pyproject
-BuildOption(install):   _cffi_backend cffi
+
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}
+
 %description
 Foreign Function Interface for Python calling C code.
 

--- a/SPECS/python-ci-info/python-ci-info.spec
+++ b/SPECS/python-ci-info/python-ci-info.spec
@@ -15,6 +15,7 @@ License:        MIT
 URL:            https://github.com/mgxd/ci-info
 #!RemoteAsset:  sha256:34d5a18726b3780abdf985234b871ac33124d64dd8e294870b8cc5b410c18418
 Source:         https://files.pythonhosted.org/packages/source/c/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{pypi_name}

--- a/SPECS/python-colorama/python-colorama.spec
+++ b/SPECS/python-colorama/python-colorama.spec
@@ -9,19 +9,22 @@
 Name:           python-%{srcname}
 Version:        0.4.6
 Release:        %autorelease
-License:        BSD-3-Clause
-URL:            https://pypi.org/project/colorama/
 Summary:        Colored terminal text rendering for Python
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
+License:        BSD-3-Clause
+URL:            https://pypi.org/project/colorama
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/c/%{srcname}/%{srcname}-%{version}.tar.gz
-
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
 BuildSystem:    pyproject
-BuildOption(install): -l %{srcname} +auto
+
+BuildOption(install):  -l %{srcname} +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 %description
 Makes ANSI escape character sequences, for producing colored
 terminal text and cursor positioning, work under MS Windows.

--- a/SPECS/python-colorlog/python-colorlog.spec
+++ b/SPECS/python-colorlog/python-colorlog.spec
@@ -13,17 +13,18 @@ Summary:        Colored formatter for the Python logging module
 License:        MIT
 URL:            https://github.com/borntyping/python-colorlog
 #!RemoteAsset
-Source:         https://github.com/borntyping/python-colorlog/archive/refs/tags/v%{version}.tar.gz
+Source:         https://files.pythonhosted.org/packages/source/c/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): -l %{srcname}
+BuildOption(install):  -l %{srcname}
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
-BuildRequires:  python3-pip
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-wheel
-BuildRequires:  python3-pytest
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+BuildRequires:  python3dist(pytest)
 
 Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}

--- a/SPECS/python-configparser/python-configparser.spec
+++ b/SPECS/python-configparser/python-configparser.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/jaraco/configparser
 #!RemoteAsset:  sha256:b629cc8ae916e3afbd36d1b3d093f34193d851e11998920fdcfc4552218b7b70
 Source0:        https://files.pythonhosted.org/packages/source/c/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l backports

--- a/SPECS/python-cryptography/python-cryptography.spec
+++ b/SPECS/python-cryptography/python-cryptography.spec
@@ -15,21 +15,22 @@ URL:            https://cryptography.io/en/latest/
 VCS:            git:https://github.com/pyca/cryptography
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/c/%{srcname}/%{srcname}-%{version}.tar.gz
+# TODO: Remove the vendor source after
 #!RemoteAsset
 Source1:        https://github.com/TakoPack/%{name}-vendor/releases/download/vendor-%{version}/%{srcname}-%{version}-vendor.tar.bz2
 BuildSystem:    pyproject
 
 BuildOption(prep):  -a1
-BuildOption(install): %{srcname}
+BuildOption(install):  %{srcname}
 
 BuildRequires:  rust
 BuildRequires:  pkgconfig(openssl)
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-cffi
-BuildRequires:  python3-devel
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-pip
-BuildRequires:  python3-maturin
+BuildRequires:  python3dist(cffi)
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(maturin)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-distlib/python-distlib.spec
+++ b/SPECS/python-distlib/python-distlib.spec
@@ -9,21 +9,22 @@
 Name:           python-%{srcname}
 Version:        0.3.7
 Release:        %autorelease
-# TODO: Is this the correct license? Or should it be Python-2.0?
-License:        PSF-2.0
-URL:            https://github.com/pypa/distlib
 Summary:        Distribution utilities
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
+License:        Python-2.0
+URL:            https://github.com/pypa/distlib
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/d/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
-BuildRequires:  pyproject-rpm-macros
 BuildSystem:    pyproject
 
-BuildOption(install): -l %{srcname} +auto
+BuildOption(install):  -l %{srcname} +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 %description
 Distlib is a library which implements low-level functions that
 relate to packaging and distribution of Python software.  It is intended to be

--- a/SPECS/python-django/python-django.spec
+++ b/SPECS/python-django/python-django.spec
@@ -19,10 +19,11 @@ BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}
 
-BuildRequires:  python3-devel
-BuildRequires:  python3-asgiref
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(asgiref)
 # Tests?
-BuildRequires:  python3-jinja2
+BuildRequires:  python3dist(jinja2)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}
@@ -33,12 +34,12 @@ development and a clean, pragmatic design. It focuses on automating as
 much as possible and adhering to the DRY (Don't Repeat Yourself)
 principle.
 
-%package -n %{srcname}-bash-completion
+%package        bash-completion
 Summary:        Bash completion files for Django
 BuildRequires:  bash-completion
 Requires:       bash-completion
 
-%description -n %{srcname}-bash-completion
+%description    bash-completion
 This package contains the Bash completion files form Django high-level
 Python Web framework.
 
@@ -78,7 +79,7 @@ sed -i '/.po$/d' %{pyproject_files}
 %{_bindir}/django-admin
 %{_mandir}/man1/django-admin.1*
 
-%files -n %{srcname}-bash-completion
+%files bash-completion
 %{bash_completions_dir}/*
 
 %changelog

--- a/SPECS/python-docopt-ng/python-docopt-ng.spec
+++ b/SPECS/python-docopt-ng/python-docopt-ng.spec
@@ -9,18 +9,22 @@
 Name:           python-%{srcname}
 Version:        0.9.0
 Release:        %autorelease
+Summary:        Jazzband-maintained fork of docopt, the humane command line arguments parser.
 License:        MIT
 URL:            https://github.com/jazzband/docopt-ng
-Summary:        Jazzband-maintained fork of docopt, the humane command line arguments parser.
+#!RemoteAsset
+Source0:        https://files.pythonhosted.org/packages/source/d/%{srcname}/docopt_ng-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  docopt +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}
-#!RemoteAsset
-Source0:       https://files.pythonhosted.org/packages/source/d/%{srcname}/docopt_ng-%{version}.tar.gz
-BuildArch:      noarch
 
-BuildRequires:  python3-devel
-BuildSystem:    pyproject
-BuildOption(install): docopt +auto
 %description
 This library allows the user to define a command-line
 interface from a program's help message rather than specifying it
@@ -33,5 +37,6 @@ programmatically with command-line parsers like @code{getopt} and
 %files -f %{pyproject_files}
 %doc README*
 %license LICENSE-MIT
+
 %changelog
 %{?autochangelog}

--- a/SPECS/python-docutils/python-docutils.spec
+++ b/SPECS/python-docutils/python-docutils.spec
@@ -9,19 +9,22 @@
 Name:           python-%{srcname}
 Version:        0.21.2
 Release:        %autorelease
+Summary:        Python Documentation Utilities
 License:        BSD-2-Clause AND Python-2.0 AND GPL-2.0-or-later AND GPL-3.0-or-later AND LicenseRef-openRuyi-Public-Domain
 URL:            https://docutils.sourceforge.net/
-Summary:        Python Documentation Utilities
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/d/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
-
 BuildSystem:    pyproject
-BuildRequires:  python3-devel
 
-BuildOption(install): -l %{srcname} +auto
+BuildOption(install):  -l %{srcname} +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 %description
 Docutils is a modular system for processing documentation into useful
 formats, such as HTML, XML, and LaTeX.  It uses @dfn{reStructuredText}, an

--- a/SPECS/python-editables/python-editables.spec
+++ b/SPECS/python-editables/python-editables.spec
@@ -9,18 +9,22 @@
 Name:           python-%{srcname}
 Version:        0.5
 Release:        %autorelease
+Summary:        Editable installations
 License:        MIT
 URL:            https://github.com/pfmoore/editables
-Summary:        Editable installations
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/e/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}
 
-BuildRequires:  python3-devel
-BuildSystem:    pyproject
-BuildOption(install): -l %{srcname}
 %description
 A Python library for creating “editable wheels”
 

--- a/SPECS/python-emoji/python-emoji.spec
+++ b/SPECS/python-emoji/python-emoji.spec
@@ -14,6 +14,7 @@ License:        BSD-3-Clause
 URL:            https://github.com/carpedm20/emoji
 #!RemoteAsset:  sha256:eae4ab7d86456a70a00a985125a03263a5eac54cd55e51d7e184b1ed3b6757e4
 Source0:        https://files.pythonhosted.org/packages/source/e/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-environs/python-environs.spec
+++ b/SPECS/python-environs/python-environs.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/sloria/environs
 #!RemoteAsset:  sha256:f7b8f6fcf3301bc674bc9c03e39b5986d116126ffb96764efd34c339ed9464ee
 Source0:        https://files.pythonhosted.org/packages/source/e/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-execnet/python-execnet.spec
+++ b/SPECS/python-execnet/python-execnet.spec
@@ -19,15 +19,16 @@ Source0:        https://files.pythonhosted.org/packages/source/e/%{srcname}/%{sr
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): -l %{srcname}
+BuildOption(install):  -l %{srcname}
 
+BuildRequires:  pyproject-rpm-macros
 BuildRequires:  procps-ng
 BuildRequires:  pkgconfig(python3)
 %if %{with doc}
 BuildRequires:  make
 BuildRequires:  sphinx-build
 %endif
-BuildRequires:  python3-pytest
+BuildRequires:  python3dist(pytest)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-executing/python-executing.spec
+++ b/SPECS/python-executing/python-executing.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/alexmojaki/executing
 #!RemoteAsset:  sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4
 Source0:        https://files.pythonhosted.org/packages/source/e/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-expandvars/python-expandvars.spec
+++ b/SPECS/python-expandvars/python-expandvars.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/aio-libs/yarl
 #!RemoteAsset:  sha256:6c5822b7b756a99a356b915dd1267f52ab8a4efaa135963bd7f4bd5d368f71d7
 Source0:        https://files.pythonhosted.org/packages/source/e/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-fastjsonschema/python-fastjsonschema.spec
+++ b/SPECS/python-fastjsonschema/python-fastjsonschema.spec
@@ -14,16 +14,17 @@ License:        BSD-3-Clause
 URL:            https://github.com/horejsek/python-fastjsonschema
 #!RemoteAsset
 Source:         https://files.pythonhosted.org/packages/source/f/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}
 
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-pip
+BuildRequires:  python3dist(pip)
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-wheel
-BuildRequires:  python3-pytest
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+BuildRequires:  python3dist(pytest)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-flaky/python-flaky.spec
+++ b/SPECS/python-flaky/python-flaky.spec
@@ -17,12 +17,12 @@ Source0:        https://files.pythonhosted.org/packages/source/f/%{srcname}/%{sr
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): -l %{srcname}
+BuildOption(install):  -l %{srcname}
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 # Tests
-BuildRequires:  python3-pytest
+BuildRequires:  python3dist(pytest)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-flask-restful/python-flask-restful.spec
+++ b/SPECS/python-flask-restful/python-flask-restful.spec
@@ -18,12 +18,12 @@ Source0:        https://files.pythonhosted.org/packages/source/f/%{srcname}/Flas
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): flask_restful
+BuildOption(install):  flask_restful
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 # Tests
-BuildRequires:  python3-pycryptodome
+BuildRequires:  python3dist(pycryptodome)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-flit-core/python-flit-core.spec
+++ b/SPECS/python-flit-core/python-flit-core.spec
@@ -33,10 +33,10 @@ URL:            https://flit.pypa.io/
 Source0:        https://files.pythonhosted.org/packages/source/f/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 %if %{without bootstrap}
 BuildRequires:  python3-packaging
-BuildRequires:  python3-pip
+BuildRequires:  python3dist(pip)
 %endif
 BuildRequires:  expat
 

--- a/SPECS/python-flit_scm/python-flit_scm.spec
+++ b/SPECS/python-flit_scm/python-flit_scm.spec
@@ -9,18 +9,22 @@
 Name:           python-%{srcname}
 Version:        1.7.0
 Release:        %autorelease
+Summary:        PEP 518 build backend that uses setuptools_scm and flit
 License:        MIT
 URL:            https://gitlab.com/WillDaSilva/flit_scm
-Summary:        PEP 518 build backend that uses setuptools_scm and flit
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/f/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
 BuildSystem:    pyproject
-BuildOption(install): -l %{srcname} +auto
+
+BuildOption(install):  -l %{srcname} +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 %description
 A PEP 518 build backend that uses setuptools_scm to generate a version file
 from your version control system, then flit_core to build the package.

--- a/SPECS/python-freezegun/python-freezegun.spec
+++ b/SPECS/python-freezegun/python-freezegun.spec
@@ -9,18 +9,22 @@
 Name:           python-%{srcname}
 Version:        1.5.5
 Release:        %autorelease
+Summary:        Test utility for mocking the datetime module
 License:        Apache-2.0
 URL:            https://github.com/spulec/freezegun
-Summary:        Test utility for mocking the datetime module
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/f/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
 BuildSystem:    pyproject
-BuildOption(install): -l %{srcname} +auto
+
+BuildOption(install):  -l %{srcname} +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 %description
 FreezeGun is a library that allows your python tests to travel through
 time by mocking the datetime module.

--- a/SPECS/python-gast/python-gast.spec
+++ b/SPECS/python-gast/python-gast.spec
@@ -17,7 +17,7 @@ Source0:        https://files.pythonhosted.org/packages/source/g/%{srcname}/%{sr
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): %{srcname}
+BuildOption(install):  %{srcname}
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)

--- a/SPECS/python-genshi/python-genshi.spec
+++ b/SPECS/python-genshi/python-genshi.spec
@@ -20,10 +20,10 @@ BuildOption(install):  -l %{srcname}
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-pip
-BuildRequires:  python3-wheel
-BuildRequires:  python3-pytest
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(wheel)
+BuildRequires:  python3dist(pytest)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-gitdb/python-gitdb.spec
+++ b/SPECS/python-gitdb/python-gitdb.spec
@@ -14,6 +14,7 @@ License:        BSD-3-Clause
 URL:            https://github.com/gitpython-developers/gitdb
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/g/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  %{srcname}

--- a/SPECS/python-gssapi/python-gssapi.spec
+++ b/SPECS/python-gssapi/python-gssapi.spec
@@ -16,8 +16,8 @@ URL:            https://github.com/pythongssapi/python-gssapi
 Source0:        https://files.pythonhosted.org/packages/source/g/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildSystem:    pyproject
 
-BuildOption(install): %{srcname}
-BuildOption(check): -e "gssapi.tests.*"
+BuildOption(install):  %{srcname}
+BuildOption(check):  -e "gssapi.tests.*"
 
 BuildRequires:  pkgconfig(krb5)
 BuildRequires:  pkgconfig(python3)
@@ -31,7 +31,8 @@ Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}
 
 %description
-Python-GSSAPI provides both low-level and high level wrappers around the GSSAPI C libraries. While it focuses on the Kerberos mechanism, it should also be useable with other GSSAPI mechanisms.
+Python-GSSAPI provides both low-level and high level wrappers around the GSSAPI C libraries.
+While it focuses on the Kerberos mechanism, it should also be useable with other GSSAPI mechanisms.
 
 %generate_buildrequires
 %pyproject_buildrequires

--- a/SPECS/python-h2/python-h2.spec
+++ b/SPECS/python-h2/python-h2.spec
@@ -17,10 +17,10 @@ Source0:        https://files.pythonhosted.org/packages/source/h/%{srcname}/%{sr
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): %{srcname}
+BuildOption(install):  %{srcname}
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-hatch-requirements-txt/python-hatch-requirements-txt.spec
+++ b/SPECS/python-hatch-requirements-txt/python-hatch-requirements-txt.spec
@@ -19,7 +19,7 @@ BuildSystem:    pyproject
 
 BuildOption(install):  -l hatch_requirements_txt
 
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  python3dist(hatchling)
 BuildRequires:  python3dist(pip)

--- a/SPECS/python-hatch_fancy_pypi_readme/python-hatch_fancy_pypi_readme.spec
+++ b/SPECS/python-hatch_fancy_pypi_readme/python-hatch_fancy_pypi_readme.spec
@@ -9,18 +9,22 @@
 Name:           python-%{srcname}
 Version:        25.1.0
 Release:        %autorelease
+Summary:        Fancy PyPI READMEs with Hatch
 License:        MIT
 URL:            https://github.com/hynek/hatch-fancy-pypi-readme
-Summary:        Fancy PyPI READMEs with Hatch
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/h/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
 BuildSystem:    pyproject
-BuildOption(install): -l %{srcname} +auto
+
+BuildOption(install):  -l %{srcname} +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 %description
 This hatch plugin allows defining a project description in
 terms of concatenated fragments that are based on static strings, files and

--- a/SPECS/python-html5lib/python-html5lib.spec
+++ b/SPECS/python-html5lib/python-html5lib.spec
@@ -16,22 +16,22 @@ License:        MIT
 URL:            https://github.com/html5lib/html5lib-python
 #!RemoteAsset
 Source:         https://files.pythonhosted.org/packages/source/h/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-pip
-BuildRequires:  python3-wheel
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(six) >= 1.9
 BuildRequires:  python3dist(webencodings)
-
 %if %{with tests}
 # for tests
-BuildRequires:  python3-pytest
-BuildRequires:  python3-pytest-expect
+BuildRequires:  python3(pytest)
+BuildRequires:  python3(pytest-expect)
 %endif
 
 Provides:       python3-%{srcname}

--- a/SPECS/python-httplib2/python-httplib2.spec
+++ b/SPECS/python-httplib2/python-httplib2.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/httplib2/httplib2
 #!RemoteAsset:  sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24
 Source0:        https://files.pythonhosted.org/packages/source/h/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 # some deps we don't have yet,just skip it.
@@ -43,20 +44,20 @@ other HTTP libraries.
 
 %check
 %pytest -k "not test_unknown_server \
-	and not test_socks5_auth \
-	and not test_server_not_found_error_is_raised_for_invalid_hostname \
-	and not test_functional_noproxy_star_https \
-	and not test_sni_set_servername_callback \
-	and not test_not_trusted_ca \
-	and not test_invalid_ca_certs_path \
-	and not test_max_tls_version \
-	and not test_get_301_via_https \
-	and not test_client_cert_password_verified \
-	and not test_get_via_https \
-	and not test_min_tls_version \
-	and not test_client_cert_verified \
-	and not test_inject_space \
-	and not test_get_301_no_redirect"
+    and not test_socks5_auth \
+    and not test_server_not_found_error_is_raised_for_invalid_hostname \
+    and not test_functional_noproxy_star_https \
+    and not test_sni_set_servername_callback \
+    and not test_not_trusted_ca \
+    and not test_invalid_ca_certs_path \
+    and not test_max_tls_version \
+    and not test_get_301_via_https \
+    and not test_client_cert_password_verified \
+    and not test_get_via_https \
+    and not test_min_tls_version \
+    and not test_client_cert_verified \
+    and not test_inject_space \
+    and not test_get_301_no_redirect"
 
 %files -f %{pyproject_files}
 %doc README.md

--- a/SPECS/python-hyperframe/python-hyperframe.spec
+++ b/SPECS/python-hyperframe/python-hyperframe.spec
@@ -17,10 +17,10 @@ Source0:        https://files.pythonhosted.org/packages/source/h/%{srcname}/%{sr
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): %{srcname}
+BuildOption(install):  %{srcname}
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-hypothesis/python-hypothesis.spec
+++ b/SPECS/python-hypothesis/python-hypothesis.spec
@@ -17,10 +17,10 @@ Source0:        https://files.pythonhosted.org/packages/source/h/%{srcname}/%{sr
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): -l %{srcname} '_%{srcname}_*'
+BuildOption(install):  -l %{srcname} '_%{srcname}_*'
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-installer/python-installer.spec
+++ b/SPECS/python-installer/python-installer.spec
@@ -9,20 +9,23 @@
 Name:           python-%{srcname}
 Version:        0.7.0
 Release:        %autorelease
+Summary:        Installer library for Python wheels
 License:        MIT
 URL:            https://installer.rtfd.io/
-Summary:        Installer library for Python wheels
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
 #!RemoteAsset
-Source0:       https://files.pythonhosted.org/packages/source/i/%{srcname}/%{srcname}-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/source/i/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname} +auto
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 BuildRequires:  pytest
-BuildSystem:    pyproject
-BuildOption(install): -l %{srcname} +auto
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 %description
 This package provides a low-level library for installing a Python
 package from a wheel distribution.  It provides basic functionality and

--- a/SPECS/python-invoke/python-invoke.spec
+++ b/SPECS/python-invoke/python-invoke.spec
@@ -9,18 +9,18 @@
 Name:           python-%{srcname}
 Version:        2.2.1
 Release:        %autorelease
+Summary:        Pythonic task execution
 License:        BSD-3-Clause
 URL:            https://www.pyinvoke.org/
-Summary:        Pythonic task execution
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/i/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): -l %{srcname} +auto
+BuildOption(install):  -l %{srcname} +auto
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
-
+BuildRequires:  pkgconfig(python3)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}
@@ -36,7 +36,6 @@ instead of servers and network commands.
 
 # TODO: Enable tests.
 %check
-
 
 %files -f %{pyproject_files}
 %doc README*

--- a/SPECS/python-ipython-pygments-lexers/python-ipython-pygments-lexers.spec
+++ b/SPECS/python-ipython-pygments-lexers/python-ipython-pygments-lexers.spec
@@ -14,6 +14,7 @@ License:        BSD-3-Clause
 URL:            https://github.com/ipython/ipython-pygments-lexers
 #!RemoteAsset:  sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81
 Source0:        https://files.pythonhosted.org/packages/source/i/ipython-pygments-lexers/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-iso639/python-iso639.spec
+++ b/SPECS/python-iso639/python-iso639.spec
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname iso639
+
+Name:           python-%{srcname}
+Version:        0.1.4
+Release:        %autorelease
+Summary:        ISO639-2 support for Python.
+License:        MIT
+URL:            https://github.com/janpipek/iso639-python
+#!RemoteAsset
+Source0:        https://files.pythonhosted.org/packages/source/i/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
+%description
+A simple (really simple) library for working with ISO639-2 language codes.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%{?autochangelog}

--- a/SPECS/python-isodate/python-isodate.spec
+++ b/SPECS/python-isodate/python-isodate.spec
@@ -14,6 +14,7 @@ License:        BSD-3-Clause
 URL:            https://github.com/gweis/isodate
 #!RemoteAsset:  sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6
 Source0:        https://files.pythonhosted.org/packages/source/i/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-jedi/python-jedi.spec
+++ b/SPECS/python-jedi/python-jedi.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/davidhalter/jedi
 #!RemoteAsset:  sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0
 Source0:        https://files.pythonhosted.org/packages/source/j/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-jsonpath-ng/python-jsonpath-ng.spec
+++ b/SPECS/python-jsonpath-ng/python-jsonpath-ng.spec
@@ -14,17 +14,18 @@ License:        Apache-2.0 AND WTFPL
 URL:            https://github.com/h2non/jsonpath-ng
 #!RemoteAsset
 Source:         https://files.pythonhosted.org/packages/source/j/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l jsonpath_ng
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-pip
-BuildRequires:  python3-wheel
-BuildRequires:  python3-pytest
-BuildRequires:  python3-ply
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(wheel)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(ply)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-jsonpointer/python-jsonpointer.spec
+++ b/SPECS/python-jsonpointer/python-jsonpointer.spec
@@ -17,10 +17,10 @@ Source0:        https://files.pythonhosted.org/packages/source/j/%{srcname}/%{sr
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): %{srcname}
+BuildOption(install):  %{srcname}
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-jsonschema/python-jsonschema.spec
+++ b/SPECS/python-jsonschema/python-jsonschema.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/Julian/jsonschema
 #!RemoteAsset
 Source:         https://files.pythonhosted.org/packages/source/j/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}
@@ -22,15 +23,15 @@ BuildOption(check):  -e 'jsonschema.benchmarks*' -e 'jsonschema.tests.test_jsons
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-hatchling
-BuildRequires:  python3-hatch-vcs
-BuildRequires:  python3-pip
-BuildRequires:  python3-setuptools
-BuildRequires:  python-hatch_fancy_pypi_readme
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(hatch-vcs)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(hatch-fancy-pypi-readme)
 # for tests
-BuildRequires:  python3-pytest
-BuildRequires:  python3-attrs
-BuildRequires:  python3-pyrsistent
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(attrs)
+BuildRequires:  python3dist(pyrsistent)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-langcodes/python-langcodes.spec
+++ b/SPECS/python-langcodes/python-langcodes.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/georgkrause/langcodes
 #!RemoteAsset:  sha256:40bff315e01b01d11c2ae3928dd4f5cbd74dd38f9bd912c12b9a3606c143f731
 Source0:        https://files.pythonhosted.org/packages/source/l/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-libarchive_c/python-libarchive_c.spec
+++ b/SPECS/python-libarchive_c/python-libarchive_c.spec
@@ -9,19 +9,24 @@
 Name:           python-%{srcname}
 Version:        5.3
 Release:        %autorelease
-License:        public-domain
-URL:            https://github.com/Changaco/python-libarchive-c
 Summary:        Python interface to libarchive
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
+License:        LicenseRef-openRuyi-Public-Domain
+URL:            https://github.com/Changaco/python-libarchive-c
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/l/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
 
-BuildRequires:  python3-devel
+BuildOption(install):  -l libarchive +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 Requires:       libarchive
 
-BuildSystem:    pyproject
-BuildOption(install): -l libarchive +auto
 %description
 This package provides Python bindings to libarchive, a C library to
 access possibly compressed archives in many different formats.  It uses

--- a/SPECS/python-libclang/python-libclang.spec
+++ b/SPECS/python-libclang/python-libclang.spec
@@ -14,6 +14,7 @@ License:        Apache-2.0 WITH LLVM-exception
 URL:            https://github.com/sighingnow/libclang
 #!RemoteAsset:  sha256:a1214966d08d73d971287fc3ead8dfaf82eb07fb197680d8b3859dbbbbf78250
 Source:         https://files.pythonhosted.org/packages/source/l/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l clang
@@ -24,10 +25,10 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 
-Requires:       clang
-
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}
+
+Requires:       clang
 
 %description
 This package provides Python bindings for the Clang C library.

--- a/SPECS/python-libevdev/python-libevdev.spec
+++ b/SPECS/python-libevdev/python-libevdev.spec
@@ -14,15 +14,16 @@ License:        MIT
 URL:            https://gitlab.freedesktop.org/libevdev/python-libevdev
 #!RemoteAsset
 Source:         https://files.pythonhosted.org/packages/source/l/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-pip
-BuildRequires:  python3-pytest
-BuildRequires:  python3-hatchling
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(hatchling)
 BuildRequires:  pkgconfig(libevdev)
 
 Provides:       python3-%{srcname}

--- a/SPECS/python-license-expression/python-license-expression.spec
+++ b/SPECS/python-license-expression/python-license-expression.spec
@@ -17,6 +17,7 @@ License:        Apache-2.0
 URL:            https://github.com/nexB/license-expression
 #!RemoteAsset
 Source:         https://files.pythonhosted.org/packages/source/l/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{pypi_name}
@@ -29,15 +30,14 @@ BuildRequires:  python3dist(setuptools-scm)
 # for tests.
 BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(boolean-py)
-
 %if %{with doc}
 BuildRequires:  python3dist(sphinx)
 BuildRequires:  python3dist(sphinxcontrib-apidoc)
 BuildRequires:  python3dist(sphinx-rtd-theme)
 %endif
 
-Provides:       python3-%{pypi_name}
-%python_provide python3-%{pypi_name}
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
 
 %description
 This module defines a mini language to parse, validate, simplify, normalize and
@@ -51,7 +51,7 @@ conventions and license identifiers aliases to resolve and normalize licenses.
 Summary:        Documentation for python-license-expression
 License:        Apache-2.0 AND BSD-2-Clause AND MIT
 BuildArch:      noarch
-Requires:       python3-license_expression = %{version}-%{release}
+Requires:       python3-license-expression = %{version}-%{release}
 
 %description    doc
 Documentation for license-expression.

--- a/SPECS/python-linkify-it-py/python-linkify-it-py.spec
+++ b/SPECS/python-linkify-it-py/python-linkify-it-py.spec
@@ -14,17 +14,18 @@ License:        MIT
 URL:            https://github.com/tsutsu3/linkify-it-py
 #!RemoteAsset
 Source:         https://files.pythonhosted.org/packages/source/l/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l linkify_it
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-pip
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-wheel
-BuildRequires:  python3-pytest
-BuildRequires:  python3-uc-micro-py
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(uc-micro-py)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-looseversion/python-looseversion.spec
+++ b/SPECS/python-looseversion/python-looseversion.spec
@@ -14,6 +14,7 @@ License:        PSF-2.0
 URL:            https://github.com/effigies/looseversion
 #!RemoteAsset:  sha256:ebde65f3f6bb9531a81016c6fef3eb95a61181adc47b7f949e9c0ea47911669e
 Source0:        https://files.pythonhosted.org/packages/source/l/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-lxml/python-lxml.spec
+++ b/SPECS/python-lxml/python-lxml.spec
@@ -21,9 +21,9 @@ URL:            https://github.com/lxml/lxml
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/l/%{srcname}/%{srcname}-%{version}.tar.gz
 
-BuildRequires:  libxml2-devel
-BuildRequires:  libxslt-devel
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(libxml-2.0)
+BuildRequires:  pkgconfig(libxslt)
+BuildRequires:  pkgconfig(python3)
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  expat
 

--- a/SPECS/python-markdown-it-py/python-markdown-it-py.spec
+++ b/SPECS/python-markdown-it-py/python-markdown-it-py.spec
@@ -16,15 +16,16 @@ License:        MIT
 URL:            https://github.com/executablebooks/markdown-it-py
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/m/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l markdown_it
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-pip
-BuildRequires:  python3-flit-core
-BuildRequires:  python3-pytest
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(flit-core)
+BuildRequires:  python3dist(pytest)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-marshmallow/python-marshmallow.spec
+++ b/SPECS/python-marshmallow/python-marshmallow.spec
@@ -15,6 +15,7 @@ URL:            https://marshmallow.readthedocs.io/
 VCS:            git:https://github.com/marshmallow-code/marshmallow/
 #!RemoteAsset:  sha256:4d1d66189c8d279ca73a6b0599d74117e5f8a3830b5cd766b75c2bb08e3464e7
 Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-matplotlib-inline/python-matplotlib-inline.spec
+++ b/SPECS/python-matplotlib-inline/python-matplotlib-inline.spec
@@ -14,6 +14,7 @@ License:        BSD-3-Clause
 URL:            https://github.com/ipython/matplotlib-inline
 #!RemoteAsset:  sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe
 Source0:        https://files.pythonhosted.org/packages/source/m/matplotlib-inline/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-maturin/python-maturin.spec
+++ b/SPECS/python-maturin/python-maturin.spec
@@ -19,13 +19,13 @@ Source1:        https://github.com/TakoPack/python-%{srcname}-vendor/releases/do
 BuildSystem:    pyproject
 
 BuildOption(prep):  -a1
-BuildOption(install): %{srcname}
+BuildOption(install):  %{srcname}
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-setuptools-rust
-BuildRequires:  python3-pip
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-rust)
+BuildRequires:  python3dist(pip)
 BuildRequires:  rust
 BuildRequires:  cargo
 

--- a/SPECS/python-mccabe/python-mccabe.spec
+++ b/SPECS/python-mccabe/python-mccabe.spec
@@ -9,18 +9,22 @@
 Name:           python-%{srcname}
 Version:        0.7.0
 Release:        %autorelease
+Summary:        McCabe checker, plugin for flake8
 License:        MIT
 URL:            https://github.com/PyCQA/mccabe
-Summary:        McCabe checker, plugin for flake8
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
 BuildSystem:    pyproject
-BuildOption(install): -l %{srcname} +auto
+
+BuildOption(install):  -l %{srcname} +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 %description
 This package provides a Flake8 plug-in to compute the McCabe cyclomatic
 complexity of Python source code.

--- a/SPECS/python-mdurl/python-mdurl.spec
+++ b/SPECS/python-mdurl/python-mdurl.spec
@@ -14,15 +14,16 @@ License:        MIT
 URL:            https://github.com/executablebooks/mdurl
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-pip
-BuildRequires:  python3-flit-core
-BuildRequires:  python3-pytest
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(flit-core)
+BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(pytest-randomly)
 
 Provides:       python3-%{srcname}

--- a/SPECS/python-meh/python-meh.spec
+++ b/SPECS/python-meh/python-meh.spec
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           python-meh
+Version:        0.52
+Release:        %autorelease
+Summary:        A python library for handling exceptions
+License:        GPL-2.0-or-later
+URL:            https://github.com/rhinstaller/python-meh
+#!RemoteAsset:  sha256:7b66046b4693e7631aad299e5a55d0255962608cd03372f559745c575aa8c920
+Source0:        https://github.com/rhinstaller/python-meh/archive/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    autotools
+
+BuildOption(install):  DESTDIR=%{buildroot}
+
+BuildRequires:  make
+BuildRequires:  gettext
+BuildRequires:  intltool
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(dbus-python)
+
+Provides:       python3-meh
+%python_provide python3-meh
+
+Requires:       python3dist(dbus-python)
+Requires:       python3dist(rpm)
+Requires:       python3dist(pygobject)
+
+%description
+The python-meh package is a python library for handling, saving,
+and reporting exceptions.
+
+# No configure
+%conf
+
+%check
+make test
+
+%files
+%doc COPYING
+%{python3_sitelib}/*
+%{_datadir}/python-meh
+
+%changelog
+%autochangelog

--- a/SPECS/python-meson-python/python-meson-python.spec
+++ b/SPECS/python-meson-python/python-meson-python.spec
@@ -12,14 +12,15 @@ Release:        %autorelease
 License:        MIT
 URL:            https://github.com/mesonbuild/meson-python
 Summary:        Meson-based build backend for Python
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/meson_python-%{version}.tar.gz
 BuildArch:      noarch
+BuildSystem:    pyproject
 
-BuildRequires:  python3-devel
+BuildOption(install):  -l mesonpy +auto
+
 BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
 BuildRequires:  patchelf
 BuildRequires:  python3dist(colorama)
 BuildRequires:  python3dist(pip)
@@ -27,17 +28,19 @@ BuildRequires:  python3dist(cython)
 BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(pyproject-metadata)
 BuildRequires:  meson
-BuildSystem:    pyproject
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 Requires:       meson
 Requires:       ninja
 Requires:       patchelf
-BuildOption(install): -l mesonpy +auto
+
 %description
 Meson-python is a PEP 517 build backend for Meson projects.
 
 # XXX: %%pyproject_buildrequires no work with this package.
 %generate_buildrequires
-
 
 %files -f %{pyproject_files}
 

--- a/SPECS/python-minidump/python-minidump.spec
+++ b/SPECS/python-minidump/python-minidump.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/skelsec/minidump
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-mitogen/python-mitogen.spec
+++ b/SPECS/python-mitogen/python-mitogen.spec
@@ -14,6 +14,7 @@ License:        BSD-3-Clause
 URL:            https://github.com/mitogen-hq/mitogen
 #!RemoteAsset:  sha256:6ac841a1b520c3136062ec930b95f6f4718ed8c3136ef3d7caf1a1d8e92d4823
 Source:         https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-ml-dtypes/python-ml-dtypes.spec
+++ b/SPECS/python-ml-dtypes/python-ml-dtypes.spec
@@ -19,11 +19,11 @@ BuildSystem:    pyproject
 BuildOption(install):  -l %{srcname}
 
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-pip
+BuildRequires:  python3dist(pip)
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-wheel
-BuildRequires:  python3-numpy
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+BuildRequires:  python3dist(numpy)
 BuildRequires:  gcc-c++
 
 Provides:       python3-%{srcname}

--- a/SPECS/python-mpmath/python-mpmath.spec
+++ b/SPECS/python-mpmath/python-mpmath.spec
@@ -9,22 +9,26 @@
 Name:           python-%{srcname}
 Version:        1.3.0
 Release:        %autorelease
+Summary:        Arbitrary-precision floating-point arithmetic in python
 License:        BSD-3-Clause
 URL:            https://mpmath.org
-Summary:        Arbitrary-precision floating-point arithmetic in python
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
+BuildSystem:    pyproject
 
-BuildRequires:  python3-devel
+BuildOption(install):  -l %{srcname} +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
 BuildRequires:  pytest
 BuildRequires:  python3dist(setuptools) >= 40.8
 BuildRequires:  python3dist(packaging)
 BuildRequires:  python3dist(pip)
-BuildSystem:    pyproject
-BuildOption(install): -l %{srcname} +auto
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 %description
 @code{mpmath} can be used as an arbitrary-precision substitute for
 Python's float/complex types and math/cmath modules, but also does much

--- a/SPECS/python-msgpack/python-msgpack.spec
+++ b/SPECS/python-msgpack/python-msgpack.spec
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %global srcname msgpack
-%global python3_pkgversion 3
 
 Name:           python-%{srcname}
 Version:        1.1.2
@@ -17,11 +16,11 @@ URL:            https://msgpack.org/
 Source0:        https://github.com/msgpack/msgpack-python/archive/v%{version}/%{srcname}-%{version}.tar.gz
 BuildSystem:    pyproject
 
-BuildOption(install): -l %{srcname}
+BuildOption(install):  -l %{srcname}
 
 BuildRequires:  gcc-c++
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(cython)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)

--- a/SPECS/python-munkres/python-munkres.spec
+++ b/SPECS/python-munkres/python-munkres.spec
@@ -15,6 +15,7 @@ URL:            http://software.clapper.org/munkres/
 VCS:            git:https://github.com/bmc/munkres
 #!RemoteAsset:  sha256:fc44bf3c3979dada4b6b633ddeeb8ffbe8388ee9409e4d4e8310c2da1792db03
 Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-mypy-extensions/python-mypy-extensions.spec
+++ b/SPECS/python-mypy-extensions/python-mypy-extensions.spec
@@ -15,8 +15,8 @@ License:        MIT
 URL:            https://github.com/python/mypy_extensions
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
-BuildSystem:    pyproject
 BuildArch:      noarch
+BuildSystem:    pyproject
 
 BuildOption(install):  %{srcname}
 

--- a/SPECS/python-nanobind/python-nanobind.spec
+++ b/SPECS/python-nanobind/python-nanobind.spec
@@ -14,12 +14,13 @@ License:        BSD-3-Clause
 URL:            https://nanobind.readthedocs.org/
 #!RemoteAsset:  sha256:08509910ce6d1fadeed69cb0880d4d4fcb77739c6af9bd8fb4419391a3ca4c6b
 Source:         https://files.pythonhosted.org/packages/source/n/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname} -L
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(scikit-build-core)
 BuildRequires:  python3dist(pip)
 BuildRequires:  cmake

--- a/SPECS/python-narwhals/python-narwhals.spec
+++ b/SPECS/python-narwhals/python-narwhals.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/narwhals-dev/narwhals
 #!RemoteAsset:  sha256:a9585975b99d95084268445a1fdd881311fa26ef1caa18020d959d5b2ff9a965
 Source0:        https://files.pythonhosted.org/packages/source/n/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-netaddr/python-netaddr.spec
+++ b/SPECS/python-netaddr/python-netaddr.spec
@@ -3,6 +3,7 @@
 # SPDX-FileContributor: Yafen Fang <yafen@iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
+
 %global srcname netaddr
 %bcond doc 0
 
@@ -21,11 +22,11 @@ BuildOption(install):  -l %{srcname}
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-pytest
+BuildRequires:  python3dist(pytest)
 %if %{with doc}
-BuildRequires:  python3-sphinx
-BuildRequires:  python3-sphinx-issues
-BuildRequires:  python3-furo
+BuildRequires:  python3dist(sphinx)
+BuildRequires:  python3dist(sphinx-issues)
+BuildRequires:  python3dist(furo)
 %endif
 
 Provides:       python3-%{srcname}

--- a/SPECS/python-nibabel/python-nibabel.spec
+++ b/SPECS/python-nibabel/python-nibabel.spec
@@ -15,6 +15,7 @@ URL:            http://nipy.org/nibabel/
 VCS:            git:https://github.com/nipy/nibabel
 #!RemoteAsset:  sha256:8d2006b70d727fd0a798a88ae5fd64339741f436fcfc83d6ea3256cdbc51c5b7
 Source:         https://files.pythonhosted.org/packages/source/n/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-nipype/python-nipype.spec
+++ b/SPECS/python-nipype/python-nipype.spec
@@ -16,6 +16,7 @@ License:        Apache-2.0
 URL:            https://github.com/nipy/nipype
 #!RemoteAsset:  sha256:19e5d6cefa70997198f78bc665ef4d3d3cb53325b5b98a72e51aefadaf6b3e0e
 Source:         https://files.pythonhosted.org/packages/source/n/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-norpm/python-norpm.spec
+++ b/SPECS/python-norpm/python-norpm.spec
@@ -13,15 +13,16 @@ Summary:        RPM Macro Expansion in Python
 License:        LGPL-2.1-or-later
 #!RemoteAsset:  sha256:9c32c8e41c1937a79c67735e19d3969be28b308d63bc31b1cfb790b1f556ab0c
 Source:         https://files.pythonhosted.org/packages/source/n/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l norpm
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-wheel
-BuildRequires:  python3-pytest
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(pip) >= 19
 BuildRequires:  python3dist(ply)
 

--- a/SPECS/python-ntplib/python-ntplib.spec
+++ b/SPECS/python-ntplib/python-ntplib.spec
@@ -17,10 +17,10 @@ Source0:        https://files.pythonhosted.org/packages/source/n/%{srcname}/%{sr
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): %{srcname}
+BuildOption(install):  %{srcname}
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-opencc-python-reimplemented/python-opencc-python-reimplemented.spec
+++ b/SPECS/python-opencc-python-reimplemented/python-opencc-python-reimplemented.spec
@@ -15,6 +15,7 @@ License:        Apache-2.0
 URL:            https://github.com/yichen0831/opencc-python
 #!RemoteAsset:  sha256:4f777ea3461a25257a7b876112cfa90bb6acabc6dfb843bf4d11266e43579dee
 Source0:        https://files.pythonhosted.org/packages/source/o/%{packagename}/%{packagename}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-opt-einsum/python-opt-einsum.spec
+++ b/SPECS/python-opt-einsum/python-opt-einsum.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/dgasmith/opt_einsum
 #!RemoteAsset:  sha256:96ca72f1b886d148241348783498194c577fa30a8faac108586b14f1ba4473ac
 Source0:        https://files.pythonhosted.org/packages/source/o/opt-einsum/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-parameterized/python-parameterized.spec
+++ b/SPECS/python-parameterized/python-parameterized.spec
@@ -16,26 +16,23 @@ License:        BSD-2-Clause
 URL:            https://github.com/wolever/parameterized
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l parameterized
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-pip
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-wheel
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+%if %{with tests}
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(nose2)
+%endif
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}
-
-%if %{with tests}
-BuildRequires:  python3-pytest
-BuildRequires:  python3-nose2
-%endif
-
-Provides:       python3-parameterized = %{version}-%{release}
-%python_provide python3-parameterized
 
 %description
 Parameterized testing with any Python test framework.

--- a/SPECS/python-paramiko/python-paramiko.spec
+++ b/SPECS/python-paramiko/python-paramiko.spec
@@ -14,6 +14,7 @@ License:        LGPL-2.1-or-later
 URL:            https://github.com/paramiko/paramiko
 #!RemoteAsset
 Source:         https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l paramiko
@@ -21,9 +22,9 @@ BuildOption(install):  -l paramiko
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pytest
-BuildRequires:  python3-pip
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-wheel
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-parso/python-parso.spec
+++ b/SPECS/python-parso/python-parso.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/davidhalter/parso
 #!RemoteAsset:  sha256:034d7354a9a018bdce352f48b2a8a450f05e9d6ee85db84764e9b6bd96dafe5a
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-passlib/python-passlib.spec
+++ b/SPECS/python-passlib/python-passlib.spec
@@ -14,6 +14,7 @@ License:        BSD-3-Clause AND Beerware AND UnixCrypt AND ISC
 URL:            https://foss.heptapod.net/python-libs/passlib
 #!RemoteAsset
 Source:         https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname} -L
@@ -21,10 +22,10 @@ BuildOption(check):  -e passlib.ext.django.models
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-pip
-BuildRequires:  python3-wheel
-BuildRequires:  python3-pytest
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(wheel)
+BuildRequires:  python3dist(pytest)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-paste/python-paste.spec
+++ b/SPECS/python-paste/python-paste.spec
@@ -17,12 +17,12 @@ Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{sr
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): %{srcname}
+BuildOption(install):  %{srcname}
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 # Tests
-BuildRequires:  python3-pytest
+BuildRequires:  python3dist(pytest)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-pdm_backend/python-pdm_backend.spec
+++ b/SPECS/python-pdm_backend/python-pdm_backend.spec
@@ -12,15 +12,19 @@ Release:        %autorelease
 License:        MIT
 URL:            https://pdm-backend.fming.dev/
 Summary:        PEP 517 build backend for PDM
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
 BuildSystem:    pyproject
-BuildOption(install): pdm +auto
+
+BuildOption(install):  pdm +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 %description
 PDM-Backend is a build backend that supports the latest packaging
 standards, which includes PEP 517, PEP 621 and PEP 660.

--- a/SPECS/python-pexpect/python-pexpect.spec
+++ b/SPECS/python-pexpect/python-pexpect.spec
@@ -14,6 +14,7 @@ License:        ISCL
 URL:            https://pexpect.readthedocs.io
 #!RemoteAsset:  sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-pipdeptree/python-pipdeptree.spec
+++ b/SPECS/python-pipdeptree/python-pipdeptree.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/naiquevin/pipdeptree
 #!RemoteAsset:  sha256:0f78fe4bcf36a72d0d006aee0f4e315146cb278e4c4d51621f370a3d6b8861c1
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 # remove graphviz test

--- a/SPECS/python-platformdirs/python-platformdirs.spec
+++ b/SPECS/python-platformdirs/python-platformdirs.spec
@@ -9,18 +9,22 @@
 Name:           python-%{srcname}
 Version:        4.4.0
 Release:        %autorelease
+Summary:        Determine the appropriate platform-specific directories
 License:        MIT
 URL:            https://github.com/platformdirs/platformdirs
-Summary:        Determine the appropriate platform-specific directories
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
 BuildSystem:    pyproject
-BuildOption(install): -l %{srcname} +auto
+
+BuildOption(install):  -l %{srcname} +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 %description
 When writing applications, finding the right location to
 store user data and configuration varies per platform.  Even for

--- a/SPECS/python-poetry_core/python-poetry_core.spec
+++ b/SPECS/python-poetry_core/python-poetry_core.spec
@@ -9,18 +9,22 @@
 Name:           python-%{srcname}
 Version:        2.1.2
 Release:        %autorelease
+Summary:        Poetry PEP 517 build back-end
 License:        MIT
 URL:            https://github.com/python-poetry/poetry-core
-Summary:        Poetry PEP 517 build back-end
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
 BuildSystem:    pyproject
-BuildOption(install): poetry +auto
+
+BuildOption(install):  poetry +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}
+
 %description
 The poetry-core module provides a PEP 517 build back-end
 implementation developed for Poetry.  This project is intended to be

--- a/SPECS/python-portalocker/python-portalocker.spec
+++ b/SPECS/python-portalocker/python-portalocker.spec
@@ -14,6 +14,7 @@ License:        BSD-3-Clause
 URL:            https://github.com/WoLpH/portalocker
 #!RemoteAsset:  sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-prettytable/python-prettytable.spec
+++ b/SPECS/python-prettytable/python-prettytable.spec
@@ -17,10 +17,10 @@ Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{sr
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): %{srcname}
+BuildOption(install):  %{srcname}
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-process-tests/python-process-tests.spec
+++ b/SPECS/python-process-tests/python-process-tests.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname process-tests
+
+Name:           python-%{srcname}
+Version:        3.0.0
+Release:        %autorelease
+Summary:        Tools for testing processes.
+License:        BSD-2-Clause
+URL:            https://github.com/ionelmc/python-process-tests
+#!RemoteAsset
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l process_tests
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
+%description
+Tools for testing processes.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+
+%changelog
+%{?autochangelog}

--- a/SPECS/python-psutil/python-psutil.spec
+++ b/SPECS/python-psutil/python-psutil.spec
@@ -9,23 +9,24 @@
 Name:           python-%{srcname}
 Version:        7.2.2
 Release:        %autorelease
+Summary:        Library for retrieving information on running processes
 License:        BSD-3-Clause
 URL:            https://github.com/giampaolo/psutil
-Summary:        Library for retrieving information on running processes
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
-
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
 
-BuildRequires:  gcc
+BuildOption(install):  -l %{srcname} +auto
+
 BuildRequires:  sed
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  python3dist(pip) >= 19
 BuildRequires:  python3dist(setuptools) >= 43
-BuildSystem:    pyproject
-BuildOption(install):  -l %{srcname} +auto
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 %description
 @code{psutil} (Python system and process utilities) is a library for
 retrieving information on running processes and system utilization (CPU,

--- a/SPECS/python-ptyprocess/python-ptyprocess.spec
+++ b/SPECS/python-ptyprocess/python-ptyprocess.spec
@@ -14,6 +14,7 @@ License:        ISC
 URL:            https://github.com/pexpect/ptyprocess
 #!RemoteAsset:  sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-puccinialin/python-puccinialin.spec
+++ b/SPECS/python-puccinialin/python-puccinialin.spec
@@ -14,6 +14,7 @@ License:        MIT OR Apache-2.0
 URL:            https://github.com/konstin/puccinialin
 #!RemoteAsset:  sha256:e19f6316967ae100bf3fb92d8af95e3cec11ce0de58acd2f1a0bca835403a394
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-pure-eval/python-pure-eval.spec
+++ b/SPECS/python-pure-eval/python-pure-eval.spec
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %global srcname pure_eval
+%global pypi_name pure-eval
 
 Name:           python-pure-eval
 Version:        0.2.3
@@ -13,7 +14,8 @@ Summary:        Safely evaluate AST nodes without side effects
 License:        MIT
 URL:            http://github.com/alexmojaki/pure_eval
 #!RemoteAsset:  sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42
-Source0:        https://files.pythonhosted.org/packages/source/p/pure-eval/%{srcname}-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/source/p/%{pypi_name}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}
@@ -26,8 +28,8 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
+Provides:       python3-%{pypi_name}
+%python_provide python3-%{pypi_name}
 
 %description
 This is a Python package that lets you safely

--- a/SPECS/python-pybind11-stubgen/python-pybind11-stubgen.spec
+++ b/SPECS/python-pybind11-stubgen/python-pybind11-stubgen.spec
@@ -14,6 +14,7 @@ License:        BSD-3-Clause
 URL:            https://github.com/pybind/pybind11-stubgen
 #!RemoteAsset:  sha256:758d6d6bbeefc62ad7f78d5e5bbf357ccf6af83cd4504f5f549403f452942708
 Source0:        https://files.pythonhosted.org/packages/source/p/pybind11-stubgen/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-pydantic/python-pydantic.spec
+++ b/SPECS/python-pydantic/python-pydantic.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/pydantic/pydantic
 #!RemoteAsset:  sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-pydot/python-pydot.spec
+++ b/SPECS/python-pydot/python-pydot.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/pydot/pydot
 #!RemoteAsset:  sha256:c2148f681c4a33e08bf0e26a9e5f8e4099a82e0e2a068098f32ce86577364ad5
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-pydub/python-pydub.spec
+++ b/SPECS/python-pydub/python-pydub.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/jiaaro/pydub
 #!RemoteAsset:  sha256:980a33ce9949cab2a569606b65674d748ecbca4f0796887fd6f46173a7b0d30f
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 # PATCH-FIX-OPENSUSE skip_libopenh264-7.patch gh#jiaaro/pydub#700 mcepl@suse.com

--- a/SPECS/python-pyenchant/python-pyenchant.spec
+++ b/SPECS/python-pyenchant/python-pyenchant.spec
@@ -17,10 +17,10 @@ Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{sr
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): -L enchant
+BuildOption(install):  -L enchant
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 BuildRequires:  enchant
 
 Provides:       python3-%{srcname}
@@ -37,7 +37,6 @@ library by Dom Lachowicz.
 
 # TODO: Fix tests
 %check
-
 
 %files -f %{pyproject_files}
 %doc README.rst

--- a/SPECS/python-pygments/python-pygments.spec
+++ b/SPECS/python-pygments/python-pygments.spec
@@ -15,22 +15,23 @@ URL:            https://pygments.org/
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l pygments
+BuildOption(check):  -e 'pygments.sphinxext*'
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(docutils)
+
 Provides:       python3-pygments
 %python_provide python3-pygments
 
-BuildRequires:  python3-devel
-BuildSystem:    pyproject
-
-BuildRequires:  python3-docutils
-BuildOption(install):  -l pygments
-BuildOption(check):    -e 'pygments.sphinxext*'
 %description
 Pygments is a syntax highlighting package written in Python.
 
-
 %generate_buildrequires
 %pyproject_buildrequires
-
 
 %files -f %{pyproject_files}
 %license LICENSE*

--- a/SPECS/python-pyinotify/python-pyinotify.spec
+++ b/SPECS/python-pyinotify/python-pyinotify.spec
@@ -17,10 +17,10 @@ Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{sr
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): -l %{srcname}
+BuildOption(install):  -l %{srcname}
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-pyjwt/python-pyjwt.spec
+++ b/SPECS/python-pyjwt/python-pyjwt.spec
@@ -18,10 +18,10 @@ BuildArch:      noarch
 BuildSystem:    pyproject
 
 # Import as jwt
-BuildOption(install): jwt
+BuildOption(install):  jwt
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-pykickstart/python-pykickstart.spec
+++ b/SPECS/python-pykickstart/python-pykickstart.spec
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pykickstart
+
+Name:           python-%{srcname}
+Version:        3.69
+Release:        %autorelease
+Summary:        Python module for manipulating kickstart files
+License:        GPL-2.0-only
+URL:            http://fedoraproject.org/wiki/pykickstart
+VCS:            git:https://github.com/pykickstart/pykickstart.git
+#!RemoteAsset
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    autotools
+
+BuildOption(build):  PYTHON=%{__python3}
+BuildOption(install):  PYTHON=%{__python3} DESTDIR=%{buildroot}
+
+BuildRequires:  make
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(requests)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(pytest-xdist)
+BuildRequires:  python3dist(pytest-cov)
+
+Provides:       python3-%{srcname}
+Provides:       python3-%{srcname}%{?_isa}
+%python_provide python3-%{srcname}
+
+%description
+Python utilities for manipulating kickstart files.
+
+# No configure
+%conf
+
+%install -a
+# TODO: Avoid illegal package names
+rm -rf %{buildroot}%{python3_sitelib}/pykickstart/locale/*@*
+rm -rf %{buildroot}%{python3_sitelib}/pykickstart/locale/en_GB/
+%find_lang %{srcname} --generate-subpackages
+
+# TODO: Currently our python don't provide readline module
+# and this is a mistake
+%check
+make PYTHON=%{__python3} test-no-coverage ||:
+
+%files
+%license COPYING
+%doc README.rst
+%doc data/kickstart.vim
+%doc docs/2to3
+%doc docs/programmers-guide
+%doc docs/kickstart-docs.txt
+%{_bindir}/ksvalidator
+%{_bindir}/ksflatten
+%{_bindir}/ksverdiff
+%{_bindir}/ksshell
+%{_mandir}/man1/ksflatten.1.gz
+%{_mandir}/man1/ksshell.1.gz
+%{_mandir}/man1/ksvalidator.1.gz
+%{_mandir}/man1/ksverdiff.1.gz
+%{python3_sitelib}/pykickstart
+%{python3_sitelib}/pykickstart-%{version}.dist-info
+
+%changelog
+%{?autochangelog}

--- a/SPECS/python-pylsqpack/python-pylsqpack.spec
+++ b/SPECS/python-pylsqpack/python-pylsqpack.spec
@@ -16,10 +16,10 @@ URL:            https://github.com/aiortc/pylsqpack
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildSystem:    pyproject
 
-BuildOption(install): %{srcname}
+BuildOption(install):  %{srcname}
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-pymilvus/python-pymilvus.spec
+++ b/SPECS/python-pymilvus/python-pymilvus.spec
@@ -14,6 +14,7 @@ License:        Apache-2.0
 URL:            https://github.com/milvus-io/pymilvus
 #!RemoteAsset:  sha256:c53a3d84ff15814e251be13edda70a98a1c8a6090d7597a908387cbb94a9504a
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 # Skip bulk_writer, don't need it for now

--- a/SPECS/python-pymongo/python-pymongo.spec
+++ b/SPECS/python-pymongo/python-pymongo.spec
@@ -44,8 +44,7 @@ Provides:       python3-bson
 %description -n python-bson
 BSON is a binary-encoded serialization of JSON-like documents. BSON is designed
 to be lightweight, traversable, and efficient. BSON, like JSON, supports the
-embedding of objects and arrays within other objects and arrays.  This package
-contains the python3 version of this module.
+embedding of objects and arrays within other objects and arrays.
 
 %package     -n python-pymongo-gridfs
 Summary:        Python GridFS driver for MongoDB
@@ -54,9 +53,7 @@ Provides:       python3-pymongo-gridfs
 %python_provide python3-pymongo-gridfs
 
 %description -n python-pymongo-gridfs
-GridFS is a storage specification for large objects in MongoDB.  This package
-contains the python3 version of this module.
-
+GridFS is a storage specification for large objects in MongoDB.
 # TODO: enable submodule in the future
 # pyproject_extras_subpkg -n python3-pymongo ocsp snappy zstd
 
@@ -70,51 +67,51 @@ export PYMONGO_C_EXT_MUST_BUILD=1
 %check
 # Skip tests that require network/nameservers and tests that cause segfaults
 %pytest -v \
-  --deselect=test/asynchronous/test_client.py::AsyncClientUnitTest::test_connection_timeout_ms_propagates_to_DNS_resolver \
-  --deselect=test/asynchronous/test_client.py::AsyncClientUnitTest::test_detected_environment_logging \
-  --deselect=test/asynchronous/test_client.py::AsyncClientUnitTest::test_detected_environment_warning \
-  --deselect=test/test_client.py::ClientUnitTest::test_connection_timeout_ms_propagates_to_DNS_resolver \
-  --deselect=test/test_client.py::ClientUnitTest::test_detected_environment_logging \
-  --deselect=test/test_client.py::ClientUnitTest::test_detected_environment_warning \
-  --deselect=test/test_srv_polling.py::TestSrvPolling::test_10_all_dns_selected \
-  --deselect=test/test_srv_polling.py::TestSrvPolling::test_11_all_dns_selected \
-  --deselect=test/test_srv_polling.py::TestSrvPolling::test_12_new_dns_randomly_selected \
-  --deselect=test/test_srv_polling.py::TestSrvPolling::test_addition \
-  --deselect=test/test_srv_polling.py::TestSrvPolling::test_dns_failures \
-  --deselect=test/test_srv_polling.py::TestSrvPolling::test_dns_record_lookup_empty \
-  --deselect=test/test_srv_polling.py::TestSrvPolling::test_does_not_flipflop \
-  --deselect=test/test_srv_polling.py::TestSrvPolling::test_recover_from_initially_empty_seedlist \
-  --deselect=test/test_srv_polling.py::TestSrvPolling::test_recover_from_initially_erroring_seedlist \
-  --deselect=test/test_srv_polling.py::TestSrvPolling::test_removal \
-  --deselect=test/test_srv_polling.py::TestSrvPolling::test_replace_both_with_one \
-  --deselect=test/test_srv_polling.py::TestSrvPolling::test_replace_both_with_two \
-  --deselect=test/test_srv_polling.py::TestSrvPolling::test_replace_one \
-  --deselect=test/test_srv_polling.py::TestSrvPolling::test_srv_service_name \
-  --deselect=test/test_srv_polling.py::TestSrvPolling::test_srv_waits_to_poll \
-  --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_10_all_dns_selected \
-  --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_11_all_dns_selected \
-  --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_12_new_dns_randomly_selected \
-  --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_addition \
-  --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_dns_failures \
-  --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_dns_record_lookup_empty \
-  --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_does_not_flipflop \
-  --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_recover_from_initially_empty_seedlist \
-  --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_recover_from_initially_erroring_seedlist \
-  --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_removal \
-  --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_replace_both_with_one \
-  --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_replace_both_with_two \
-  --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_replace_one \
-  --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_srv_service_name \
-  --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_srv_waits_to_poll \
-  --deselect=test/test_uri_spec.py::TestAllScenarios::test_test_uri_options_srv-options_SRV_URI_with_custom_srvServiceName \
-  --deselect=test/test_uri_spec.py::TestAllScenarios::test_test_uri_options_srv-options_SRV_URI_with_invalid_type_for_srvMaxHosts \
-  --deselect=test/test_uri_spec.py::TestAllScenarios::test_test_uri_options_srv-options_SRV_URI_with_negative_integer_for_srvMaxHosts \
-  --deselect=test/test_uri_spec.py::TestAllScenarios::test_test_uri_options_srv-options_SRV_URI_with_positive_srvMaxHosts_and_loadBalanced=false \
-  --deselect=test/test_uri_spec.py::TestAllScenarios::test_test_uri_options_srv-options_SRV_URI_with_srvMaxHosts \
-  --deselect=test/test_uri_spec.py::TestAllScenarios::test_test_uri_options_srv-options_SRV_URI_with_srvMaxHosts=0_and_loadBalanced=true \
-  --deselect=test/test_uri_spec.py::TestAllScenarios::test_test_uri_options_srv-options_SRV_URI_with_srvMaxHosts=0_and_replicaSet \
-  --deselect=test/asynchronous/test_custom_types.py::TestBSONCustomTypeEncoderAndFallbackEncoderTandem::test_infinite_loop_exceeds_max_recursion_depth \
-  --deselect=test/test_custom_types.py::TestBSONCustomTypeEncoderAndFallbackEncoderTandem::test_infinite_loop_exceeds_max_recursion_depth
+    --deselect=test/asynchronous/test_client.py::AsyncClientUnitTest::test_connection_timeout_ms_propagates_to_DNS_resolver \
+    --deselect=test/asynchronous/test_client.py::AsyncClientUnitTest::test_detected_environment_logging \
+    --deselect=test/asynchronous/test_client.py::AsyncClientUnitTest::test_detected_environment_warning \
+    --deselect=test/test_client.py::ClientUnitTest::test_connection_timeout_ms_propagates_to_DNS_resolver \
+    --deselect=test/test_client.py::ClientUnitTest::test_detected_environment_logging \
+    --deselect=test/test_client.py::ClientUnitTest::test_detected_environment_warning \
+    --deselect=test/test_srv_polling.py::TestSrvPolling::test_10_all_dns_selected \
+    --deselect=test/test_srv_polling.py::TestSrvPolling::test_11_all_dns_selected \
+    --deselect=test/test_srv_polling.py::TestSrvPolling::test_12_new_dns_randomly_selected \
+    --deselect=test/test_srv_polling.py::TestSrvPolling::test_addition \
+    --deselect=test/test_srv_polling.py::TestSrvPolling::test_dns_failures \
+    --deselect=test/test_srv_polling.py::TestSrvPolling::test_dns_record_lookup_empty \
+    --deselect=test/test_srv_polling.py::TestSrvPolling::test_does_not_flipflop \
+    --deselect=test/test_srv_polling.py::TestSrvPolling::test_recover_from_initially_empty_seedlist \
+    --deselect=test/test_srv_polling.py::TestSrvPolling::test_recover_from_initially_erroring_seedlist \
+    --deselect=test/test_srv_polling.py::TestSrvPolling::test_removal \
+    --deselect=test/test_srv_polling.py::TestSrvPolling::test_replace_both_with_one \
+    --deselect=test/test_srv_polling.py::TestSrvPolling::test_replace_both_with_two \
+    --deselect=test/test_srv_polling.py::TestSrvPolling::test_replace_one \
+    --deselect=test/test_srv_polling.py::TestSrvPolling::test_srv_service_name \
+    --deselect=test/test_srv_polling.py::TestSrvPolling::test_srv_waits_to_poll \
+    --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_10_all_dns_selected \
+    --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_11_all_dns_selected \
+    --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_12_new_dns_randomly_selected \
+    --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_addition \
+    --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_dns_failures \
+    --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_dns_record_lookup_empty \
+    --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_does_not_flipflop \
+    --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_recover_from_initially_empty_seedlist \
+    --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_recover_from_initially_erroring_seedlist \
+    --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_removal \
+    --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_replace_both_with_one \
+    --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_replace_both_with_two \
+    --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_replace_one \
+    --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_srv_service_name \
+    --deselect=test/asynchronous/test_srv_polling.py::TestSrvPolling::test_srv_waits_to_poll \
+    --deselect=test/test_uri_spec.py::TestAllScenarios::test_test_uri_options_srv-options_SRV_URI_with_custom_srvServiceName \
+    --deselect=test/test_uri_spec.py::TestAllScenarios::test_test_uri_options_srv-options_SRV_URI_with_invalid_type_for_srvMaxHosts \
+    --deselect=test/test_uri_spec.py::TestAllScenarios::test_test_uri_options_srv-options_SRV_URI_with_negative_integer_for_srvMaxHosts \
+    --deselect=test/test_uri_spec.py::TestAllScenarios::test_test_uri_options_srv-options_SRV_URI_with_positive_srvMaxHosts_and_loadBalanced=false \
+    --deselect=test/test_uri_spec.py::TestAllScenarios::test_test_uri_options_srv-options_SRV_URI_with_srvMaxHosts \
+    --deselect=test/test_uri_spec.py::TestAllScenarios::test_test_uri_options_srv-options_SRV_URI_with_srvMaxHosts=0_and_loadBalanced=true \
+    --deselect=test/test_uri_spec.py::TestAllScenarios::test_test_uri_options_srv-options_SRV_URI_with_srvMaxHosts=0_and_replicaSet \
+    --deselect=test/asynchronous/test_custom_types.py::TestBSONCustomTypeEncoderAndFallbackEncoderTandem::test_infinite_loop_exceeds_max_recursion_depth \
+    --deselect=test/test_custom_types.py::TestBSONCustomTypeEncoderAndFallbackEncoderTandem::test_infinite_loop_exceeds_max_recursion_depth
 
 %files -f %{pyproject_files}
 %doc README.md

--- a/SPECS/python-pyopenssl/python-pyopenssl.spec
+++ b/SPECS/python-pyopenssl/python-pyopenssl.spec
@@ -14,12 +14,13 @@ License:        Apache-2.0
 URL:            https://github.com/pyca/pyopenssl
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): OpenSSL
+BuildOption(install):  OpenSSL
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 BuildRequires:  openssl
 
 Provides:       python3-%{srcname}

--- a/SPECS/python-pyparsing/python-pyparsing.spec
+++ b/SPECS/python-pyparsing/python-pyparsing.spec
@@ -10,21 +10,22 @@
 Name:           python-%{srcname}
 Version:        3.2.1
 Release:        %autorelease
+Summary:        Python parsing class library
 License:        MIT
 URL:            https://github.com/pyparsing/pyparsing
-Summary:        Python parsing class library
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
-BuildSystem:    pyproject
 BuildArch:      noarch
+BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname} +auto
 # skip the part of the tests,as we have no railroad yet.
 BuildOption(check):  -e pyparsing.diagram
 
+BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-pip
-BuildRequires:  python3-flit-core
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(flit-core)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-pyparted/python-pyparted.spec
+++ b/SPECS/python-pyparted/python-pyparted.spec
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pyparted
+
+Name:           python-pyparted
+Version:        3.13.0
+Release:        %autorelease
+Summary:        Python bindings for GNU parted
+License:        GPL-2.0-or-later
+URL:            https://github.com/dcantrell/pyparted
+#!RemoteAsset
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    autotools
+
+BuildRequires:  make
+BuildRequires:  gcc
+BuildRequires:  pkgconfig(libparted)
+BuildRequires:  e2fsprogs
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
+%description
+The python-pyparted package is used for manipulating
+partition tables.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+# No configure
+%conf
+
+%check
+make test
+
+%files
+%doc AUTHORS HACKING NEWS README.md RELEASE TODO
+%license LICENSE
+%{python3_sitearch}/_ped.*.so
+%{python3_sitearch}/parted
+%{python3_sitearch}/%{srcname}-%{version}-*.egg-info
+
+%changelog
+%{?autochangelog}

--- a/SPECS/python-pyproject-api/python-pyproject-api.spec
+++ b/SPECS/python-pyproject-api/python-pyproject-api.spec
@@ -17,10 +17,10 @@ Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/pypr
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): pyproject_api
+BuildOption(install):  pyproject_api
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-pyproject-metadata/python-pyproject-metadata.spec
+++ b/SPECS/python-pyproject-metadata/python-pyproject-metadata.spec
@@ -13,14 +13,14 @@ Summary:        PEP 621 metadata parsing
 License:        MIT
 URL:            https://github.com/FFY00/python-pyproject-metadata
 #!RemoteAsset
-Source0:         https://github.com/FFY00/python-pyproject-metadata/archive/refs/tags/%{version}.tar.gz#/pyproject-metadata-%{version}.tar.gz
-
+Source0:        https://github.com/FFY00/python-pyproject-metadata/archive/refs/tags/%{version}.tar.gz#/pyproject-metadata-%{version}.tar.gz
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
-BuildRequires:  pyproject-rpm-macros
 BuildSystem:    pyproject
+
 BuildOption(install):  -l pyproject_metadata  +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-pyproject_hooks/python-pyproject_hooks.spec
+++ b/SPECS/python-pyproject_hooks/python-pyproject_hooks.spec
@@ -9,18 +9,22 @@
 Name:           python-%{srcname}
 Version:        1.2.0
 Release:        %autorelease
+Summary:        Low-level library for calling @file{pyproject.toml} backends
 License:        MIT
 URL:            https://github.com/pypa/pyproject-hooks
-Summary:        Low-level library for calling @file{pyproject.toml} backends
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
 BuildSystem:    pyproject
-BuildOption(install): -l %{srcname} +auto
+
+BuildOption(install):  -l %{srcname} +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 %description
 @code{pyproject-hooks} is a low-level library for calling build backends
 in @file{pyproject.toml}-based projects.  It provides basic functionality to

--- a/SPECS/python-pyroute2/python-pyroute2.spec
+++ b/SPECS/python-pyroute2/python-pyroute2.spec
@@ -21,9 +21,10 @@ BuildOption(install):  %{srcname}
 BuildOption(check):  -e 'pyroute2.cli.auth.*'
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(mitogen)
+
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}
 

--- a/SPECS/python-pyrsistent/python-pyrsistent.spec
+++ b/SPECS/python-pyrsistent/python-pyrsistent.spec
@@ -17,10 +17,10 @@ Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{sr
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): -l %{srcname} _pyrsistent_version
+BuildOption(install):  -l %{srcname} _pyrsistent_version
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-pyserial/python-pyserial.spec
+++ b/SPECS/python-pyserial/python-pyserial.spec
@@ -14,6 +14,7 @@ License:        BSD-3-Clause
 URL:            http://pypi.python.org/pypi/pyserial
 #!RemoteAsset
 Source:         https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l serial
@@ -26,9 +27,9 @@ BuildOption(check):  -e serial.urlhandler.protocol_cp2110
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-pip
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-wheel
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-pysocks/python-pysocks.spec
+++ b/SPECS/python-pysocks/python-pysocks.spec
@@ -17,10 +17,10 @@ Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{sr
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): -l socks sockshandler
+BuildOption(install):  -l socks sockshandler
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 
 Provides:       python3-pysocks
 %python_provide python3-pysocks

--- a/SPECS/python-pytest-cov/python-pytest-cov.spec
+++ b/SPECS/python-pytest-cov/python-pytest-cov.spec
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pytest-cov
+%global alternativename pytest_cov
+
+Name:           python-pytest-cov
+Version:        7.0.0
+Release:        %autorelease
+Summary:        Pytest plugin for measuring coverage.
+License:        GPL-2.0-only
+URL:            https://github.com/pytest-dev/pytest-cov
+#!RemoteAsset
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{alternativename}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  %{alternativename}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(requests)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(pytest-xdist)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
+%description
+This plugin produces coverage reports. Compared to just using coverage run this
+plugin does some extras:
+
+  • Subprocess support: you can fork or run stuff in a subprocess and will get
+    covered without any fuss.
+  • Xdist support: you can use all of pytest-xdist’s features and still get
+    coverage.
+  • Consistent pytest behavior. If you run coverage run -m pytest you will have
+    slightly different sys.path (CWD will be in it, unlike when running
+    pytest).
+
+All features offered by the coverage package should work, either through
+pytest-cov’s command line options or through coverage’s config file.
+
+# Disable tests
+%generate_buildrequires
+%pyproject_buildrequires -r -x testing
+
+%check
+
+%files -f %{pyproject_files}
+%license LICENSE
+%doc *.rst
+
+%changelog
+%{?autochangelog}

--- a/SPECS/python-pytest-dotenv/python-pytest-dotenv.spec
+++ b/SPECS/python-pytest-dotenv/python-pytest-dotenv.spec
@@ -9,18 +9,22 @@
 Name:           python-%{srcname}
 Version:        0.5.2
 Release:        %autorelease
+Summary:        Automatically detect and load a .env file before running tests
 License:        MIT
 URL:            https://github.com/quiqua/pytest-dotenv
-Summary:        Automatically detect and load a .env file before running tests
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
 BuildSystem:    pyproject
-BuildOption(install): -l pytest_dotenv +auto
+
+BuildOption(install):  -l pytest_dotenv +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 %description
 This Pytest plugin automatically detects and loads environment variables
 from a .env file before running tests.

--- a/SPECS/python-pytest-env/python-pytest-env.spec
+++ b/SPECS/python-pytest-env/python-pytest-env.spec
@@ -9,19 +9,22 @@
 Name:           python-pytest-env
 Version:        1.1.5
 Release:        %autorelease
+Summary:        Pytest plugin that allows you to add environment variables
 License:        MIT
 URL:            https://github.com/MobileDynasty/pytest-env
-Summary:        Pytest plugin that allows you to add environment variables
-Provides:       python3-pytest-env
-%python_provide python3-pytest-env
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  %{srcname} +auto
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
-BuildSystem:    pyproject
-BuildOption(install): %{srcname} +auto
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-pytest-env
+%python_provide python3-pytest-env
+
 %description
 This is a @code{py.test} plugin that enables you to set environment
 variables in the @file{pytest.ini} file.

--- a/SPECS/python-pytest-forked/python-pytest-forked.spec
+++ b/SPECS/python-pytest-forked/python-pytest-forked.spec
@@ -17,10 +17,10 @@ Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{sr
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): pytest_forked
+BuildOption(install):  pytest_forked
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-pytest-freezer/python-pytest-freezer.spec
+++ b/SPECS/python-pytest-freezer/python-pytest-freezer.spec
@@ -9,19 +9,22 @@
 Name:           python-pytest-freezer
 Version:        0.4.9
 Release:        %autorelease
+Summary:        Pytest plugin providing a fixture interface for spulec/freezegun
 License:        MIT
 URL:            https://github.com/pytest-dev/pytest-freezer/
-Summary:        Pytest plugin providing a fixture interface for spulec/freezegun
-Provides:       python3-pytest-freezer
-%python_provide python3-pytest-freezer
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname} +auto
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
-BuildSystem:    pyproject
-BuildOption(install): -l %{srcname} +auto
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-pytest-freezer
+%python_provide python3-pytest-freezer
+
 %description
 Pytest plugin providing a fixture interface for
 @url{https://github.com/spulec/freezegun, freezegun}.

--- a/SPECS/python-pytest-relaxed/python-pytest-relaxed.spec
+++ b/SPECS/python-pytest-relaxed/python-pytest-relaxed.spec
@@ -9,18 +9,22 @@
 Name:           python-%{srcname}
 Version:        2.0.2
 Release:        %autorelease
+Summary:        Relaxed test discovery for pytest
 License:        BSD-2-clause
 URL:            https://github.com/bitprophet/pytest-relaxed
-Summary:        Relaxed test discovery for pytest
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
 BuildSystem:    pyproject
-BuildOption(install): pytest_relaxed +auto
+
+BuildOption(install):  pytest_relaxed +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 %description
 This package provides relaxed test discovery for pytest.
 

--- a/SPECS/python-python-pam/python-python-pam.spec
+++ b/SPECS/python-python-pam/python-python-pam.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname python-pam
+
+Name:           python-%{srcname}
+Version:        2.0.2
+Release:        %autorelease
+Summary:        Python PAM module using ctypes, py3
+License:        MIT
+URL:            https://github.com/FirefighterBlu3/python-pam
+#!RemoteAsset
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l pam
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
+%description
+This module provides an authenticate function that allows the caller to
+authenticate a given username / password against the PAM system on Linux.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+# No check for this
+%check
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%{?autochangelog}

--- a/SPECS/python-qemu-qmp/python-qemu-qmp.spec
+++ b/SPECS/python-qemu-qmp/python-qemu-qmp.spec
@@ -7,36 +7,38 @@
 %bcond doc 0
 %bcond tests 0
 
-Name:           python-qemu-qmp
+%global srcname qemu-qmp
+%global pypi_name qemu.qmp
+
+Name:           python-%{srcname}
 Version:        0.0.5
 Release:        %autorelease
 Summary:        QEMU Monitor Protocol library
 License:        GPL-2.0-only AND LGPL-2.0-or-later
 URL:            https://pypi.org/project/qemu.qmp
-#!RemoteAsset
-Source:         https://files.pythonhosted.org/packages/82/53/a7668df6a6051ecf714b3831526a8a754a3dae9a5ddea3e4f99a09547234/qemu_qmp-%{version}.tar.gz
+#!RemoteAsset:  sha256:1d1b9a9a5d57edfe2de3a1d888612823b09aff946951a902e79e9655a2aabbfd
+Source:         https://files.pythonhosted.org/packages/source/q/%{pypi_name}/qemu_qmp-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): -l qemu
+BuildOption(install):  -l qemu
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
-BuildRequires:  python3-pip
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-setuptools_scm
-BuildRequires:  python3-wheel
-
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm)
+BuildRequires:  python3dist(wheel)
 %if %{with tests}
-BuildRequires:  python3-pytest
+BuildRequires:  python3dist(pytest)
 %endif
-
 %if %{with doc}
-BuildRequires:  python3-sphinx
-BuildRequires:  python3-sphinx-rtd-theme
+BuildRequires:  python3dist(sphinx)
+BuildRequires:  python3dist(sphinx-rtd-theme)
 %endif
 
-Provides:       python3-qemu-qmp = %{version}-%{release}
-%python_provide python3-qemu-qmp
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
 
 %description
 qemu.qmp is a QEMU Monitor Protocol ("QMP") library written in Python,
@@ -51,7 +53,6 @@ This package provides offline HTML documentation for python3-qemu-qmp.
 
 %generate_buildrequires
 %pyproject_buildrequires
-
 
 %install -a
 rm -f %{buildroot}%{_bindir}/qmp-tui
@@ -86,4 +87,4 @@ install -Dpm 0644 man/*.1 -t %{buildroot}%{_mandir}/man1/
 %endif
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-requests/python-requests.spec
+++ b/SPECS/python-requests/python-requests.spec
@@ -9,18 +9,21 @@
 Name:           python-%{srcname}
 Version:        2.32.5
 Release:        %autorelease
+Summary:        Python HTTP library
 License:        Apache-2.0
 URL:            https://requests.readthedocs.io/
-Summary:        Python HTTP library
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/r/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
 BuildSystem:    pyproject
-BuildOption(install): -l %{srcname} +auto
+
+BuildOption(install):  -l %{srcname} +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
 %description
 Requests is a Python HTTP client library.  It aims to be easier to use
 than Python’s urllib2 library.

--- a/SPECS/python-resolvelib/python-resolvelib.spec
+++ b/SPECS/python-resolvelib/python-resolvelib.spec
@@ -9,19 +9,22 @@
 Name:           python-%{srcname}
 Version:        1.1.0
 Release:        %autorelease
+Summary:        Abstract dependencies resolver
 License:        ISC
 URL:            https://github.com/sarugaku/resolvelib
-Summary:        Abstract dependencies resolver
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/r/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
-BuildRequires:  pyproject-rpm-macros
 BuildSystem:    pyproject
-BuildOption(install): -l %{srcname} +auto
+
+BuildOption(install):  -l %{srcname} +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 %description
 The ResolveLib library provides a @code{Resolver} class that includes
 dependency resolution logic.

--- a/SPECS/python-reuse/python-reuse.spec
+++ b/SPECS/python-reuse/python-reuse.spec
@@ -14,6 +14,7 @@ License:        Apache-2.0 AND CC0-1.0 AND CC-BY-SA-4.0 AND GPL-3.0-or-later
 URL:            https://github.com/fsfe/reuse-tool
 #!RemoteAsset:  sha256:4feae057a2334c9a513e6933cdb9be819d8b822f3b5b435a36138bd218897d23
 Source:         https://files.pythonhosted.org/packages/source/r/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l reuse -L

--- a/SPECS/python-rich/python-rich.spec
+++ b/SPECS/python-rich/python-rich.spec
@@ -16,17 +16,18 @@ License:        MIT
 URL:            https://github.com/Textualize/rich
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/r/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname} -L
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-pip
-BuildRequires:  python3-poetry_core
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(poetry-core)
 %if %{with tests}
-BuildRequires:  python3-pytest
-BuildRequires:  python3-attrs
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(attrs)
 %endif
 
 Provides:       python3-%{srcname}

--- a/SPECS/python-rpmautospec/python-rpmautospec.spec
+++ b/SPECS/python-rpmautospec/python-rpmautospec.spec
@@ -20,14 +20,15 @@ URL:            https://github.com/fedora-infra/rpmautospec
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/r/%{srcname}/%{srcname}-%{version}.tar.gz
 Source1:        rpmautospec.in
+BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): %{srcname}
+BuildOption(install):  %{srcname}
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 %if %{with manpages}
-BuildRequires:  python3-click-man
+BuildRequires:  python3dist(click-man)
 %endif
 BuildRequires:  rpm-build
 BuildRequires:  libgit2

--- a/SPECS/python-rtslib-fb/python-rtslib-fb.spec
+++ b/SPECS/python-rtslib-fb/python-rtslib-fb.spec
@@ -15,12 +15,13 @@ URL:            https://github.com/open-iscsi/rtslib-fb
 # This is a mess - 251
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/r/rtslib_fb/rtslib_fb-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): -l 'rtslib*'
+BuildOption(install):  -l 'rtslib*'
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 BuildRequires:  pkgconfig(systemd)
 
 Provides:       python3-%{srcname}

--- a/SPECS/python-schedutils/python-schedutils.spec
+++ b/SPECS/python-schedutils/python-schedutils.spec
@@ -12,14 +12,14 @@ Release:        %autorelease
 Summary:        Linux scheduler python bindings
 License:        GPL-2.0-only
 URL:            https://git.kernel.org/cgit/libs/python/python-schedutils/python-schedutils.git
-#!RemoteAsset
+#!RemoteAsset:  sha256:90a24f8d46574513b3d334b473e128c456e7eddaec6e3dd198d7e5ad69ddc12f
 Source0:        https://cdn.kernel.org/pub/software/libs/python/%{name}/%{name}-%{version}.tar.xz
 BuildSystem:    pyproject
 
-BuildOption(install): %{srcname}
+BuildOption(install):  %{srcname}
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}
@@ -39,4 +39,4 @@ functions and friends.
 %{_mandir}/man1/ptaskset.1*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-scikit-build-core/python-scikit-build-core.spec
+++ b/SPECS/python-scikit-build-core/python-scikit-build-core.spec
@@ -17,26 +17,26 @@ License:        Apache-2.0 AND MIT
 URL:            https://github.com/scikit-build/scikit-build-core
 #!RemoteAsset
 Source:         https://files.pythonhosted.org/packages/source/s/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{pypi_name}
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-pip
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-hatchling
-BuildRequires:  python3-hatch-vcs
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(hatch-vcs)
 BuildRequires:  cmake
 BuildRequires:  ninja
-BuildRequires:  gcc
 BuildRequires:  gcc-c++
 %if %{with test}
 # for tests.
-BuildRequires:  python3-pytest
-BuildRequires:  python3-virtualenv
-BuildRequires:  python3-numpy
-BuildRequires:  python3-pybind11
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(virtualenv)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(pybind11)
 %endif
 
 Provides:       python3-%{srcname}

--- a/SPECS/python-semantic-version/python-semantic-version.spec
+++ b/SPECS/python-semantic-version/python-semantic-version.spec
@@ -21,11 +21,12 @@ BuildSystem:    pyproject
 BuildOption(install):  -l %{srcname}
 # skip the tests as we have no django yet.
 BuildOption(check):  -e semantic_version.django_fields
+
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
-BuildRequires:  python3-pip
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-wheel
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
 
 # We provide these for compatibility
 Provides:       python3-%{srcname}

--- a/SPECS/python-setuptools-gettext/python-setuptools-gettext.spec
+++ b/SPECS/python-setuptools-gettext/python-setuptools-gettext.spec
@@ -9,20 +9,23 @@
 Name:           python-setuptools-gettext
 Version:        0.1.14
 Release:        %autorelease
+Summary:        Setuptools plugin for gettext
 License:        GPL-2.0-or-later
 URL:            https://github.com/breezy-team/setuptools-gettext
-Summary:        Setuptools plugin for gettext
-Provides:       python3-setuptools-gettext
-%python_provide python3-setuptools-gettext
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
+BuildSystem:    pyproject
 
-BuildRequires:  python3-devel
+BuildOption(install):  -l %{srcname} +auto
+
+BuildRequires:  pkgconfig(python3)
 BuildRequires:  pytest
 BuildRequires:  gettext
-BuildSystem:    pyproject
-BuildOption(install): -l %{srcname} +auto
+
+Provides:       python3-setuptools-gettext
+%python_provide python3-setuptools-gettext
+
 %description
 This package provides a plugin for Setuptools for gettext.
 

--- a/SPECS/python-shellingham/python-shellingham.spec
+++ b/SPECS/python-shellingham/python-shellingham.spec
@@ -14,6 +14,7 @@ License:        ISC
 URL:            https://github.com/sarugaku/shellingham
 #!RemoteAsset:  sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de
 Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-simpleline/python-simpleline.spec
+++ b/SPECS/python-simpleline/python-simpleline.spec
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname simpleline
+
+Name:           python-%{srcname}
+Version:        1.9.0
+Release:        %autorelease
+Summary:        Python text UI framework
+License:        MIT
+URL:            https://github.com/janpipek/iso639-python
+#!RemoteAsset
+Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    autotools
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  gettext
+BuildRequires:  make
+BuildRequires:  intltool
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(pygobject)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
+Requires:       python3dist(rpm)
+
+%description
+Simpleline is a Python library for creating text UI.
+It is designed to be used with line-based machines
+and tools (e.g. serial console) so that every new line
+is appended to the bottom of the screen.
+Printed lines are never rewritten!
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+# No configure
+%conf
+
+%install -a
+# TODO: Avoid illegal package names
+rm -rf %{buildroot}%{_datadir}/locale/*@*
+rm -rf %{buildroot}%{_datadir}/locale/en_GB/
+%find_lang %{name} --generate-subpackages
+
+%check
+make test
+
+%files
+%doc ChangeLog README.md
+%license LICENSE.md
+%{python3_sitelib}/*
+
+%changelog
+%{?autochangelog}

--- a/SPECS/python-smartypants/python-smartypants.spec
+++ b/SPECS/python-smartypants/python-smartypants.spec
@@ -9,18 +9,22 @@
 Name:           python-%{srcname}
 Version:        2.0.2
 Release:        %autorelease
+Summary:        Translate punctuation characters into smart quotes
 License:        BSD-3-Clause AND BSD-2-Clause
 URL:            https://github.com/leohemsted/smartypants.py
-Summary:        Translate punctuation characters into smart quotes
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
 BuildSystem:    pyproject
-BuildOption(install): -l %{srcname} +auto
+
+BuildOption(install):  -l %{srcname} +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 %description
 SmartyPants is a free web publishing plug-in for Movable
 Type, Blosxom, and BBEdit that easily translates plain ASCII

--- a/SPECS/python-sniffio/python-sniffio.spec
+++ b/SPECS/python-sniffio/python-sniffio.spec
@@ -17,10 +17,10 @@ Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{sr
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): %{srcname}
+BuildOption(install):  %{srcname}
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-socks/python-socks.spec
+++ b/SPECS/python-socks/python-socks.spec
@@ -14,6 +14,7 @@ License:        Apache-2.0
 URL:            https://github.com/romis2012/python-socks
 #!RemoteAsset:  sha256:340f82778b20a290bdd538ee47492978d603dff7826aaf2ce362d21ad9ee6f1b
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-socksio/python-socksio.spec
+++ b/SPECS/python-socksio/python-socksio.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/sethmlarson/socksio
 #!RemoteAsset:  sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac
 Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 # change the dep version of python-flit-core.

--- a/SPECS/python-spacy-legacy/python-spacy-legacy.spec
+++ b/SPECS/python-spacy-legacy/python-spacy-legacy.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/explosion/spacy-loggers
 #!RemoteAsset:  sha256:b37d6e0c9b6e1d7ca1cf5bc7152ab64a4c4671f59c85adaf7a3fcb870357a774
 Source0:        https://files.pythonhosted.org/packages/source/s/spacy_legacy/spacy-legacy-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-spacy-loggers/python-spacy-loggers.spec
+++ b/SPECS/python-spacy-loggers/python-spacy-loggers.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/explosion/spacy-loggers
 #!RemoteAsset:  sha256:d60b0bdbf915a60e516cc2e653baeff946f0cfc461b452d11a4d5458c6fe5f24
 Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/spacy-loggers-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-sphinxcontrib-devhelp/python-sphinxcontrib-devhelp.spec
+++ b/SPECS/python-sphinxcontrib-devhelp/python-sphinxcontrib-devhelp.spec
@@ -7,18 +7,22 @@
 Name:           python-sphinxcontrib-devhelp
 Version:        2.0.0
 Release:        %autorelease
+Summary:        Sphinx extension for creating Devhelp documents
 License:        BSD-2-Clause
 URL:            https://github.com/sphinx-doc/sphinxcontrib-devhelp
-Summary:        Sphinx extension for creating Devhelp documents
-Provides:       python3-sphinxcontrib-devhelp
-%python_provide python3-sphinxcontrib-devhelp
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/s/sphinxcontrib_devhelp/sphinxcontrib_devhelp-%{version}.tar.gz
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
 BuildSystem:    pyproject
-BuildOption(install): -l sphinxcontrib +auto
+
+BuildOption(install):  -l sphinxcontrib +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-sphinxcontrib-devhelp
+%python_provide python3-sphinxcontrib-devhelp
+
 %description
 sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document.
 

--- a/SPECS/python-sphinxcontrib-serializinghtml/python-sphinxcontrib-serializinghtml.spec
+++ b/SPECS/python-sphinxcontrib-serializinghtml/python-sphinxcontrib-serializinghtml.spec
@@ -9,18 +9,22 @@
 Name:           python-%{srcname}
 Version:        2.0.0
 Release:        %autorelease
+Summary:        Sphinx extension to serialize HTML files
 License:        BSD-2-clause
 URL:            https://github.com/sphinx-doc/sphinxcontrib-serializinghtml
-Summary:        Sphinx extension to serialize HTML files
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/sphinxcontrib_serializinghtml-%{version}.tar.gz
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
 BuildSystem:    pyproject
-BuildOption(install): -l sphinxcontrib +auto
+
+BuildOption(install):  -l sphinxcontrib +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 %description
 @code{sphinxcontrib-serializinghtml} is a Sphinx extension which outputs
 "serialized" HTML files.

--- a/SPECS/python-sqlparse/python-sqlparse.spec
+++ b/SPECS/python-sqlparse/python-sqlparse.spec
@@ -9,20 +9,23 @@
 Name:           python-%{srcname}
 Version:        0.5.3
 Release:        %autorelease
+Summary:        Non-validating SQL parser
 License:        BSD-3-Clause
 URL:            https://github.com/andialbrecht/sqlparse
-Summary:        Non-validating SQL parser
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
-BuildRequires:  python3-pytest
-BuildRequires:  pyproject-rpm-macros
 BuildSystem:    pyproject
-BuildOption(install): -l %{srcname} +auto
+
+BuildOption(install):  -l %{srcname} +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(pytest)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 %description
 Sqlparse is a non-validating SQL parser for Python.  It
 provides support for parsing, splitting and formatting SQL statements.

--- a/SPECS/python-stack-data/python-stack-data.spec
+++ b/SPECS/python-stack-data/python-stack-data.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/alexmojaki/stack_data
 #!RemoteAsset:  sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9
 Source0:        https://files.pythonhosted.org/packages/source/s/stack_data/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-systemd/python-systemd.spec
+++ b/SPECS/python-systemd/python-systemd.spec
@@ -11,8 +11,6 @@ Release:        %autorelease
 Summary:        Python module wrapping libsystemd functionality
 License:        LGPL-2.1-or-later
 URL:            https://github.com/systemd/python-systemd
-Provides:       python3-systemd
-%python_provide python3-systemd
 #!RemoteAsset
 Source0:        %{url}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 BuildSystem:    pyproject
@@ -20,13 +18,16 @@ BuildSystem:    pyproject
 # https://github.com/systemd/python-systemd/pull/140
 Patch0:         0001-docs-update-intersphinx-_-mapping.patch
 
-BuildOption(install): systemd +auto
+BuildOption(install):  systemd +auto
 
-BuildRequires:  python3-devel
-BuildRequires:  python3-setuptools
-BuildRequires:  python-rpm-macros
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(setuptools)
 BuildRequires:  pytest
 BuildRequires:  pkgconfig(libsystemd)
+
+Provides:       python3-systemd
+%python_provide python3-systemd
 
 %description
 Python module for native access to the libsystemd facilities. Functionality

--- a/SPECS/python-tensile/python-tensile.spec
+++ b/SPECS/python-tensile/python-tensile.spec
@@ -17,10 +17,12 @@ License:        MIT
 URL:            https://github.com/ROCm/Tensile
 #!RemoteAsset
 Source0:        %{url}/archive/rocm-%{rocm_version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{upstreamname}
 
+BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
 Requires:       cmake-filesystem

--- a/SPECS/python-toml/python-toml.spec
+++ b/SPECS/python-toml/python-toml.spec
@@ -17,11 +17,13 @@ URL:            https://github.com/uiri/toml
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/t/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
-BuildRequires:  pyproject-rpm-macros
 BuildSystem:    pyproject
-BuildOption(install): -l %{srcname} +auto
+
+BuildOption(install):  -l %{srcname} +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
 %description
 python-toml is a library for parsing and creating Tom's Obvious, Minimal
 Language (TOML) configuration files.

--- a/SPECS/python-tomlkit/python-tomlkit.spec
+++ b/SPECS/python-tomlkit/python-tomlkit.spec
@@ -9,23 +9,24 @@
 Name:           python-%{srcname}
 Version:        0.13.2
 Release:        %autorelease
+Summary:        Style-preserving TOML library
 License:        MIT
 URL:            https://github.com/sdispater/tomlkit
-Summary:        Style-preserving TOML library
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/t/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
-BuildRequires:  pyproject-rpm-macros
-
-BuildRequires:  pytest
-BuildRequires:  python3dist(pyyaml)
-
 BuildSystem:    pyproject
-BuildOption(install): %{srcname} +auto
+
+BuildOption(install):  %{srcname} +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(pyyaml)
+BuildRequires:  pytest
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 %description
 TOML Kit is a 1.0.0rc1-compliant TOML library.  It includes a parser that
 preserves all comments, indentations, whitespace and internal element ordering,

--- a/SPECS/python-tqdm/python-tqdm.spec
+++ b/SPECS/python-tqdm/python-tqdm.spec
@@ -14,6 +14,7 @@ License:        MPL-2.0 AND MIT
 URL:            https://github.com/tqdm/tqdm
 #!RemoteAsset:  sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2
 Source0:        https://files.pythonhosted.org/packages/source/t/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-typer-slim/python-typer-slim.spec
+++ b/SPECS/python-typer-slim/python-typer-slim.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/fastapi/typer
 #!RemoteAsset:  sha256:73495dd08c2d0940d611c5a8c04e91c2a0a98600cbd4ee19192255a233b6dbfd
 Source0:        https://files.pythonhosted.org/packages/source/t/typer-slim/typer_slim-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-typing-extensions/python-typing-extensions.spec
+++ b/SPECS/python-typing-extensions/python-typing-extensions.spec
@@ -17,10 +17,10 @@ Source0:        https://files.pythonhosted.org/packages/source/t/%{srcname}/%{sr
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): -l %{srcname}
+BuildOption(install):  -l %{srcname}
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 
 Provides:       python3-typing-extensions
 %python_provide python3-typing-extensions

--- a/SPECS/python-typing-inspection/python-typing-inspection.spec
+++ b/SPECS/python-typing-inspection/python-typing-inspection.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/pydantic/typing-inspection
 #!RemoteAsset:  sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464
 Source0:        https://files.pythonhosted.org/packages/source/t/typing-inspection/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-typogrify/python-typogrify.spec
+++ b/SPECS/python-typogrify/python-typogrify.spec
@@ -9,9 +9,9 @@
 Name:           python-%{srcname}
 Version:        2.1.0
 Release:        %autorelease
+Summary:        Filters to transform text into typographically-improved HTML
 License:        BSD-3-Clause
 URL:            https://github.com/justinmayer/typogrify
-Summary:        Filters to transform text into typographically-improved HTML
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/t/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
@@ -19,11 +19,12 @@ BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname} +auto
 
-BuildRequires:  python3-devel
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
 # For check
 BuildRequires:  pytest
-BuildRequires:  python3-jinja2
-BuildRequires:  python3-django
+BuildRequires:  python3dist(jinja2)
+BuildRequires:  python3dist(django)
 
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}

--- a/SPECS/python-urllib3/python-urllib3.spec
+++ b/SPECS/python-urllib3/python-urllib3.spec
@@ -9,20 +9,23 @@
 Name:           python-%{srcname}
 Version:        2.5.0
 Release:        %autorelease
+Summary:        HTTP library with thread-safe connection pooling
 License:        MIT
 URL:            https://urllib3.readthedocs.io/
-Summary:        HTTP library with thread-safe connection pooling
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/u/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname} +auto
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 BuildRequires:  pytest
-BuildSystem:    pyproject
-BuildOption(install): -l %{srcname} +auto
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 %description
 Urllib3 supports features left out of urllib and urllib2 libraries.  It
 can reuse the same socket connection for multiple requests, it can POST files,

--- a/SPECS/python-webencodings/python-webencodings.spec
+++ b/SPECS/python-webencodings/python-webencodings.spec
@@ -9,19 +9,22 @@
 Name:           python-%{srcname}
 Version:        0.5.1
 Release:        %autorelease
+Summary:        Character encoding aliases for legacy web content
 License:        BSD-3-Clause
 URL:            https://github.com/SimonSapin/python-webencodings
-Summary:        Character encoding aliases for legacy web content
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/w/%{srcname}/%{srcname}-%{version}.tar.gz
-
 BuildArch:      noarch
-
-BuildRequires:  python3-devel
 BuildSystem:    pyproject
-BuildOption(install): %{srcname} +auto
+
+BuildOption(install):  %{srcname} +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
 %description
 In order to be compatible with legacy web content when interpreting
 something like @code{Content-Type: text/html; charset=latin1}, tools need

--- a/SPECS/python-xkbregistry/python-xkbregistry.spec
+++ b/SPECS/python-xkbregistry/python-xkbregistry.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+# TODO: Investigate why fedora use 0.3 for anaconda, upstream already 1.5 - 251
+
+%global srcname xkbregistry
+
+Name:           python-%{srcname}
+Version:        0.3
+Release:        %autorelease
+Summary:        Bindings for libxkbregistry using cffi
+License:        MIT
+URL:            https://github.com/sde1000/python-xkbregistry
+#!RemoteAsset
+Source0:        https://files.pythonhosted.org/packages/source/x/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pkgconfig(xkbcommon)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
+Requires:       libxkbcommon
+
+%description
+Python bindings for libxkbregistry using cffi.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%{?autochangelog}

--- a/SPECS/python-xmltodict/python-xmltodict.spec
+++ b/SPECS/python-xmltodict/python-xmltodict.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/martinblech/xmltodict
 #!RemoteAsset
 Source0:        https://files.pythonhosted.org/packages/source/x/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}

--- a/SPECS/python-zhconv/python-zhconv.spec
+++ b/SPECS/python-zhconv/python-zhconv.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/gumblex/zhconv
 #!RemoteAsset:  sha256:ad42d9057ca0605f8e41d62b67ca797f879f58193ee6840562c51459b2698c45
 Source:         https://files.pythonhosted.org/packages/source/z/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}


### PR DESCRIPTION
Add these packages:

  - pycairo
  - PyGObject (Delete `python-pygobject`)
  - python-blivet
  - python-iso639
  - python-meh
  - python-process-tests
  - python-pykickstart
  - python-pyparted
  - python-pytest-cov
  - python-python-dotenv
  - python-python-magic
  - python-python-pam
  - python-xkbregistry

The other 175 commits are all file formatting changes.