### PR TITLE
SPECS: Fix python spec file formatting - Q & R

### DIFF
--- a/SPECS/python-qemu-qmp/python-qemu-qmp.spec
+++ b/SPECS/python-qemu-qmp/python-qemu-qmp.spec
@@ -71,8 +71,8 @@ install -Dpm 0644 man/*.1 -t %{buildroot}%{_mandir}/man1/
 %endif
 
 %files -f %{pyproject_files}
-%license LICENSE LICENSE_GPL2
 %doc README.rst
+%license LICENSE LICENSE_GPL2
 %{_bindir}/qmp-shell
 %{_bindir}/qmp-shell-wrap
 %if %{with doc}
@@ -82,8 +82,8 @@ install -Dpm 0644 man/*.1 -t %{buildroot}%{_mandir}/man1/
 
 %if %{with doc}
 %files doc
-%license LICENSE LICENSE_GPL2
 %doc html
+%license LICENSE LICENSE_GPL2
 %endif
 
 %changelog

--- a/SPECS/python-rdflib/python-rdflib.spec
+++ b/SPECS/python-rdflib/python-rdflib.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Python library for working with RDF
 License:        BSD-3-Clause
 URL:            https://github.com/RDFLib/rdflib
-#!RemoteAsset
+#!RemoteAsset:  sha256:663083443908b1830e567350d72e74d9948b310f827966358d76eebdc92bf592
 Source:         https://files.pythonhosted.org/packages/source/r/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -21,6 +21,9 @@ BuildSystem:    pyproject
 Patch0:         0001-Fix-py3.14-test-failure-due-to-NotImplemented-change.patch
 
 BuildOption(install):  %{srcname}
+# If we add python3dist(httpx) here, then the tests will fail.
+BuildOption(check):  -e rdflib.contrib.graphdb.client
+BuildOption(check):  -e rdflib.contrib.rdf4j.client
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python)
@@ -28,7 +31,7 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(poetry-core)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -43,14 +46,14 @@ Queries and Update statements - and SPARQL function extension mechanisms.
 %generate_buildrequires
 %pyproject_buildrequires
 
-%check
+%check -a
 %pytest -k "not test_sparqleval and not test_parser"\
         -m "not webtest"
 
 %files -f %{pyproject_files}
-%license LICENSE
 %doc README.md
+%license LICENSE
 %{_bindir}/*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-redis/python-redis.spec
+++ b/SPECS/python-redis/python-redis.spec
@@ -28,7 +28,7 @@ BuildRequires:  python3dist(hatchling)
 BuildRequires:  python3dist(cryptography)
 BuildRequires:  python3dist(requests)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -38,8 +38,8 @@ The Python interface to the Redis key-value store.
 %pyproject_buildrequires
 
 %files -f %{pyproject_files}
-%license LICENSE
 %doc README.md
+%license LICENSE
 
 %changelog
 %autochangelog

--- a/SPECS/python-regex/python-regex.spec
+++ b/SPECS/python-regex/python-regex.spec
@@ -23,7 +23,8 @@ BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -44,4 +45,4 @@ An alternate regex implementation. It differs from "re" in that
 %files -f %{pyproject_files}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-requests-file/python-requests-file.spec
+++ b/SPECS/python-requests-file/python-requests-file.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Transport adapter for using file:// URLs with python-requests
 License:        Apache-2.0
 URL:            https://codeberg.org/dashea/requests-file
-#!RemoteAsset
+#!RemoteAsset:  sha256:f14243d7796c588f3521bd423c5dea2ee4cc730e54a3cac9574d78aca1272576
 Source0:        https://files.pythonhosted.org/packages/source/r/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python)
 
-Provides:       python3-requests-file
+Provides:       python3-requests-file = %{version}-%{release}
 %python_provide python3-requests-file
 
 %description
@@ -37,4 +37,4 @@ library to allow local file system access via file:// URLs.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-requests-ftp/python-requests-ftp.spec
+++ b/SPECS/python-requests-ftp/python-requests-ftp.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        FTP transport adapter for python-requests
 License:        Apache-2.0
 URL:            https://github.com/Lukasa/requests-ftp
-#!RemoteAsset
+#!RemoteAsset:  sha256:7504ceb5cba8a5c0135ed738596820a78c5f2be92d79b29f96ba99b183d8057a
 Source0:        https://files.pythonhosted.org/packages/source/r/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  requests_ftp
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -40,4 +40,4 @@ use with the awesome Requests Python library.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-requests/python-requests.spec
+++ b/SPECS/python-requests/python-requests.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Python HTTP library
 License:        Apache-2.0
 URL:            https://requests.readthedocs.io/
-#!RemoteAsset
+#!RemoteAsset:  sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf
 Source0:        https://files.pythonhosted.org/packages/source/r/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,8 +22,9 @@ BuildOption(install):  -l %{srcname} +auto
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
+
 %description
 Requests is a Python HTTP client library.  It aims to be easier to use
 than Python’s urllib2 library.
@@ -35,4 +36,4 @@ than Python’s urllib2 library.
 %doc README*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-resolvelib/python-resolvelib.spec
+++ b/SPECS/python-resolvelib/python-resolvelib.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Abstract dependencies resolver
 License:        ISC
 URL:            https://github.com/sarugaku/resolvelib
-#!RemoteAsset
+#!RemoteAsset:  sha256:b68591ef748f58c1e2a2ac28d0961b3586ae8b25f60b0ba9a5e4f3d87c1d6a79
 Source0:        https://files.pythonhosted.org/packages/source/r/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,11 +22,11 @@ BuildOption(install):  -l %{srcname} +auto
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
-The ResolveLib library provides a @code{Resolver} class that includes
+The ResolveLib library provides a Resolver class that includes
 dependency resolution logic.
 
 %generate_buildrequires
@@ -36,4 +36,4 @@ dependency resolution logic.
 %doc README*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-responses/python-responses.spec
+++ b/SPECS/python-responses/python-responses.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Python library to mock out calls with Python requests
 License:        Apache-2.0
 URL:            https://github.com/getsentry/responses
-#!RemoteAsset
+#!RemoteAsset:  sha256:9374d047a575c8f781b94454db5cab590b6029505f488d12899ddb10a4af1cf4
 Source:         https://files.pythonhosted.org/packages/source/r/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -30,7 +30,7 @@ BuildRequires:  python3dist(pytest-asyncio)
 BuildRequires:  python3dist(requests)
 BuildRequires:  python3dist(pyyaml)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -40,8 +40,8 @@ A utility library for mocking out the requests Python library.
 %pyproject_buildrequires
 
 %files -f %{pyproject_files}
-%license LICENSE
 %doc README.rst
+%license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-reuse/python-reuse.spec
+++ b/SPECS/python-reuse/python-reuse.spec
@@ -32,7 +32,7 @@ BuildRequires:  python3dist(python-debian)
 BuildRequires:  python3dist(click)
 BuildRequires:  python3dist(pytest)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -44,9 +44,9 @@ generates a project's bill of materials.
 %pyproject_buildrequires
 
 %files -f %{pyproject_files}
-%license LICENSES/*.txt
 %doc README.md CHANGELOG.md
+%license LICENSES/*.txt
 %{_bindir}/reuse
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-rfc3986/python-rfc3986.spec
+++ b/SPECS/python-rfc3986/python-rfc3986.spec
@@ -32,8 +32,8 @@ A Python implementation of RFC 3986 including validation and authority parsing.
 %pyproject_buildrequires
 
 %files -f %{pyproject_files}
-%license LICENSE
 %doc README.rst
+%license LICENSE
 
 %changelog
 %autochangelog

--- a/SPECS/python-rich/python-rich.spec
+++ b/SPECS/python-rich/python-rich.spec
@@ -14,7 +14,7 @@ Release:        %autorelease
 Summary:        Render rich text and beautiful formatting in the terminal
 License:        MIT
 URL:            https://github.com/Textualize/rich
-#!RemoteAsset
+#!RemoteAsset:  sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4
 Source0:        https://files.pythonhosted.org/packages/source/r/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -30,7 +30,7 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(attrs)
 %endif
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -40,14 +40,14 @@ The Rich API makes it easy to add color and style to terminal output.
 %generate_buildrequires
 %pyproject_buildrequires
 
-%check
 %if %{with tests}
+%check -a
 %pytest -vv
 %endif
 
 %files -f %{pyproject_files}
-%license LICENSE
 %doc README.md
+%license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-rpm-generators/python-rpm-generators.spec
+++ b/SPECS/python-rpm-generators/python-rpm-generators.spec
@@ -25,7 +25,7 @@ BuildArch:      noarch
 
 %package     -n python3-rpm-generators
 Summary:        %{summary}
-Requires:       python3-packaging
+Requires:       python3dist(packaging)
 Requires:       rpm
 Requires:       python-srpm-macros
 
@@ -49,4 +49,4 @@ install -Dpm0755 -t %{buildroot}%{_rpmconfigdir} *.py
 %{_rpmconfigdir}/pythonbundles.py
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-rpmautospec-core/python-rpmautospec-core.spec
+++ b/SPECS/python-rpmautospec-core/python-rpmautospec-core.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Minimum functionality for rpmautospec
 License:        MIT
 URL:            https://github.com/fedora-infra/rpmautospec-core
-#!RemoteAsset
+#!RemoteAsset:  sha256:c0acf19ed013355d02c1e28220ad9d6f9088f7f61b4a29d16d5364298bc6e6f3
 Source0:        https://files.pythonhosted.org/packages/source/r/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-rpmautospec-core
+Provides:       python3-rpmautospec-core = %{version}-%{release}
 %python_provide python3-rpmautospec-core
 
 %description
@@ -40,4 +40,4 @@ sed -i -e 's|^\(.*/LICENSE\)|%%license \1|g' %{pyproject_files}
 %doc README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-rpmautospec/python-rpmautospec.spec
