### PR TITLE
SPECS: python- pysocks: Fix python spec file formatting.

### DIFF
--- a/SPECS/python-PySocks/python-PySocks.spec
+++ b/SPECS/python-PySocks/python-PySocks.spec
@@ -6,13 +6,13 @@
 
 %global srcname PySocks
 
-Name:           python-pysocks
+Name:           python-%{srcname}
 Version:        1.7.1
 Release:        %autorelease
 Summary:        A Python SOCKS client module
 License:        BSD-3-Clause
 URL:            https://github.com/Anorov/PySocks
-#!RemoteAsset
+#!RemoteAsset:  sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,8 +22,8 @@ BuildOption(install):  -l socks sockshandler
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-pysocks
-%python_provide python3-pysocks
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
 
 %description
 A fork of SocksiPy with bug fixes and extra features. Acts as a
@@ -37,4 +37,4 @@ drop-in replacement to the socket module.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-pysocks/python-pysocks.spec
+++ b/SPECS/python-pysocks/python-pysocks.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        A Python SOCKS client module
 License:        BSD-3-Clause
 URL:            https://github.com/Anorov/PySocks
-#!RemoteAsset
+#!RemoteAsset:  sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  -l socks sockshandler
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-pysocks
+Provides:       python3-pysocks = %{version}-%{release}
 %python_provide python3-pysocks
 
 %description
@@ -37,4 +37,4 @@ drop-in replacement to the socket module.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
This PR fixes the virtual provides issue, and updates the `#!RemoteAsset` value and changes `%{?autochangelog}` to `%autochangelog`.
