### PR TITLE
SPECS: Fix python spec file formatting - A part

### DIFF
--- a/SPECS/python-accelerate/python-accelerate.spec
+++ b/SPECS/python-accelerate/python-accelerate.spec
@@ -13,7 +13,7 @@ Summary:        Tools for distributed and mixed precision PyTorch training
 License:        MIT
 URL:            https://pypi.org/project/accelerate/
 VCS:            git:https://github.com/huggingface/accelerate
-#!RemoteAsset
+#!RemoteAsset:  sha256:d631b4e0f5b3de4aff2d7e9e6857d164810dfc3237d54d017f075122d057b236
 Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -27,7 +27,7 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -42,4 +42,4 @@ different devices and distributed setups with minimal code changes.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-acres/python-acres.spec
+++ b/SPECS/python-acres/python-acres.spec
@@ -14,6 +14,7 @@ License:        Apache-2.0
 URL:            https://github.com/nipreps/acres
 #!RemoteAsset:  sha256:128b6447bf5df3b6210264feccbfa018b4ac5bd337358319aec6563f99db8f3a
 Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname} -L
@@ -24,7 +25,7 @@ BuildRequires:  python3dist(pdm-backend)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(pytest)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -42,4 +43,4 @@ export PDM_BUILD_SCM_VERSION='%{version}'
 %doc README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-aiohappyeyeballs/python-aiohappyeyeballs.spec
+++ b/SPECS/python-aiohappyeyeballs/python-aiohappyeyeballs.spec
@@ -14,6 +14,7 @@ License:        PSF-2.0
 URL:            https://github.com/aio-libs/aiohappyeyeballs
 #!RemoteAsset:  sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558
 Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname} -L
@@ -24,7 +25,7 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(poetry-core)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -42,4 +43,4 @@ names via another method such as zeroconf.
 %doc README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-aiohttp-socks/python-aiohttp-socks.spec
+++ b/SPECS/python-aiohttp-socks/python-aiohttp-socks.spec
@@ -15,6 +15,7 @@ License:        Apache-2.0
 URL:            https://pypi.org/project/aiohttp-socks/
 #!RemoteAsset:  sha256:0afe51638527c79077e4bd6e57052c87c4824233d6e20bb061c53766421b10f0
 Source0:        https://files.pythonhosted.org/packages/source/a/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{pypi_name}
@@ -27,6 +28,9 @@ BuildRequires:  python3dist(python-socks[asyncio])
 BuildRequires:  python3dist(aiohttp)
 BuildRequires:  python3dist(python-socks)
 
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
 %description
 SOCKS proxy connector for aiohttp. SOCKS4(a) and SOCKS5 are supported.
 
@@ -37,4 +41,4 @@ SOCKS proxy connector for aiohttp. SOCKS4(a) and SOCKS5 are supported.
 %doc README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-aiohttp/python-aiohttp.spec
+++ b/SPECS/python-aiohttp/python-aiohttp.spec
@@ -31,7 +31,8 @@ BuildRequires:  python3dist(attrs)
 BuildRequires:  python3dist(frozenlist)
 BuildRequires:  python3dist(propcache)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -50,4 +51,4 @@ with middlewares and pluggable routing.
 %doc README.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-aioquic/python-aioquic.spec
+++ b/SPECS/python-aioquic/python-aioquic.spec
@@ -12,17 +12,18 @@ Release:        %autorelease
 Summary:        DNS toolkit for Python
 License:        BSD-3-Clause
 URL:            https://github.com/aiortc/aioquic
-#!RemoteAsset
+#!RemoteAsset:  sha256:28d070b2183e3e79afa9d4e7bd558960d0d53aeb98bc0cf0a358b279ba797c92
 Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildSystem:    pyproject
 
-BuildOption(install): %{srcname} -l
+BuildOption(install):  %{srcname} -l
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 BuildRequires:  pkgconfig(openssl)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -37,4 +38,4 @@ A library for the QUIC network protocol in Python. It features a minimal TLS
 %doc README.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-aiosignal/python-aiosignal.spec
+++ b/SPECS/python-aiosignal/python-aiosignal.spec
@@ -14,6 +14,7 @@ License:        Apache-2.0
 URL:            https://github.com/aio-libs/aiosignal
 #!RemoteAsset:  sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7
 Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}
@@ -24,7 +25,7 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(frozenlist)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -38,4 +39,4 @@ collections.abc.MutableSequence, and which can be made immutable.
 %doc CHANGES.rst README.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-altair/python-altair.spec
