### PR TITLE
SPECS: Fix python spec file formatting - G part

### DIFF
--- a/SPECS/python-GitPython/python-GitPython.spec
+++ b/SPECS/python-GitPython/python-GitPython.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Python Git Library
 License:        BSD-3-Clause
 URL:            https://github.com/gitpython-developers/GitPython
-#!RemoteAsset
+#!RemoteAsset:  sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f
 Source0:        https://files.pythonhosted.org/packages/source/g/gitpython/gitpython-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -27,7 +27,7 @@ BuildRequires:  python3dist(gitdb)
 # used for check
 BuildRequires:  git
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -50,4 +50,4 @@ and data streaming.
 %doc CHANGES AUTHORS
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-gast/python-gast.spec
+++ b/SPECS/python-gast/python-gast.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Python AST that abstracts the underlying Python version
 License:        BSD-3-Clause
 URL:            https://github.com/serge-sans-paille/gast/
-#!RemoteAsset
+#!RemoteAsset:  sha256:88fc5300d32c7ac6ca7b515310862f71e6fdf2c029bbec7c66c0f5dd47b6b1fb
 Source0:        https://files.pythonhosted.org/packages/source/g/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -24,13 +24,14 @@ BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
 A generic AST to represent Python2 and Python3's Abstract Syntax Tree(AST).
 
-GAST provides a compatibility layer between the AST of various Python versions, as produced by ast.parse from the standard ast module.
+GAST provides a compatibility layer between the AST of various Python
+versions, as produced by ast.parse from the standard ast module.
 
 %build -p
 rm %{_builddir}/%{name}-%{version}/gast/ast2.py # No use of Python 2.
@@ -43,4 +44,4 @@ rm %{_builddir}/%{name}-%{version}/gast/ast2.py # No use of Python 2.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-genshi/python-genshi.spec
+++ b/SPECS/python-genshi/python-genshi.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Toolkit for stream-based generation of output for the web
 License:        BSD-3-Clause
 URL:            https://genshi.edgewall.org/
-#!RemoteAsset
+#!RemoteAsset:  sha256:85b0db113625314f0f44f3fe6ef0eb2564d6c34dd2ee5677b495d15142bb4973
 Source:         https://files.pythonhosted.org/packages/source/g/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildSystem:    pyproject
 
@@ -25,7 +25,8 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(pytest)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -36,7 +37,7 @@ textual content for output generation on the web.
 %generate_buildrequires
 %pyproject_buildrequires
 
-%check
+%check -a
 %pytest
 
 %files -f %{pyproject_files}
@@ -44,4 +45,4 @@ textual content for output generation on the web.
 %license COPYING
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-gitdb/python-gitdb.spec
+++ b/SPECS/python-gitdb/python-gitdb.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Git Object Database
 License:        BSD-3-Clause
 URL:            https://github.com/gitpython-developers/gitdb
-#!RemoteAsset
+#!RemoteAsset:  sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b
 Source0:        https://files.pythonhosted.org/packages/source/g/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -26,7 +26,7 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(smmap)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -43,4 +43,4 @@ allowing to handle large objects with a small memory footprint.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-glad2/python-glad2.spec
+++ b/SPECS/python-glad2/python-glad2.spec
@@ -14,6 +14,7 @@ License:        MIT AND Apache-2.0
 URL:            https://github.com/Dav1dde/glad
 #!RemoteAsset:  sha256:b84079b9fa404f37171b961bdd1d8da21370e6c818defb8481c5b3fe3d6436da
 Source:         https://files.pythonhosted.org/packages/source/g/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l glad
@@ -25,7 +26,7 @@ BuildRequires:  python3dist(jinja2)
 BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(setuptools)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description

--- a/SPECS/python-greenlet/python-greenlet.spec
+++ b/SPECS/python-greenlet/python-greenlet.spec
@@ -25,6 +25,7 @@ BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(setuptools)
 
 Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description

--- a/SPECS/python-gssapi/python-gssapi.spec
+++ b/SPECS/python-gssapi/python-gssapi.spec
@@ -27,7 +27,8 @@ BuildRequires:  python3dist(decorator)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -45,4 +46,4 @@ cd %{_builddir}/%{name}-%{version}
 %license LICENSE.txt
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Key updates are as follows:

- Our virtual `python3-xxx` must provide the complete `%{version}-%{release}`.
- Correct the `#!RemoteAsset` to include the sha256 checksum value.
- Update `%{?autochangelog}` to `%autochangelog`.
