### PR TITLE
scripts/remoteassetify.py: Improve weird url handling

### DIFF
--- a/scripts/remoteassetify.py
+++ b/scripts/remoteassetify.py
@@ -135,13 +135,6 @@ def get_sources(text: str) -> str:
         if not m:
             continue
 
-        if ':' not in value:
-            # Probably not URL
-            continue
-
-        if re.search(r'%[a-z_{]', value, re.IGNORECASE):
-            message('WARN', f'Possible unexpanded RPM macro in:\n    > {line}')
-
         result[key] = value.strip()
 
     return result
@@ -251,9 +244,16 @@ def main():
         print('INFO: No supported #!RemoteAsset found', file=sys.stderr)
         return
 
-    for key in assets:
+    for key, data in assets.items():
         if key not in sources:
             raise ValueError(f'{key} key not found in parsed spec, that is odd')
+
+        url = sources[key]
+
+        if ':' not in url:
+            message('WARN', f'Unrecognized URL: {url}', data['lineno'] + 1, spec_lines[data['lineno'] + 1])
+        elif re.search(r'%[a-z_{]', url, re.IGNORECASE):
+            message('WARN', f'Possible unexpanded RPM macro in URL: {url}', data['lineno'] + 1, spec_lines[data['lineno'] + 1])
 
     if args.dry_run:
         if sys.stdout.isatty():

--- a/scripts/remoteassetify.py
+++ b/scripts/remoteassetify.py
@@ -33,7 +33,7 @@ arg_parser.add_argument('--verbose', action='store_true', help='Generate more de
 arg_parser.add_argument('--unsafe-optional-enosys', action='store_true', help='UNSAFE: Allow running rpmspec without enosys')
 arg_parser.add_argument('--workflow', action='store_true', help='Generate some messages as workflow commands')
 
-CURL_DOWNLOAD = shlex.split("""curl --fail --location --user-agent 'scripts/remoteassetify.py https://github.com/openRuyi-Project/openruyi' -o""")
+CURL_DOWNLOAD = shlex.split("""curl --fail --location --proto '=http,https' --user-agent 'scripts/remoteassetify.py https://github.com/openRuyi-Project/openruyi' -o""")
 
 CHECKSUM_TYPES = { 'sha256' }
 


### PR DESCRIPTION
First commit improves upon https://github.com/openRuyi-Project/openRuyi/actions/runs/24439575221/job/72055531809 to generate these messages, instead of erroring out with a confusing message:

```
WARN: Unrecognized URL: openRuyi.der in line 38:
    > Source5:        openRuyi.der
::warning file=SPECS/ovmf/ovmf.spec,line=38::Unrecognized URL: openRuyi.der
WARN: Unrecognized URL: dbxupdate_x64.bin in line 40:
    > Source6:        dbxupdate_x64.bin
::warning file=SPECS/ovmf/ovmf.spec,line=40::Unrecognized URL: dbxupdate_x64.bin
```

Second commit tries to prevent weird requests from our CI by restricting protocol to `http://` and `https://`. We don't have anything else in tree so far (`rg --pcre2 'Source\d*:\s+(?!https?:)\w+:'`)