### PR TITLE
SPECS: libfaketime: Backport upstream patch to fix ISO C23 issue.

### DIFF
--- a/SPECS/libfaketime/0001-Add-const-qualifiers-to-fix-build-with-ISO-C23.patch
+++ b/SPECS/libfaketime/0001-Add-const-qualifiers-to-fix-build-with-ISO-C23.patch
@@ -1,0 +1,32 @@
+From dbe865dfdba0145d993d70b7fd4ec88b2f47554b Mon Sep 17 00:00:00 2001
+From: Tomas Korbar <tkorbar@redhat.com>
+Date: Mon, 15 Dec 2025 11:03:21 +0100
+Subject: [PATCH] Add const qualifiers to fix build with ISO C23
+
+Fix https://github.com/wolfcw/libfaketime/issues/524
+---
+ src/libfaketime.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/libfaketime.c b/src/libfaketime.c
+index ef1dca9..02839c8 100644
+--- a/src/libfaketime.c
++++ b/src/libfaketime.c
+@@ -2666,7 +2666,7 @@ int timespec_get(struct timespec *ts, int base)
+ static void parse_ft_string(const char *user_faked_time)
+ {
+   struct tm user_faked_time_tm;
+-  char * tmp_time_fmt;
++  const char * tmp_time_fmt;
+   char * nstime_str;
+ 
+   if (!strncmp(user_faked_time, user_faked_time_saved, BUFFERLEN))
+@@ -3338,7 +3338,7 @@ static void prepare_config_contents(char *contents)
+ bool str_array_contains(const char *haystack, const char *needle)
+ {
+   size_t needle_len = strlen(needle);
+-  char *pos = strstr(haystack, needle);
++  const char *pos = strstr(haystack, needle);
+   while (pos) {
+     if (pos == haystack || *(pos - 1) == ',') {
+       char nextc = *(pos + needle_len);

--- a/SPECS/libfaketime/libfaketime.spec
+++ b/SPECS/libfaketime/libfaketime.spec
@@ -15,9 +15,11 @@ Release:        %autorelease
 Summary:        FakeTime Preload Library
 License:        GPL-2.0-only
 URL:            https://github.com/wolfcw/libfaketime
-#!RemoteAsset
+#!RemoteAsset:  sha256:4fc32218697c052adcdc5ee395581f2554ca56d086ac817ced2be0d6f1f8a9fa
 Source:         https://github.com/wolfcw/libfaketime/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 BuildSystem:    autotools
+
+Patch0:         0001-Add-const-qualifiers-to-fix-build-with-ISO-C23.patch
 
 BuildOption(build):  PREFIX=%{_prefix}
 BuildOption(build):  LIBDIRNAME=%{_libdir}/%{name}
@@ -48,4 +50,4 @@ having to change the system-wide time, using a preload library.
 %{_libdir}/lib*.so*
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Current the build error is:
```
[   92s] libfaketime.c:2629:38: error: assignment discards 鈥榗onst鈥� qualifier from pointer target type [-Werror=discarded-qualifiers]
[   92s]  2629 |       else if (NULL != (tmp_time_fmt = strchr(user_faked_time, 'i')))
```