### PR TITLE
SPECS: Fix python spec file formatting - I & J & K part

### DIFF
--- a/SPECS/python-idna/python-idna.spec
+++ b/SPECS/python-idna/python-idna.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Internationalized domain names in applications
 License:        BSD-3-Clause
 URL:            https://github.com/kjd/idna
-#!RemoteAsset
+#!RemoteAsset:  sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9
 Source0:        https://files.pythonhosted.org/packages/source/i/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  -l %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -42,4 +42,4 @@ specification.
 %doc README*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-ijson/python-ijson.spec
+++ b/SPECS/python-ijson/python-ijson.spec
@@ -30,7 +30,7 @@ BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(pip)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -44,4 +44,4 @@ Iterative JSON parser with standard Python iterator interfaces.
 %doc README.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-importlib-metadata/python-importlib-metadata.spec
+++ b/SPECS/python-importlib-metadata/python-importlib-metadata.spec
@@ -15,6 +15,7 @@ License:        Apache-2.0
 URL:            https://github.com/python/importlib_metadata
 #!RemoteAsset:  sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc
 Source:         https://files.pythonhosted.org/packages/source/i/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{pypi_name}
@@ -26,7 +27,7 @@ BuildRequires:  python3dist(coherent-licensed)
 BuildRequires:  python3dist(setuptools-scm[toml])
 BuildRequires:  python3dist(zipp)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description

--- a/SPECS/python-iniconfig/python-iniconfig.spec
+++ b/SPECS/python-iniconfig/python-iniconfig.spec
@@ -30,7 +30,7 @@ BuildRequires:  python3dist(hatchling)
 BuildRequires:  python3dist(packaging)
 BuildRequires:  python3dist(pip)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description

--- a/SPECS/python-iniparse/python-iniparse.spec
+++ b/SPECS/python-iniparse/python-iniparse.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Accessing and Modifying INI files
 License:        MIT
 URL:            https://github.com/candlepin/python-iniparse
-#!RemoteAsset
+#!RemoteAsset:  sha256:932e5239d526e7acb504017bb707be67019ac428a6932368e6851691093aa842
 Source0:        https://files.pythonhosted.org/packages/source/i/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -41,4 +41,4 @@ rm -vfr %{buildroot}%{_docdir}/*
 %doc README.md Changelog
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-installer/python-installer.spec
+++ b/SPECS/python-installer/python-installer.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Installer library for Python wheels
 License:        MIT
 URL:            https://installer.rtfd.io/
-#!RemoteAsset
+#!RemoteAsset:  sha256:a26d3e3116289bb08216e0d0f7d925fcef0b0194eedfa0c944bcaaa106c4b631
 Source0:        https://files.pythonhosted.org/packages/source/i/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -21,9 +21,9 @@ BuildOption(install):  -l %{srcname} +auto
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  pytest
+BuildRequires:  python3dist(pytest)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -42,4 +42,4 @@ abstractions for handling wheels and installing packages from wheels.
 %doc CONTRIBUTING.md README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-interegular/python-interegular.spec
+++ b/SPECS/python-interegular/python-interegular.spec
@@ -22,7 +22,7 @@ BuildOption(install):  -l %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description

--- a/SPECS/python-invoke/python-invoke.spec
+++ b/SPECS/python-invoke/python-invoke.spec
@@ -12,17 +12,19 @@ Release:        %autorelease
 Summary:        Pythonic task execution
 License:        BSD-3-Clause
 URL:            https://www.pyinvoke.org/
-#!RemoteAsset
+#!RemoteAsset:  sha256:515bf49b4a48932b79b024590348da22f39c4942dff991ad1fb8b8baea1be707
 Source0:        https://files.pythonhosted.org/packages/source/i/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname} +auto
+# No modules named 'yaml'
+BuildOption(check):  -e invoke.vendor.yaml.cyaml
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -34,11 +36,8 @@ instead of servers and network commands.
 %generate_buildrequires
 %pyproject_buildrequires
 
-# TODO: Enable tests.
-%check
-
 %files -f %{pyproject_files}
 %doc README*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-ipdb/python-ipdb.spec
+++ b/SPECS/python-ipdb/python-ipdb.spec
@@ -14,6 +14,7 @@ License:        BSD-3-Clause
 URL:            https://github.com/gotcha/ipdb
 #!RemoteAsset:  sha256:e3ac6018ef05126d442af680aad863006ec19d02290561ac88b8b1c0b0cfc726
 Source0:        https://files.pythonhosted.org/packages/source/i/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}
