### PR TITLE
SPEC: ovmf add support for secure boot

### DIFF
--- a/SPECS/ovmf/0001-OvmfPkg-RiscVVirt-Make-SecureBootDefaultKeysInit-dri.patch
+++ b/SPECS/ovmf/0001-OvmfPkg-RiscVVirt-Make-SecureBootDefaultKeysInit-dri.patch
@@ -1,0 +1,67 @@
+From a1abc3032cd271671ee3aa488725305e45a17724 Mon Sep 17 00:00:00 2001
+From: Richard Lyu <richard.lyu@suse.com>
+Date: Thu, 26 Feb 2026 15:01:54 +0800
+Subject: [PATCH] OvmfPkg/RiscVVirt: Make SecureBootDefaultKeysInit driver
+ configurable
+
+When Secure Boot is enabled, the SecureBootDefaultKeysInit driver is
+not always required. There are alternative methods for enrollment,
+such as EnrollDefaultKeys.efi or virt-firmware. Therefore, make the
+SecureBootDefaultKeysInit driver an optional build component.
+
+Wrap SecureBootDefaultKeysInit.inf with the SECURE_BOOT_DEFAULT_KEYS
+condition, allowing builds to optionally configure the driver.
+
+Signed-off-by: Richard Lyu <richard.lyu@suse.com>
+---
+ OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc | 13 +++++++------
+ OvmfPkg/RiscVVirt/RiscVVirtQemu.fdf |  2 ++
+ 2 files changed, 9 insertions(+), 6 deletions(-)
+
+diff --git a/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc b/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
+index db2efccab7..d3ae3aff70 100644
+--- a/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
++++ b/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
+@@ -35,12 +35,13 @@
+   # Defines for default states.  These can be changed on the command line.
+   # -D FLAG=VALUE
+   #
+-  DEFINE TTY_TERMINAL            = FALSE
+-  DEFINE SECURE_BOOT_ENABLE      = FALSE
+-  DEFINE QEMU_PV_VARS            = FALSE
+-  DEFINE TPM2_ENABLE             = FALSE
+-  DEFINE TPM2_CONFIG_ENABLE      = FALSE
+-  DEFINE DEBUG_ON_SERIAL_PORT    = TRUE
++  DEFINE TTY_TERMINAL             = FALSE
++  DEFINE SECURE_BOOT_ENABLE       = FALSE
++  DEFINE SECURE_BOOT_DEFAULT_KEYS = FALSE
++  DEFINE QEMU_PV_VARS             = FALSE
++  DEFINE TPM2_ENABLE              = FALSE
++  DEFINE TPM2_CONFIG_ENABLE       = FALSE
++  DEFINE DEBUG_ON_SERIAL_PORT     = TRUE
+ 
+   #
+   # Shell can be useful for debugging but should not be enabled for production
+diff --git a/OvmfPkg/RiscVVirt/RiscVVirtQemu.fdf b/OvmfPkg/RiscVVirt/RiscVVirtQemu.fdf
+index eebab647fa..cd3f768ae9 100644
+--- a/OvmfPkg/RiscVVirt/RiscVVirtQemu.fdf
++++ b/OvmfPkg/RiscVVirt/RiscVVirtQemu.fdf
+@@ -89,6 +89,7 @@ INF  MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteDxe.inf
+ !endif
+ !if $(SECURE_BOOT_ENABLE) == TRUE
+   INF  SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigDxe.inf
++  !if $(SECURE_BOOT_DEFAULT_KEYS) == TRUE
+   INF  OvmfPkg/RiscVVirt/Feature/SecureBoot/SecureBootDefaultKeysInit/SecureBootDefaultKeysInit.inf
+ 
+   FILE FREEFORM = 85254ea7-4759-4fc4-82d4-5eed5fb0a4a0 {
+@@ -107,6 +108,7 @@ INF  MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteDxe.inf
+   FILE FREEFORM = 5740766a-718e-4dc0-9935-c36f7d3f884f {
+     SECTION RAW = OvmfPkg/RiscVVirt/Feature/SecureBoot/SecureBootKeys/dbx/dbxupdate_x64.bin
+   }
++  !endif
+ !endif
+ INF  MdeModulePkg/Universal/MonotonicCounterRuntimeDxe/MonotonicCounterRuntimeDxe.inf
+ INF  MdeModulePkg/Universal/ResetSystemRuntimeDxe/ResetSystemRuntimeDxe.inf
+-- 
+2.47.3
+

--- a/SPECS/ovmf/ovmf.spec
+++ b/SPECS/ovmf/ovmf.spec
@@ -27,6 +27,9 @@ URL:            https://github.com/tianocore/edk2
 #!RemoteAsset:  git+https://github.com/tianocore/edk2.git#edk2-stable%{version}
 Source0:        edk2-stable-%{version}.tar.gz
 
+# https://github.com/tianocore/edk2/commit/a1abc3032cd271671ee3aa488725305e45a17724
+Patch0:         0001-OvmfPkg-RiscVVirt-Make-SecureBootDefaultKeysInit-dri.patch
+
 BuildRequires:  gcc
 %ifarch x86_64
 BuildRequires:  nasm
@@ -40,8 +43,8 @@ BuildRequires:  python3
 BuildRequires:  coreutils
 
 %description
- UEFI firmware for ${arch_s} virtual machines. Open Virtual Machine Firmware
- is a build of EDK II for %{arch_s} virtual machines.
+UEFI firmware for ${arch_s} virtual machines. Open Virtual Machine Firmware
+is a build of EDK II for %{arch_s} virtual machines.
 
 %prep
 %autosetup -p1 -n edk2-stable-%{version}
@@ -50,17 +53,17 @@ BuildRequires:  coreutils
 export PACKAGES_PATH=$PWD
 source edksetup.sh
 make -C $EDK_TOOLS_PATH
-build -t GCC5 -b RELEASE -a %{targetarch} -p %{platformfile}
+build -t GCC -b RELEASE -a %{targetarch} -p %{platformfile} -D SECURE_BOOT_ENABLE
 
 %install
 %ifarch x86_64
-install -D -m 644 Build/OvmfX64/RELEASE_GCC5/FV/OVMF.fd %{buildroot}%{_datadir}/ovmf/OVMF.fd
+install -D -m 644 Build/OvmfX64/RELEASE_GCC/FV/OVMF.fd %{buildroot}%{_datadir}/ovmf/OVMF.fd
 %endif
 %ifarch riscv64
-truncate -s 32M Build/RiscVVirtQemu/RELEASE_GCC5/FV/RISCV_VIRT_CODE.fd
-truncate -s 32M Build/RiscVVirtQemu/RELEASE_GCC5/FV/RISCV_VIRT_VARS.fd
-install -D -m 644 Build/RiscVVirtQemu/RELEASE_GCC5/FV/RISCV_VIRT_CODE.fd %{buildroot}%{_datadir}/ovmf/virt_code.fd
-install -D -m 644 Build/RiscVVirtQemu/RELEASE_GCC5/FV/RISCV_VIRT_VARS.fd %{buildroot}%{_datadir}/ovmf/virt_vars.fd
+truncate -s 32M Build/RiscVVirtQemu/RELEASE_GCC/FV/RISCV_VIRT_CODE.fd
+truncate -s 32M Build/RiscVVirtQemu/RELEASE_GCC/FV/RISCV_VIRT_VARS.fd
+install -D -m 644 Build/RiscVVirtQemu/RELEASE_GCC/FV/RISCV_VIRT_CODE.fd %{buildroot}%{_datadir}/ovmf/virt_code.fd
+install -D -m 644 Build/RiscVVirtQemu/RELEASE_GCC/FV/RISCV_VIRT_VARS.fd %{buildroot}%{_datadir}/ovmf/virt_vars.fd
 %endif
 
 %files


### PR DESCRIPTION
This patch requires a certificate. I should not possess the key file for this certificate. It can be generated using the following command.

```shell
openssl req -new -x509 -newkey rsa:2048 -nodes -days 3650 \
	-keyout openruyi_db_key.pem -out openruyi_db_cert.pem \
	-subj "/CN=openRuyi UEFI db Certificate/" \
	-addext "extendedKeyUsage=codeSigning"

openssl x509 -in openruyi_db_cert.pem -outform DER -out openruyi_db_cert.der

cp openruyi_db_cert.der openRuyi.crt
```