### PR TITLE
SPECS: bpftool, libbpf: Upgrade version.

### DIFF
--- a/SPECS/bpftool/bpftool.spec
+++ b/SPECS/bpftool/bpftool.spec
@@ -6,12 +6,12 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 Name:           bpftool
-Version:        7.6.0
+Version:        7.7.0
 Release:        %autorelease
 Summary:        Tool for inspection and manipulation of BPF programs and maps
 License:        GPL-2.0-only OR BSD-2-Clause
 URL:            https://github.com/libbpf/bpftool
-#!RemoteAsset
+#!RemoteAsset:  sha256:7d46a381f607432bdb5201a08b889924b6a4883bf09e8efca82a86a7d122cc97
 Source0:        https://github.com/libbpf/bpftool/releases/download/v%{version}/bpftool-libbpf-v%{version}-sources.tar.gz
 BuildSystem:    autotools
 
@@ -34,6 +34,7 @@ BuildRequires:  clang
 BuildRequires:  python3-docutils
 BuildRequires:  llvm-devel
 BuildRequires:  pkgconfig(bash-completion)
+BuildRequires:  pkgconfig(libssl)
 
 %description
 bpftool allows for inspection and simple modification of BPF objects (programs
@@ -60,4 +61,4 @@ mv %{buildroot}%{_prefix}/sbin %{buildroot}%{_bindir}
 %{_mandir}/man8/bpftool*.8*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/libbpf/libbpf.spec
+++ b/SPECS/libbpf/libbpf.spec
@@ -8,12 +8,12 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 Name:           libbpf
-Version:        1.6.2
+Version:        1.7.0
 Release:        %autorelease
 Summary:        C library for managing eBPF programs and maps
 License:        LGPL-2.1-only OR BSD-2-Clause
 URL:            https://github.com/libbpf/libbpf
-#!RemoteAsset
+#!RemoteAsset:  sha256:7ab5feffbf78557f626f2e3e3204788528394494715a30fc2070fcddc2051b7b
 Source:         https://github.com/libbpf/libbpf/archive/v%{version}.tar.gz
 BuildSystem:    autotools
 
@@ -60,4 +60,4 @@ developing applications that use %{name}.
 %{_libdir}/libbpf.a
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Upgrade bpftool to 7.7.0, libbpf to 1.7.0.
This also fix their failures with glibc 2.43.

From [bpftool](https://github.com/libbpf/bpftool/releases), [libbpf](https://github.com/libbpf/libbpf/releases) release notes, there is no obvious API breakage.

pkgconfig(libssl) is an additional build dependency of newer bpftool.