### PR TITLE
SPECS: Fix python spec file formatting - U

### DIFF
--- a/SPECS/python-uc-micro-py/python-uc-micro-py.spec
+++ b/SPECS/python-uc-micro-py/python-uc-micro-py.spec
@@ -4,8 +4,6 @@
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
-%global pypi_name uc_micro
-
 %global srcname uc-micro-py
 
 Name:           python-%{srcname}
@@ -14,12 +12,12 @@ Release:        %autorelease
 Summary:        Micro subset of Unicode data files for linkify-it.py
 License:        MIT
 URL:            https://github.com/tsutsu3/uc.micro-py
-#!RemoteAsset
+#!RemoteAsset:  sha256:d321b92cff673ec58027c04015fcaa8bb1e005478643ff4a500882eaab88c48a
 Source0:        https://files.pythonhosted.org/packages/source/u/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install):  -l %{pypi_name}
+BuildOption(install):  -l uc_micro
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
@@ -28,7 +26,7 @@ BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(pytest)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -38,11 +36,11 @@ Python port of uc.micro (JavaScript).
 %generate_buildrequires
 %pyproject_buildrequires
 
-%check
+%check -a
 %pytest -v
 
 %files -f %{pyproject_files}
 %doc CHANGELOG.md README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-uritemplate/python-uritemplate.spec
+++ b/SPECS/python-uritemplate/python-uritemplate.spec
@@ -32,8 +32,8 @@ Simple python library to deal with URI Templates.
 %pyproject_buildrequires
 
 %files -f %{pyproject_files}
-%license LICENSE
 %doc README.rst
+%license LICENSE
 
 %changelog
 %autochangelog

--- a/SPECS/python-urlgrabber/python-urlgrabber.spec
+++ b/SPECS/python-urlgrabber/python-urlgrabber.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        A high-level cross-protocol url-grabber
 License:        LGPL-2.0-or-later
 URL:            https://github.com/rpm-software-management/urlgrabber
-#!RemoteAsset
+#!RemoteAsset:  sha256:075af8afabae6362482d254e5ac3ffa595d1766117b684e53d9c25c2e937e139
 Source0:        https://files.pythonhosted.org/packages/source/u/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -37,11 +37,11 @@ authentication, proxies and more.
 rm -rf %{buildroot}%{_docdir}/urlgrabber-%{version}
 
 %files -f %{pyproject_files}
-%license LICENSE
 %doc ChangeLog README TODO
+%license LICENSE
 # Extra stuff
 %{_bindir}/urlgrabber
 %{_libexecdir}/urlgrabber-ext-down
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-urllib3/python-urllib3.spec
+++ b/SPECS/python-urllib3/python-urllib3.spec
@@ -12,18 +12,26 @@ Release:        %autorelease
 Summary:        HTTP library with thread-safe connection pooling
 License:        MIT
 URL:            https://urllib3.readthedocs.io/
-#!RemoteAsset
+#!RemoteAsset:  sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760
 Source0:        https://files.pythonhosted.org/packages/source/u/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname} +auto
+# No module named 'js'
+BuildOption(check):  -e urllib3.contrib.emscripten
+BuildOption(check):  -e 'urllib3.contrib.emscripten.*'
+# No module named 'socks'
+BuildOption(check):  -e urllib3.contrib.socks
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  pytest
+BuildRequires:  python3dist(pytest)
+# For tests
+BuildRequires:  python3dist(pyopenssl)
+BuildRequires:  python3dist(h2)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -34,13 +42,8 @@ supports url redirection and retries, and also gzip and deflate decoding.
 %generate_buildrequires
 %pyproject_buildrequires
 
-# TODO: Add tests requires.
-%check
-
-
-
 %files -f %{pyproject_files}
 %doc README*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-uvloop/python-uvloop.spec
+++ b/SPECS/python-uvloop/python-uvloop.spec
@@ -25,6 +25,7 @@ BuildRequires:  python3dist(cython)
 BuildRequires:  python3dist(setuptools)
 
 Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -35,8 +36,8 @@ uvloop is implemented in Cython and uses libuv under the hood.
 %pyproject_buildrequires
 
 %files -f %{pyproject_files}
-%license LICENSE-APACHE LICENSE-MIT
 %doc README.rst
+%license LICENSE-APACHE LICENSE-MIT
 
 %changelog
 %autochangelog


### PR DESCRIPTION
Key updates are as follows:

- Our virtual `python3-xxx` must provide the complete `%{version}-%{release}`.
- Correct the `#!RemoteAsset` to include the sha256 checksum value.
- Update `%{?autochangelog}` to `%autochangelog`.
