### PR TITLE
SPECS: add several python packages

### DIFF
--- a/SPECS/python-aiosqlite/python-aiosqlite.spec
+++ b/SPECS/python-aiosqlite/python-aiosqlite.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname aiosqlite
+
+Name:           python-%{srcname}
+Version:        0.22.1
+Release:        %autorelease
+Summary:        Asyncio bridge to the standard sqlite3 module
+License:        MIT
+URL:            https://github.com/omnilib/aiosqlite
+VCS:            git:https://github.com/omnilib/aiosqlite.git
+#!RemoteAsset:  sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650
+Source:         https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+aiosqlite provides a friendly, async interface to sqlite3, wrapping the
+standard library sqlite3 module in a thin layer of async/await syntax.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-alembic/python-alembic.spec
+++ b/SPECS/python-alembic/python-alembic.spec
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname alembic
+
+Name:           python-%{srcname}
+Version:        1.18.4
+Release:        %autorelease
+Summary:        A database migration tool for SQLAlchemy
+License:        MIT
+URL:            https://alembic.sqlalchemy.org
+VCS:            git:https://github.com/sqlalchemy/alembic.git
+#!RemoteAsset:  sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc
+Source:         https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+BuildOption(check):  -e "%{srcname}.templates.*" -e "%{srcname}.testing.suite*"
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(setuptools)
+
+Requires:       python3dist(sqlalchemy)
+Requires:       python3dist(mako)
+Requires:       python3dist(typing-extensions)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Alembic is a database migration tool written by the author of SQLAlchemy.
+It provides a full suite of well-known database migration patterns including
+emission of ALTER statements, automatic generation of migration scripts,
+and support for multiple databases.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+%{_bindir}/alembic
+
+%changelog
+%autochangelog

--- a/SPECS/python-annotated-doc/python-annotated-doc.spec
+++ b/SPECS/python-annotated-doc/python-annotated-doc.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname annotated-doc
+%global pypi_name annotated_doc
+
+Name:           python-%{srcname}
+Version:        0.0.4
+Release:        %autorelease
+Summary:        Document parameters and attributes inline with Annotated
+License:        MIT
+URL:            https://github.com/fastapi/annotated-doc
+VCS:            git:https://github.com/fastapi/annotated-doc.git
+#!RemoteAsset:  sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4
+Source:         https://files.pythonhosted.org/packages/source/a/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{pypi_name}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(pdm-backend)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+annotated-doc provides a way to document parameters, class attributes, return
+types, and variables inline using typing.Annotated.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+%doc README.md
+
+%changelog
+%autochangelog

--- a/SPECS/python-deprecated/python-deprecated.spec
+++ b/SPECS/python-deprecated/python-deprecated.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname deprecated
+
+Name:           python-%{srcname}
+Version:        1.3.1
+Release:        %autorelease
+Summary:        Python @deprecated decorator to deprecate old classes, functions or methods
+License:        MIT
+URL:            https://github.com/laurent-laporte-pro/deprecated
+VCS:            git:https://github.com/laurent-laporte-pro/deprecated.git
+#!RemoteAsset:  sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223
+Source:         https://files.pythonhosted.org/packages/source/D/Deprecated/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(setuptools)
+
+Requires:       python3dist(wrapt)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Deprecated provides a @deprecated decorator for Python to mark old classes,
+functions, or methods as deprecated. It emits warnings when deprecated code
+is called.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE.rst
+%doc README.md
+
+%changelog
+%autochangelog

--- a/SPECS/python-fastapi/python-fastapi.spec
+++ b/SPECS/python-fastapi/python-fastapi.spec
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname fastapi
+
+Name:           python-%{srcname}
+Version:        0.135.3
+Release:        %autorelease
+Summary:        High-performance async web framework for building APIs
+License:        MIT
+URL:            https://github.com/fastapi/fastapi
+VCS:            git:https://github.com/fastapi/fastapi.git
+#!RemoteAsset:  sha256:bd6d7caf1a2bdd8d676843cdcd2287729572a1ef524fc4d65c17ae002a1be654
+Source:         https://files.pythonhosted.org/packages/source/f/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(pdm-backend)
+BuildRequires:  python3dist(jinja2)
+BuildRequires:  python3dist(httpx)
+
+Requires:       python3dist(starlette)
+Requires:       python3dist(pydantic)
+Requires:       python3dist(typing-extensions)
+Requires:       python3dist(typing-inspection)
+Requires:       python3dist(annotated-doc)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+FastAPI is a modern, high-performance web framework for building APIs with
+Python based on standard type hints. It is built on top of Starlette for web
+routing and Pydantic for data validation.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+%doc README.md
+%{_bindir}/fastapi
+
+%changelog
+%autochangelog

