### PR TITLE
SPECS: Fix python spec file formatting - L part

### DIFF
--- a/SPECS/python-langcodes/python-langcodes.spec
+++ b/SPECS/python-langcodes/python-langcodes.spec
@@ -26,7 +26,7 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(pytest)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -45,4 +45,4 @@ won't find in the ISO standard.
 %license LICENSE.txt
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-langtable/python-langtable.spec
+++ b/SPECS/python-langtable/python-langtable.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        guess reasonable defaults for locale, keyboard, territory, ...
 License:        GPL-3.0-or-later
 URL:            https://github.com/mike-fabian/langtable
-#!RemoteAsset
+#!RemoteAsset:  sha256:725b94121856a3b76d2345e8596954b82ed1eda78513e55ac55fbe4a4823e66e
 Source0:        https://files.pythonhosted.org/packages/source/l/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -23,7 +23,7 @@ BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  perl
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -44,4 +44,4 @@ already known.
 %license COPYING unicode-license.txt
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-language-data/python-language-data.spec
+++ b/SPECS/python-language-data/python-language-data.spec
@@ -5,16 +5,15 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %global srcname language_data
-%global pypi_name language_data
 
-Name:           python-%{srcname}
+Name:           python-language-data
 Version:        1.4.0
 Release:        %autorelease
 Summary:        Library for language data
 License:        MIT
 URL:            https://github.com/rspeer/language_data
 #!RemoteAsset:  sha256:800e6457e7beda781c156e02d7707e38db2ded026472e07e2c055dc8446ee574
-Source0:        https://files.pythonhosted.org/packages/source/l/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/source/l/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
 
@@ -28,8 +27,8 @@ BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(marisa-trie)
 
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
+Provides:       python3-language-data = %{version}-%{release}
+%python_provide python3-language-data
 
 %description
 This package provides language data and functions for working with it.
@@ -43,4 +42,4 @@ It is a dependency for other libraries like langcodes.
 %doc README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-libarchive-c/python-libarchive-c.spec
+++ b/SPECS/python-libarchive-c/python-libarchive-c.spec
@@ -6,13 +6,13 @@
 
 %global srcname libarchive_c
 
-Name:           python-%{srcname}
+Name:           python-libarchive-c
 Version:        5.3
 Release:        %autorelease
 Summary:        Python interface to libarchive
 License:        LicenseRef-openRuyi-Public-Domain
 URL:            https://github.com/Changaco/python-libarchive-c
-#!RemoteAsset
+#!RemoteAsset:  sha256:5ddb42f1a245c927e7686545da77159859d5d4c6d00163c59daff4df314dae82
 Source0:        https://files.pythonhosted.org/packages/source/l/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,15 +22,15 @@ BuildOption(install):  -l libarchive +auto
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
+Provides:       python3-libarchive-c = %{version}-%{release}
+%python_provide python3-libarchive-c
 
 Requires:       libarchive
 
 %description
 This package provides Python bindings to libarchive, a C library to
 access possibly compressed archives in many different formats.  It uses
-Python's @code{ctypes} foreign function interface (FFI).
+Python's ctypes foreign function interface (FFI).
 
 %generate_buildrequires
 %pyproject_buildrequires
@@ -39,4 +39,4 @@ Python's @code{ctypes} foreign function interface (FFI).
 %doc README*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-libclang/python-libclang.spec
+++ b/SPECS/python-libclang/python-libclang.spec
@@ -25,7 +25,7 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 Requires:       clang
@@ -41,4 +41,4 @@ This package provides Python bindings for the Clang C library.
 %doc README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-libevdev/python-libevdev.spec
+++ b/SPECS/python-libevdev/python-libevdev.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Python bindings to the libevdev evdev device wrapper library
 License:        MIT
 URL:            https://gitlab.freedesktop.org/libevdev/python-libevdev
-#!RemoteAsset
+#!RemoteAsset:  sha256:dc3369cd1401767b9ecb1117cd6b73faba9038e3bd9e1695a710a9e9d9415e8d
 Source:         https://files.pythonhosted.org/packages/source/l/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -26,7 +26,7 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(hatchling)
 BuildRequires:  pkgconfig(libevdev)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -37,11 +37,11 @@ devices and create uinput devices.
 %generate_buildrequires
 %pyproject_buildrequires
 
-%check
+%check -a
 %pytest -v
 
 %files -f %{pyproject_files}
 %doc README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-libnacl/python-libnacl.spec
+++ b/SPECS/python-libnacl/python-libnacl.spec
@@ -26,7 +26,7 @@ BuildRequires:  pkgconfig(libsodium)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(poetry-core)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description

