### PR TITLE
SPECS: bindfs: Update to 1.18.4.

### DIFF
--- a/SPECS/bindfs/bindfs.spec
+++ b/SPECS/bindfs/bindfs.spec
@@ -7,18 +7,17 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 Name:           bindfs
-Version:        1.17.7
+Version:        1.18.4
 Release:        %autorelease
 Summary:        A FUSE filesystem for mirroring a directory with altered permissions
 License:        GPL-2.0-or-later
 URL:            https://bindfs.org/
 VCS:            git:https://github.com/mpartel/bindfs
-#!RemoteAsset
+#!RemoteAsset:  sha256:3266d0aab787a9328bbb0ed561a371e19f1ff077273e6684ca92a90fedb2fe24
 Source:         https://bindfs.org/downloads/bindfs-%{version}.tar.gz
 BuildSystem:    autotools
 
 BuildRequires:  pkgconfig(fuse)
-BuildRequires:  gcc
 BuildRequires:  make
 BuildRequires:  autoconf
 BuildRequires:  automake
@@ -29,7 +28,7 @@ Requires:       fuse
 bindfs is a FUSE filesystem for mirroring a directory to another directory
 and altering permission bits in the mirror.
 
-# TODO: enabel when we have ruby.
+# Our build system doesn't provide /dev/fuse in the build environment
 %check
 
 %files
@@ -39,4 +38,4 @@ and altering permission bits in the mirror.
 %{_mandir}/man1/bindfs.1*
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
I removed the comment in the `%check` section because our current build system does not provide `/dev/fuse`.