+++ b/SPECS/python-altair/python-altair.spec
@@ -28,7 +28,7 @@ BuildRequires:  python3dist(jsonschema)
 BuildRequires:  python3dist(narwhals)
 BuildRequires:  python3dist(typing-extensions)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -46,4 +46,4 @@ Vega and Vega-Lite.
 %doc README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-aniso8601/python-aniso8601.spec
+++ b/SPECS/python-aniso8601/python-aniso8601.spec
@@ -24,7 +24,7 @@ BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(python-dateutil)
 BuildRequires:  python3dist(setuptools)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description

--- a/SPECS/python-annotated-types/python-annotated-types.spec
+++ b/SPECS/python-annotated-types/python-annotated-types.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Reusable constraint types to use with typing
 License:        MIT
 URL:            https://github.com/annotated-types/annotated-types
-#!RemoteAsset
+#!RemoteAsset:  sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89
 Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -24,7 +24,7 @@ BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(hatchling)
 BuildRequires:  python3dist(pip)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -38,4 +38,4 @@ This package provides metadata objects which can be used to represent common con
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-anyio/python-anyio.spec
+++ b/SPECS/python-anyio/python-anyio.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Compatibility layer for multiple asynchronous event loop implementations
 License:        MIT
 URL:            https://github.com/agronholm/anyio
-#!RemoteAsset
+#!RemoteAsset:  sha256:82a8d0b81e318cc5ce71a5f1f8b5c4e63619620b63141ef8c995fa0db95a57c4
 Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -20,10 +20,10 @@ BuildSystem:    pyproject
 BuildOption(install):  -l %{srcname}
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  pytest
+BuildRequires:  python3dist(pytest)
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -36,4 +36,4 @@ of either asyncio or trio.
 %files -f %{pyproject_files}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-appdirs/python-appdirs.spec
+++ b/SPECS/python-appdirs/python-appdirs.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Determine platform-specific dirs, e.g. a "user data dir"
 License:        MIT
 URL:            https://github.com/ActiveState/appdirs
-#!RemoteAsset
+#!RemoteAsset:  sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41
 Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  -l %{srcname} +auto
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -36,4 +36,4 @@ directories, e.g. a "user data dir".
 %doc README.rst CHANGES.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-apscheduler/python-apscheduler.spec
+++ b/SPECS/python-apscheduler/python-apscheduler.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/agronholm/apscheduler
 #!RemoteAsset:  sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41
 Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}
@@ -25,7 +26,7 @@ BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(setuptools-scm)
 BuildRequires:  python3dist(tzlocal)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -59,4 +60,4 @@ APscheduler provides multiple job stores.
 %doc README.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-archinfo/python-archinfo.spec
+++ b/SPECS/python-archinfo/python-archinfo.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Collection of classes that contain architecture-specific information
 License:        BSD
 URL:            https://github.com/angr/archinfo
-#!RemoteAsset
+#!RemoteAsset:  sha256:b46da3d0ee6cc7b46230c8e4f1dec9606b9acf814ea585ddaa794b82a7976628
 Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -24,7 +24,7 @@ BuildRequires:  pyproject-rpm-macros
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(pip) >= 19
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -38,4 +38,4 @@ information. It is useful for cross-architecture tools.
 %doc README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-argcomplete/python-argcomplete.spec
+++ b/SPECS/python-argcomplete/python-argcomplete.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Bash tab completion for argparse
 License:        Apache-2.0
 URL:            https://github.com/kislyuk/argcomplete
-#!RemoteAsset
+#!RemoteAsset:  sha256:62e8ed4fd6a45864acc8235409461b72c9a28ee785a2011cc5eb78318786c89c
 Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -40,4 +40,4 @@ arguments for your Python application.
 %{_bindir}/register-python-argcomplete
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-argparse-manpage/python-argparse-manpage.spec
+++ b/SPECS/python-argparse-manpage/python-argparse-manpage.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Build manual page from Python's ArgumentParser object
 License:        Apache-2.0
 URL:            https://github.com/praiskup/argparse-manpage
-#!RemoteAsset
+#!RemoteAsset:  sha256:1deab76b212ac8753cbb67b9d2d2bc0949bbc338bb1cc3547f0890cb34108b32
 Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/argparse_manpage-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -20,17 +20,17 @@ BuildSystem:    pyproject
 BuildOption(install):  -l argparse_manpage build_manpages +auto
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  pytest
+BuildRequires:  python3dist(pytest)
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
 This package provides tools to build manual pages from Python's
