### PR TITLE
SPECS: Fix python spec file formatting - F part

### DIFF
--- a/SPECS/python-fastjsonschema/python-fastjsonschema.spec
+++ b/SPECS/python-fastjsonschema/python-fastjsonschema.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Fastest Python implementation of JSON schema
 License:        BSD-3-Clause
 URL:            https://github.com/horejsek/python-fastjsonschema
-#!RemoteAsset
+#!RemoteAsset:  sha256:b1eb43748041c880796cd077f1a07c3d94e93ae84bba5ed36800a33554ae05de
 Source:         https://files.pythonhosted.org/packages/source/f/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -26,7 +26,7 @@ BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(pytest)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -37,7 +37,7 @@ The main purpose is to have a really fast implementation.
 %generate_buildrequires
 %pyproject_buildrequires
 
-%check
+%check -a
 %pytest -m "not benchmark"
 
 %files -f %{pyproject_files}
@@ -45,4 +45,4 @@ The main purpose is to have a really fast implementation.
 %doc README.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-filelock/python-filelock.spec
+++ b/SPECS/python-filelock/python-filelock.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Platform independent file lock
 License:        Unlicense
 URL:            https://github.com/tox-dev/py-filelock
-#!RemoteAsset
+#!RemoteAsset:  sha256:711e943b4ec6be42e1d4e6690b48dc175c822967466bb31c0c293f34334c13f4
 Source0:        https://files.pythonhosted.org/packages/source/f/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,11 +22,11 @@ BuildOption(install):  -l %{srcname} +auto
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  pyproject-rpm-macros
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
-@code{filelock} contains a single module implementing
+filelock contains a single module implementing
 a platform independent file lock in Python, which provides a simple way of
 inter-process communication.
 
@@ -37,4 +37,4 @@ inter-process communication.
 %doc README*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-flaky/python-flaky.spec
+++ b/SPECS/python-flaky/python-flaky.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Plugin for pytest that automatically reruns flaky tests
 License:        Apache-2.0
 URL:            https://github.com/box/flaky
-#!RemoteAsset
+#!RemoteAsset:  sha256:47204a81ec905f3d5acfbd61daeabcada8f9d4031616d9bcb0618461729699f5
 Source0:        https://files.pythonhosted.org/packages/source/f/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -24,7 +24,7 @@ BuildRequires:  pkgconfig(python3)
 # Tests
 BuildRequires:  python3dist(pytest)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -36,7 +36,7 @@ those tests or marking them to @skip, they can be automatically retried.
 %generate_buildrequires
 %pyproject_buildrequires
 
-%check
+%check -a
 # adapted from upstream's tox.ini
 %pytest -v -k 'example and not options' --doctest-modules test/test_pytest/
 %pytest -v -k 'example and not options' test/test_pytest/
@@ -47,4 +47,4 @@ those tests or marking them to @skip, they can be automatically retried.
 %doc README.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-flask-restful/python-flask-restful.spec
+++ b/SPECS/python-flask-restful/python-flask-restful.spec
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %global srcname flask-restful
+%global pypi_name Flask-RESTful
 
 Name:           python-%{srcname}
 Version:        0.3.10
@@ -12,9 +13,8 @@ Release:        %autorelease
 Summary:        Simple framework for creating REST APIs
 License:        BSD-3-Clause
 URL:            https://github.com/flask-restful/flask-restful
-# This is messed up upstream... - 251
-#!RemoteAsset
-Source0:        https://files.pythonhosted.org/packages/source/f/%{srcname}/Flask-RESTful-%{version}.tar.gz
+#!RemoteAsset:  sha256:fe4af2ef0027df8f9b4f797aba20c5566801b6ade995ac63b588abf1a59cec37
+Source0:        https://files.pythonhosted.org/packages/source/f/%{srcname}/%{pypi_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
 
