### PR TITLE
SPECS: Fix python spec file formatting - M part

### DIFF
--- a/SPECS/python-mako/python-mako.spec
+++ b/SPECS/python-mako/python-mako.spec
@@ -19,13 +19,19 @@ BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  %{srcname}
+# We don't have python-lingua
+BuildOption(check):  -e mako.ext.linguaplugin
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(markupsafe)
+# For tests
+BuildRequires:  python3dist(babel)
+BuildRequires:  python3dist(pygments)
+BuildRequires:  python3dist(pytest)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 Requires:       python3dist(six)
@@ -51,9 +57,6 @@ sed -i '/tag_build = dev/d' setup.cfg
 mv %{buildroot}/%{_bindir}/mako-render %{buildroot}/%{_bindir}/mako-render-%{python3_version}
 ln -s ./mako-render-%{python3_version} %{buildroot}/%{_bindir}/mako-render-3
 ln -s ./mako-render-%{python3_version} %{buildroot}/%{_bindir}/mako-render
-
-# Skip the import test suite, which requires lingua or something
-%check
 
 %files -f %{pyproject_files}
 %license LICENSE

--- a/SPECS/python-marisa-trie/python-marisa-trie.spec
+++ b/SPECS/python-marisa-trie/python-marisa-trie.spec
@@ -27,7 +27,8 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(cython)
 BuildRequires:  gcc-c++
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -45,4 +46,4 @@ methods like prefix search.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-markdown-it-py/python-markdown-it-py.spec
+++ b/SPECS/python-markdown-it-py/python-markdown-it-py.spec
@@ -4,9 +4,8 @@
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
-%global pypi_name markdown_it_py
-
 %global srcname markdown-it-py
+%global pypi_name markdown_it_py
 
 Name:           python-%{srcname}
 Version:        4.0.0
@@ -14,7 +13,7 @@ Release:        %autorelease
 Summary:        Python port of markdown-it
 License:        MIT
 URL:            https://github.com/executablebooks/markdown-it-py
-#!RemoteAsset
+#!RemoteAsset:  sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3
 Source0:        https://files.pythonhosted.org/packages/source/m/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -27,7 +26,7 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(flit-core)
 BuildRequires:  python3dist(pytest)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -37,13 +36,10 @@ syntax, and is pluggable.
 %generate_buildrequires
 %pyproject_buildrequires
 
-%check
-# No tests here.
-
 %files -f %{pyproject_files}
 %license LICENSE LICENSE.markdown-it
 %doc README.md
 %{_bindir}/markdown-it
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-markdown/python-markdown.spec
+++ b/SPECS/python-markdown/python-markdown.spec
@@ -13,17 +13,18 @@ Release:        %autorelease
 Summary:        Markdown implementation in Python
 License:        BSD-3-Clause
 URL:            https://python-markdown.github.io/
-#!RemoteAsset
+#!RemoteAsset:  sha256:247b9a70dd12e27f67431ce62523e675b866d254f900c4fe75ce3dda62237c45
 Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  %{srcname}
 
+BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(pyyaml)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -48,4 +49,4 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} \
 %{_bindir}/markdown_py
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-markupsafe/python-markupsafe.spec
+++ b/SPECS/python-markupsafe/python-markupsafe.spec
@@ -22,7 +22,8 @@ BuildOption(install):  %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description

--- a/SPECS/python-marshmallow/python-marshmallow.spec
+++ b/SPECS/python-marshmallow/python-marshmallow.spec
@@ -28,7 +28,7 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(ordered-set)
 BuildRequires:  python3dist(simplejson)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -48,4 +48,4 @@ Marshmallow schemas can be used to:
 %doc CHANGELOG.rst README.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-matplotlib-inline/python-matplotlib-inline.spec
+++ b/SPECS/python-matplotlib-inline/python-matplotlib-inline.spec
@@ -27,7 +27,7 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -38,12 +38,12 @@ and related clients, as shown below.
 %generate_buildrequires
 %pyproject_buildrequires
 
+# We don't have python-matplotlib
 %check
-# Skip all tests, as they require matplotlib on runtime
 
 %files -f %{pyproject_files}
 %doc README.md
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-maturin/python-maturin.spec
+++ b/SPECS/python-maturin/python-maturin.spec
@@ -12,9 +12,9 @@ Release:        %autorelease
 Summary:        Build and publish Rust crates as Python packages
 License:        Apache-2.0 OR MIT
 URL:            https://github.com/PyO3/maturin
-#!RemoteAsset
+#!RemoteAsset:  sha256:2c2ae37144811d365509889ed7220b0598487f1278c2441829c3abf56cc6324a
 Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
-#!RemoteAsset
+#!RemoteAsset:  sha256:1f1d31f07dc2715e7d3eef9f2c4875690f5e40d7b8e7de4aff778a759d0b9414
 Source1:        https://github.com/TakoPack/python-%{srcname}-vendor/releases/download/vendor-%{version}/%{srcname}-%{version}-vendor.tar.bz2
 BuildSystem:    pyproject
 
