### PR TITLE
SPECS: add gemmlowp

### DIFF
--- a/SPECS/gemmlowp/2000-contrib-add-packager-options.patch
+++ b/SPECS/gemmlowp/2000-contrib-add-packager-options.patch
@@ -1,0 +1,52 @@
+--- a/contrib/CMakeLists.txt
++++ b/contrib/CMakeLists.txt
+@@ -10,6 +10,9 @@
+ include(CTest) # option(BUILD_TESTING). ON by default.
+ include(GNUInstallDirs)
+ 
++option(GEMMLOWP_INSTALL_LEGACY_EIGHT_BIT_INT_GEMM
++       "Install the deprecated eight_bit_int_gemm target and headers" ON)
++
+ # Set C++11 as default standard
+ set(CMAKE_CXX_STANDARD 11)
+ 
+@@ -59,9 +62,15 @@
+ target_include_directories(gemmlowp INTERFACE
+     $<BUILD_INTERFACE:${gemmlowp_src}>
+     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/gemmlowp>)
+-target_link_libraries(gemmlowp INTERFACE eight_bit_int_gemm)
++if(GEMMLOWP_INSTALL_LEGACY_EIGHT_BIT_INT_GEMM)
++  target_link_libraries(gemmlowp INTERFACE eight_bit_int_gemm)
++else()
++  target_link_libraries(gemmlowp INTERFACE $<BUILD_INTERFACE:eight_bit_int_gemm>)
++endif()
+ 
+-install(FILES ${eight_bit_int_gemm_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gemmlowp/eight_bit_int_gemm)
++if(GEMMLOWP_INSTALL_LEGACY_EIGHT_BIT_INT_GEMM)
++  install(FILES ${eight_bit_int_gemm_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gemmlowp/eight_bit_int_gemm)
++endif()
+ file(GLOB meta_headers "${gemmlowp_src}/meta/*.h")
+ install(FILES ${meta_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gemmlowp/meta)
+ file(GLOB public_headers "${gemmlowp_src}/public/*.h")
+@@ -73,11 +82,16 @@
+ file(GLOB fixedpoint_headers "${gemmlowp_src}/fixedpoint/*.h")
+ install(FILES ${fixedpoint_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gemmlowp/fixedpoint)
+ 
+-install(TARGETS gemmlowp eight_bit_int_gemm
+-        EXPORT  gemmlowp-config # support find_package(gemmlowp CONFIG)
+-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++if(GEMMLOWP_INSTALL_LEGACY_EIGHT_BIT_INT_GEMM)
++  install(TARGETS gemmlowp eight_bit_int_gemm
++          EXPORT  gemmlowp-config # support find_package(gemmlowp CONFIG)
++          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++else()
++  install(TARGETS gemmlowp
++          EXPORT  gemmlowp-config)
++endif()
+ 
+ install(EXPORT  gemmlowp-config  # export gemmlowp::gemmlowp
+         NAMESPACE gemmlowp::     #        gemmlowp::eight_bit_int_gemm

--- a/SPECS/gemmlowp/gemmlowp.spec
+++ b/SPECS/gemmlowp/gemmlowp.spec
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: panglars <panghao.riscv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global commit 16e8662c34917be0065110bfcd9cc27d30f52fdf
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+Name:           gemmlowp
+Version:        0+git20231103.%{shortcommit}
+Release:        %autorelease
+Summary:        Header-only low-precision GEMM library for quantized matrix multiplication
+License:        Apache-2.0
+URL:            https://github.com/google/gemmlowp
+VCS:            git:https://github.com/google/gemmlowp.git
+#!RemoteAsset:  sha256:c3feb896a1b42595cf9a508ed64ed0dc3cd84fffdb8eed790d02d0534ab322ce
+Source0:        %{url}/archive/%{commit}/%{name}-%{commit}.tar.gz
+BuildSystem:    cmake
+
+# Downstream packaging patch to keep the installed package header-only.
+# It disables installation/export of the deprecated eight_bit_int_gemm target.
+Patch2000:         2000-contrib-add-packager-options.patch
+
+BuildOption(conf):  -S contrib
+BuildOption(conf):  -DBUILD_TESTING:BOOL=OFF
+BuildOption(conf):  -DGEMMLOWP_INSTALL_LEGACY_EIGHT_BIT_INT_GEMM:BOOL=OFF
+
+BuildRequires:  cmake
+BuildRequires:  gcc-c++
+
+%description
+gemmlowp is a header-only C++11 library for low-precision GEMM operations.
+It provides a small public interface for quantized matrix multiplication and
+installs CMake package metadata for consumers of the header-only API.
+
+%prep
+%autosetup -p1 -n %{name}-%{commit}
+
+%install -a
+rm -f %{buildroot}%{_libdir}/libeight_bit_int_gemm.a
+
+%check
+# no check
+
+%files
+%license LICENSE
+%doc README.md AUTHORS CONTRIBUTORS
+%{_includedir}/gemmlowp/
+%{_libdir}/cmake/gemmlowp/
+
+%changelog
+%autochangelog


### PR DESCRIPTION
internal requirement

AI disclosure: gpt-5.4 used for research gemmlowp packaging, generate spec outline and patch file. All code in this PR was either written by me, or reviewed by me prior to submitting.