### PR TITLE
SPECS: dracut: Update to 110 & Fix %check.

### DIFF
--- a/SPECS/dracut/dracut.spec
+++ b/SPECS/dracut/dracut.spec
@@ -6,12 +6,12 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 Name:           dracut
-Version:        108
+Version:        110
 Release:        %autorelease
 Summary:        Library to create ISO 9660 disk images
 License:        GPL-2.0-or-later AND LGPL-2.0-or-later
 URL:            https://github.com/dracut-ng/dracut-ng
-#!RemoteAsset
+#!RemoteAsset:  sha256:0d357853f8cf2371d89a8ebcbbb1fd2c1c85a79d8866925fd7385eaeb20a27dc
 Source:         %{url}/archive/refs/tags/%{version}.tar.gz
 BuildSystem:    autotools
 
@@ -20,10 +20,11 @@ BuildOption(conf):  --bashcompletiondir=$(pkg-config --variable=completionsdir b
 BuildOption(conf):  --libdir=%{_prefix}/lib
 BuildOption(conf):  --disable-dracut-cpio
 BuildOption(conf):  --disable-documentation
+# We can't run the whole test suite in the build environment
+BuildOption(check):  TESTS="80 81"
 
 BuildRequires:  bash
 BuildRequires:  git-core
-
 BuildRequires:  pkgconfig
 BuildRequires:  systemd
 BuildRequires:  bash-completion
@@ -92,10 +93,6 @@ mkdir -p %{buildroot}%{_prefix}/lib/dracutdracut.conf.d
 
 rm -f %{buildroot}%{_mandir}/man?/*suse*
 
-# TODO: make tests pass.
-%check
-
-
 %files
 %{_bindir}/dracut
 %{_datadir}/bash-completion/completions/dracut
@@ -104,7 +101,6 @@ rm -f %{buildroot}%{_mandir}/man?/*suse*
 %dir %{_prefix}/lib/dracut
 %dir %{_prefix}/lib/dracut/modules.d
 %{_prefix}/lib/dracut/dracut-functions.sh
-%{_prefix}/lib/dracut/dracut-init.sh
 %{_prefix}/lib/dracut/dracut-functions
 %{_prefix}/lib/dracut/dracut-version.sh
 %{_prefix}/lib/dracut/dracut-logger.sh
@@ -129,7 +125,6 @@ rm -f %{buildroot}%{_mandir}/man?/*suse*
 %{_prefix}/lib/dracut/modules.d/11systemd-battery-check
 %{_prefix}/lib/dracut/modules.d/11systemd-coredump
 %{_prefix}/lib/dracut/modules.d/11systemd-creds
-%{_prefix}/lib/dracut/modules.d/11systemd-cryptsetup
 %{_prefix}/lib/dracut/modules.d/11systemd-hostnamed
 %{_prefix}/lib/dracut/modules.d/11systemd-initrd
 %{_prefix}/lib/dracut/modules.d/11systemd-integritysetup
@@ -137,14 +132,13 @@ rm -f %{buildroot}%{_mandir}/man?/*suse*
 %{_prefix}/lib/dracut/modules.d/11systemd-ldconfig
 %{_prefix}/lib/dracut/modules.d/11systemd-modules-load
 %{_prefix}/lib/dracut/modules.d/11systemd-networkd
-%{_prefix}/lib/dracut/modules.d/11systemd-pcrphase
+%{_prefix}/lib/dracut/modules.d/11systemd-pcrextend
 %{_prefix}/lib/dracut/modules.d/11systemd-portabled
 %{_prefix}/lib/dracut/modules.d/11systemd-pstore
 %{_prefix}/lib/dracut/modules.d/11systemd-repart
 %{_prefix}/lib/dracut/modules.d/11systemd-resolved
 %{_prefix}/lib/dracut/modules.d/11systemd-sysext
 %{_prefix}/lib/dracut/modules.d/11systemd-sysctl
-%{_prefix}/lib/dracut/modules.d/68systemd-sysusers
 %{_prefix}/lib/dracut/modules.d/11systemd-timedated
 %{_prefix}/lib/dracut/modules.d/11systemd-timesyncd
 %{_prefix}/lib/dracut/modules.d/11systemd-tmpfiles
@@ -162,14 +156,13 @@ rm -f %{buildroot}%{_mandir}/man?/*suse*
 %{_prefix}/lib/dracut/modules.d/20i18n
 %{_prefix}/lib/dracut/modules.d/30convertfs
 %{_prefix}/lib/dracut/modules.d/35connman
-# TODO: Is this obsolete?
-%{_prefix}/lib/dracut/modules.d/35network-legacy
 %{_prefix}/lib/dracut/modules.d/35network-manager
 %{_prefix}/lib/dracut/modules.d/40network
 %{_prefix}/lib/dracut/modules.d/45drm
 %{_prefix}/lib/dracut/modules.d/45simpledrm
 %{_prefix}/lib/dracut/modules.d/45net-lib
 %{_prefix}/lib/dracut/modules.d/45plymouth
+%{_prefix}/lib/dracut/modules.d/45systemd-import
 %{_prefix}/lib/dracut/modules.d/45url-lib
 %{_prefix}/lib/dracut/modules.d/68lvmmerge
 %{_prefix}/lib/dracut/modules.d/68lvmthinpool-monitor
@@ -184,11 +177,13 @@ rm -f %{buildroot}%{_mandir}/man?/*suse*
 %{_prefix}/lib/dracut/modules.d/70fs-lib
 %{_prefix}/lib/dracut/modules.d/70img-lib
 %{_prefix}/lib/dracut/modules.d/70kernel-modules
+%{_prefix}/lib/dracut/modules.d/70kernel-modules-export
 %{_prefix}/lib/dracut/modules.d/70kernel-modules-extra
 %{_prefix}/lib/dracut/modules.d/70kernel-network-modules
 %{_prefix}/lib/dracut/modules.d/70livenet
 %{_prefix}/lib/dracut/modules.d/70lvm
 %{_prefix}/lib/dracut/modules.d/70mdraid
+%{_prefix}/lib/dracut/modules.d/70memdisk
 %{_prefix}/lib/dracut/modules.d/70multipath
 %{_prefix}/lib/dracut/modules.d/70nvdimm
 %{_prefix}/lib/dracut/modules.d/70numlock
@@ -198,6 +193,7 @@ rm -f %{buildroot}%{_mandir}/man?/*suse*
 %{_prefix}/lib/dracut/modules.d/70qemu
 %{_prefix}/lib/dracut/modules.d/70qemu-net
 %{_prefix}/lib/dracut/modules.d/70uefi-lib
+%{_prefix}/lib/dracut/modules.d/71systemd-cryptsetup
 %{_prefix}/lib/dracut/modules.d/73crypt-gpg
 %{_prefix}/lib/dracut/modules.d/73crypt-loop
 %{_prefix}/lib/dracut/modules.d/73fido2
@@ -237,6 +233,7 @@ rm -f %{buildroot}%{_mandir}/man?/*suse*
 %{_prefix}/lib/dracut/modules.d/77syslog
 %{_prefix}/lib/dracut/modules.d/77usrmount
 %{_prefix}/lib/dracut/modules.d/77initqueue
+%{_prefix}/lib/dracut/modules.d/78systemd-sysusers
 %{_prefix}/lib/dracut/modules.d/80base
 %{_prefix}/lib/dracut/modules.d/81busybox
 %{_prefix}/lib/dracut/modules.d/84memstrack
@@ -274,4 +271,4 @@ rm -f %{buildroot}%{_mandir}/man?/*suse*
 %dir %{_localstatedir}/lib/dracut/overlay
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
In the current build environment, because the test failures are very environment-specific, we can’t run the whole check suite.

Keeping tests 80 and 81 preserves coverage while avoiding false negatives.