@@ -27,7 +28,7 @@ BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(ipython)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -44,4 +45,4 @@ better introspection with the same interface as the pdb module.
 %{_bindir}/ipdb3
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-ipython-pygments-lexers/python-ipython-pygments-lexers.spec
+++ b/SPECS/python-ipython-pygments-lexers/python-ipython-pygments-lexers.spec
@@ -27,7 +27,7 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -41,4 +41,4 @@ A Pygments plugin for IPython code & console sessions.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-ipython/python-ipython.spec
+++ b/SPECS/python-ipython/python-ipython.spec
@@ -14,6 +14,7 @@ License:        BSD-3-Clause
 URL:            https://ipython.org
 #!RemoteAsset:  sha256:cd9e656be97618a0676d058134cd44e6dc7012c0e5cb36a9ce96a8c904adaf77
 Source0:        https://files.pythonhosted.org/packages/source/i/ipython/ipython-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 # Skip import tests and some other modules that are not needed for the package
@@ -30,7 +31,7 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -47,4 +48,4 @@ IPython provides a rich toolkit to help you make the most out of using Python in
 %{_mandir}/man1/ipython.1.gz
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-iso639/python-iso639.spec
+++ b/SPECS/python-iso639/python-iso639.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        ISO639-2 support for Python.
 License:        MIT
 URL:            https://github.com/janpipek/iso639-python
-#!RemoteAsset
+#!RemoteAsset:  sha256:88b70cf6c64ee9c2c2972292818c8beb32db9ea6f4de1f8471a9b081a3d92e98
 Source0:        https://files.pythonhosted.org/packages/source/i/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -23,7 +23,7 @@ BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(setuptools)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -37,4 +37,4 @@ A simple (really simple) library for working with ISO639-2 language codes.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-isodate/python-isodate.spec
+++ b/SPECS/python-isodate/python-isodate.spec
@@ -28,7 +28,7 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(setuptools-scm)
 BuildRequires:  python3dist(setuptools-scm[toml])
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -44,4 +44,4 @@ representations mentioned in the standard.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-itsdangerous/python-itsdangerous.spec
+++ b/SPECS/python-itsdangerous/python-itsdangerous.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Library for passing trusted data to untrusted environments
 License:        BSD-3-Clause
 URL:            https://github.com/mitsuhiko/itsdangerous
-#!RemoteAsset
+#!RemoteAsset:  sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173
 Source0:        https://files.pythonhosted.org/packages/source/i/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -42,4 +42,4 @@ Signatures (JWS).
 %doc CHANGES.rst README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-jedi/python-jedi.spec
+++ b/SPECS/python-jedi/python-jedi.spec
@@ -27,7 +27,7 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -44,4 +44,4 @@ search and finding references.
 %license LICENSE.txt
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-jieba/python-jieba.spec
+++ b/SPECS/python-jieba/python-jieba.spec
@@ -12,12 +12,12 @@ Release:        %autorelease
 Summary:        Chinese text segmentation
 License:        MIT
 URL:            https://github.com/fxsjy/jieba
-#!RemoteAsset
+#!RemoteAsset:  sha256:055ca12f62674fafed09427f176506079bc135638a14e23e25be909131928db2
 Source0:        https://files.pythonhosted.org/packages/source/j/%{srcname}/%{srcname}-%{version}.tar.gz
 # The tarball from PyPI does not have README.md and LICENSE. So we fetch files from GitHub additionally.
-#!RemoteAsset
+#!RemoteAsset:  sha256:f7e986b6d4d067cd057b0e98a678fed7b4a76f9866571d7d65cfdada8afe4c0c
 Source1:        https://raw.githubusercontent.com/fxsjy/jieba/refs/tags/v%{version}/README.md
-#!RemoteAsset
+#!RemoteAsset:  sha256:18ba0984839f85853b29fadaf992f7dba8fd0ca0fbeae34de2b8735222dc7a37
 Source2:        https://raw.githubusercontent.com/fxsjy/jieba/refs/tags/v%{version}/LICENSE
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -31,11 +31,12 @@ BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(numpy)
 BuildRequires:  python3dist(whoosh)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
-"Jieba" (Chinese for "to stutter") Chinese text segmentation: built to be the best Python Chinese word segmentation module.
+"Jieba" (Chinese for "to stutter") Chinese text segmentation:
+built to be the best Python Chinese word segmentation module.
 
 %generate_buildrequires
 %pyproject_buildrequires
@@ -49,4 +50,4 @@ cp %{SOURCE2} LICENSE
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-jinja2/python-jinja2.spec
+++ b/SPECS/python-jinja2/python-jinja2.spec
@@ -26,7 +26,7 @@ BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(pytest)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -44,8 +44,7 @@ environments.
 %pyproject_buildrequires
 
 %files -f %{pyproject_files}
-%doc README.md
-%doc docs/examples
+%doc README.md docs/examples
 %license LICENSE.txt
 
 %changelog

--- a/SPECS/python-jmespath/python-jmespath.spec
+++ b/SPECS/python-jmespath/python-jmespath.spec
@@ -24,7 +24,7 @@ BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description

--- a/SPECS/python-joblib/python-joblib.spec
+++ b/SPECS/python-joblib/python-joblib.spec
@@ -12,12 +12,16 @@ Release:        %autorelease
 Summary:        Lightweight pipelining: using Python functions as pipeline jobs
 License:        BSD-3-Clause
 URL:            https://github.com/joblib/joblib