--- a/SPECS/python-librt/python-librt.spec
+++ b/SPECS/python-librt/python-librt.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Mypyc runtime library
 License:        MIT
 URL:            https://github.com/mypyc/librt
-#!RemoteAsset
+#!RemoteAsset:  sha256:1a4ede613941d9c3470b0368be851df6bb78ab218635512d0370b27a277a0862
 Source0:        https://files.pythonhosted.org/packages/source/l/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildSystem:    pyproject
 
@@ -23,11 +23,14 @@ BuildRequires:  pyproject-rpm-macros
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
-This library contains efficient C implementations of various Python standard library classes and functions. Mypyc can use these fast implementations when compiling Python code to native extension modules.
+This library contains efficient C implementations of various Python
+standard library classes and functions. Mypyc can use these fast
+implementations when compiling Python code to native extension modules.
 
 %generate_buildrequires
 %pyproject_buildrequires
@@ -37,4 +40,4 @@ This library contains efficient C implementations of various Python standard lib
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-license-expression/python-license-expression.spec
+++ b/SPECS/python-license-expression/python-license-expression.spec
@@ -6,8 +6,8 @@
 
 %bcond doc 0
 
-%global pypi_name license_expression
 %global srcname license-expression
+%global pypi_name license_expression
 
 Name:           python-%{srcname}
 Version:        30.4.4
@@ -15,7 +15,7 @@ Release:        %autorelease
 Summary:        Library to parse, compare, simplify and normalize license expressions
 License:        Apache-2.0
 URL:            https://github.com/nexB/license-expression
-#!RemoteAsset
+#!RemoteAsset:  sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd
 Source:         https://files.pythonhosted.org/packages/source/l/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -36,7 +36,7 @@ BuildRequires:  python3dist(sphinxcontrib-apidoc)
 BuildRequires:  python3dist(sphinx-rtd-theme)
 %endif
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -51,7 +51,7 @@ conventions and license identifiers aliases to resolve and normalize licenses.
 Summary:        Documentation for python-license-expression
 License:        Apache-2.0 AND BSD-2-Clause AND MIT
 BuildArch:      noarch
-Requires:       python3-license-expression = %{version}-%{release}
+Requires:       python3dist(license-expression) = %{version}-%{release}
 
 %description    doc
 Documentation for license-expression.
@@ -84,4 +84,4 @@ rm -rf html/.{doctrees,buildinfo}
 %endif
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-linkify-it-py/python-linkify-it-py.spec
+++ b/SPECS/python-linkify-it-py/python-linkify-it-py.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Link recognition library with full Unicode support
 License:        MIT
 URL:            https://github.com/tsutsu3/linkify-it-py
-#!RemoteAsset
+#!RemoteAsset:  sha256:68cda27e162e9215c17d786649d1da0021a451bdc436ef9e0fa0ba5234b9b048
 Source:         https://files.pythonhosted.org/packages/source/l/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -27,7 +27,7 @@ BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(uc-micro-py)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -38,7 +38,7 @@ plain text.
 %generate_buildrequires
 %pyproject_buildrequires
 
-%check
+%check -a
 %pytest -v
 
 %files -f %{pyproject_files}
@@ -46,4 +46,4 @@ plain text.
 %doc CHANGELOG.md README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-linux-procfs/python-linux-procfs.spec
+++ b/SPECS/python-linux-procfs/python-linux-procfs.spec
@@ -21,7 +21,7 @@ BuildOption(install):  -l procfs
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(setuptools)
 
-Provides:       python3-linux-procfs
+Provides:       python3-linux-procfs = %{version}-%{release}
 %python_provide python3-linux-procfs
 
 Requires:       python3dist(six)

--- a/SPECS/python-lm-format-enforcer/python-lm-format-enforcer.spec
+++ b/SPECS/python-lm-format-enforcer/python-lm-format-enforcer.spec
@@ -30,7 +30,7 @@ BuildRequires:  python3dist(pydantic)
 BuildRequires:  python3dist(pyyaml)
 BuildRequires:  python3dist(numpy)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description

--- a/SPECS/python-looseversion/python-looseversion.spec
+++ b/SPECS/python-looseversion/python-looseversion.spec
@@ -26,7 +26,7 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(flit-core)
 BuildRequires:  python3dist(pytest)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -45,4 +45,4 @@ LooseVersion.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Key updates are as follows:

- Our virtual `python3-xxx` must provide the complete `%{version}-%{release}`.
- Correct the `#!RemoteAsset` to include the sha256 checksum value.
- Update `%{?autochangelog}` to `%autochangelog`.

---

Regarding `python-language-data` & `python-libarchive-c`: These packages need to conform to our Python naming convention.