--- a/SPECS/python-gevent/python-gevent.spec
+++ b/SPECS/python-gevent/python-gevent.spec
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname gevent
+
+Name:           python-%{srcname}
+Version:        26.4.0
+Release:        %autorelease
+Summary:        Coroutine-based network library
+License:        MIT
+URL:            https://github.com/gevent/gevent
+VCS:            git:https://github.com/gevent/gevent.git
+#!RemoteAsset:  sha256:288d03addfccf0d1c67268358b6759b04392bf3bc35d26f3d9a45c82899c292d
+Source:         https://files.pythonhosted.org/packages/source/g/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+BuildOption(check):  -e "%{srcname}.tests*" -e "%{srcname}.testing*"
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(cython)
+BuildRequires:  python3dist(dnspython)
+
+Requires:       python3dist(greenlet)
+Requires:       python3dist(zope-event)
+Requires:       python3dist(zope-interface)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+gevent is a coroutine-based Python networking library that uses greenlet to
+provide a high-level synchronous API on top of the libev or libuv event loop.
+Features include lightweight execution units based on greenlets, a familiar API
+that re-uses concepts from the Python standard library, cooperative sockets
+with SSL support, DNS queries performed through a threadpool or c-ares, and the
+ability to use standard library interfaces with cooperative sockets.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE NOTICE
+%doc README.rst CHANGES.rst AUTHORS
+
+%changelog
+%autochangelog

--- a/SPECS/python-greenlet/python-greenlet.spec
+++ b/SPECS/python-greenlet/python-greenlet.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname greenlet
+
+Name:           python-%{srcname}
+Version:        3.4.0
+Release:        %autorelease
+Summary:        Lightweight in-process concurrent programming
+License:        MIT AND PSF-2.0
+URL:            https://github.com/python-greenlet/greenlet
+VCS:            git:https://github.com/python-greenlet/greenlet.git
+#!RemoteAsset:  sha256:f50a96b64dafd6169e595a5c56c9146ef80333e67d4476a65a9c55f400fc22ff
+Source:         https://files.pythonhosted.org/packages/source/g/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+BuildOption(check):  -e "%{srcname}.tests*"
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+The greenlet package is a spin-off of Stackless, a version of CPython that
+supports micro-threads called "tasklets". Tasklets run pseudo-concurrently
+and are synchronized with data exchanges on "channels". A "greenlet" is a
+still more primitive notion of micro-thread with no implicit scheduling.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE LICENSE.PSF
+%doc README.rst
+%{_includedir}/python%{python3_version}/%{srcname}/%{srcname}.h
+
+%changelog
+%autochangelog

--- a/SPECS/python-gunicorn/python-gunicorn.spec
+++ b/SPECS/python-gunicorn/python-gunicorn.spec
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname gunicorn
+
+Name:           python-%{srcname}
+Version:        25.3.0
+Release:        %autorelease
+Summary:        WSGI HTTP server for UNIX
+License:        MIT
+URL:            https://gunicorn.org
+VCS:            git:https://github.com/benoitc/gunicorn.git
+#!RemoteAsset:  sha256:f74e1b2f9f76f6cd1ca01198968bd2dd65830edc24b6e8e4d78de8320e2fe889
+Source:         https://files.pythonhosted.org/packages/source/g/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+BuildOption(check):  -e "%{srcname}.app.pasterapp" -e "%{srcname}.workers.geventlet" -e "%{srcname}.workers.ggevent"
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(tornado)
+
+Requires:       python3dist(packaging)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Gunicorn is a Python WSGI HTTP server for UNIX. It is a pre-fork worker model
+server ported from Ruby Unicorn. It supports various worker types and is
+commonly used to serve Flask and Django applications in production.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE NOTICE
+%doc README.md
+%{_bindir}/gunicorn
+%{_bindir}/gunicornc
+
+%changelog
+%autochangelog