-@code{ArgumentParser} object.
+ArgumentParser object.
 
-%pyproject_extras_subpkg -n python3-%{srcname} setuptools
+%pyproject_extras_subpkg -n python-%{srcname} setuptools
 
 %generate_buildrequires
 %pyproject_buildrequires
@@ -39,4 +39,4 @@ This package provides tools to build manual pages from Python's
 %doc README*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-arpy/python-arpy.spec
+++ b/SPECS/python-arpy/python-arpy.spec
@@ -12,8 +12,9 @@ Release:        %autorelease
 Summary:        Library for accessing "ar" files
 License:        BSD-3-Clause
 URL:            https://github.com/viraptor/arpy
-#!RemoteAsset
+#!RemoteAsset:  sha256:8302829a991cfcef2630b61e00f315db73164021cecbd7fb1fc18525f83f339c
 Source:         https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname} -L
@@ -25,7 +26,7 @@ BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(pytest)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -37,11 +38,8 @@ does not support the symbol tables, but can ignore them gracefully.
 %generate_buildrequires
 %pyproject_buildrequires
 
-%check
-%pytest
-
 %files -f %{pyproject_files}
 %doc README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-arrow/python-arrow.spec
+++ b/SPECS/python-arrow/python-arrow.spec
@@ -26,7 +26,7 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(python-dateutil)
 BuildRequires:  python3dist(pytzdata)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -46,4 +46,4 @@ sed -i 's/tzdata;python_version/pytzdata;python_version/' pyproject.toml
 %doc README.rst CHANGELOG.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-asgiref/python-asgiref.spec
+++ b/SPECS/python-asgiref/python-asgiref.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        ASGI specs, helper code, and adapters
 License:        BSD-3-Clause AND Apache-2.0
 URL:            https://github.com/django/asgiref
-#!RemoteAsset
+#!RemoteAsset:  sha256:c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590
 Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,13 +22,13 @@ BuildOption(install):  -l %{srcname} +auto
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  pyproject-rpm-macros
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
 ASGI is a standard for Python asynchronous web apps and servers to
 communicate with each other, and positioned as an asynchronous successor to
-WSGI.  This package includes libraries for implementing ASGI servers.
+WSGI. This package includes libraries for implementing ASGI servers.
 
 %generate_buildrequires
 %pyproject_buildrequires
@@ -37,4 +37,4 @@ WSGI.  This package includes libraries for implementing ASGI servers.
 %doc README.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-asn1crypto/python-asn1crypto.spec
+++ b/SPECS/python-asn1crypto/python-asn1crypto.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Fast Python ASN.1 parser and serializer
 License:        Apache-2.0
 URL:            https://github.com/wbond/asn1crypto
-#!RemoteAsset
+#!RemoteAsset:  sha256:13ae38502be632115abf8a24cbe5f4da52e3b5231990aff31123c805306ccb9c
 Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -36,4 +36,4 @@ PKCS#12, PKCS#5, X.509 and TSP.
 %files -f %{pyproject_files}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-astor/python-astor.spec
+++ b/SPECS/python-astor/python-astor.spec
@@ -14,6 +14,7 @@ License:        BSD-3-Clause
 URL:            https://github.com/berkerpeksag/astor
 #!RemoteAsset:  sha256:6a6effda93f4e1ce9f618779b2dd1d9d84f1e32812c23a29b3fff6fd7f63fa5e
 Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}
@@ -24,7 +25,7 @@ BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(wheel)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -38,4 +39,4 @@ astor is designed to allow easy manipulation of Python source via the AST.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-asttokens/python-asttokens.spec
+++ b/SPECS/python-asttokens/python-asttokens.spec
@@ -14,6 +14,7 @@ License:        Apache-2.0
 URL:            https://github.com/gristlabs/asttokens
 #!RemoteAsset:  sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7
 Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}
@@ -26,7 +27,7 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -44,4 +45,4 @@ for example for automated refactoring or highlighting.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-asyncssh/python-asyncssh.spec
+++ b/SPECS/python-asyncssh/python-asyncssh.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Asynchronous SSHv2 client and server library
 License:        EPL-2.0 OR GPL-2.0-or-later
 URL:            https://asyncssh.timeheart.net/