+++ b/SPECS/python-rpmautospec/python-rpmautospec.spec
@@ -17,7 +17,7 @@ Release:        %autorelease
 Summary:        Package and CLI tool to generate release fields and changelogs
 License:        MIT AND GPL-2.0-only WITH GCC-exception-2.0 AND (MIT OR GPL-2.0-or-later WITH GCC-exception-2.0)
 URL:            https://github.com/fedora-infra/rpmautospec
-#!RemoteAsset
+#!RemoteAsset:  sha256:66fa5540871c1140ed051c89b0624f14eaf59609452448360fa58cd7211e7a41
 Source0:        https://files.pythonhosted.org/packages/source/r/%{srcname}/%{srcname}-%{version}.tar.gz
 Source1:        rpmautospec.in
 BuildArch:      noarch
@@ -37,7 +37,7 @@ BuildRequires:  bash-completion
 Requires:       rpm-build
 Requires:       python-click
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -124,4 +124,4 @@ touch -r %{S:1} %{buildroot}%{_bindir}/rpmautospec
 %{_rpmmacrodir}/macros.rpmautospec
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-rtslib-fb/python-rtslib-fb.spec
+++ b/SPECS/python-rtslib-fb/python-rtslib-fb.spec
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %global srcname rtslib-fb
+%global pypi_name rtslib_fb
 
 Name:           python-%{srcname}
 Version:        2.2.3