--- a/SPECS/python-httptools/python-httptools.spec
+++ b/SPECS/python-httptools/python-httptools.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname httptools
+
+Name:           python-%{srcname}
+Version:        0.7.1
+Release:        %autorelease
+Summary:        A collection of framework independent HTTP protocol utils
+License:        MIT
+URL:            https://github.com/MagicStack/httptools
+VCS:            git:https://github.com/MagicStack/httptools.git
+#!RemoteAsset:  sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9
+Source:         https://files.pythonhosted.org/packages/source/h/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(cython)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+A collection of framework independent HTTP protocol utils. httptools is a
+Python binding for the nodejs HTTP parser, providing high-performance HTTP
+parsing capabilities.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+%doc README.md
+
+%changelog
+%autochangelog

--- a/SPECS/python-more-itertools/python-more-itertools.spec
+++ b/SPECS/python-more-itertools/python-more-itertools.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname more-itertools
+%global pypi_name more_itertools
+
+Name:           python-%{srcname}
+Version:        11.0.2
+Release:        %autorelease
+Summary:        More routines for operating on iterables, beyond itertools
+License:        MIT
+URL:            https://github.com/more-itertools/more-itertools
+VCS:            git:https://github.com/more-itertools/more-itertools.git
+#!RemoteAsset:  sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804
+Source:         https://files.pythonhosted.org/packages/source/m/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{pypi_name}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(flit-core)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+more-itertools provides additional building blocks, recipes, and routines for
+working with Python iterables beyond what the standard itertools module offers.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+%doc README.rst
+
+%changelog
+%autochangelog

--- a/SPECS/python-opentelemetry-api/python-opentelemetry-api.spec
+++ b/SPECS/python-opentelemetry-api/python-opentelemetry-api.spec
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname opentelemetry-api
+%global pypi_name opentelemetry_api
+
+Name:           python-%{srcname}
+Version:        1.41.0
+Release:        %autorelease
+Summary:        OpenTelemetry Python API
+License:        Apache-2.0
+URL:            https://github.com/open-telemetry/opentelemetry-python
+VCS:            git:https://github.com/open-telemetry/opentelemetry-python.git
+#!RemoteAsset:  sha256:9421d911326ec12dee8bc933f7839090cad7a3f13fcfb0f9e82f8174dc003c09
+Source:         https://files.pythonhosted.org/packages/source/o/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l opentelemetry
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Requires:       python3dist(importlib-metadata)
+Requires:       python3dist(typing-extensions)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+OpenTelemetry Python API provides the core API for OpenTelemetry tracing,
+metrics, and logging in Python. It defines the interfaces and no-op
+implementations that are used by the OpenTelemetry SDK and instrumentation
+libraries.
+
+%prep -a
+# Relax importlib-metadata upper bound
+sed -i 's/importlib-metadata >= 6.0, < 8.8.0/importlib-metadata >= 6.0/' pyproject.toml
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+%doc README.rst
+
+%changelog
+%autochangelog

--- a/SPECS/python-opentelemetry-semantic-conventions/python-opentelemetry-semantic-conventions.spec
+++ b/SPECS/python-opentelemetry-semantic-conventions/python-opentelemetry-semantic-conventions.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname opentelemetry-semantic-conventions
+%global pypi_name opentelemetry_semantic_conventions
+
+Name:           python-%{srcname}
+Version:        0.62b0
+Release:        %autorelease
+Summary:        OpenTelemetry Semantic Conventions
+License:        Apache-2.0
+URL:            https://github.com/open-telemetry/opentelemetry-python
+VCS:            git:https://github.com/open-telemetry/opentelemetry-python.git
+#!RemoteAsset:  sha256:cbfb3c8fc259575cf68a6e1b94083cc35adc4a6b06e8cf431efa0d62606c0097
+Source:         https://files.pythonhosted.org/packages/source/o/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l opentelemetry
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Requires:       python3dist(opentelemetry-api)
+Requires:       python3dist(typing-extensions)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+This package provides the OpenTelemetry Semantic Conventions for Python,
+a set of well-defined attribute keys and values for common telemetry concepts.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+%doc README.rst
+
+%changelog
+%autochangelog

