### PR TITLE
SPECS: Fix python spec file formatting - H part

### DIFF
--- a/SPECS/python-h11/python-h11.spec
+++ b/SPECS/python-h11/python-h11.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        A pure-Python, bring-your-own-I/O implementation of HTTP/11
 License:        MIT
 URL:            https://github.com/encode/h11
-#!RemoteAsset
+#!RemoteAsset:  sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1
 Source0:        https://files.pythonhosted.org/packages/source/h/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  -l %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -36,4 +36,4 @@ inspired by hyper-h2.
 %doc README.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-h2/python-h2.spec
+++ b/SPECS/python-h2/python-h2.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        HTTP/2 State-Machine based protocol implementation
 License:        MIT
 URL:            https://github.com/python-hyper/hyper-h2
-#!RemoteAsset
+#!RemoteAsset:  sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1
 Source0:        https://files.pythonhosted.org/packages/source/h/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -38,4 +38,4 @@ speak HTTP/2 regardless of your programming paradigm.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-hatch-fancy-pypi-readme/python-hatch-fancy-pypi-readme.spec
+++ b/SPECS/python-hatch-fancy-pypi-readme/python-hatch-fancy-pypi-readme.spec
@@ -6,13 +6,13 @@
 
 %global srcname hatch_fancy_pypi_readme
 
-Name:           python-%{srcname}
+Name:           python-hatch-fancy-pypi-readme
 Version:        25.1.0
 Release:        %autorelease
 Summary:        Fancy PyPI READMEs with Hatch
 License:        MIT
 URL:            https://github.com/hynek/hatch-fancy-pypi-readme
-#!RemoteAsset
+#!RemoteAsset:  sha256:9c58ed3dff90d51f43414ce37009ad1d5b0f08ffc9fc216998a06380f01c0045
 Source0:        https://files.pythonhosted.org/packages/source/h/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,8 +22,8 @@ BuildOption(install):  -l %{srcname} +auto
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
+Provides:       python3-hatch-fancy-pypi-readme = %{version}-%{release}
+%python_provide python3-hatch-fancy-pypi-readme
 
 %description
 This hatch plugin allows defining a project description in
@@ -37,4 +37,4 @@ parts of files defined using cut-off points or regular expressions.
 %doc README*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-hatch-nodejs-version/python-hatch-nodejs-version.spec
+++ b/SPECS/python-hatch-nodejs-version/python-hatch-nodejs-version.spec
@@ -24,7 +24,7 @@ BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(hatchling)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -41,4 +41,4 @@ Node.js build metadata.
 %license LICENSE.txt
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-hatch-requirements-txt/python-hatch-requirements-txt.spec
+++ b/SPECS/python-hatch-requirements-txt/python-hatch-requirements-txt.spec
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %global srcname hatch-requirements-txt
+%global pypi_name hatch_requirements_txt
 
 Name:           python-hatch-requirements-txt
 Version:        0.4.1
@@ -12,19 +13,19 @@ Release:        %autorelease
 Summary:        Hatchling plugin to read project dependencies from requirements.txt
 License:        MIT
 URL:            https://github.com/repo-helper/hatch-requirements-txt
-#!RemoteAsset
-Source0:        https://files.pythonhosted.org/packages/source/h/%{srcname}/hatch_requirements_txt-%{version}.tar.gz
+#!RemoteAsset:  sha256:2c686e5758fd05bb55fa7d0c198fdd481f8d3aaa3c693260f5c0d74ce3547d20
+Source0:        https://files.pythonhosted.org/packages/source/h/%{srcname}/%{pypi_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install):  -l hatch_requirements_txt
+BuildOption(install):  -l %{pypi_name}
 
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  python3dist(hatchling)
 BuildRequires:  python3dist(pip)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -37,4 +38,4 @@ Provides:       python3-%{srcname}
 %doc README.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-hatch-vcs/python-hatch-vcs.spec
+++ b/SPECS/python-hatch-vcs/python-hatch-vcs.spec
@@ -30,16 +30,15 @@ BuildRequires:  python3dist(hatchling)
 BuildRequires:  python3dist(pluggy)
 BuildRequires:  python3dist(setuptools-scm)
 
+Provides:       python3-hatch-vcs = %{version}-%{release}
+%python_provide python3-hatch-vcs
+
 %description
 This provides a plugin for Hatch that uses your preferred version control
 system (like Git) to determine project versions.
 
-Provides:       python3-hatch-vcs
-%python_provide python3-hatch-vcs
-
 %files -f %{pyproject_files}
-%doc README.md
-%doc HISTORY.md
+%doc README.md HISTORY.md
 
 %changelog
 %autochangelog