-#!RemoteAsset
+#!RemoteAsset:  sha256:c3ce72b01be4f97b40e62844dd384227e5ff5a401a3793007c42f86a5c8eb537
 Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -27,7 +27,7 @@ BuildRequires:  python3dist(pyopenssl)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(typing-extensions)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -48,4 +48,4 @@ rm ./tests/sspi_stub.py
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-attrs/python-attrs.spec
+++ b/SPECS/python-attrs/python-attrs.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Attributes without boilerplate
 License:        MIT
 URL:            https://github.com/python-attrs/attrs
-#!RemoteAsset
+#!RemoteAsset:  sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11
 Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  -l attr %{srcname} +auto
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -37,4 +37,4 @@ object protocols.
 %doc README*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-awscrt/python-awscrt.spec
+++ b/SPECS/python-awscrt/python-awscrt.spec
@@ -24,7 +24,8 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  cmake
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description

--- a/SPECS/python-azure-core/python-azure-core.spec
+++ b/SPECS/python-azure-core/python-azure-core.spec
@@ -15,6 +15,7 @@ License:        MIT
 URL:            https://pypi.org/project/azure-core/
 #!RemoteAsset:  sha256:8194d2682245a3e4e3151a667c686464c3786fed7918b394d035bdcd61bb5993
 Source0:        https://files.pythonhosted.org/packages/source/a/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l azure
@@ -26,6 +27,9 @@ BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(requests)
 BuildRequires:  python3dist(typing-extensions)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
 
 %description
 Azure Core shared client library for Python.
@@ -41,4 +45,4 @@ Azure Core shared client library for Python.
 %doc CHANGELOG.md CLIENT_LIBRARY_DEVELOPER.md README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-azure-storage-blob/python-azure-storage-blob.spec
+++ b/SPECS/python-azure-storage-blob/python-azure-storage-blob.spec
@@ -16,6 +16,7 @@ License:        MIT
 URL:            https://pypi.org/project/%{srcname}/
 #!RemoteAsset:  sha256:e7d98ea108258d29aa0efbfd591b2e2075fa1722a2fae8699f0b3c9de11eff41
 Source0:        https://files.pythonhosted.org/packages/source/a/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{modname}
@@ -31,7 +32,7 @@ BuildRequires:  python3dist(isodate)
 BuildRequires:  python3dist(cryptography)
 BuildRequires:  python3dist(azure-core)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -45,4 +46,4 @@ Azure Storage Blobs client library for Python.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-pytest/python-pytest.spec
+++ b/SPECS/python-pytest/python-pytest.spec
@@ -7,21 +7,24 @@
 
 %global srcname pytest
 
-Name:           %{srcname}
-Version:        9.0.1
+Name:           python-%{srcname}
+Version:        9.0.3
 Release:        %autorelease
 Summary:        Simple powerful testing with Python
 License:        MIT
 URL:            https://pytest.org
 VCS:            git:https://github.com/pytest-dev/pytest
-#!RemoteAsset
+#!RemoteAsset:  sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
+BuildSystem:    pyproject
 
-BuildRequires:  python3-devel
+BuildOption(install):  _pytest pytest py
+
+BuildRequires:  pkgconfig(python3)
 BuildRequires:  pyproject-rpm-macros
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -29,18 +32,12 @@ The pytest framework makes it easy to write small tests, yet scales to support
 complex functional testing for applications and libraries.
 
 %prep
-%autosetup -p1
+%autosetup -p1 -n %{srcname}-%{version}
 
 %generate_buildrequires
 %pyproject_buildrequires -r
 
-%build
-%pyproject_wheel
-
-%install
-%pyproject_install
-%pyproject_save_files _pytest pytest py
-
+%install -a
 mv %{buildroot}%{_bindir}/pytest %{buildroot}%{_bindir}/pytest-%{python3_version}
 ln -snf pytest-%{python3_version} %{buildroot}%{_bindir}/pytest-3
 mv %{buildroot}%{_bindir}/py.test %{buildroot}%{_bindir}/py.test-%{python3_version}
@@ -64,4 +61,4 @@ find %{buildroot}%{python3_sitelib} \
 %{_bindir}/py.test-%{python3_version}
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Key updates are as follows:

- Our virtual `python3-xxx` must provide the complete `%{version}-%{release}`.
- Correct the `#!RemoteAsset` to include the sha256 checksum value.
- Update `%{?autochangelog}` to `%autochangelog`.

---

Regarding `pytest`: This package needs to conform to our Python naming convention, so it should be renamed to `python-pytest`. Additionally, update its version to 9.0.3.