### PR TITLE
SPECS: Fix python spec file formatting - E part

### DIFF
--- a/SPECS/python-editables/python-editables.spec
+++ b/SPECS/python-editables/python-editables.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Editable installations
 License:        MIT
 URL:            https://github.com/pfmoore/editables
-#!RemoteAsset
+#!RemoteAsset:  sha256:309627d9b5c4adc0e668d8c6fa7bac1ba7c8c5d415c2d27f60f081f8e80d1de2
 Source0:        https://files.pythonhosted.org/packages/source/e/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  -l %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -40,4 +40,4 @@ Python, without needing a reinstall.
 %doc README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-editdistance/python-editdistance.spec
+++ b/SPECS/python-editdistance/python-editdistance.spec
@@ -28,7 +28,8 @@ BuildRequires:  python3dist(wheel)
 BuildRequires:  gcc-c++
 BuildRequires:  python3dist(pytest)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -47,4 +48,4 @@ find %{buildroot}%{python3_sitearch} -type f \( \
 %doc README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-editorconfig/python-editorconfig.spec
+++ b/SPECS/python-editorconfig/python-editorconfig.spec
@@ -26,7 +26,7 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -42,4 +42,4 @@ styles between different editors and IDEs.
 %{_bindir}/editorconfig
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-emoji/python-emoji.spec
+++ b/SPECS/python-emoji/python-emoji.spec
@@ -26,7 +26,7 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(pytest)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -42,4 +42,4 @@ consortium is supported in addition to a bunch of aliases.
 %license LICENSE.txt
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-en-core-web-sm/python-en-core-web-sm.spec
+++ b/SPECS/python-en-core-web-sm/python-en-core-web-sm.spec
@@ -27,6 +27,9 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(spacy) >= 3.8.0
 
+Provides:       python3-en-core-web-sm = %{version}-%{release}
+%python_provide python3-en-core-web-sm
+
 Requires:       python3dist(spacy) >= 3.8.0
 
 %description
@@ -43,4 +46,4 @@ This is a spaCy language model for English, trained on OntoNotes 5 corpus.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-environs/python-environs.spec
+++ b/SPECS/python-environs/python-environs.spec
@@ -28,7 +28,7 @@ BuildRequires:  python3dist(flit-core)
 BuildRequires:  python3dist(python-dotenv)
 BuildRequires:  python3dist(marshmallow)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -44,4 +44,4 @@ The Twelve-Factor App methodology.
 %doc README.md CHANGELOG.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-etelemetry/python-etelemetry.spec
+++ b/SPECS/python-etelemetry/python-etelemetry.spec
@@ -32,7 +32,7 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(requests)
 BuildRequires:  python3dist(ci-info)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -46,4 +46,4 @@ A lightweight python client to communicate with the etelemetry server.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-ethtool/python-ethtool.spec
+++ b/SPECS/python-ethtool/python-ethtool.spec
@@ -14,20 +14,21 @@ Release:        %autorelease
 Summary:        Python module to interface with ethtool
 License:        GPL-2.0-or-later
 URL:            https://github.com/fedora-python/python-ethtool
-#!RemoteAsset
+#!RemoteAsset:  sha256:567260ea5805063bbcff71dabd6fb820f89bc84f720e9ebe315c7eef1449d908
 Source0:        https://files.pythonhosted.org/packages/source/e/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildSystem:    pyproject
 
-BuildOption(install): -l %{srcname}
+BuildOption(install):  -l %{srcname}
 
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-devel
+BuildRequires:  pkgconfig(python3)
 BuildRequires:  pkgconfig(libnl-3.0)
 %if %{with doc}
 BuildRequires:  asciidoc
 %endif
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -45,4 +46,4 @@ PCI locations.
 %{_bindir}/pethtool
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-exceptiongroup/python-exceptiongroup.spec
+++ b/SPECS/python-exceptiongroup/python-exceptiongroup.spec
@@ -14,6 +14,7 @@ License:        MIT or PSF-2.0
 URL:            https://github.com/agronholm/exceptiongroup
 #!RemoteAsset:  sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219
 Source:         https://files.pythonhosted.org/packages/source/e/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}
@@ -23,7 +24,7 @@ BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(flit-scm)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description

--- a/SPECS/python-execnet/python-execnet.spec
+++ b/SPECS/python-execnet/python-execnet.spec
@@ -14,12 +14,16 @@ Release:        %autorelease
 Summary:        Distributed Python deployment and communication
 License:        MIT AND GPL-2.0-or-later
 URL:            http://codespeak.net/execnet
-#!RemoteAsset
+#!RemoteAsset:  sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd
 Source0:        https://files.pythonhosted.org/packages/source/e/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}
+# We don't have python-servicemanager yet
+BuildOption(check):  -e execnet.script.quitserver
+BuildOption(check):  -e execnet.script.shell
+BuildOption(check):  -e execnet.script.socketserverservice
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  procps-ng
@@ -30,7 +34,7 @@ BuildRequires:  sphinx-build
 %endif
 BuildRequires:  python3dist(pytest)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -65,7 +69,7 @@ rm doc/_build/html/.buildinfo
 %install -p
 SETUPTOOLS_SCM_PRETEND_VERSION=%{version}
 
-%check
+%check -a
 %pytest -k "not gevent and not eventlet and not test_dont_write_bytecode" testing
 
 %files -f %{pyproject_files}
@@ -73,4 +77,4 @@ SETUPTOOLS_SCM_PRETEND_VERSION=%{version}
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-executing/python-executing.spec
+++ b/SPECS/python-executing/python-executing.spec
@@ -27,7 +27,7 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -42,4 +42,4 @@ a frame is currently doing, particularly the AST node being executed.
 %license LICENSE.txt
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-expandvars/python-expandvars.spec
+++ b/SPECS/python-expandvars/python-expandvars.spec
@@ -24,7 +24,7 @@ BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(hatchling)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -42,4 +42,4 @@ value if some variable is not defined.
 %doc README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-expecttest/python-expecttest.spec
+++ b/SPECS/python-expecttest/python-expecttest.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/ezyang/expecttest
 #!RemoteAsset:  sha256:6e8512fb86523ada1f94fd1b14e280f924e379064bb8a29ee399950e513eeccd
 Source:         https://files.pythonhosted.org/packages/source/e/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname} -L
@@ -24,7 +25,7 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(flit-scm)
 BuildRequires:  python3dist(poetry-core)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description


### PR DESCRIPTION
Key updates are as follows:

- Our virtual `python3-xxx` must provide the complete `%{version}-%{release}`.
- Correct the `#!RemoteAsset` to include the sha256 checksum value.
- Update `%{?autochangelog}` to `%autochangelog`.