@@ -25,7 +25,7 @@ BuildRequires:  pkgconfig(python3)
 # Tests
 BuildRequires:  python3dist(pycryptodome)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -39,4 +39,4 @@ Flask-RESTful provides the building blocks for creating a REST API.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-flask/python-flask.spec
+++ b/SPECS/python-flask/python-flask.spec
@@ -13,7 +13,7 @@ Summary:        A micro-framework for Python based on Werkzeug, Jinja 2 and good
 License:        BSD-3-Clause
 URL:            https://flask.palletsprojects.com/
 VCS:            git:https://github.com/pallets/flask
-#!RemoteAsset
+#!RemoteAsset:  sha256:bf656c15c80190ed628ad08cdfd3aaa35beb087855e2f494910aa3774cc4fd87
 Source0:        https://files.pythonhosted.org/packages/source/f/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -24,7 +24,7 @@ BuildRequires:  make
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -47,4 +47,4 @@ authentication technologies and more.
 %{_bindir}/flask
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-flit-scm/python-flit-scm.spec
+++ b/SPECS/python-flit-scm/python-flit-scm.spec
@@ -6,13 +6,13 @@
 
 %global srcname flit_scm
 
-Name:           python-%{srcname}
+Name:           python-flit-scm
 Version:        1.7.0
 Release:        %autorelease
 Summary:        PEP 518 build backend that uses setuptools_scm and flit
 License:        MIT
 URL:            https://gitlab.com/WillDaSilva/flit_scm
-#!RemoteAsset
+#!RemoteAsset:  sha256:961bd6fb24f31bba75333c234145fff88e6de0a90fc0f7e5e7c79deca69f6bb2
 Source0:        https://files.pythonhosted.org/packages/source/f/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,8 +22,8 @@ BuildOption(install):  -l %{srcname} +auto
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
+Provides:       python3-flit-scm = %{version}-%{release}
+%python_provide python3-flit-scm
 
 %description
 A PEP 518 build backend that uses setuptools_scm to generate a version file
@@ -36,4 +36,4 @@ from your version control system, then flit_core to build the package.
 %doc README*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-freezegun/python-freezegun.spec
+++ b/SPECS/python-freezegun/python-freezegun.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Test utility for mocking the datetime module
 License:        Apache-2.0
 URL:            https://github.com/spulec/freezegun
-#!RemoteAsset
+#!RemoteAsset:  sha256:ac7742a6cc6c25a2c35e9292dfd554b897b517d2dec26891a2e8debf205cb94a
 Source0:        https://files.pythonhosted.org/packages/source/f/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  -l %{srcname} +auto
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -36,4 +36,4 @@ time by mocking the datetime module.
 %doc README*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-frozenlist/python-frozenlist.spec
+++ b/SPECS/python-frozenlist/python-frozenlist.spec
@@ -25,7 +25,8 @@ BuildRequires:  python3dist(expandvars)
 BuildRequires:  python3dist(cython)
 BuildRequires:  python3dist(setuptools)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -39,4 +40,4 @@ collections.abc.MutableSequence, and which can be made immutable.
 %doc CHANGES.rst README.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-fsspec/python-fsspec.spec
+++ b/SPECS/python-fsspec/python-fsspec.spec
@@ -35,32 +35,32 @@ Provides:       python3-%{srcname} = %{version}-%{release}
 Fsspec provides a unified Python interface for local, remote, and embedded
 filesystems.
 