--- a/SPECS/python-prometheus-client/python-prometheus-client.spec
+++ b/SPECS/python-prometheus-client/python-prometheus-client.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname prometheus-client
+%global pypi_name prometheus_client
+
+Name:           python-%{srcname}
+Version:        0.25.0
+Release:        %autorelease
+Summary:        Python client for the Prometheus monitoring system
+License:        Apache-2.0 AND BSD-2-Clause
+URL:            https://github.com/prometheus/client_python
+VCS:            git:https://github.com/prometheus/client_python.git
+#!RemoteAsset:  sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28
+Source:         https://files.pythonhosted.org/packages/source/p/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{pypi_name}
+BuildOption(check):  -e "%{pypi_name}.twisted*"
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(aiohttp)
+BuildRequires:  python3dist(django)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+prometheus-client is the official Python client library for Prometheus. It
+provides metric types, a default registry, and an HTTP endpoint for scraping.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE NOTICE
+%doc README.md
+
+%changelog
+%autochangelog

--- a/SPECS/python-psycopg/python-psycopg.spec
+++ b/SPECS/python-psycopg/python-psycopg.spec
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname psycopg
+
+Name:           python-%{srcname}
+Version:        3.3.3
+Release:        %autorelease
+Summary:        PostgreSQL database adapter for Python
+License:        LGPL-3.0-only
+URL:            https://psycopg.org
+VCS:            git:https://github.com/psycopg/psycopg.git
+#!RemoteAsset:  sha256:5e9a47458b3c1583326513b2556a2a9473a1001a56c9efe9e587245b43148dd9
+Source:         https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+# Skip import check for modules requiring libpq or optional deps at import time
+BuildOption(check):  -e "%{srcname}.pq" -e "%{srcname}.types.shapely" -e "%{srcname}.crdb*"
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pkgconfig(libpq)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(numpy)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+psycopg is a PostgreSQL database adapter for the Python programming language.
+It is a complete rewrite of the psycopg2 package, designed for Python 3 and
+based on the libpq PostgreSQL client library. psycopg 3 supports both
+synchronous and asynchronous operation.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE.txt
+%doc README.rst
+
+%changelog
+%autochangelog

--- a/SPECS/python-py-cpuinfo/python-py-cpuinfo.spec
+++ b/SPECS/python-py-cpuinfo/python-py-cpuinfo.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname py-cpuinfo
+
+Name:           python-%{srcname}
+Version:        9.0.0
+Release:        %autorelease
+Summary:        Get CPU information with pure Python
+License:        MIT
+URL:            https://github.com/workhorsy/py-cpuinfo
+VCS:            git:https://github.com/workhorsy/py-cpuinfo.git
+#!RemoteAsset:  sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l cpuinfo
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+py-cpuinfo gets CPU information with pure Python. It supports many operating
+systems and reports vendor, architecture, cache, and feature data.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+%doc README.rst
+%{_bindir}/cpuinfo
+
+%changelog
+%autochangelog

--- a/SPECS/python-pybase64/python-pybase64.spec
+++ b/SPECS/python-pybase64/python-pybase64.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pybase64
+
+Name:           python-%{srcname}
+Version:        1.4.3
+Release:        %autorelease
+Summary:        Fast Base64 encoding and decoding for Python
+License:        BSD-2-Clause
+URL:            https://github.com/mayeut/pybase64
+VCS:            git:https://github.com/mayeut/pybase64.git
+#!RemoteAsset:  sha256:c2ed274c9e0ba9c8f9c4083cfe265e66dd679126cd9c2027965d807352f3f053
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname} -L
+
+BuildRequires:  cmake
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+pybase64 provides fast Base64 encoding and decoding for Python with an
+optimized native extension and a compatible Python interface.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+%doc README.rst
+%{_bindir}/pybase64
+
+%changelog
+%autochangelog