--- a/SPECS/python-hatchling/python-hatchling.spec
+++ b/SPECS/python-hatchling/python-hatchling.spec
@@ -30,11 +30,11 @@ BuildRequires:  python3dist(pathspec)
 BuildRequires:  python3dist(pluggy)
 BuildRequires:  python3dist(trove-classifiers)
 
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
 %description
 This is the extensible, standards compliant build backend used by Hatch.
-
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
 
 %files -f %{pyproject_files}
 %doc README.md

--- a/SPECS/python-hf-xet/python-hf-xet.spec
+++ b/SPECS/python-hf-xet/python-hf-xet.spec
@@ -13,10 +13,10 @@ Summary:        Fast transfer layer for large files on Hugging Face Hub
 License:        Apache-2.0
 URL:            https://pypi.org/project/hf-xet/
 VCS:            git:https://github.com/huggingface/xet-core
-#!RemoteAsset
+#!RemoteAsset:  sha256:e130ee08984783d12717444e538587fa2119385e5bd8fc2bb9f930419b73a7af
 Source0:        https://files.pythonhosted.org/packages/source/h/%{srcname}/%{srcname}-%{version}.tar.gz
 # TODO(vendor): if OBS cannot access GitHub release directly, switch to _service(download_url) as fallback.
-#!RemoteAsset
+#!RemoteAsset:  sha256:3700b275ebb7f821fcf8ff7b3943670c3d5820f98a292881ae9e1f5d8fb8a252
 Source1:        https://github.com/software-vendor/python-hf-xet/releases/download/vendor-%{version}/hf_xet-%{version}-vendor.tar.zst
 BuildSystem:    pyproject
 
@@ -32,6 +32,7 @@ BuildRequires:  rust
 BuildRequires:  cargo
 
 Provides:       python3-hf-xet = %{version}-%{release}
+Provides:       python3-hf-xet%{?_isa} = %{version}-%{release}
 %python_provide python3-hf-xet
 
 %description
@@ -56,4 +57,4 @@ EOF2
 %license hf_xet/LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-hiredis/python-hiredis.spec
+++ b/SPECS/python-hiredis/python-hiredis.spec
@@ -21,7 +21,9 @@ BuildOption(install):  -l %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+# TODO: We need some kind of CI to detect this - 251
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description

--- a/SPECS/python-hiredis/python-hiredis.spec
+++ b/SPECS/python-hiredis/python-hiredis.spec
@@ -21,7 +21,8 @@ BuildOption(install):  -l %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description

--- a/SPECS/python-hpack/python-hpack.spec
+++ b/SPECS/python-hpack/python-hpack.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Pure-Python HPACK header compression
 License:        MIT
 URL:            https://github.com/python-hyper/hpack
-#!RemoteAsset
+#!RemoteAsset:  sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca
 Source0:        https://files.pythonhosted.org/packages/source/h/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -38,4 +38,4 @@ use of nghttp2 if it's available.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-html5lib/python-html5lib.spec
+++ b/SPECS/python-html5lib/python-html5lib.spec
@@ -14,7 +14,7 @@ Release:        %autorelease
 Summary:        A python based HTML parser/tokenizer
 License:        MIT
 URL:            https://github.com/html5lib/html5lib-python
-#!RemoteAsset
+#!RemoteAsset:  sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f
 Source:         https://files.pythonhosted.org/packages/source/h/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -28,13 +28,15 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(six) >= 1.9
 BuildRequires:  python3dist(webencodings)
+# For tests
+BuildRequires:  python3dist(genshi)
+BuildRequires:  python3dist(lxml)
 %if %{with tests}
-# for tests
 BuildRequires:  python3(pytest)
 BuildRequires:  python3(pytest-expect)
 %endif
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -44,8 +46,8 @@ specification for maximum compatibility with major desktop web browsers.
 %generate_buildrequires
 %pyproject_buildrequires
 
-%check
 %if %{with tests}
+%check -a
 %pytest
 %endif
 
@@ -54,4 +56,4 @@ specification for maximum compatibility with major desktop web browsers.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-httpcore/python-httpcore.spec
+++ b/SPECS/python-httpcore/python-httpcore.spec
@@ -12,8 +12,8 @@ Release:        %autorelease
 Summary:        Minimal low-level Python HTTP client
 License:        BSD-3-Clause
 URL:            https://github.com/encode/httpcore
-#!RemoteAsset
-Source0:        %{url}/archive/%{version}/%{srcname}-%{version}.tar.gz
+#!RemoteAsset:  sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8
+Source0:        https://files.pythonhosted.org/packages/source/h/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
 
@@ -22,7 +22,7 @@ BuildOption(install):  -l %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -36,4 +36,4 @@ one thing only: Sending HTTP requests.
 %doc README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-httplib2/python-httplib2.spec