-%pyproject_extras_subpkg -n python3-%{srcname} abfs
-%pyproject_extras_subpkg -n python3-%{srcname} adl
-%pyproject_extras_subpkg -n python3-%{srcname} arrow
-%pyproject_extras_subpkg -n python3-%{srcname} dask
-%pyproject_extras_subpkg -n python3-%{srcname} dev
-%pyproject_extras_subpkg -n python3-%{srcname} doc
-%pyproject_extras_subpkg -n python3-%{srcname} dropbox
-%pyproject_extras_subpkg -n python3-%{srcname} full
-%pyproject_extras_subpkg -n python3-%{srcname} fuse
-%pyproject_extras_subpkg -n python3-%{srcname} gcs
-%pyproject_extras_subpkg -n python3-%{srcname} git
-%pyproject_extras_subpkg -n python3-%{srcname} github
-%pyproject_extras_subpkg -n python3-%{srcname} gs
-%pyproject_extras_subpkg -n python3-%{srcname} gui
-%pyproject_extras_subpkg -n python3-%{srcname} hdfs
-%pyproject_extras_subpkg -n python3-%{srcname} http
-%pyproject_extras_subpkg -n python3-%{srcname} libarchive
-%pyproject_extras_subpkg -n python3-%{srcname} oci
-%pyproject_extras_subpkg -n python3-%{srcname} s3
-%pyproject_extras_subpkg -n python3-%{srcname} sftp
-%pyproject_extras_subpkg -n python3-%{srcname} smb
-%pyproject_extras_subpkg -n python3-%{srcname} ssh
-%pyproject_extras_subpkg -n python3-%{srcname} test
-%pyproject_extras_subpkg -n python3-%{srcname} test-downstream
-%pyproject_extras_subpkg -n python3-%{srcname} test-full
-%pyproject_extras_subpkg -n python3-%{srcname} tqdm
+%pyproject_extras_subpkg -n python-%{srcname} abfs
+%pyproject_extras_subpkg -n python-%{srcname} adl
+%pyproject_extras_subpkg -n python-%{srcname} arrow
+%pyproject_extras_subpkg -n python-%{srcname} dask
+%pyproject_extras_subpkg -n python-%{srcname} dev
+%pyproject_extras_subpkg -n python-%{srcname} doc
+%pyproject_extras_subpkg -n python-%{srcname} dropbox
+%pyproject_extras_subpkg -n python-%{srcname} full
+%pyproject_extras_subpkg -n python-%{srcname} fuse
+%pyproject_extras_subpkg -n python-%{srcname} gcs
+%pyproject_extras_subpkg -n python-%{srcname} git
+%pyproject_extras_subpkg -n python-%{srcname} github
+%pyproject_extras_subpkg -n python-%{srcname} gs
+%pyproject_extras_subpkg -n python-%{srcname} gui
+%pyproject_extras_subpkg -n python-%{srcname} hdfs
+%pyproject_extras_subpkg -n python-%{srcname} http
+%pyproject_extras_subpkg -n python-%{srcname} libarchive
+%pyproject_extras_subpkg -n python-%{srcname} oci
+%pyproject_extras_subpkg -n python-%{srcname} s3
+%pyproject_extras_subpkg -n python-%{srcname} sftp
+%pyproject_extras_subpkg -n python-%{srcname} smb
+%pyproject_extras_subpkg -n python-%{srcname} ssh
+%pyproject_extras_subpkg -n python-%{srcname} test
+%pyproject_extras_subpkg -n python-%{srcname} test-downstream
+%pyproject_extras_subpkg -n python-%{srcname} test-full
+%pyproject_extras_subpkg -n python-%{srcname} tqdm
 
 %generate_buildrequires
 %pyproject_buildrequires

--- a/SPECS/python-ftfy/python-ftfy.spec
+++ b/SPECS/python-ftfy/python-ftfy.spec
@@ -25,7 +25,7 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(hatchling)
 BuildRequires:  python3dist(wcwidth)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -40,4 +40,4 @@ ftfy fixes mojibake and other glitches in Unicode text, after the fact.
 %{_bindir}/ftfy
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Key updates are as follows:

- Our virtual `python3-xxx` must provide the complete `%{version}-%{release}`.
- Correct the `#!RemoteAsset` to include the sha256 checksum value.
- Update `%{?autochangelog}` to `%autochangelog`.

---

Regarding `python-flit-scm`: This package needs to conform to our Python naming convention.