### PR TITLE
SPECS: {libsigsegv,rocm-bandwidth-test}: Formatting fixes

### DIFF
--- a/SPECS/libsigsegv/libsigsegv.spec
+++ b/SPECS/libsigsegv/libsigsegv.spec
@@ -11,12 +11,11 @@ Version:        2.15
 Release:        %autorelease
 Summary:        Library for Handling Page Faults in User Mode
 License:        GPL-2.0-or-later
-#!RemoteAsset
 URL:            https://www.gnu.org/software/libsigsegv/
 VCS:            git:https://git.savannah.gnu.org/git/libsigsegv.git
-#!RemoteAsset
+#!RemoteAsset:  sha256:036855660225cb3817a190fc00e6764ce7836051bacb48d35e26444b8c1729d9
 Source0:        https://ftpmirror.gnu.org/gnu/%{name}/%{name}-%{version}.tar.gz
-#!RemoteAsset
+#!RemoteAsset:  sha256:72a772fbea15850a1dac43bf4a05822367fb29725d8e0d69ae4759953874f3fe
 Source1:        https://ftpmirror.gnu.org/gnu/%{name}/%{name}-%{version}.tar.gz.sig
 BuildSystem:    autotools
 
@@ -47,4 +46,4 @@ available.
 %{_libdir}/libsigsegv.a
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/rocm-bandwidth-test/rocm-bandwidth-test.spec
+++ b/SPECS/rocm-bandwidth-test/rocm-bandwidth-test.spec
@@ -20,8 +20,8 @@ Summary:        Bandwidth test for ROCm
 # License mismatch
 # https://github.com/ROCm/rocm_bandwidth_test/issues/127
 License:        NCSA AND MIT
-#!RemoteAsset
 URL:            https://github.com/ROCm/rocm_bandwidth_test
+#!RemoteAsset:  sha256:70cd7918dd07564241576e4ae8a4c5d007f87aa3d93589baded49022dc2cf27b
 Source0:        %{url}/archive/rocm-%{version}.tar.gz
 # From base_test.cpp
 Source1:        LICENSE.NCSA.txt
@@ -71,4 +71,4 @@ rm -f %{buildroot}%{_prefix}/share/doc/rocm-bandwidth-test/LICENSE.txt
 %{_bindir}/rocm-bandwidth-test
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
These are the only two `#!RemoteAsset` lines that are not recognized with `remoteassetify.py` from #108. (Except Git URLs with `#!CreateArchive` which I don't know how to handle yet.)