@@ -29,7 +29,8 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  rust
 BuildRequires:  cargo
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -58,4 +59,4 @@ EOF
 %{_bindir}/maturin
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-mccabe/python-mccabe.spec
+++ b/SPECS/python-mccabe/python-mccabe.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        McCabe checker, plugin for flake8
 License:        MIT
 URL:            https://github.com/PyCQA/mccabe
-#!RemoteAsset
+#!RemoteAsset:  sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325
 Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  -l %{srcname} +auto
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -36,4 +36,4 @@ complexity of Python source code.
 %doc README.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-mdurl/python-mdurl.spec
+++ b/SPECS/python-mdurl/python-mdurl.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Markdown URL utilities
 License:        MIT
 URL:            https://github.com/executablebooks/mdurl
-#!RemoteAsset
+#!RemoteAsset:  sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba
 Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -26,7 +26,7 @@ BuildRequires:  python3dist(flit-core)
 BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(pytest-randomly)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -40,4 +40,4 @@ URL utilities for markdown-it parser.
 %doc README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-meh/python-meh.spec
+++ b/SPECS/python-meh/python-meh.spec
@@ -24,7 +24,7 @@ BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(dbus-python)
 
-Provides:       python3-meh
+Provides:       python3-meh = %{version}-%{release}
 %python_provide python3-meh
 
 Requires:       python3dist(dbus-python)

--- a/SPECS/python-meson-python/python-meson-python.spec
+++ b/SPECS/python-meson-python/python-meson-python.spec
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %global srcname meson-python
+%global pypi_name meson_python
 
 Name:           python-%{srcname}
 Version:        0.18.0
@@ -12,8 +13,8 @@ Release:        %autorelease
 License:        MIT
 URL:            https://github.com/mesonbuild/meson-python
 Summary:        Meson-based build backend for Python
-#!RemoteAsset
-Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/meson_python-%{version}.tar.gz
+#!RemoteAsset:  sha256:c56a99ec9df669a40662fe46960321af6e4b14106c14db228709c1628e23848d
+Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{pypi_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
 
@@ -29,7 +30,7 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(pyproject-metadata)
 BuildRequires:  meson
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 Requires:       meson
@@ -45,4 +46,4 @@ Meson-python is a PEP 517 build backend for Meson projects.
 %files -f %{pyproject_files}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-minidump/python-minidump.spec
+++ b/SPECS/python-minidump/python-minidump.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Python library to parse Windows minidump file format
 License:        MIT
 URL:            https://github.com/skelsec/minidump
-#!RemoteAsset
+#!RemoteAsset:  sha256:f7ae09b944f3b17ccf5cecc66f9ff5a7a45b053474a13aeb012f4c9204470437
 Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -23,7 +23,7 @@ BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(setuptools)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -48,4 +48,4 @@ rm -rf minidump/writer.py
 %{_bindir}/minidump
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-mitogen/python-mitogen.spec
+++ b/SPECS/python-mitogen/python-mitogen.spec
@@ -25,7 +25,7 @@ BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(pip)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -48,4 +48,4 @@ remote machine aside from an SSH connection.
 %{python3_sitelib}/ansible_%{srcname}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-ml-dtypes/python-ml-dtypes.spec
+++ b/SPECS/python-ml-dtypes/python-ml-dtypes.spec
@@ -6,13 +6,13 @@
 
 %global srcname ml_dtypes
 
-Name:           python-%{srcname}
+Name:           python-ml-dtypes
 Version:        0.5.4
 Release:        %autorelease
 Summary:        A stand-alone implementation of several NumPy dtype extensions
 License:        Apache-2.0
 URL:            https://github.com/jax-ml/ml_dtypes
-#!RemoteAsset
+#!RemoteAsset:  sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453
 Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildSystem:    pyproject
 
@@ -26,7 +26,8 @@ BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(numpy)
 BuildRequires:  gcc-c++
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -43,4 +44,4 @@ used in machine learning libraries, including:
 %doc README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-mpmath/python-mpmath.spec
+++ b/SPECS/python-mpmath/python-mpmath.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Arbitrary-precision floating-point arithmetic in python
 License:        BSD-3-Clause
 URL:            https://mpmath.org
-#!RemoteAsset
+#!RemoteAsset:  sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f
 Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -21,16 +21,16 @@ BuildOption(install):  -l %{srcname} +auto
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  pytest
+BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(setuptools) >= 40.8
 BuildRequires:  python3dist(packaging)
 BuildRequires:  python3dist(pip)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
-@code{mpmath} can be used as an arbitrary-precision substitute for
+mpmath can be used as an arbitrary-precision substitute for
 Python's float/complex types and math/cmath modules, but also does much
 more advanced mathematics.
 
@@ -41,4 +41,4 @@ more advanced mathematics.
 %doc README.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-msgpack/python-msgpack.spec
+++ b/SPECS/python-msgpack/python-msgpack.spec
@@ -12,8 +12,8 @@ Release:        %autorelease
 Summary:        Python MessagePack (de)serializer
 License:        Apache-2.0
 URL:            https://msgpack.org/
-#!RemoteAsset
-Source0:        https://github.com/msgpack/msgpack-python/archive/v%{version}/%{srcname}-%{version}.tar.gz
+#!RemoteAsset:  sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e
+Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}
@@ -21,9 +21,12 @@ BuildOption(install):  -l %{srcname}
 BuildRequires:  gcc-c++
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3dist(cython)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
 
 %description
 MessagePack is a binary-based efficient data interchange format that is
