### PR TITLE
scripts/remoteassetify.py: Handle %if*, %else, %endif

### DIFF
--- a/scripts/remoteassetify.py
+++ b/scripts/remoteassetify.py
@@ -57,8 +57,7 @@ def spec_filter(text: str) -> str:
     GOOD = [
         r'^Source\d*:',
         r'^(Name|Version|Release|Summary|License|URL|VCS|Description):',
-        r'^%(description|package)(\s+|$)',
-        r'^%(global|define)\s+',
+        r'^%(description|package|global|define|if\w*|else|endif)(\s+|$)',
     ]
 
     BAD = [
@@ -72,6 +71,9 @@ def spec_filter(text: str) -> str:
     for line in text.splitlines():
         if not any(re.search(r, line, re.IGNORECASE) for r in GOOD):
             continue
+
+        if line.startswith('%if'):
+            line = '%if 1'
 
         if any(re.search(r, line, re.IGNORECASE) for r in BAD):
             continue


### PR DESCRIPTION
Old-ish versions of RPM fail fatally with an error with stuff like two different Name keys, which we use sometimes for bootstrap. Add %if\w*, %else, %endif to GOOD to handle these.

However, we do want to enable as many lines as possible. Therefore, replace "%if*" with "%if 1" so that stuff like "%if %{with bootstrap}" gets included.

---

This should fix the check on #18

It worked for me on RPM 4.20.1. Apparently not failing on non-fatal errors is a new feature.