--- a/SPECS/python-pyctcdecode/python-pyctcdecode.spec
+++ b/SPECS/python-pyctcdecode/python-pyctcdecode.spec
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pyctcdecode
+
+Name:           python-%{srcname}
+Version:        0.5.0
+Release:        %autorelease
+Summary:        CTC beam search decoder for speech recognition
+License:        Apache-2.0
+URL:            https://github.com/kensho-technologies/pyctcdecode
+VCS:            git:https://github.com/kensho-technologies/pyctcdecode.git
+#!RemoteAsset:  sha256:f3bcb313e43ca16a54938b3e77b0b375328653bba932668243db745fde513a2c
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
+Requires:       python3dist(numpy)
+Requires:       python3dist(pygtrie) < 3
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+pyctcdecode provides a CTC beam search decoder for speech recognition models.
+It integrates language model scoring and prefix trie based decoding in Python.
+
+%prep -a
+# openRuyi currently ships NumPy 2.x, so relax the upstream upper bound.
+sed -i 's/numpy>=1.15.0,<2.0.0/numpy>=1.15.0/' pyproject.toml
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+%doc README.md
+
+%changelog
+%autochangelog

--- a/SPECS/python-pydantic-settings/python-pydantic-settings.spec
+++ b/SPECS/python-pydantic-settings/python-pydantic-settings.spec
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pydantic-settings
+%global pypi_name pydantic_settings
+
+Name:           python-%{srcname}
+Version:        2.13.1
+Release:        %autorelease
+Summary:        Settings management using Pydantic
+License:        MIT
+URL:            https://github.com/pydantic/pydantic-settings
+VCS:            git:https://github.com/pydantic/pydantic-settings.git
+#!RemoteAsset:  sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025
+Source:         https://files.pythonhosted.org/packages/source/p/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{pypi_name}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(hatchling)
+
+Requires:       python3dist(pydantic)
+Requires:       python3dist(python-dotenv)
+Requires:       python3dist(typing-inspection)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+pydantic-settings provides settings management for Python applications using
+Pydantic models. It supports reading configuration from environment variables,
+dotenv files, and other sources.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+%doc README.md
+
+%changelog
+%autochangelog

--- a/SPECS/python-pygtrie/python-pygtrie.spec
+++ b/SPECS/python-pygtrie/python-pygtrie.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pygtrie
+
+Name:           python-%{srcname}
+Version:        2.5.0
+Release:        %autorelease
+Summary:        Trie data structure implementation for Python
+License:        Apache-2.0
+URL:            https://github.com/mina86/pygtrie
+VCS:            git:https://github.com/mina86/pygtrie.git
+#!RemoteAsset:  sha256:203514ad826eb403dab1d2e2ddd034e0d1534bbe4dbe0213bb0593f66beba4e2
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname} -L
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+pygtrie provides a trie data structure implementation for Python. It includes
+mutable mappings optimized for prefix lookup operations.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+
+%changelog
+%autochangelog

--- a/SPECS/python-python-json-logger/python-python-json-logger.spec
+++ b/SPECS/python-python-json-logger/python-python-json-logger.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname python-json-logger
+%global pypi_name python_json_logger
+
+Name:           python-%{srcname}
+Version:        4.1.0
+Release:        %autorelease
+Summary:        JSON formatter for the Python logging package
+License:        BSD-2-Clause
+URL:            https://nhairs.github.io/python-json-logger
+VCS:            git:https://github.com/nhairs/python-json-logger.git
+#!RemoteAsset:  sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l pythonjsonlogger
+BuildOption(check):  -e pythonjsonlogger.msgspec -e pythonjsonlogger.orjson
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+python-json-logger provides JSON formatters for the Python logging package.
+It helps applications emit structured log records for machines and people.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+%doc README.md
+%doc NOTICE
+
+%changelog
+%autochangelog

