### PR TITLE
SPECS: rpm: Fix rpmuncompress bug.

### DIFF
--- a/SPECS/rpm/2000-fix-rpmuncompress-handle-dir-without-slash.patch
+++ b/SPECS/rpm/2000-fix-rpmuncompress-handle-dir-without-slash.patch
@@ -1,0 +1,67 @@
+From 49e374a2b5592b24ae34db9b0620afbeefde45b0 Mon Sep 17 00:00:00 2001
+From: yyjeqhc <jialin.oerv@isrc.iscas.ac.cn>
+Date: Thu, 16 Apr 2026 14:02:51 +0800
+Subject: [PATCH] rpmuncompress: handle top-level dir entries without trailing
+ slash.
+
+Signed-off-by: yyjeqhc <jialin.oerv@isrc.iscas.ac.cn>
+---
+ tools/rpmuncompress.c | 28 ++++++++++++++++++++--------
+ 1 file changed, 20 insertions(+), 8 deletions(-)
+
+diff --git a/tools/rpmuncompress.c b/tools/rpmuncompress.c
+index c664444..1604dd6 100644
+--- a/tools/rpmuncompress.c
++++ b/tools/rpmuncompress.c
+@@ -100,6 +100,7 @@ static char * singleRoot(const char *path)
+ 	struct archive *a;
+ 	struct archive_entry *entry;
+ 	int r, ret = -1, rootLen;
++	int rootNoSlash = 0;
+ 	char *rootName = NULL;
+ 
+ 	a = archive_read_new();
+@@ -115,21 +116,32 @@ static char * singleRoot(const char *path)
+ 	rootName = xstrdup(archive_entry_pathname(entry));
+ 	char *sep = strchr(rootName, '/');
+ 	if (sep == NULL) {
+-	    /* No directories in the pathname */
+-	    ret = 0;
+-	    goto afree;
++	    if (archive_entry_filetype(entry) != AE_IFDIR) {
++			/* No directories in the pathname */
++			ret = 0;
++			goto afree;
++	    }
++	    rootLen = strlen(rootName);
++	    rootNoSlash = 1;
++	} else {
++	    rootLen = sep - rootName + 1;
+ 	}
+ 
+ 	/* Do all entries in the archive start with the same lead directory? */
+-	rootLen = sep - rootName + 1;
+ 	while (archive_read_next_header(a, &entry) == ARCHIVE_OK) {
+ 	    const char *p = archive_entry_pathname(entry);
+-	    if (strncmp(rootName, p, rootLen)) {
+-		ret = 0;
+-		goto afree;
++	    if (rootNoSlash) {
++			if (strncmp(rootName, p, rootLen) || (p[rootLen] != '/' && p[rootLen] != '\0')) {
++				ret = 0;
++				goto afree;
++			}
++	    } else if (strncmp(rootName, p, rootLen)) {
++			ret = 0;
++			goto afree;
+ 	    }
+ 	}
+-	*sep = '\0';
++	if (sep)
++	    *sep = '\0';
+ 	ret = 1;
+ 
+ afree:
+-- 
+2.43.0
+

--- a/SPECS/rpm/rpm.spec
+++ b/SPECS/rpm/rpm.spec
@@ -4,8 +4,8 @@
 # SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
-
 #
+
 # avoid bootstrapping problem
 %define _binary_payload w9.bzdio
 
@@ -18,7 +18,7 @@ Version:        4.20.1
 Release:        %autorelease
 URL:            https://rpm.org/
 VCS:            git:https://github.com/rpm-software-management/rpm.git
-#!RemoteAsset
+#!RemoteAsset:  sha256:52647e12638364533ab671cbc8e485c96f9f08889d93fe0ed104a6632661124f
 Source:         https://ftp.osuosl.org/pub/rpm/releases/rpm-4.20.x/rpm-%{version}.tar.bz2
 #!RemoteAsset:  git+https://github.com/rpm-software-management/rpmpgp_legacy#1.1
 #!CreateArchive
@@ -68,6 +68,9 @@ Patch157:       cmake_fhardened.diff
 Patch158:       archcheck.diff
 Patch159:       emptypw.diff
 Patch160:       buildsysprep.diff
+# Fix rpmuncompress single-root archive detection for top-level directory
+# entries stored without a trailing slash.
+Patch2000:      2000-fix-rpmuncompress-handle-dir-without-slash.patch
 Patch6464:      auto-config-update-aarch64-ppc64le.diff
 
 BuildRequires:  binutils
@@ -209,6 +212,7 @@ rm -rf sqlite
 %patch -P 141 -P 142
 %patch -P 150 -P 151 -P 154 -P 155 -P 156 -P 157 -P 158 -P 159
 %patch -P 160
+%patch 2000 -p1
 
 %ifarch riscv64
 %patch -P 6464
@@ -406,4 +410,4 @@ sed -e '/^%%__systemd_sysusers/s/^/#/' -i %{buildroot}%{_prefix}/lib/rpm/macros
 %doc %{_mandir}/man8/rpm-plugin-unshare*
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
```sh
tar -ztf Devel-CallChecker-0.009.tar.gz
Devel-CallChecker-0.009
Devel-CallChecker-0.009/.gitignore
Devel-CallChecker-0.009/Build.PL
Devel-CallChecker-0.009/Changes
Devel-CallChecker-0.009/MANIFEST
Devel-CallChecker-0.009/META.json
Devel-CallChecker-0.009/META.yml
Devel-CallChecker-0.009/README
Devel-CallChecker-0.009/SIGNATURE
```
Fix %autosetup extraction failure when the first archive entry has no '/'.

In this case, %autosetup does not extract the contents into %{name}-%{version}
because rpmuncompress does not treat the first entry as a directory.