### PR TITLE
SPECS: Fix python spec file formatting - S

### DIFF
--- a/SPECS/python-s3transfer/python-s3transfer.spec
+++ b/SPECS/python-s3transfer/python-s3transfer.spec
@@ -26,7 +26,7 @@ BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(botocore)
 BuildRequires:  python3dist(awscrt)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -36,8 +36,8 @@ S3transfer is a Python library for managing Amazon S3 transfers.
 %pyproject_buildrequires
 
 %files -f %{pyproject_files}
-%license LICENSE.txt
 %doc README.rst
+%license LICENSE.txt
 
 %changelog
 %autochangelog

--- a/SPECS/python-safetensors/python-safetensors.spec
+++ b/SPECS/python-safetensors/python-safetensors.spec
@@ -15,7 +15,7 @@ URL:            https://github.com/huggingface/safetensors
 #!RemoteAsset:  sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0
 Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
 # TODO: use system crates in the future
-#!RemoteAsset
+#!RemoteAsset:  sha256:710d5402bab8653296ad7bd1fe1c4fdb9cb69f85c2449ceb5209981c999276cb
 Source1:        https://github.com/software-vendor/python-%{srcname}-vendor/releases/download/vendor-%{version}/safetensors-%{version}-vendor.tar.bz2
 BuildSystem:    pyproject
 
@@ -33,7 +33,8 @@ BuildRequires:  python3dist(maturin)
 BuildRequires:  python3dist(numpy)
 BuildRequires:  rust
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -58,4 +59,4 @@ EOF
 %license safetensors/LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-schedutils/python-schedutils.spec
+++ b/SPECS/python-schedutils/python-schedutils.spec
@@ -21,11 +21,12 @@ BuildOption(install):  %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
-Python interface for the Linux scheduler sched_{get,set}{affinity,scheduler}\
+Python interface for the Linux scheduler sched_{get,set}{affinity,scheduler}
 functions and friends.
 
 %generate_buildrequires

--- a/SPECS/python-scikit-build-core/python-scikit-build-core.spec
+++ b/SPECS/python-scikit-build-core/python-scikit-build-core.spec
@@ -15,7 +15,7 @@ Release:        %autorelease
 Summary:        Build backend for CMake based projects
 License:        Apache-2.0 AND MIT
 URL:            https://github.com/scikit-build/scikit-build-core
-#!RemoteAsset
+#!RemoteAsset:  sha256:5982ccd839735be99cfd3b92a8847c6c196692f476c215da84b79d2ad12f9f1b
 Source:         https://files.pythonhosted.org/packages/source/s/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -31,15 +31,13 @@ BuildRequires:  python3dist(hatch-vcs)
 BuildRequires:  cmake
 BuildRequires:  ninja
 BuildRequires:  gcc-c++
-%if %{with test}
-# for tests.
+# For tests
 BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(virtualenv)
 BuildRequires:  python3dist(numpy)
 BuildRequires:  python3dist(pybind11)
-%endif
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -51,15 +49,14 @@ cp -p src/scikit_build_core/_vendor/pyproject_metadata/LICENSE LICENSE-pyproject
 %generate_buildrequires
 %pyproject_buildrequires
 
-%check
 %if %{with test}
-%pyproject_check_import
+%check -a
 %pytest -m "not network"
 %endif
 
 %files -f %{pyproject_files}
-%license LICENSE LICENSE-pyproject-metadata
 %doc README.md
+%license LICENSE LICENSE-pyproject-metadata
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-scikit-learn/python-scikit-learn.spec
+++ b/SPECS/python-scikit-learn/python-scikit-learn.spec
@@ -37,6 +37,7 @@ Requires:       python3dist(joblib)
 Requires:       python3dist(threadpoolctl)
 
 Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -56,8 +57,8 @@ sed -i 's/"scipy>=1.10.0,<1.17.0"/"scipy>=1.10.0"/' pyproject.toml
 %pyproject_buildrequires -p
 
 %files -f %{pyproject_files}
-%license COPYING
 %doc README.rst
+%license COPYING
 
 %changelog
 %autochangelog

