### PR TITLE
SPECS: Fix python spec file formatting - O part

### DIFF
--- a/SPECS/python-oauthlib/python-oauthlib.spec
+++ b/SPECS/python-oauthlib/python-oauthlib.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        An implementation of the OAuth request-signing logic
 License:        BSD-3-Clause
 URL:            https://github.com/oauthlib/oauthlib
-#!RemoteAsset
+#!RemoteAsset:  sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918
 Source0:        https://files.pythonhosted.org/packages/source/o/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -40,4 +40,4 @@ very little effort.
 %doc README.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-opencc-python-reimplemented/python-opencc-python-reimplemented.spec
+++ b/SPECS/python-opencc-python-reimplemented/python-opencc-python-reimplemented.spec
@@ -4,21 +4,20 @@
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
-%global srcname opencc
-%global packagename opencc-python-reimplemented
+%global srcname opencc-python-reimplemented
 
-Name:           python-opencc-python-reimplemented
+Name:           python-%{srcname}
 Version:        0.1.7
 Release:        %autorelease
 Summary:        OpenCC made with Python
 License:        Apache-2.0
 URL:            https://github.com/yichen0831/opencc-python
 #!RemoteAsset:  sha256:4f777ea3461a25257a7b876112cfa90bb6acabc6dfb843bf4d11266e43579dee
-Source0:        https://files.pythonhosted.org/packages/source/o/%{packagename}/%{packagename}-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/source/o/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install):  -l %{srcname}
+BuildOption(install):  -l opencc
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
@@ -26,7 +25,7 @@ BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(wheel)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -40,4 +39,4 @@ Open Chinese convert (OpenCC) in pure Python
 %license LICENSE.txt
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-opt-einsum/python-opt-einsum.spec
+++ b/SPECS/python-opt-einsum/python-opt-einsum.spec
@@ -4,20 +4,21 @@
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
-%global srcname opt_einsum
+%global srcname opt-einsum
+%global pypi_name opt_einsum
 
-Name:           python-opt-einsum
+Name:           python-%{srcname}
 Version:        3.4.0
 Release:        %autorelease
 Summary:        Path optimization of einsum functions
 License:        MIT
 URL:            https://github.com/dgasmith/opt_einsum
 #!RemoteAsset:  sha256:96ca72f1b886d148241348783498194c577fa30a8faac108586b14f1ba4473ac
-Source0:        https://files.pythonhosted.org/packages/source/o/opt-einsum/%{srcname}-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/source/o/opt-einsum/%{pypi_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install):  -l %{srcname}
+BuildOption(install):  -l %{pypi_name}
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
@@ -30,7 +31,7 @@ BuildRequires:  python3dist(hatchling)
 BuildRequires:  python3dist(hatch-vcs)
 BuildRequires:  python3dist(hatch-fancy-pypi-readme)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -48,4 +49,4 @@ cuBLAS, or other specialized routines.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-ordered-set/python-ordered-set.spec
+++ b/SPECS/python-ordered-set/python-ordered-set.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Custom MutableSet that remembers its order
 License:        MIT
 URL:            https://github.com/rspeer/ordered-set
-#!RemoteAsset
+#!RemoteAsset:  sha256:694a8e44c87657c59292ede72891eb91d34131f6531463aab3009191c77364a8
 Source0:        https://files.pythonhosted.org/packages/source/o/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,11 +22,11 @@ BuildOption(install):  ordered_set
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
-An OrderedSet is a custom MutableSet that remembers its order, so that every\
+An OrderedSet is a custom MutableSet that remembers its order, so that every
 entry has an index that can be looked up.
 
 %generate_buildrequires
@@ -37,4 +37,4 @@ entry has an index that can be looked up.
 %license MIT-LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-orjson/python-orjson.spec
+++ b/SPECS/python-orjson/python-orjson.spec
@@ -28,7 +28,8 @@ BuildRequires:  python3dist(wheel)
 BuildRequires:  cargo
 BuildRequires:  rust
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -45,4 +46,4 @@ datetime, numpy, and UUID instances natively.
 %license LICENSE-APACHE LICENSE-MIT LICENSE-MPL-2.0
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-outcome/python-outcome.spec
+++ b/SPECS/python-outcome/python-outcome.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Capture the outcome of Python function calls
 License:        Apache-2.0 OR MIT
 URL:            https://github.com/python-trio/outcome
-#!RemoteAsset
+#!RemoteAsset:  sha256:9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8
 Source0:        https://files.pythonhosted.org/packages/source/o/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -36,4 +36,4 @@ function call, so that it can be passed around.
 %doc README.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Key updates are as follows:

- Our virtual `python3-xxx` must provide the complete `%{version}-%{release}`.
- Correct the `#!RemoteAsset` to include the sha256 checksum value.
- Update `%{?autochangelog}` to `%autochangelog`.