--- a/SPECS/python-python-multipart/python-python-multipart.spec
+++ b/SPECS/python-python-multipart/python-python-multipart.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname python-multipart
+%global pypi_name python_multipart
+
+Name:           python-%{srcname}
+Version:        0.0.22
+Release:        %autorelease
+Summary:        Streaming multipart parser for Python
+License:        Apache-2.0
+URL:            https://github.com/Kludex/python-multipart
+VCS:            git:https://github.com/Kludex/python-multipart.git
+#!RemoteAsset:  sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l multipart %{pypi_name}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(pip)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+python-multipart is a streaming multipart parser for Python. It is commonly
+used by web frameworks to process multipart form uploads.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE.txt
+%doc README.md
+
+%changelog
+%autochangelog

--- a/SPECS/python-scikit-learn/python-scikit-learn.spec
+++ b/SPECS/python-scikit-learn/python-scikit-learn.spec
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname scikit-learn
+%global pypi_name scikit_learn
+
+Name:           python-%{srcname}
+Version:        1.8.0
+Release:        %autorelease
+Summary:        A set of Python modules for machine learning and data mining
+License:        BSD-3-Clause
+URL:            https://scikit-learn.org
+VCS:            git:https://github.com/scikit-learn/scikit-learn.git
+#!RemoteAsset:  sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd
+Source:         https://files.pythonhosted.org/packages/source/s/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l sklearn
+BuildOption(check):  -e "sklearn.*.tests*" -e "sklearn.tests*" -e "sklearn.conftest" -e "sklearn.externals.array_api_compat.cupy*" -e "sklearn.externals.array_api_compat.dask*"
+
+BuildRequires:  meson
+BuildRequires:  ninja
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(meson-python)
+BuildRequires:  python3dist(cython)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(scipy)
+BuildRequires:  python3dist(torch)
+
+Requires:       python3dist(numpy)
+Requires:       python3dist(scipy)
+Requires:       python3dist(joblib)
+Requires:       python3dist(threadpoolctl)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+scikit-learn is a Python module for machine learning built on top of SciPy
+and is distributed under the 3-Clause BSD license. It features various
+classification, regression and clustering algorithms including support vector
+machines, random forests, gradient boosting, k-means and DBSCAN, and is
+designed to interoperate with the Python numerical and scientific libraries
+NumPy and SciPy.
+
+%prep -a
+# Relax upper bounds on numpy and scipy for openRuyi
+sed -i 's/"numpy>=2,<2.4.0"/"numpy>=2"/' pyproject.toml
+sed -i 's/"scipy>=1.10.0,<1.17.0"/"scipy>=1.10.0"/' pyproject.toml
+
+%generate_buildrequires
+%pyproject_buildrequires -p
+
+%files -f %{pyproject_files}
+%license COPYING
+%doc README.rst
+
+%changelog
+%autochangelog

--- a/SPECS/python-sentencepiece/python-sentencepiece.spec
+++ b/SPECS/python-sentencepiece/python-sentencepiece.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname sentencepiece
+
+Name:           python-%{srcname}
+Version:        0.2.1
+Release:        %autorelease
+Summary:        Unsupervised text tokenizer and detokenizer
+License:        Apache-2.0
+URL:            https://github.com/google/sentencepiece
+#!RemoteAsset:  sha256:8138cec27c2f2282f4a34d9a016e3374cd40e5c6e9cb335063db66a0a3b71fad
+Source:         https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname} -L
+
+BuildRequires:  cmake
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(protobuf)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+SentencePiece is an unsupervised text tokenizer and detokenizer mainly for
+Neural Network-based text generation systems. SentencePiece implements
+subword units (e.g., byte-pair-encoding (BPE) and unigram language model)
+with the extension of direct training from raw sentences. This package
+bundles the SentencePiece C++ library.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+
+%changelog
+%autochangelog

