### PR TITLE
SPECS: Fix python spec file formatting - W

### DIFF
--- a/SPECS/python-Whoosh/python-Whoosh.spec
+++ b/SPECS/python-Whoosh/python-Whoosh.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Pure-Python full text indexing, search, and spell checking library
 License:        BSD-2-Clause
 URL:            http://bitbucket.org/mchaput/whoosh
-#!RemoteAsset
+#!RemoteAsset:  sha256:7ca5633dbfa9e0e0fa400d3151a8a0c4bec53bd2ecedc0a67705b17565c31a83
 Source0:        https://files.pythonhosted.org/packages/source/w/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -25,7 +25,7 @@ BuildOption(check):  -e whoosh.automata.nfa
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -42,4 +42,4 @@ needs.
 %license LICENSE.txt
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-w3lib/python-w3lib.spec
+++ b/SPECS/python-w3lib/python-w3lib.spec
@@ -26,7 +26,7 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(pytest)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -41,4 +41,4 @@ extracting base url, translating entities, encoding multipart/form-data, etc.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-wasabi/python-wasabi.spec
+++ b/SPECS/python-wasabi/python-wasabi.spec
@@ -26,7 +26,7 @@ BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(pip)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -36,8 +36,8 @@ A lightweight console printing and formatting toolkit.
 %pyproject_buildrequires
 
 %files -f %{pyproject_files}
-%license LICENSE
 %doc README.md
+%license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-wcwidth/python-wcwidth.spec
+++ b/SPECS/python-wcwidth/python-wcwidth.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Measures number of Terminal column cells of wide-character codes
 License:        MIT
 URL:            https://github.com/jquast/wcwidth
-#!RemoteAsset
+#!RemoteAsset:  sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5
 Source0:        https://files.pythonhosted.org/packages/source/w/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  -l %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -37,4 +37,4 @@ printable width of a string on a Terminal.
 %doc README.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-weasel/python-weasel.spec
+++ b/SPECS/python-weasel/python-weasel.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        A small and easy workflow system
 License:        MIT
 URL:            https://github.com/explosion/weasel
-#!RemoteAsset
+#!RemoteAsset:  sha256:f293d6174398e8f478c78481e00c503ee4b82ea7a3e6d0d6a01e46a6b1396845
 Source0:        https://files.pythonhosted.org/packages/source/w/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -33,7 +33,7 @@ BuildRequires:  python3dist(srsly)
 BuildRequires:  python3dist(typer-slim)
 BuildRequires:  python3dist(wasabi)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -50,4 +50,4 @@ custom pipelines.
 %{_bindir}/weasel
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-webencodings/python-webencodings.spec
+++ b/SPECS/python-webencodings/python-webencodings.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Character encoding aliases for legacy web content
 License:        BSD-3-Clause
 URL:            https://github.com/SimonSapin/python-webencodings
-#!RemoteAsset
+#!RemoteAsset:  sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923
 Source0:        https://files.pythonhosted.org/packages/source/w/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,17 +22,17 @@ BuildOption(install):  %{srcname} +auto
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
 In order to be compatible with legacy web content when interpreting
-something like @code{Content-Type: text/html; charset=latin1}, tools need
+something like Content-Type: text/html; charset=latin1, tools need
 to use a particular set of aliases for encoding labels as well as some
-overriding rules.  For example, @code{US-ASCII} and @code{iso-8859-1} on
-the web are actually aliases for @code{windows-1252}, and a @code{UTF-8}
-or @code{UTF-16} BOM takes precedence over any other encoding declaration.
-The WHATWG @url{https://encoding.spec.whatwg.org/,Encoding} standard
+overriding rules.  For example, US-ASCII and iso-8859-1 on
+the web are actually aliases for windows-1252, and a UTF-8
+or UTF-16 BOM takes precedence over any other encoding declaration.
+The WHATWG https://encoding.spec.whatwg.org/,Encoding standard
 defines all such details so that implementations do not have to
 reverse-engineer each other.
 
@@ -47,4 +47,4 @@ is Python’s.
 %doc README*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-websocket-client/python-websocket-client.spec
+++ b/SPECS/python-websocket-client/python-websocket-client.spec
@@ -5,9 +5,8 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %global srcname websocket_client
-%global pyname websocket-client
 
-Name:           python-%{pyname}
+Name:           python-websocket-client
 Version:        1.9.0
 Release:        %autorelease
 Summary:        WebSocket client for python
@@ -15,6 +14,7 @@ License:        Apache-2.0
 URL:            https://github.com/websocket-client/websocket-client
 #!RemoteAsset:  sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98
 Source0:        https://files.pythonhosted.org/packages/source/w/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l websocket
@@ -26,8 +26,8 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(pytest)
 
-Provides:       python3-%{pyname}
-%python_provide python3-%{pyname}
+Provides:       python3-websocket-client = %{version}-%{release}
+%python_provide python3-websocket-client
 
 %description
 websocket-client is a WebSocket client for Python. It provides access to low
@@ -37,7 +37,7 @@ WebSocket protocol.
 %generate_buildrequires
 %pyproject_buildrequires
 
-%check
+%check -a
 %pytest -v websocket/tests
 
 %files -f %{pyproject_files}
@@ -45,4 +45,4 @@ WebSocket protocol.
 %{_bindir}/wsdump
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-websockets/python-websockets.spec
+++ b/SPECS/python-websockets/python-websockets.spec
@@ -36,8 +36,8 @@ performance.
 %pyproject_buildrequires
 
 %files -f %{pyproject_files}
-%license LICENSE
 %doc README.rst
+%license LICENSE
 %{_bindir}/websockets
 
 %changelog

--- a/SPECS/python-werkzeug/python-werkzeug.spec
+++ b/SPECS/python-werkzeug/python-werkzeug.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Comprehensive WSGI web application library
 License:        BSD-3-Clause
 URL:            https://github.com/pallets/werkzeug
-#!RemoteAsset
+#!RemoteAsset:  sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746
 Source0:        https://files.pythonhosted.org/packages/source/w/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,7 +22,7 @@ BuildOption(install):  %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -41,4 +41,4 @@ routing system and a bunch of community contributed addon modules.
 %license LICENSE.txt
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-wrapt/python-wrapt.spec
+++ b/SPECS/python-wrapt/python-wrapt.spec
@@ -26,7 +26,8 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(wheel)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -46,19 +47,12 @@ is used for performance critical components. An automatic fallback to a
 pure Python implementation is also provided where a target system does not
 have a compiler to allow the C extension to be compiled.
 
-Documentation
--------------
-
-For further information on the **wrapt** module see:
-
-* http://wrapt.readthedocs.org/
-
 %generate_buildrequires
 %pyproject_buildrequires
 
 %files -f %{pyproject_files}
-%license LICENSE
 %doc README.md
+%license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Key updates are as follows:

- Our virtual `python3-xxx` must provide the complete `%{version}-%{release}`.
- Correct the `#!RemoteAsset` to include the sha256 checksum value.
- Update `%{?autochangelog}` to `%autochangelog`.
