### PR TITLE
SPECS: add python-pytest-plugins

### DIFF
--- a/SPECS/python-pytest-dependency/python-pytest-dependency.spec
+++ b/SPECS/python-pytest-dependency/python-pytest-dependency.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pytest-dependency
+%global pypi_name pytest_dependency
+
+Name:           python-%{srcname}
+Version:        0.6.1
+Release:        %autorelease
+Summary:        Manage dependencies between pytest tests
+License:        Apache-2.0
+URL:            https://github.com/RKrahl/pytest-dependency
+VCS:            git:https://github.com/RKrahl/pytest-dependency.git
+#!RemoteAsset:  sha256:246c24d2a5fc743a942cec4408853640e56a05ba58d46e5b213a1d4b738a2464
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l pytest_dependency
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
+%description
+pytest-dependency manages dependencies between tests. It can skip tests whose
+prerequisites failed or were skipped during the same test run.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE.txt
+%doc CHANGES.rst README.rst
+
+%changelog
+%autochangelog

--- a/SPECS/python-pytest-order/python-pytest-order.spec
+++ b/SPECS/python-pytest-order/python-pytest-order.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pytest-order
+%global pypi_name pytest_order
+
+Name:           python-%{srcname}
+Version:        1.3.0
+Release:        %autorelease
+Summary:        Run pytest tests in a specific order
+License:        MIT
+URL:            https://github.com/pytest-dev/pytest-order
+VCS:            git:https://github.com/pytest-dev/pytest-order.git
+#!RemoteAsset:  sha256:51608fec3d3ee9c0adaea94daa124a5c4c1d2bb99b00269f098f414307f23dde
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l pytest_order
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
+%description
+pytest-order is a pytest plugin that lets tests run in a user-defined order.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+%doc README.md CHANGELOG.md
+
+%changelog
+%autochangelog

--- a/SPECS/python-pytest-random-order/python-pytest-random-order.spec
+++ b/SPECS/python-pytest-random-order/python-pytest-random-order.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pytest-random-order
+%global pypi_name pytest_random_order
+
+Name:           python-%{srcname}
+Version:        1.2.0
+Release:        %autorelease
+Summary:        Randomize the order of pytest tests
+License:        MIT
+URL:            https://github.com/jbasko/pytest-random-order
+VCS:            git:https://github.com/jbasko/pytest-random-order.git
+#!RemoteAsset:  sha256:12b2d4ee977ec9922b5e3575afe13c22cbdb06e3d03e550abc43df137b90439a
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l random_order
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm) >= 8
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
+%description
+pytest-random-order randomizes test execution order while keeping controls for
+bucketed and repeatable runs.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+%doc README.rst CHANGELOG.rst
+
+%changelog
+%autochangelog

--- a/SPECS/python-pytest-rerunfailures/python-pytest-rerunfailures.spec
+++ b/SPECS/python-pytest-rerunfailures/python-pytest-rerunfailures.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pytest-rerunfailures
+%global pypi_name pytest_rerunfailures
+
+Name:           python-%{srcname}
+Version:        16.1
+Release:        %autorelease
+Summary:        Re-run flaky pytest failures
+License:        MPL-2.0
+URL:            https://github.com/pytest-dev/pytest-rerunfailures
+VCS:            git:https://github.com/pytest-dev/pytest-rerunfailures.git
+#!RemoteAsset:  sha256:c38b266db8a808953ebd71ac25c381cb1981a78ff9340a14bcb9f1b9bff1899e
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l pytest_rerunfailures
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(setuptools) >= 40
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
+%description
+pytest-rerunfailures is a pytest plugin that re-runs failed tests to reduce
+noise from flaky failures.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+%doc README.rst CHANGES.rst
+
+%changelog
+%autochangelog

--- a/SPECS/python-pytest-rich/python-pytest-rich.spec
+++ b/SPECS/python-pytest-rich/python-pytest-rich.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pytest-rich
+%global pypi_name pytest_rich
+
+Name:           python-%{srcname}
+Version:        0.2.0
+Release:        %autorelease
+Summary:        Rich terminal output for pytest sessions
+License:        MIT
+URL:            https://github.com/nicoddemus/pytest-rich
+VCS:            git:https://github.com/nicoddemus/pytest-rich.git
+#!RemoteAsset:  sha256:a5cf6c83497de65788c8a609f616fafedac50295c48f2eb3184bc08b67a9893e
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l pytest_rich
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(setuptools) >= 42
+BuildRequires:  python3dist(setuptools-scm)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
+%description
+pytest-rich uses Rich to render more readable and colorful pytest session
+output.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+%doc README.rst CHANGELOG.md
+
+%changelog
+%autochangelog

--- a/SPECS/python-pytest-timeout/python-pytest-timeout.spec
+++ b/SPECS/python-pytest-timeout/python-pytest-timeout.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pytest-timeout
+%global pypi_name pytest_timeout
+
+Name:           python-%{srcname}
+Version:        2.4.0
+Release:        %autorelease
+Summary:        Abort hanging pytest tests
+License:        MIT
+URL:            https://github.com/pytest-dev/pytest-timeout
+VCS:            git:https://github.com/pytest-dev/pytest-timeout.git
+#!RemoteAsset:  sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l pytest_timeout
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname}
+%python_provide python3-%{srcname}
+
+%description
+pytest-timeout adds timeout handling for hanging pytest tests and sessions.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+%doc README.rst
+
+%changelog
+%autochangelog


### PR DESCRIPTION
These packages are needed because many Python projects rely on these pytest plugins during testing. Adding them improves test support in openRuyi, reduces downstream patching, and makes the Python package ecosystem more complete.