--- a/SPECS/python-soundfile/python-soundfile.spec
+++ b/SPECS/python-soundfile/python-soundfile.spec
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname soundfile
+
+Name:           python-%{srcname}
+Version:        0.13.1
+Release:        %autorelease
+Summary:        An audio library based on libsndfile, CFFI and NumPy
+License:        BSD-3-Clause
+URL:            https://github.com/bastibe/python-soundfile
+VCS:            git:https://github.com/bastibe/python-soundfile.git
+#!RemoteAsset:  sha256:b2c68dab1e30297317080a5b43df57e302584c49e2942defdde0acccc53f0e5b
+Source:         https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname} _soundfile
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pkgconfig(sndfile)
+BuildRequires:  python3dist(cffi)
+BuildRequires:  python3dist(setuptools)
+
+Requires:       python3dist(cffi)
+Requires:       python3dist(numpy)
+Requires:       libsndfile
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+python-soundfile is an audio library based on libsndfile, CFFI and NumPy.
+Full documentation is available on https://python-soundfile.readthedocs.io/.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+%doc README.rst
+
+%changelog
+%autochangelog

--- a/SPECS/python-sqlalchemy/python-sqlalchemy.spec
+++ b/SPECS/python-sqlalchemy/python-sqlalchemy.spec
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname sqlalchemy
+
+Name:           python-%{srcname}
+Version:        2.0.49
+Release:        %autorelease
+Summary:        Database Abstraction Library
+License:        MIT
+URL:            https://www.sqlalchemy.org
+VCS:            git:https://github.com/sqlalchemy/sqlalchemy.git
+#!RemoteAsset:  sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f
+Source:         https://files.pythonhosted.org/packages/source/s/sqlalchemy/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+BuildOption(check):  -e "%{srcname}.testing.plugin.*"
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(cython)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(mypy)
+BuildRequires:  python3dist(pytest)
+
+Requires:       python3dist(typing-extensions)
+Requires:       python3dist(greenlet)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+SQLAlchemy is the Python SQL toolkit and Object Relational Mapper that gives
+application developers the full power and flexibility of SQL. It provides a
+full suite of well known enterprise-level persistence patterns, designed for
+efficient and high-performing database access, adapted into a simple and
+Pythonic domain language.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+%doc README.rst README.dialects.rst
+
+%changelog
+%autochangelog

--- a/SPECS/python-starlette/python-starlette.spec
+++ b/SPECS/python-starlette/python-starlette.spec
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname starlette
+
+Name:           python-%{srcname}
+Version:        1.0.0
+Release:        %autorelease
+Summary:        The little ASGI library that shines
+License:        BSD-3-Clause
+URL:            https://github.com/Kludex/starlette
+VCS:            git:https://github.com/Kludex/starlette.git
+#!RemoteAsset:  sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149
+Source:         https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(itsdangerous)
+BuildRequires:  python3dist(jinja2)
+BuildRequires:  python3dist(httpx)
+
+Requires:       python3dist(anyio)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Starlette is a lightweight ASGI framework for building async web services in
+Python. It provides routing, middleware, WebSocket support, and other tools for
+high-performance web applications.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE.md
+%doc README.md
+
+%changelog
+%autochangelog

--- a/SPECS/python-uvicorn/python-uvicorn.spec
+++ b/SPECS/python-uvicorn/python-uvicorn.spec
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname uvicorn
+
+Name:           python-%{srcname}
+Version:        0.44.0
+Release:        %autorelease
+Summary:        The lightning-fast ASGI server
+License:        BSD-3-Clause
+URL:            https://github.com/Kludex/uvicorn
+VCS:            git:https://github.com/Kludex/uvicorn.git
+#!RemoteAsset:  sha256:6c942071b68f07e178264b9152f1f16dfac5da85880c4ce06366a96d70d4f31e
+Source:         https://files.pythonhosted.org/packages/source/u/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+BuildOption(check):  -e "%{srcname}.protocols.websockets.wsproto_impl" -e "%{srcname}.supervisors.watchfilesreload"
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(uvloop)
+BuildRequires:  python3dist(httptools)
+BuildRequires:  python3dist(websockets)
+BuildRequires:  python3dist(gunicorn)
+
+Requires:       python3dist(click)
+Requires:       python3dist(h11)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Uvicorn is a lightning-fast ASGI server implementation, using uvloop and
+httptools. It supports HTTP/1.1 and WebSockets.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE.md
+%{_bindir}/uvicorn
+
+%changelog
+%autochangelog