@@ -37,12 +40,9 @@ rm -rf test/test_timestamp.py
 %generate_buildrequires
 %pyproject_buildrequires
 
-%build -p
-make cython
-
 %files -f %{pyproject_files}
 %doc README.md
 %license COPYING
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-multidict/python-multidict.spec
+++ b/SPECS/python-multidict/python-multidict.spec
@@ -26,7 +26,8 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(psutil)
 BuildRequires:  python3dist(setuptools)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -40,4 +41,4 @@ than once in the container.
 %doc README.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-multiprocess/python-multiprocess.spec
+++ b/SPECS/python-multiprocess/python-multiprocess.spec
@@ -28,7 +28,7 @@ BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(dill) >= 0.4.1
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description

--- a/SPECS/python-munkres/python-munkres.spec
+++ b/SPECS/python-munkres/python-munkres.spec
@@ -26,7 +26,7 @@ BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(pip)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -42,4 +42,4 @@ Assignment Problem.
 %license LICENSE.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-murmurhash/python-murmurhash.spec
+++ b/SPECS/python-murmurhash/python-murmurhash.spec
@@ -27,7 +27,8 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(pip)
 BuildRequires:  gcc-c++
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -41,4 +42,4 @@ Cython bindings for MurmurHash2.
 %doc README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-mypy-extensions/python-mypy-extensions.spec
+++ b/SPECS/python-mypy-extensions/python-mypy-extensions.spec
@@ -4,32 +4,34 @@
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
-%global srcname mypy_extensions
-%global pypi_name mypy-extensions
+%global srcname mypy-extensions
+%global pypi_name mypy_extensions
 
-Name:           python-%{pypi_name}
+Name:           python-%{srcname}
 Version:        1.1.0
 Release:        %autorelease
 Summary:        Type system extensions for programs checked with the mypy type checker
 License:        MIT
 URL:            https://github.com/python/mypy_extensions
-#!RemoteAsset
-Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
+#!RemoteAsset:  sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558
+Source0:        https://files.pythonhosted.org/packages/source/m/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install):  %{srcname}
+BuildOption(install):  %{pypi_name}
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(flit-core)
 BuildRequires:  python3dist(pip)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
-The `mypy_extensions` module defines extensions to the Python standard library `typing` module that are supported by the mypy type checker and the mypyc compiler.
+The `mypy_extensions` module defines extensions to the Python standard
+library `typing` module that are supported by the mypy type checker and
+the mypyc compiler.
 
 %generate_buildrequires
 %pyproject_buildrequires
@@ -39,4 +41,4 @@ The `mypy_extensions` module defines extensions to the Python standard library `
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-mypy/python-mypy.spec
+++ b/SPECS/python-mypy/python-mypy.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Optional static typing for Python
 License:        MIT
 URL:            https://www.mypy-lang.org/
-#!RemoteAsset
+#!RemoteAsset:  sha256:19d88bb05303fe63f71dd2c6270daca27cb9401c4ca8255fe50d1d920e0eb9ba
 Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -32,11 +32,15 @@ BuildRequires:  python3dist(types-psutil)
 BuildRequires:  python3dist(types-setuptools)
 BuildRequires:  python3dist(typing-extensions)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
-Add type annotations to your Python programs, and use mypy to type check them. Mypy is essentially a Python linter on steroids, and it can catch many programming errors by analyzing your program, without actually having to run it. Mypy has a powerful type system with features such as type inference, gradual typing, generics and union types.
+Add type annotations to your Python programs, and use mypy to type check them.
+Mypy is essentially a Python linter on steroids, and it can catch many programming
+errors by analyzing your program, without actually having to run it. Mypy has a
+powerful type system with features such as type inference, gradual typing, generics
+and union types.
 
 %prep -a
 # The test suites have bugs that halt the checking process.
@@ -56,4 +60,4 @@ rm -rf %{_builddir}/python-%{srcname}-%{version}/mypyc/test
 %{_bindir}/stubtest
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Key updates are as follows:

- Our virtual `python3-xxx` must provide the complete `%{version}-%{release}`.
- Correct the `#!RemoteAsset` to include the sha256 checksum value.
- Update `%{?autochangelog}` to `%autochangelog`.