--- a/SPECS/python-scipy/python-scipy.spec
+++ b/SPECS/python-scipy/python-scipy.spec
@@ -22,6 +22,16 @@ BuildSystem:    pyproject
 BuildOption(build):  -Csetup-args=-Dblas=openblas64
 BuildOption(build):  -Csetup-args=-Dlapack=openblas64
 BuildOption(install):  -l %{srcname} -L
+# We don't have python3dist(pooch)
+BuildOption(check):  -e scipy.datasets.tests.test_data
+# We have python3dist(hypothesis), but will it cause circular dependencies?
+BuildOption(check):  -e scipy.integrate.tests.test_quadrature
+BuildOption(check):  -e scipy.ndimage.tests.test_filters
+BuildOption(check):  -e scipy.special.tests.test_support_alternative_backends
+BuildOption(check):  -e scipy.stats.tests.test_continuous
+BuildOption(check):  -e scipy.stats.tests.test_stats
+# No module named 'marray'
+BuildOption(check):  -e scipy.stats.tests.test_marray
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
@@ -33,8 +43,11 @@ BuildRequires:  python3dist(pybind11)
 BuildRequires:  python3dist(pythran)
 BuildRequires:  python3dist(pip)
 BuildRequires:  pkgconfig(openblas64)
+# For tests
+BuildRequires:  python3dist(pytest)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -46,10 +59,7 @@ Data validation using Python type hints.
 %build -p
 export FC=gfortran
 
-%check
-# skip tests as some deps we don't have yet.
-
 %files -f %{pyproject_files}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-semantic-version/python-semantic-version.spec
+++ b/SPECS/python-semantic-version/python-semantic-version.spec
@@ -13,7 +13,7 @@ Release:        %autorelease
 Summary:        Library implementing the 'SemVer' scheme
 License:        BSD-2-Clause
 URL:            https://github.com/rbarrois/python-semanticversion
-#!RemoteAsset
+#!RemoteAsset:  sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c
 Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -28,10 +28,7 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 
-# We provide these for compatibility
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
-Provides:       python3-semantic-version
+Provides:       python3-semantic-version = %{version}-%{release}
 %python_provide python3-semantic-version
 
 %description
@@ -42,4 +39,4 @@ Python.
 %doc README.rst ChangeLog CREDITS
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-semver/python-semver.spec
+++ b/SPECS/python-semver/python-semver.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Python helper for Semantic Versioning
 License:        BSD-3-Clause
 URL:            https://github.com/python-semver/python-semver
-#!RemoteAsset
+#!RemoteAsset:  sha256:afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602
 Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -29,7 +29,7 @@ BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(pytest)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -38,13 +38,13 @@ A Python module for semantic versioning. Simplifies comparing versions.
 %generate_buildrequires
 %pyproject_buildrequires
 
-%check
+%check -a
 %pytest
 
 %files -f %{pyproject_files}
-%license LICENSE.txt
 %doc README.rst CHANGELOG.rst
+%license LICENSE.txt
 %{_bindir}/pysemver
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-service-identity/python-service-identity.spec
+++ b/SPECS/python-service-identity/python-service-identity.spec
@@ -22,7 +22,7 @@ BuildOption(install):  -l %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-service-identity
+Provides:       python3-service-identity = %{version}-%{release}
 %python_provide python3-service-identity
 
 %description

--- a/SPECS/python-service-identity/python-service-identity.spec
+++ b/SPECS/python-service-identity/python-service-identity.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Service identity verification for pyOpenSSL
 License:        MIT
 URL:            https://github.com/pyca/service-identity
-#!RemoteAsset
+#!RemoteAsset:  sha256:b8683ba13f0d39c6cd5d625d2c5f65421d6d707b013b375c355751557cbe8e09
 Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -40,4 +40,4 @@ relevant RFCs too.
 %doc README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-setproctitle/python-setproctitle.spec
+++ b/SPECS/python-setproctitle/python-setproctitle.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Python module to customize a process title
 License:        BSD-3-Clause
 URL:            http://pypi.python.org/pypi/setproctitle
-#!RemoteAsset
+#!RemoteAsset:  sha256:6283b7a58477dd8478fbb9e76defb37968ee4ba47b05ec1c053cb39638bd7398
 Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildSystem:    pyproject
 