@@ -12,9 +13,8 @@ Release:        %autorelease
 Summary:        API for Linux kernel LIO SCSI target
 License:        Apache-2.0
 URL:            https://github.com/open-iscsi/rtslib-fb
-# This is a mess - 251
-#!RemoteAsset
-Source0:        https://files.pythonhosted.org/packages/source/r/rtslib_fb/rtslib_fb-%{version}.tar.gz
+#!RemoteAsset:  sha256:c1053889b572fde4c0a9b468b508e4e838781364a60f4746e9c5f92aef459de6
+Source0:        https://files.pythonhosted.org/packages/source/r/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
 
@@ -24,7 +24,7 @@ BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  pkgconfig(systemd)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -56,4 +56,4 @@ install -m 644 systemd/target.service %{buildroot}%{_unitdir}/target.service
 %{_unitdir}/target.service
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-ruamel-yaml-clib/python-ruamel-yaml-clib.spec
+++ b/SPECS/python-ruamel-yaml-clib/python-ruamel-yaml-clib.spec
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %global srcname ruamel.yaml.clib
+%global pypi_name ruamel_yaml_clib
 
 Name:           python-ruamel-yaml-clib
 Version:        0.2.15
@@ -12,9 +13,9 @@ Release:        %autorelease
 Summary:        C version of reader, parser and emitter for ruamel.yaml derived from libyaml
 License:        MIT
 URL:            https://sourceforge.net/projects/ruamel-yaml-clib/
-#Source0:        https://files.pythonhosted.org/packages/source/r/%%{srcname}/%%{srcname}-%{version}.tar.gz
-#!RemoteAsset
-Source0:        https://yaml.dev/ruamel-dl-tagged-releases/%{srcname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:46e4cc8c43ef6a94885f72512094e482114a8a706d3c555a34ed4b0d20200600
+Source0:        https://files.pythonhosted.org/packages/source/r/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+#Source0:        https://yaml.dev/ruamel-dl-tagged-releases/%{srcname}-%{version}.tar.xz
 BuildSystem:    pyproject
 
 BuildOption(install):  -l _ruamel_yaml
@@ -26,7 +27,8 @@ BuildRequires:  python3dist(cython)
 # For %check
 BuildRequires:  python3dist(ruamel-yaml)
 
-Provides:       python3-ruamel-yaml-clib
+Provides:       python3-ruamel-yaml-clib = %{version}-%{release}
+Provides:       python3-ruamel-yaml-clib%{?_isa} = %{version}-%{release}
 %python_provide python3-ruamel-yaml-clib
 
 Requires:       python3dist(ruamel-yaml)
@@ -60,4 +62,4 @@ rmdir ruamel.yaml.clib
 %doc README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-ruamel-yaml/python-ruamel-yaml.spec
+++ b/SPECS/python-ruamel-yaml/python-ruamel-yaml.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        YAML 1.2 loader/dumper package for Python
 License:        MIT
 URL:            https://sourceforge.net/projects/ruamel-yaml/
-#!RemoteAsset
+#!RemoteAsset:  sha256:a6e587512f3c998b2225d68aa1f35111c29fad14aed561a26e73fab729ec5e5a
 Source0:        https://files.pythonhosted.org/packages/source/r/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  -l ruamel
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-ruamel-yaml
+Provides:       python3-ruamel-yaml = %{version}-%{release}
 %python_provide python3-ruamel-yaml
 
 %description
@@ -36,4 +36,4 @@ comments, seq/map flow style, and map key order.
 %doc README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Key updates are as follows:

- Our virtual `python3-xxx` must provide the complete `%{version}-%{release}`.
- Correct the `#!RemoteAsset` to include the sha256 checksum value.
- Update `%{?autochangelog}` to `%autochangelog`.
