### PR TITLE
add missing %dir

### DIFF
--- a/SPECS/binutils/binutils.spec
+++ b/SPECS/binutils/binutils.spec
@@ -19,7 +19,7 @@ Version:        2.45
 Release:        %autorelease
 URL:            https://www.gnu.org/software/binutils/
 VCS:            git:https://sourceware.org/git/binutils-gdb.git
-#!RemoteAsset
+#!RemoteAsset:  sha256:1393f90db70c2ebd785fb434d6127f8888c559d5eeb9c006c354b203bab3473e
 Source0:        https://ftpmirror.gnu.org/gnu/binutils/binutils-%{version}.tar.bz2
 BuildSystem:    autotools
 
@@ -124,6 +124,8 @@ fi;
 
 %files
 %defattr(-,root,root)
+%dir %{_prefix}/%{_host}
+%dir %{_prefix}/%{_host}/lib
 %{_prefix}/%{_host}/bin/*
 %{_prefix}/%{_host}/lib/ldscripts
 %{_libdir}/libsframe.so.*
@@ -146,4 +148,4 @@ fi;
 %{_libdir}/libsframe.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/iso-codes/iso-codes.spec
+++ b/SPECS/iso-codes/iso-codes.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        ISO Code Lists and Translations
 License:        LGPL-2.1-or-later
 URL:            https://salsa.debian.org/iso-codes-team/iso-codes
-#!RemoteAsset
+#!RemoteAsset:  sha256:511f67bf4b51aa77f17c45adbff533242b50f1e370fe49a5706b6341902fac87
 Source0:        https://salsa.debian.org/iso-codes-team/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    autotools
@@ -44,6 +44,7 @@ Territory code list, and ISO-3166-2 sub-territory lists, and all their
 %files -f %{name}.lang
 %doc CHANGELOG.md README.md
 %license COPYING
+%dir %{_datadir}/xml
 %dir %{_datadir}/xml/iso-codes
 %{_datadir}/xml/iso-codes/*.xml
 %{_datadir}/iso-codes
@@ -52,4 +53,4 @@ Territory code list, and ISO-3166-2 sub-territory lists, and all their
 %{_datadir}/pkgconfig/iso-codes.pc
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/pkgconf/pkgconf.spec
+++ b/SPECS/pkgconf/pkgconf.spec
@@ -32,7 +32,7 @@ Summary:        Package compiler and linker metadata toolkit
 License:        ISC
 URL:            https://pkgconf.org/
 VCS:            git:https://github.com/pkgconf/pkgconf.git
-#!RemoteAsset
+#!RemoteAsset:  sha256:b06ff63a83536aa8c2f6422fa80ad45e4833f590266feb14eaddfe1d4c853c69
 Source0:        https://distfiles.dereferenced.org/%{name}/%{name}-%{version}.tar.xz
 # Simple wrapper script to offer platform versions of pkgconfig from Fedora
 Source1:        platform-pkg-config.in
@@ -165,6 +165,8 @@ rm -rf %{buildroot}%{_mandir}/man7
 %{_mandir}/man5/pc.5*
 %{_mandir}/man5/pkgconf-personality.5*
 %{_rpmmacrodir}/macros.pkgconf
+%dir %{_libdir}/pkgconfig
+%dir %{_datadir}/pkgconfig
 %dir %{_sysconfdir}/pkgconfig
 %dir %{_sysconfdir}/pkgconfig/personality.d
 %dir %{_datadir}/pkgconfig/personality.d
@@ -195,4 +197,4 @@ rm -rf %{buildroot}%{_mandir}/man7
 %endif
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
if we want to use `ExpandFlags: preinstallexpand` on obs, these need to be added.