### PR TITLE
SPECS: Fix python spec file formatting - N part

### DIFF
--- a/SPECS/python-nanobind/python-nanobind.spec
+++ b/SPECS/python-nanobind/python-nanobind.spec
@@ -26,7 +26,7 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  cmake
 BuildRequires:  ninja
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -41,4 +41,4 @@ versa. It is reminiscent of Boost.Python and pybind11.
 %doc README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-narwhals/python-narwhals.spec
+++ b/SPECS/python-narwhals/python-narwhals.spec
@@ -24,6 +24,9 @@ BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(hatchling)
 BuildRequires:  python3dist(pip)
 
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
 %description
 Extremely lightweight and extensible compatibility layer between
 dataframe libraries!
@@ -31,12 +34,9 @@ dataframe libraries!
 %generate_buildrequires
 %pyproject_buildrequires
 
-%check
-# skip tests as there are some deps we don't have yet.
-
 %files -f %{pyproject_files}
 %doc README.md
 %license LICENSE.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-netaddr/python-netaddr.spec
+++ b/SPECS/python-netaddr/python-netaddr.spec
@@ -13,7 +13,7 @@ Release:        %autorelease
 Summary:        A pure Python network address representation and manipulation library
 License:        BSD-3-Clause
 URL:            https://github.com/netaddr/netaddr
-#!RemoteAsset
+#!RemoteAsset:  sha256:5c3c3d9895b551b763779ba7db7a03487dc1f8e3b385af819af341ae9ef6e48a
 Source0:        https://files.pythonhosted.org/packages/source/n/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -29,7 +29,7 @@ BuildRequires:  python3dist(sphinx-issues)
 BuildRequires:  python3dist(furo)
 %endif
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -61,8 +61,8 @@ find netaddr -name "*.py" | xargs sed -i -e '1 {/^#!\//d}'
 %generate_buildrequires
 %pyproject_buildrequires
 
-%build -a
 %if %{with doc}
+%build -a
 #docs
 cd docs
 PYTHONPATH='../' sphinx-build-%{python3_version} -b html -d build/doctrees source python3/html
@@ -70,12 +70,12 @@ rm -f python3/html/.buildinfo
 %endif
 
 %files -f %{pyproject_files}
-%license COPYRIGHT.rst
 %doc AUTHORS.rst CHANGELOG.rst README.rst THANKS.rst
-%if %{with docs}
+%if %{with doc}
 %doc docs/python3/html
 %endif
+%license COPYRIGHT.rst
 %{_bindir}/netaddr
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-networkx/python-networkx.spec
+++ b/SPECS/python-networkx/python-networkx.spec
@@ -20,6 +20,8 @@ BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  %{srcname}
+# We don't have python-pygraphviz, python3dist(pytest_mpl), python-matplotlib, etc...
+BuildOption(check):  -e 'networkx.drawing.tests.*'
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
@@ -28,8 +30,12 @@ BuildRequires:  python3dist(numpy)
 BuildRequires:  python3dist(scipy)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
+# For tests
+BuildRequires:  python3dist(pandas)
+BuildRequires:  python3dist(sympy)
+BuildRequires:  python3dist(pydot)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -38,10 +44,7 @@ NetworkX is a Python package for the creation, manipulation, and study of the st
 %generate_buildrequires
 %pyproject_buildrequires
 
-%check
-# skip tests as some deps we don't have yet.
-
 %files -f %{pyproject_files}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-nibabel/python-nibabel.spec
+++ b/SPECS/python-nibabel/python-nibabel.spec
@@ -26,8 +26,10 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(hatch-vcs)
 BuildRequires:  python3dist(hatchling)
 BuildRequires:  python3dist(numpy)
+# For tests
+BuildRequires:  python3dist(pytest)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -38,9 +40,6 @@ MINC2, MGH and ECAT as well as Philips PAR/REC.
 %generate_buildrequires
 %pyproject_buildrequires
 
-%check
-# skip tests as some deps we don't have yet.
-
 %files -f %{pyproject_files}
 %license COPYING
 %doc README.rst
@@ -48,4 +47,4 @@ MINC2, MGH and ECAT as well as Philips PAR/REC.
 %{_bindir}/nib-*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-nipype/python-nipype.spec
+++ b/SPECS/python-nipype/python-nipype.spec
@@ -20,6 +20,12 @@ BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}
+# We don't have sphinx
+BuildOption(check):  -e nipype.sphinxext.apidoc
+BuildOption(check):  -e 'nipype.sphinxext.apidoc.*'
+BuildOption(check):  -e nipype.sphinxext.documenter
+# Something is wrong with this import
+BuildOption(check):  -e nipype.sphinxext.plot_workflow
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
@@ -42,8 +48,10 @@ BuildRequires:  python3dist(scipy)
 BuildRequires:  python3dist(traits)
 BuildRequires:  python3dist(looseversion)
 BuildRequires:  python3dist(nibabel)
+# For tests
+BuildRequires:  python3dist(pytest)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 Provides:       nipypecli = %{version}-%{release}
 
@@ -55,13 +63,10 @@ within a single workflow.
 %generate_buildrequires
 %pyproject_buildrequires
 
-%check
-# skip tests as some deps we don't have yet. like pandas.
-
 %files -f %{pyproject_files}
 %doc README.rst
 %license LICENSE
 %{_bindir}/nipypecli
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-norpm/python-norpm.spec
+++ b/SPECS/python-norpm/python-norpm.spec
@@ -26,7 +26,7 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(pip) >= 19
 BuildRequires:  python3dist(ply)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -45,4 +45,4 @@ Python library and PLY (used for expression parsing).
 %{_bindir}/norpm-expand-specfile
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-ntplib/python-ntplib.spec
+++ b/SPECS/python-ntplib/python-ntplib.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Python module that offers a simple interface to query NTP servers
 License:        MIT
 URL:            https://github.com/cf-natali/ntplib
-#!RemoteAsset
+#!RemoteAsset:  sha256:899d8fb5f8c2555213aea95efca02934c7343df6ace9d7628a5176b176906267
 Source0:        https://files.pythonhosted.org/packages/source/n/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -38,4 +38,4 @@ modules, it should work on any platform with a Python implementation.
 %doc CHANGELOG
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-numpy/python-numpy.spec
+++ b/SPECS/python-numpy/python-numpy.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        NumPy: array processing for numbers, strings, records, and objects
 License:        BSD-3-Clause
 URL:            https://github.com/numpy/numpy
-#!RemoteAsset
+#!RemoteAsset:  sha256:6e504f7b16118198f138ef31ba24d985b124c2c469fe8467007cf30fd992f934
 Source:         https://files.pythonhosted.org/packages/source/n/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildSystem:    pyproject
 
@@ -32,9 +32,11 @@ BuildRequires:  openblas-devel
 BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(hypothesis)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
-Provides:       python3-%{srcname}-f2py
+Provides:       python3-%{srcname}-f2py = %{version}-%{release}
+Provides:       python3-%{srcname}-f2py%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}-f2py
 
 %description
@@ -49,10 +51,10 @@ It contains among other things:
 %pyproject_buildrequires -R
 
 %files -f %{pyproject_files}
-%license LICENSE.txt
 %doc README.md THANKS.txt
+%license LICENSE.txt
 %{_bindir}/f2py
 %{_bindir}/numpy-config
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Key updates are as follows:

- Our virtual `python3-xxx` must provide the complete `%{version}-%{release}`.
- Correct the `#!RemoteAsset` to include the sha256 checksum value.
- Update `%{?autochangelog}` to `%autochangelog`.