-#!RemoteAsset
+#!RemoteAsset:  sha256:3faa5c39054b2f03ca547da9b2f52fde67c06240c31853f306aea97f13647b55
 Source0:        https://files.pythonhosted.org/packages/source/j/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  %{srcname}
+# We don't have python-distributed
+BuildOption(check):  -e joblib.test.test_dask
+# And some windows-only thing
+BuildOption(check):  -e joblib.externals.loky.backend.popen_loky_win32
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
@@ -26,7 +30,7 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(pytest-asyncio)
 BuildRequires:  python3dist(psutil)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -35,7 +39,7 @@ Joblib is a set of tools to provide lightweight pipelining in Python.
 %generate_buildrequires
 %pyproject_buildrequires
 
-%check
+%check -a
 # Always failed tests
 %pytest \
     --deselect "joblib/test/test_memory.py::test_parallel_call_cached_function_defined_in_jupyter" \
@@ -45,4 +49,4 @@ Joblib is a set of tools to provide lightweight pipelining in Python.
 %doc README.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-jsonpatch/python-jsonpatch.spec
+++ b/SPECS/python-jsonpatch/python-jsonpatch.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        JSON Patch implementation in Python
 License:        BSD-3-Clause
 URL:            https://github.com/stefankoegl/python-json-patch
-#!RemoteAsset
+#!RemoteAsset:  sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c
 Source0:        https://files.pythonhosted.org/packages/source/j/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -38,4 +38,4 @@ JSON Patch is a Library to apply JSON Patches according to RFC 6902.
 %{_bindir}/jsonpatch
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-jsonpath-ng/python-jsonpath-ng.spec
+++ b/SPECS/python-jsonpath-ng/python-jsonpath-ng.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Implementation of JSONPath for Python
 License:        Apache-2.0 AND WTFPL
 URL:            https://github.com/h2non/jsonpath-ng
-#!RemoteAsset
+#!RemoteAsset:  sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c
 Source:         https://files.pythonhosted.org/packages/source/j/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -27,7 +27,7 @@ BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(ply)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -43,4 +43,4 @@ original JSONPath proposal.
 %{_bindir}/jsonpath_ng
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-jsonpointer/python-jsonpointer.spec
+++ b/SPECS/python-jsonpointer/python-jsonpointer.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        JSON Pointer implementation in Python
 License:        BSD-3-Clause
 URL:            https://github.com/stefankoegl/python-json-pointer
-#!RemoteAsset
+#!RemoteAsset:  sha256:585cee82b70211fa9e6043b7bb89db6e1aa49524340dde8ad6b63206ea689d88
 Source0:        https://files.pythonhosted.org/packages/source/j/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -37,4 +37,4 @@ JSON Pointer is a Library to resolve JSON Pointers according to RFC 6901.
 %{_bindir}/jsonpointer
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-jsonschema/python-jsonschema.spec
+++ b/SPECS/python-jsonschema/python-jsonschema.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Implementation of JSON Schema validation for Python
 License:        MIT
 URL:            https://github.com/Julian/jsonschema
-#!RemoteAsset
+#!RemoteAsset:  sha256:0f864437ab8b6076ba6707453ef8f98a6a0d512a80e93f8abdb676f737ecb60d
 Source:         https://files.pythonhosted.org/packages/source/j/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -32,8 +32,9 @@ BuildRequires:  python3dist(hatch-fancy-pypi-readme)
 BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(attrs)
 BuildRequires:  python3dist(pyrsistent)
+BuildRequires:  python3dist(hypothesis)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -48,7 +49,7 @@ jsonschema is an implementation of JSON Schema for Python (supporting
 %generate_buildrequires
 %pyproject_buildrequires
 
-%check
+%check -a
 %pytest
 
 %files -f %{pyproject_files}
@@ -57,4 +58,4 @@ jsonschema is an implementation of JSON Schema for Python (supporting
 %{_bindir}/jsonschema
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-kiwisolver/python-kiwisolver.spec
+++ b/SPECS/python-kiwisolver/python-kiwisolver.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        A fast implementation of the Cassowary constraint solver
 License:        BSD-3-Clause AND HPND-sell-variant
 URL:            https://github.com/nucleic/kiwi
-#!RemoteAsset
+#!RemoteAsset:  sha256:c3b22c26c6fd6811b0ae8363b95ca8ce4ea3c202d3d0975b2914310ceb1bcc4d
 Source0:        https://files.pythonhosted.org/packages/source/k/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildSystem:    pyproject
 
@@ -21,7 +21,8 @@ BuildOption(install):  %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -38,4 +39,4 @@ been designed from the ground up to be lightweight and fast.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Key updates are as follows:

- Our virtual `python3-xxx` must provide the complete `%{version}-%{release}`.
- Correct the `#!RemoteAsset` to include the sha256 checksum value.
- Update `%{?autochangelog}` to `%autochangelog`.
