### PR TITLE
.github: workflows: Remove pull_request types filter

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,6 @@ permissions:
 on:
   pull_request:
     branches: [main, ci-test]
-    types: [opened, synchronize]
     paths:
      - 'SPECS/**'
 

--- a/.github/workflows/remoteasset.yaml
+++ b/.github/workflows/remoteasset.yaml
@@ -13,7 +13,6 @@ permissions:
 on:
   pull_request:
     branches: [main, ci-test]
-    types: [opened, synchronize]
     paths:
      - 'SPECS/**'
 


### PR DESCRIPTION
The default types is [opened, synchronize, reopened]. Having reopened for pull_request means that closing and reopening a PR would retrigger all these workflows, and most importantly, on the newest base branch.

This fixes the issue where you have to rebase a pull request to retrigger CI with newest workflows. Now you just reopen it.

See https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request