@@ -22,7 +22,8 @@ BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(setuptools)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -52,4 +53,4 @@ export PYTHONPATH=%{buildroot}%{python3_sitearch}
 %{python3_sitearch}/%{srcname}*.dist-info
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-setuptools/python-setuptools.spec
+++ b/SPECS/python-setuptools/python-setuptools.spec
@@ -9,62 +9,6 @@
 %global srcname setuptools
 %global python_wheel_name %{srcname}-%{version}-py3-none-any.whl
 
-# If it is set to 1, the bootstrap process will be included
-%if "%{flavor}" == "bootstrap"
-%bcond bootstrap 1
-%else
-%bcond bootstrap 0
-%endif
-
-%if %{with bootstrap}
-Name:           python-%{srcname}-bootstrap
-%else
-Name:           python-%{srcname}
-%endif
-Version:        80.9.0
-Release:        %autorelease
-Summary:        Easily build and distribute Python packages
-License:        MIT AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0) AND Python-2.0.1 AND LGPL-3.0-only
-URL:            https://pypi.python.org/pypi/setuptools
-# TODO: Use %%{pypi_source %%{srcname} %%{version}} in the future - 251
-#       Otherwise https://files.pythonhosted.org/packages/source/a/abc/%%{srcname}-%%{version}.tar.gz
-#!RemoteAsset
-Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
-BuildArch:      noarch
-
-# setuptools rewrites all shebangs to "#!python" which breaks workflows
-# where no external installers (usually rewriting this) are involved.
-# https://github.com/pypa/setuptools/issues/4883
-# - Resolution: deprecated functionality won't be fixed.
-# brp-mangle-shebang script cannot mangle this and fails for many pkgs.
-Patch0:         0001-Revert-Always-rewrite-a-Python-shebang-to-python.patch
-
-BuildRequires:  pkgconfig(python3)
-BuildRequires:  expat
-
-%if %{with bootstrap}
-BuildRequires:  unzip
-%endif
-
-# python3 bootstrap: this is built before the final build of python3, which
-# adds the dependency on python3-rpm-generators, so we require it manually
-BuildRequires:  python3-rpm-generators
-# we also use %%{_pyproject_wheeldir}, so an explicit requirement on the pyproject-macros is needed
-BuildRequires:  pyproject-rpm-macros
-
-%if %{without bootstrap}
-# Not to use the pre-generated egg-info, we use setuptools from previous build to generate it
-BuildRequires:  python3-setuptools
-%endif
-
-%description
-Setuptools is a collection of enhancements to the Python distutils that allow
-you to more easily build and distribute Python packages, especially ones that
-have dependencies on other packages.
-
-This package also contains the runtime components of setuptools, necessary to
-execute the software that requires pkg_resources.
-
 # Virtual provides for the packages bundled by setuptools.
 # Bundled packages are defined in multiple files. Generate the list with:
 # pip freeze --path setuptools/_vendor > vendored.txt
@@ -88,8 +32,53 @@ Provides: bundled(python3dist(wheel)) = 0.45.1
 Provides: bundled(python3dist(zipp)) = 3.19.2
 }
 
-%package     -n python3-setuptools
-Summary:        Easily build and distribute Python 3 packages
+# If it is set to 1, the bootstrap process will be included
+%if "%{flavor}" == "bootstrap"
+%bcond bootstrap 1
+%else
+%bcond bootstrap 0
+%endif
+
+%if %{with bootstrap}
+Name:           python-%{srcname}-bootstrap
+%else
+Name:           python-%{srcname}
+%endif
+Version:        80.9.0
+Release:        %autorelease
+Summary:        Easily build and distribute Python packages
+License:        MIT AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0) AND Python-2.0.1 AND LGPL-3.0-only
+URL:            https://pypi.python.org/pypi/setuptools
+# TODO: Use %%{pypi_source %%{srcname} %%{version}} in the future - 251
+#       Otherwise https://files.pythonhosted.org/packages/source/a/abc/%%{srcname}-%%{version}.tar.gz
+#!RemoteAsset:  sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c
+Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+
+# setuptools rewrites all shebangs to "#!python" which breaks workflows
+# where no external installers (usually rewriting this) are involved.
+# https://github.com/pypa/setuptools/issues/4883
+# - Resolution: deprecated functionality won't be fixed.
+# brp-mangle-shebang script cannot mangle this and fails for many pkgs.
+Patch0:         0001-Revert-Always-rewrite-a-Python-shebang-to-python.patch
+
+BuildRequires:  pkgconfig(python3)
+
+%if %{with bootstrap}
+BuildRequires:  unzip
+%endif
+
+# python3 bootstrap: this is built before the final build of python3, which
+# adds the dependency on python3-rpm-generators, so we require it manually
+BuildRequires:  python3-rpm-generators
+# we also use %%{_pyproject_wheeldir}, so an explicit requirement on the pyproject-macros is needed
+BuildRequires:  pyproject-rpm-macros
+
+%if %{without bootstrap}
+# Not to use the pre-generated egg-info, we use setuptools from previous build to generate it
+BuildRequires:  python3-setuptools
+%endif
+
 %{bundled}
 
 # For users who might see ModuleNotFoundError: No module named 'pkg_resoureces'