--- a/SPECS/python-uvloop/python-uvloop.spec
+++ b/SPECS/python-uvloop/python-uvloop.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname uvloop
+
+Name:           python-%{srcname}
+Version:        0.22.1
+Release:        %autorelease
+Summary:        Fast implementation of asyncio event loop on top of libuv
+License:        Apache-2.0 OR MIT
+URL:            https://github.com/MagicStack/uvloop
+#!RemoteAsset:  sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f
+Source:         https://files.pythonhosted.org/packages/source/u/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pkgconfig(libuv)
+BuildRequires:  python3dist(cython)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+uvloop is a fast, drop-in replacement of the built-in asyncio event loop.
+uvloop is implemented in Cython and uses libuv under the hood.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE-APACHE LICENSE-MIT
+%doc README.rst
+
+%changelog
+%autochangelog

--- a/SPECS/python-websockets/python-websockets.spec
+++ b/SPECS/python-websockets/python-websockets.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname websockets
+
+Name:           python-%{srcname}
+Version:        16.0
+Release:        %autorelease
+Summary:        An implementation of the WebSocket Protocol (RFC 6455 and 7692)
+License:        BSD-3-Clause
+URL:            https://github.com/python-websockets/websockets
+VCS:            git:https://github.com/python-websockets/websockets.git
+#!RemoteAsset:  sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5
+Source:         https://files.pythonhosted.org/packages/source/w/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+An implementation of the WebSocket Protocol (RFC 6455 and 7692).
+websockets is a library for building WebSocket servers and clients
+in Python with a focus on correctness, simplicity, robustness, and
+performance.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+%doc README.rst
+%{_bindir}/websockets
+
+%changelog
+%autochangelog

--- a/SPECS/python-zope-event/python-zope-event.spec
+++ b/SPECS/python-zope-event/python-zope-event.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname zope-event
+%global pypi_name zope_event
+
+Name:           python-%{srcname}
+Version:        6.1
+Release:        %autorelease
+Summary:        Very basic event publishing system
+License:        ZPL-2.1
+URL:            https://github.com/zopefoundation/zope.event
+VCS:            git:https://github.com/zopefoundation/zope.event.git
+#!RemoteAsset:  sha256:6052a3e0cb8565d3d4ef1a3a7809336ac519bc4fe38398cb8d466db09adef4f0
+Source:         https://files.pythonhosted.org/packages/source/z/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l zope
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+The zope.event package provides a simple event system, including an event
+publishing API, a very simple event-dispatching system on which more
+sophisticated event dispatching systems can be built, and a way to
+subscribe to events.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst CHANGES.rst
+%license LICENSE.txt
+
+%changelog
+%autochangelog

--- a/SPECS/python-zope-interface/python-zope-interface.spec
+++ b/SPECS/python-zope-interface/python-zope-interface.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname zope-interface
+%global pypi_name zope_interface
+
+Name:           python-%{srcname}
+Version:        8.3
+Release:        %autorelease
+Summary:        Interfaces for Python
+License:        ZPL-2.1
+URL:            https://github.com/zopefoundation/zope.interface
+VCS:            git:https://github.com/zopefoundation/zope.interface.git
+#!RemoteAsset:  sha256:e1a9de7d0b5b5c249a73b91aebf4598ce05e334303af6aa94865893283e9ff10
+Source:         https://files.pythonhosted.org/packages/source/z/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l zope
+BuildOption(check):  -e "zope.interface.tests*"
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+zope.interface provides an implementation of "object interfaces" for Python.
+Interfaces are a mechanism for labeling objects as conforming to a given API or
+contract. Several APIs are provided to query for interfaces and test whether
+objects provide or implement them.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE.txt COPYRIGHT.txt
+%doc README.rst CHANGES.rst
+
+%changelog
+%autochangelog


### PR DESCRIPTION
These packages are needed to support Python projects commonly packaged in openRuyi. They provide practical runtime or build-time dependencies such as structured logging, multipart form handling, CPU detection, fast base64 support, trie utilities, and CTC decoding for speech-related workloads. Adding them improves package compatibility and reduces downstream patching.