### PR TITLE
SPECS: audit: Update to 4.1.4 & Format spec file.

### DIFF
--- a/SPECS/audit/0001-put-bash-completions-in-bash-completions-dir.patch
+++ b/SPECS/audit/0001-put-bash-completions-in-bash-completions-dir.patch
@@ -1,0 +1,59 @@
+From d9b63ea98db063936af099bb8380bd4660824407 Mon Sep 17 00:00:00 2001
+From: misaka00251 <liuxin@iscas.ac.cn>
+Date: Wed, 15 Apr 2026 16:57:10 +0800
+Subject: [PATCH] put bash completions in 
+ /usr/share/bash-completion/completions/
+
+ Backport from https://github.com/linux-audit/audit-userspace/commit/13e79b7d2c4aa833129487c4cb5837df08e94e77
+---
+ init.d/Makefile.am           | 7 ++++---
+ init.d/audit.bash_completion | 2 +-
+ 2 files changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/init.d/Makefile.am b/init.d/Makefile.am
+index 53c6e13..e8668c1 100644
+--- a/init.d/Makefile.am
++++ b/init.d/Makefile.am
+@@ -32,6 +32,7 @@ EXTRA_DIST = auditd.service.in audit-rules.service.in augenrules.in \
+ libconfig = libaudit.conf
+ initdir = $(prefix)/lib/systemd/system
+ legacydir = $(libexecdir)/initscripts/legacy-actions/auditd
++bashcompdir = $(datadir)/bash-completion/completions
+ 
+ auditdir = $(sysconfdir)/audit
+ auditrdir = $(auditdir)/rules.d
+@@ -53,12 +54,12 @@ install-data-hook:
+ 
+ install-exec-hook:
+ 	mkdir -p ${DESTDIR}${initdir}
+-	mkdir -p ${DESTDIR}${sysconfdir}/bash_completion.d
++	mkdir -p ${DESTDIR}${bashcompdir}
+ 	$(INSTALL_SCRIPT) -D -m 644 ${builddir}/auditd.service ${DESTDIR}${initdir}
+ 	$(INSTALL_SCRIPT) -D -m 644 ${builddir}/audit-rules.service ${DESTDIR}${initdir}
+ 	chmod 0755 $(DESTDIR)$(sbindir)/augenrules
+ 	$(INSTALL_SCRIPT) -D -m 644 ${srcdir}/audit.bash_completion \
+-		${DESTDIR}${sysconfdir}/bash_completion.d/
++		${DESTDIR}${bashcompdir}
+ if INSTALL_LEGACY_ACTIONS
+ 	mkdir -p ${DESTDIR}${legacydir}
+ 	$(INSTALL_SCRIPT) -D -m 750 ${srcdir}/auditd.rotate ${DESTDIR}${legacydir}/rotate
+@@ -84,4 +85,4 @@ if INSTALL_LEGACY_ACTIONS
+ 	rm ${DESTDIR}${legacydir}/condrestart
+ endif
+ 	rm ${DESTDIR}$(prefix)/lib/tmpfiles.d/audit.conf
+-	rm ${DESTDIR}${sysconfdir}/bash_completion.d/audit.bash_completion
++	rm ${DESTDIR}${bashcompdir}/audit.bash_completion
+diff --git a/init.d/audit.bash_completion b/init.d/audit.bash_completion
+index 9f395c2..9e4be3f 100644
+--- a/init.d/audit.bash_completion
++++ b/init.d/audit.bash_completion
+@@ -1,5 +1,5 @@
+ # Bash completion for audit utilities
+-# Installed to /etc/bash_completion.d/audit
++# Installed to /usr/share/bash-completion/completions/
+ 
+ _ausearch_opts="--event --arch --comm --debug --checkpoint --eoe-timeout \
+ --exit --escape --extra-keys --extra-labels --extra-obj2 --extra-time \
+-- 
+2.53.0
+

--- a/SPECS/audit/audit.spec
+++ b/SPECS/audit/audit.spec
@@ -8,15 +8,18 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 Name:           audit
-Version:        4.0.2
+Version:        4.1.4
 Release:        %autorelease
 Summary:        Linux kernel audit subsystem utilities
 License:        GPL-2.0-or-later AND LGPL-2.1-or-later
 URL:            https://people.redhat.com/sgrubb/audit/
 VCS:            git:https://github.com/linux-audit/audit-userspace