@@ -97,9 +86,9 @@ Summary:        Easily build and distribute Python 3 packages
 %py_provides    python3-pkg_resources
 %py_provides    python3-pkg-resources
 
-%description -n python3-setuptools
-Setuptools is a collection of enhancements to the Python 3 distutils that allow
-you to more easily build and distribute Python 3 packages, especially ones that
+%description
+Setuptools is a collection of enhancements to the Python distutils that allow
+you to more easily build and distribute Python packages, especially ones that
 have dependencies on other packages.
 
 This package also contains the runtime components of setuptools, necessary to
@@ -154,7 +143,7 @@ find %{buildroot}%{python3_sitelib} -name tests -print0 | xargs -0 rm -r
 mkdir -p %{buildroot}%{python_wheel_dir}
 install -p %{_pyproject_wheeldir}/%{python_wheel_name} -t %{buildroot}%{python_wheel_dir}
 
-%files -n python3-setuptools %{?!with_bootstrap:-f %{pyproject_files}}
+%files %{?!with_bootstrap:-f %{pyproject_files}}
 %doc docs/* NEWS.rst README.rst
 %{python3_sitelib}/distutils-precedence.pth
 %if %{with bootstrap}
@@ -172,4 +161,4 @@ install -p %{_pyproject_wheeldir}/%{python_wheel_name} -t %{buildroot}%{python_w
 %{python_wheel_dir}/%{python_wheel_name}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-shellingham/python-shellingham.spec
+++ b/SPECS/python-shellingham/python-shellingham.spec
@@ -29,7 +29,7 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -43,4 +43,4 @@ Shellingham detects what shell the current Python executable is running in.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-simplejson/python-simplejson.spec
+++ b/SPECS/python-simplejson/python-simplejson.spec
@@ -27,7 +27,8 @@ BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description

--- a/SPECS/python-simpleline/python-simpleline.spec
+++ b/SPECS/python-simpleline/python-simpleline.spec
@@ -24,7 +24,8 @@ BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(pygobject)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 Requires:       python3dist(rpm)

--- a/SPECS/python-sip/python-sip.spec
+++ b/SPECS/python-sip/python-sip.spec
@@ -13,7 +13,7 @@ Summary:        A Python bindings generator for C/C++ libraries
 License:        BSD-2-Clause
 URL:            https://www.riverbankcomputing.com/software/sip/
 VCS:            git:https://github.com/Python-SIP/sip
-#!RemoteAsset
+#!RemoteAsset:  sha256:dc2e58c1798a74e1b31c28e837339822fe8fa55288ae30e8986eb28100ebca5a
 Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildSystem:    pyproject
 
@@ -30,7 +30,8 @@ BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(ply)
 BuildRequires:  python3dist(setuptools-scm) >= 8
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -55,4 +56,4 @@ tools, and a runtime module.
 %{_bindir}/sip-wheel
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-six/python-six.spec
+++ b/SPECS/python-six/python-six.spec
@@ -25,7 +25,7 @@ BuildOption(install):  -l six
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description

--- a/SPECS/python-smart-open/python-smart-open.spec
+++ b/SPECS/python-smart-open/python-smart-open.spec
@@ -28,7 +28,7 @@ BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(wrapt)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -44,4 +44,4 @@ HTTPS, SFTP, or local filesystem.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-smartypants/python-smartypants.spec
+++ b/SPECS/python-smartypants/python-smartypants.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Translate punctuation characters into smart quotes
 License:        BSD-3-Clause AND BSD-2-Clause
 URL:            https://github.com/leohemsted/smartypants.py
-#!RemoteAsset
+#!RemoteAsset:  sha256:39d64ce1d7cc6964b698297bdf391bc12c3251b7f608e6e55d857cd7c5f800c6
 Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  -l %{srcname} +auto
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -38,4 +38,4 @@ entities.
 %doc README*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-smmap/python-smmap.spec
+++ b/SPECS/python-smmap/python-smmap.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Sliding window memory map manager
 License:        BSD-3-Clause
 URL:            https://github.com/gitpython-developers/smmap
-#!RemoteAsset
+#!RemoteAsset:  sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5
 Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -24,7 +24,7 @@ BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -41,4 +41,4 @@ to allow continued operation.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-sniffio/python-sniffio.spec
+++ b/SPECS/python-sniffio/python-sniffio.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Sniff out which async library your code is running under
 License:        Apache-2.0 OR MIT
 URL:            https://github.com/python-trio/sniffio
-#!RemoteAsset
+#!RemoteAsset:  sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc
 Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -37,4 +37,4 @@ asyncio.
 %doc README.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-socks/python-socks.spec
+++ b/SPECS/python-socks/python-socks.spec
@@ -18,13 +18,18 @@ BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}
+# No module named 'curio'
+BuildOption(check):  -e python_socks.async_.curio
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
+# For tests
+BuildRequires:  python3dist(anyio)
+BuildRequires:  python3dist(trio)
 
-Provides:       python3-socks
+Provides:       python3-socks = %{version}-%{release}
 %python_provide python3-socks
 
 %description
@@ -33,16 +38,13 @@ Supports SOCKS4(a), SOCKS5, HTTP (tunneling) proxy and provides sync and async
 (asyncio, trio) APIs. It is used internally by aiohttp-socks and
 httpx-socks packages.
 
-%pyproject_extras_subpkg -n python3-socks asyncio trio curio
+%pyproject_extras_subpkg -n python-socks asyncio trio curio
 
 %generate_buildrequires
 %pyproject_buildrequires -x asyncio
-
-%check
-# skip tests as some deps we don't have yet.
 
 %files -f %{pyproject_files}
 %doc README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-socksio/python-socksio.spec
+++ b/SPECS/python-socksio/python-socksio.spec
@@ -30,7 +30,7 @@ BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(flit-core)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -45,4 +45,4 @@ SOCKS5. socksio is a sans-I/O library similar to h11 or h2.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-sortedcontainers/python-sortedcontainers.spec
+++ b/SPECS/python-sortedcontainers/python-sortedcontainers.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Pure Python sorted container types
 License:        Apache-2.0
 URL:            https://github.com/grantjenks/python-sortedcontainers
-#!RemoteAsset
+#!RemoteAsset:  sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88
 Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  -l %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -36,4 +36,4 @@ pure-Python, and fast as C-extensions.
 %doc README.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-soundfile/python-soundfile.spec
+++ b/SPECS/python-soundfile/python-soundfile.spec
@@ -41,8 +41,8 @@ Full documentation is available on https://python-soundfile.readthedocs.io/.
 %pyproject_buildrequires
 
 %files -f %{pyproject_files}
-%license LICENSE
 %doc README.rst
+%license LICENSE
 
 %changelog
 %autochangelog

--- a/SPECS/python-spacy-legacy/python-spacy-legacy.spec
+++ b/SPECS/python-spacy-legacy/python-spacy-legacy.spec
@@ -27,7 +27,7 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -35,15 +35,15 @@ This package includes outdated registered functions
 for spaCy v3.x, for example model architectures, pipeline
 components and utilities.
 
-%check
-# Skip the check; it depends on the spacy
-
 %generate_buildrequires
 %pyproject_buildrequires
+
+%check
+# Skip the check; it depends on the spacy
 
 %files -f %{pyproject_files}
 %doc README.md
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-spacy-loggers/python-spacy-loggers.spec
+++ b/SPECS/python-spacy-loggers/python-spacy-loggers.spec
@@ -26,7 +26,7 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(pytest)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -45,4 +45,4 @@ independently from the core spaCy library.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-spacy/python-spacy.spec
+++ b/SPECS/python-spacy/python-spacy.spec
@@ -39,7 +39,8 @@ BuildRequires:  python3dist(typer-slim)
 BuildRequires:  python3dist(weasel)
 BuildRequires:  python3dist(wheel)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -56,4 +57,4 @@ and was designed from day one to be used in real products.
 %{_bindir}/spacy
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-sphinxcontrib-devhelp/python-sphinxcontrib-devhelp.spec
+++ b/SPECS/python-sphinxcontrib-devhelp/python-sphinxcontrib-devhelp.spec
@@ -10,7 +10,7 @@ Release:        %autorelease
 Summary:        Sphinx extension for creating Devhelp documents
 License:        BSD-2-Clause
 URL:            https://github.com/sphinx-doc/sphinxcontrib-devhelp
-#!RemoteAsset
+#!RemoteAsset:  sha256:411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad
 Source0:        https://files.pythonhosted.org/packages/source/s/sphinxcontrib_devhelp/sphinxcontrib_devhelp-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -20,7 +20,7 @@ BuildOption(install):  -l sphinxcontrib +auto
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-sphinxcontrib-devhelp
+Provides:       python3-sphinxcontrib-devhelp = %{version}-%{release}
 %python_provide python3-sphinxcontrib-devhelp
 
 %description
@@ -29,11 +29,12 @@ sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document.
 %generate_buildrequires
 %pyproject_buildrequires
 
+# We have docutils but we don't have sphinx, so skip the check
 %check
 
 %files -f %{pyproject_files}
-%license LICENCE.rst
 %doc README.rst
+%license LICENCE.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-sphinxcontrib-serializinghtml/python-sphinxcontrib-serializinghtml.spec
+++ b/SPECS/python-sphinxcontrib-serializinghtml/python-sphinxcontrib-serializinghtml.spec
@@ -32,6 +32,9 @@ sphinxcontrib-serializinghtml is a Sphinx extension which outputs
 %generate_buildrequires
 %pyproject_buildrequires
 
+# We don't have sphinx at all...
+%check
+
 %files -f %{pyproject_files}
 %doc README*
 

--- a/SPECS/python-sphinxcontrib-serializinghtml/python-sphinxcontrib-serializinghtml.spec
+++ b/SPECS/python-sphinxcontrib-serializinghtml/python-sphinxcontrib-serializinghtml.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Sphinx extension to serialize HTML files
 License:        BSD-2-clause
 URL:            https://github.com/sphinx-doc/sphinxcontrib-serializinghtml
-#!RemoteAsset
+#!RemoteAsset:  sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d
 Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/sphinxcontrib_serializinghtml-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,20 +22,18 @@ BuildOption(install):  -l sphinxcontrib +auto
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
-@code{sphinxcontrib-serializinghtml} is a Sphinx extension which outputs
+sphinxcontrib-serializinghtml is a Sphinx extension which outputs
 "serialized" HTML files.
 
 %generate_buildrequires
 %pyproject_buildrequires
 
-%check
-
 %files -f %{pyproject_files}
 %doc README*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-sqlalchemy/python-sqlalchemy.spec
+++ b/SPECS/python-sqlalchemy/python-sqlalchemy.spec
@@ -44,8 +44,8 @@ Pythonic domain language.
 %pyproject_buildrequires
 
 %files -f %{pyproject_files}
-%license LICENSE
 %doc README.rst README.dialects.rst
+%license LICENSE
 
 %changelog
 %autochangelog

--- a/SPECS/python-sqlparse/python-sqlparse.spec
+++ b/SPECS/python-sqlparse/python-sqlparse.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Non-validating SQL parser
 License:        BSD-3-Clause
 URL:            https://github.com/andialbrecht/sqlparse
-#!RemoteAsset
+#!RemoteAsset:  sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272
 Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -23,7 +23,7 @@ BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(pytest)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -33,7 +33,7 @@ provides support for parsing, splitting and formatting SQL statements.
 %generate_buildrequires
 %pyproject_buildrequires
 
-%check
+%check -a
 %pytest -v tests
 
 %files -f %{pyproject_files}
@@ -41,4 +41,4 @@ provides support for parsing, splitting and formatting SQL statements.
 %{_bindir}/sqlformat
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-srsly/python-srsly.spec
+++ b/SPECS/python-srsly/python-srsly.spec
@@ -17,7 +17,7 @@ Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{sr
 BuildSystem:    pyproject
 
 # Needs additional dependencies
-BuildOption(check):    -e "srsly.tests.test_msgpack_api"
+BuildOption(check):  -e "srsly.tests.test_msgpack_api"
 BuildOption(install):  -l %{srcname}
 
 BuildRequires:  pyproject-rpm-macros
@@ -32,7 +32,8 @@ BuildRequires:  python3dist(psutil)
 BuildRequires:  python3dist(numpy)
 BuildRequires:  python3dist(catalogue)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -51,4 +52,4 @@ MessagePack, Pickle and YAML.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-stack-data/python-stack-data.spec
+++ b/SPECS/python-stack-data/python-stack-data.spec
@@ -27,7 +27,7 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -43,4 +43,4 @@ than the default. It powers the tracebacks in IPython and futurecoder.
 %license LICENSE.txt
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-starlette/python-starlette.spec
+++ b/SPECS/python-starlette/python-starlette.spec
@@ -41,8 +41,8 @@ high-performance web applications.
 %pyproject_buildrequires
 
 %files -f %{pyproject_files}
-%license LICENSE.md
 %doc README.md
+%license LICENSE.md
 
 %changelog
 %autochangelog

--- a/SPECS/python-sympy/python-sympy.spec
+++ b/SPECS/python-sympy/python-sympy.spec
@@ -12,12 +12,16 @@ Release:        %autorelease
 Summary:        A Python library for symbolic mathematics
 License:        BSD-3-Clause AND MIT
 URL:            https://www.sympy.org
-#!RemoteAsset
+#!RemoteAsset:  sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517
 Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  isympy sympy
+# We don't have python3dist(pyglet)
+BuildOption(check):  -e 'sympy.plotting.pygletplot.*'
+# And some upstream related errors.
+BuildOption(check):  -e sympy.galgebra
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
@@ -29,7 +33,7 @@ BuildRequires:  python3dist(setuptools)
 
 Recommends:     python3dist(scipy)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -37,9 +41,6 @@ SymPy aims to become a full-featured computer algebra system (CAS) while
 keeping the code as simple as possible in order to be comprehensible and
 easily extensible.  SymPy is written entirely in Python and does not require
 any external libraries.
-
-%check
-# lack of some deps
 
 %files -f %{pyproject_files}
 %doc AUTHORS README.md

--- a/SPECS/python-systemd/python-systemd.spec
+++ b/SPECS/python-systemd/python-systemd.spec
@@ -11,7 +11,7 @@ Release:        %autorelease
 Summary:        Python module wrapping libsystemd functionality
 License:        LGPL-2.1-or-later
 URL:            https://github.com/systemd/python-systemd
-#!RemoteAsset
+#!RemoteAsset:  sha256:38181dbd451fd418d316a92a34bc2118967930684cdd62c3e979fe8c8ebacffa
 Source0:        %{url}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 BuildSystem:    pyproject
 
@@ -23,10 +23,11 @@ BuildOption(install):  systemd +auto
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(setuptools)
-BuildRequires:  pytest
+BuildRequires:  python3dist(pytest)
 BuildRequires:  pkgconfig(libsystemd)
 
-Provides:       python3-systemd
+Provides:       python3-systemd = %{version}-%{release}
+Provides:       python3-systemd%{?_isa} = %{version}-%{release}
 %python_provide python3-systemd
 
 %description
@@ -41,5 +42,6 @@ provided by systemd. Other functionality provided the library is also wrapped.
 %files -f %{pyproject_files}
 %doc README*
 %license LICENSE.txt
+
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Key updates are as follows:

- Our virtual `python3-xxx` must provide the complete `%{version}-%{release}`.
- Correct the `#!RemoteAsset` to include the sha256 checksum value.
- Update `%{?autochangelog}` to `%autochangelog`.
