### PR TITLE
SPECS: python-python-utils: Rename package & Fix python spec file formatting.

### DIFF
--- a/SPECS/python-python-utils/python-python-utils.spec
+++ b/SPECS/python-python-utils/python-python-utils.spec
@@ -5,20 +5,23 @@
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
-%global srcname python_utils
+%global srcname python-utils
+%global pypi_name python_utils
 
-Name:           python-utils
+Name:           python-%{srcname}
 Version:        3.9.1
 Release:        %autorelease
 Summary:        Library to provide visual progress to long running operations
 License:        BSD-3-Clause
 URL:            https://github.com/WoLpH/python-utils
-#!RemoteAsset
-Source0:        https://files.pythonhosted.org/packages/source/p/%{name}/%{srcname}-%{version}.tar.gz
+#!RemoteAsset:  sha256:eb574b4292415eb230f094cbf50ab5ef36e3579b8f09e9f2ba74af70891449a0
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{pypi_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install):  -l %{srcname}
+BuildOption(install):  -l %{pypi_name}
+# No module named 'loguru'
+BuildOption(check):  -e python_utils.loguru
 
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(pip)
@@ -29,8 +32,8 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(pytest-asyncio)
 BuildRequires:  python3dist(typing-extensions)
 
-Provides:       python3-utils
-%python_provide python3-utils
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
 
 %description
 Python Utils is a collection of small Python functions and classes which
@@ -41,7 +44,7 @@ and making sure a string is in unicode or bytes format.
 %generate_buildrequires
 %pyproject_buildrequires -r
 
-%check
+%check -a
 # Ignoring test_logger.py and python_utils/loguru.py - we don't have loguru
 # and we don't have python3-pytest-cov yet.
 %pytest -o "addopts=" --ignore _python_utils_tests/test_logger.py --ignore python_utils/loguru.py
@@ -50,4 +53,4 @@ and making sure a string is in unicode or bytes format.
 %doc README.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
This PR changes `python-utils` to `python-python-utils`. Also fixes virtual provides issue, and updated `#!RemoteAsset` value and changes `%{?autochangelog}` to `%autochangelog`.