-#!RemoteAsset
-Source:         https://people.redhat.com/sgrubb/audit/%{name}-%{version}.tar.gz
+#!RemoteAsset:  sha256:8396544ea08c69b39f5c00027549394f2149b31c4a9e693097d6ce134f3ffe3d
+Source:         https://github.com/linux-audit/audit-userspace/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 BuildSystem:    autotools
+
+# Backport from https://github.com/linux-audit/audit-userspace/commit/13e79b7d2c4aa833129487c4cb5837df08e94e77
+Patch0:         0001-put-bash-completions-in-bash-completions-dir.patch
 
 BuildOption(conf):  --libexecdir=%{_libexecdir}/%{name}
 BuildOption(conf):  --with-apparmor
@@ -29,6 +32,8 @@ BuildRequires:  autoconf >= 2.12
 BuildRequires:  linux-headers >= 2.6.30
 BuildRequires:  libtool
 BuildRequires:  pkgconfig
+BuildRequires:  pkgconfig(bash-completion)
+
 Requires:       gawk
 
 %description
@@ -45,7 +50,7 @@ The audit-devel package contains the header files and development libraries
 needed for developing applications that use the audit framework.
 
 %conf -p
-autoreconf -fi
+autoreconf -fiv
 export CFLAGS="%{optflags} -fno-strict-aliasing"
 export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-Wl,-z,relro,-z,now"
@@ -58,51 +63,51 @@ install -m 0644 init.d/libaudit.conf %{buildroot}%{_sysconfdir}
 install -D -m 0644 ./m4/audit.m4  %{buildroot}%{_datadir}/aclocal/audit.m4
 
 install -d -m 750 %{buildroot}%{_sysconfdir}/audisp/plugins.d
-
-# TODO: make test pass.
-%check
+# Better naming
+mv %{buildroot}%{bash_completions_dir}/audit.bash_completion %{buildroot}%{bash_completions_dir}/audit
 
 %files
 %license COPYING
+%{_bindir}/aulast
+%{_bindir}/aulastlog
+%{_bindir}/ausyscall
+%{_sbindir}/*
 # Merged files from libaudit1
 %{_libdir}/libaudit.so.1
 %{_libdir}/libaudit.so.1.*
 %config(noreplace) %attr(640,root,root) %{_sysconfdir}/libaudit.conf
 %{_libdir}/libauparse.so.0
 %{_libdir}/libauparse.so.0.*
-
-%{_sbindir}/*
+%{_libdir}/libauplugin.so.1
+%{_libdir}/libauplugin.so.1.*
 %{_libexecdir}/%{name}/*
+%{_tmpfilesdir}/audit.conf
 %config(noreplace) %{_sysconfdir}/audit/*
 %attr(750,root,root) %dir %{_sysconfdir}/audisp
 %attr(750,root,root) %dir %{_sysconfdir}/audisp/plugins.d
-
-%{_bindir}/aulast
-%{_bindir}/aulastlog
-%{_bindir}/ausyscall
-
 %{_unitdir}/audit-rules.service
 %{_unitdir}/auditd.service
-
 %dir %{_datadir}/audit-rules
 %{_datadir}/audit-rules/*.rules
 %{_datadir}/audit-rules/README-rules
-
+%{bash_completions_dir}/audit
 %{_mandir}/man*/*
 
 %files devel
 %doc contrib/plugin
 %{_libdir}/libaudit.so
 %{_libdir}/libauparse.so
+%{_libdir}/libauplugin.so
 %{_includedir}/libaudit.h
 %{_includedir}/audit_logging.h
 %{_includedir}/audit-records.h
 %{_includedir}/auparse.h
 %{_includedir}/auparse-defs.h
