### PR TITLE
SPECS: rocm-llvm: embed rocm_gpu_list_default with quote

### DIFF
--- a/SPECS/rocm-llvm/rocm-llvm.spec
+++ b/SPECS/rocm-llvm/rocm-llvm.spec
@@ -161,10 +161,10 @@ LLVM_CMAKEDIR=`%{_libdir}/llvm%{llvm_maj_ver}/bin/llvm-config --cmakedir`
 # Only enable one target to accelerate build
 GPU_TARGET="gfx1100;gfx1101;gfx1200;gfx1201"
 
-echo "%%rocmllvm_version $CLANG_VERSION"    >  macros.rocmcompiler
-echo "%%rocmllvm_bindir $LLVM_BINDIR"       >> macros.rocmcompiler
-echo "%%rocmllvm_cmakedir $LLVM_CMAKEDIR"   >> macros.rocmcompiler
-echo "%%rocm_gpu_list_default $GPU_TARGET"  >> macros.rocmcompiler
+echo "%%rocmllvm_version $CLANG_VERSION"        >  macros.rocmcompiler
+echo "%%rocmllvm_bindir $LLVM_BINDIR"           >> macros.rocmcompiler
+echo "%%rocmllvm_cmakedir $LLVM_CMAKEDIR"       >> macros.rocmcompiler
+echo "%%rocm_gpu_list_default \"$GPU_TARGET\""  >> macros.rocmcompiler
 
 export PATH=%{_libdir}/llvm%{llvm_maj_ver}/bin:$PATH
 export INCLUDE_PATH=%{_libdir}/llvm%{llvm_maj_ver}/include


### PR DESCRIPTION
Embed double quotes into the macro value of rocm_gpu_list_default, so that all the usage of it could automatically get a properly quoted string upon expansion, without needing to add quotes on their side.

Build Log: https://build.openruyi.cn/package/show/home:Sakura286:ROCm/rocm-llvm

This can fix some build failures of rocblas/rocsolver/ollama, etc.