+++ b/SPECS/python-httplib2/python-httplib2.spec
@@ -32,7 +32,7 @@ BuildRequires:  python3dist(six)
 BuildRequires:  python3dist(cryptography)
 BuildRequires:  python3dist(pyparsing)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -42,7 +42,7 @@ other HTTP libraries.
 %generate_buildrequires
 %pyproject_buildrequires
 
-%check
+%check -a
 %pytest -k "not test_unknown_server \
     and not test_socks5_auth \
     and not test_server_not_found_error_is_raised_for_invalid_hostname \
@@ -64,4 +64,4 @@ other HTTP libraries.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-httpx/python-httpx.spec
+++ b/SPECS/python-httpx/python-httpx.spec
@@ -12,8 +12,8 @@ Release:        %autorelease
 Summary:        HTTP client for Python
 License:        BSD-3-Clause
 URL:            https://github.com/encode/httpx
-#!RemoteAsset
-Source0:        %{url}/archive/%{version}/%{srcname}-%{version}.tar.gz
+#!RemoteAsset:  sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc
+Source0:        https://files.pythonhosted.org/packages/source/h/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
 
@@ -22,7 +22,7 @@ BuildOption(install):  -l %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -37,4 +37,4 @@ Python HTTP client with async support.
 %{_bindir}/httpx
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-huggingface-hub/python-huggingface-hub.spec
+++ b/SPECS/python-huggingface-hub/python-huggingface-hub.spec
@@ -13,7 +13,7 @@ Summary:        Client library for the Hugging Face Hub
 License:        Apache-2.0
 URL:            https://pypi.org/project/huggingface-hub/
 VCS:            git:https://github.com/huggingface/huggingface_hub
-#!RemoteAsset
+#!RemoteAsset:  sha256:f281838db29265880fb543de7a23b0f81d3504675de82044307ea3c6c62f799d
 Source0:        https://files.pythonhosted.org/packages/source/h/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -44,4 +44,4 @@ sed -i 's/"typer",/"typer-slim",/' setup.py
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-hyperframe/python-hyperframe.spec
+++ b/SPECS/python-hyperframe/python-hyperframe.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        HTTP/2 framing layer for Python
 License:        MIT
 URL:            https://github.com/python-hyper/hyperframe
-#!RemoteAsset
+#!RemoteAsset:  sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08
 Source0:        https://files.pythonhosted.org/packages/source/h/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -37,4 +37,4 @@ that is capable of decoding a binary stream into HTTP/2 frames.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-hypothesis/python-hypothesis.spec
+++ b/SPECS/python-hypothesis/python-hypothesis.spec
@@ -12,31 +12,47 @@ Release:        %autorelease
 Summary:        Library for property based testing
 License:        MPL-2.0
 URL:            https://github.com/HypothesisWorks/hypothesis
-#!RemoteAsset
+#!RemoteAsset:  sha256:0ef1381f893650590f2c5918318d4c8240c79e481bbb621a49acc3dba868d80f
 Source0:        https://files.pythonhosted.org/packages/source/h/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname} '_%{srcname}_*'
+# We don't have python-libcst
+BuildOption(check):  -e hypothesis.extra.codemods
+# We don't have python-dpcontracts
+BuildOption(check):  -e hypothesis.extra.dpcontracts
+# We don't have python-black
+BuildOption(check):  -e hypothesis.extra.ghostwriter
+# We don't have python-lark
+BuildOption(check):  -e hypothesis.extra.lark
+# Test won't run even with django installed, so skip it
+BuildOption(check):  -e hypothesis.extra.django
+BuildOption(check):  -e hypothesis.extra.pandas
+BuildOption(check):  -e 'hypothesis.extra.pandas.*'
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
+# For tests
+BuildRequires:  python3dist(python-dateutil)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(pytz)
+BuildRequires:  python3dist(redis)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
-
-%{pyproject_extras_subpkg -n python%{python3_pkgversion}-hypothesis pytz,dateutil,lark,numpy,pandas,pytest,redis,zoneinfo,cli,ghostwriter,django,codemods}
 
 %description
 Flask-RESTful provides the building blocks for creating a REST API.
 
+%pyproject_extras_subpkg -n python-hypothesis pytz,dateutil,lark,numpy,pandas,pytest,redis,zoneinfo,cli,ghostwriter,django,codemods
+
 %generate_buildrequires
 %pyproject_buildrequires
-
-%check
 
 %files -f %{pyproject_files}
 %{_bindir}/hypothesis
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Key updates are as follows:

- Our virtual `python3-xxx` must provide the complete `%{version}-%{release}`.
- Correct the `#!RemoteAsset` to include the sha256 checksum value.
- Update `%{?autochangelog}` to `%autochangelog`.