+%{_includedir}/auplugin.h
 %{_datadir}/aclocal/audit.m4
 %{_libdir}/pkgconfig/audit.pc
 %{_libdir}/pkgconfig/auparse.pc
 %{_mandir}/man3/*
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
This PR fixes two problems:

1. The failure of `%check` was not caused by `audit` itself, as the `audit` testsuite passed successfully. The issue arose later during `auparse/test` in the `make check` process, where the generated output (`auparse_test.cur`) was compared to the reference file (`auparse_test.ref`).

The specific mismatch was that the reference output expected `auid=42 (gdm)`, while the build environment produced `auid=42 (unknown(42))`. Please see the logs below:

<details>

<summary>Build failed log</summary>

```
[   53s] ./auparse_test > auparse_test.cur
[   53s] diff -u ../../auparse/test/auparse_test.ref auparse_test.cur
[   53s] --- ../../auparse/test/auparse_test.ref	2024-08-08 17:40:19.000000000 +0000
[   53s] +++ auparse_test.cur	2026-04-15 07:40:56.869228319 +0000
[   53s] @@ -188,7 +188,7 @@
[   53s]          uid=0 (root)
[   53s]          subj=system_u:system_r:init_t:s0 (system_u:system_r:init_t:s0)
[   53s]          old-auid=4294967295 (unset)
[   53s] -        auid=42 (gdm)
[   53s] +        auid=42 (unknown(42))
[   53s]          tty=(none) ((none))
[   53s]          old-ses=4294967295 (4294967295)
[   53s]          ses=1 (1)
[   53s] @@ -209,7 +209,7 @@
[   53s]          items=0 (0)
[   53s]          ppid=1 (1)
[   53s]          pid=2288 (2288)
[   53s] -        auid=42 (gdm)
[   53s] +        auid=42 (unknown(42))
[   53s]          uid=0 (root)
[   53s]          gid=0 (root)
[   53s]          euid=0 (root)
[   53s] @@ -389,7 +389,7 @@
[   53s]          uid=0 (root)
[   53s]          subj=system_u:system_r:init_t:s0 (system_u:system_r:init_t:s0)
[   53s]          old-auid=4294967295 (unset)
[   53s] -        auid=42 (gdm)
[   53s] +        auid=42 (unknown(42))
[   53s]          tty=(none) ((none))
[   53s]          old-ses=4294967295 (4294967295)
[   53s]          ses=1 (1)
[   53s] @@ -410,7 +410,7 @@
[   53s]          items=0 (0)
[   53s]          ppid=1 (1)
[   53s]          pid=2288 (2288)
[   53s] -        auid=42 (gdm)
[   53s] +        auid=42 (unknown(42))
[   53s]          uid=0 (root)
[   53s]          gid=0 (root)
[   53s]          euid=0 (root)
[   53s] @@ -587,7 +587,7 @@
[   53s]          uid=0 (root)
[   53s]          subj=system_u:system_r:init_t:s0 (system_u:system_r:init_t:s0)
[   53s]          old-auid=4294967295 (unset)
[   53s] -        auid=42 (gdm)
[   53s] +        auid=42 (unknown(42))
[   53s]          tty=(none) ((none))
[   53s]          old-ses=4294967295 (4294967295)
[   53s]          ses=1 (1)
[   53s] @@ -608,7 +608,7 @@
[   53s]          items=0 (0)
[   53s]          ppid=1 (1)
[   53s]          pid=2288 (2288)
[   53s] -        auid=42 (gdm)
[   53s] +        auid=42 (unknown(42))
[   53s]          uid=0 (root)
[   53s]          gid=0 (root)
[   53s]          euid=0 (root)
[   53s] @@ -874,7 +874,7 @@
[   53s]          uid=0 (root)
[   53s]          subj=system_u:system_r:init_t:s0 (system_u:system_r:init_t:s0)
[   53s]          old-auid=4294967295 (unset)
[   53s] -        auid=42 (gdm)
[   53s] +        auid=42 (unknown(42))
[   53s]          tty=(none) ((none))
[   53s]          old-ses=4294967295 (4294967295)
[   53s]          ses=1 (1)
[   53s] @@ -895,7 +895,7 @@
[   53s]          items=0 (0)
[   53s]          ppid=1 (1)
[   53s]          pid=2288 (2288)
[   53s] -        auid=42 (gdm)
[   53s] +        auid=42 (unknown(42))
[   53s]          uid=0 (root)
[   53s]          gid=0 (root)
[   53s]          euid=0 (root)
[   53s] make[4]: *** [Makefile:714: check-local] Error 1
```

</details>

The problem disappeared after upgrading to a newer upstream version.

2. Essential Ssec file formatting.

Also, the `audit` release has moved to GitHub. It is no longer publishing new releases on people.redhat.com.