### PR TITLE
SPECS: Fix python spec file formatting - X & Y & Z

### DIFF
--- a/SPECS/python-xkbregistry/python-xkbregistry.spec
+++ b/SPECS/python-xkbregistry/python-xkbregistry.spec
@@ -22,7 +22,7 @@ BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  pkgconfig(xkbcommon)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 Requires:       libxkbcommon

--- a/SPECS/python-xmltodict/python-xmltodict.spec
+++ b/SPECS/python-xmltodict/python-xmltodict.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        Python to transform XML to JSON
 License:        MIT
 URL:            https://github.com/martinblech/xmltodict
-#!RemoteAsset
+#!RemoteAsset:  sha256:6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61
 Source0:        https://files.pythonhosted.org/packages/source/x/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -23,7 +23,7 @@ BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(pytest)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -40,4 +40,4 @@ Wikipedia.
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-xxhash/python-xxhash.spec
+++ b/SPECS/python-xxhash/python-xxhash.spec
@@ -13,7 +13,7 @@ Summary:        Python binding for xxHash
 License:        BSD-3-Clause
 URL:            https://github.com/ifduyue/python-xxhash
 VCS:            git:https://github.com/ifduyue/python-xxhash
-#!RemoteAsset
+#!RemoteAsset:  sha256:f0162a78b13a0d7617b2845b90c763339d1f1d82bb04a4b07f4ab535cc5e05d6
 Source0:        https://files.pythonhosted.org/packages/source/x/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildSystem:    pyproject
 
@@ -25,7 +25,8 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  pkgconfig(libxxhash)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -38,12 +39,9 @@ non-cryptographic hash algorithms.
 %build -p
 export XXHASH_LINK_SO=1
 
-%check
-# tests are skipped for now because pytest test dependencies are not fully available.
-
 %files -f %{pyproject_files}
 %doc README.rst CHANGELOG.rst
 %license LICENSE
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-yarl/python-yarl.spec
+++ b/SPECS/python-yarl/python-yarl.spec
@@ -30,7 +30,8 @@ BuildRequires:  python3dist(idna)
 BuildRequires:  python3dist(multidict)
 BuildRequires:  python3dist(propcache)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -43,4 +44,4 @@ The module provides handy URL class for URL parsing and changing.
 %doc CHANGES.rst README.rst
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-zhconv/python-zhconv.spec
+++ b/SPECS/python-zhconv/python-zhconv.spec
@@ -24,7 +24,7 @@ BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -41,4 +41,4 @@ and zh-hant. It also fully supports MediaWiki's manual conversion syntax.
 %files -f %{pyproject_files}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-zipp/python-zipp.spec
+++ b/SPECS/python-zipp/python-zipp.spec
@@ -14,6 +14,7 @@ License:        MIT
 URL:            https://github.com/jaraco/zipp
 #!RemoteAsset:  sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166
 Source:         https://files.pythonhosted.org/packages/source/z/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}
@@ -26,7 +27,7 @@ BuildRequires:  python3dist(coherent-licensed)
 BuildRequires:  python3dist(setuptools-scm)
 BuildRequires:  python3dist(setuptools-scm[toml])
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -36,8 +37,8 @@ A pathlib-compatible Zipfile object wrapper. A backport of the Path object.
 %pyproject_buildrequires
 
 %files -f %{pyproject_files}
-%license LICENSE
 %doc README.rst
+%license LICENSE
 
 %changelog
 %autochangelog

--- a/SPECS/python-zope-interface/python-zope-interface.spec
+++ b/SPECS/python-zope-interface/python-zope-interface.spec
@@ -25,6 +25,7 @@ BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
 Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -37,8 +38,8 @@ objects provide or implement them.
 %pyproject_buildrequires
 
 %files -f %{pyproject_files}
-%license LICENSE.txt COPYRIGHT.txt
 %doc README.rst CHANGES.rst
+%license LICENSE.txt COPYRIGHT.txt
 
 %changelog
 %autochangelog

--- a/SPECS/python-zstandard/python-zstandard.spec
+++ b/SPECS/python-zstandard/python-zstandard.spec
@@ -12,11 +12,13 @@ Release:        %autorelease
 Summary:        Zstandard bindings for Python
 License:        BSD-3-Clause
 URL:            https://github.com/indygreg/python-zstandard
-#!RemoteAsset
+#!RemoteAsset:  sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b
 Source0:        https://files.pythonhosted.org/packages/source/z/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildSystem:    pyproject
 
 BuildOption(install):  %{srcname} +auto
+# No module named 'zstandard._cffi'
+BuildOption(check):  -e zstandard.backend_cffi
 
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(pip)
@@ -24,7 +26,8 @@ BuildRequires:  python3dist(setuptools)
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(libzstd)
 
-Provides:       python3-%{srcname}
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 %description
@@ -34,13 +37,9 @@ interface are provided.
 
 %generate_buildrequires
 
-
-# TODO: Add python-ffi
-%check
-
 %files -f %{pyproject_files}
-%license LICENSE zstd/COPYING
 %doc README.rst
+%license LICENSE zstd/COPYING
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Key updates are as follows:

- Our virtual `python3-xxx` must provide the complete `%{version}-%{release}`.
- Correct the `#!RemoteAsset` to include the sha256 checksum value.
- Update `%{?autochangelog}` to `%autochangelog`.
