### PR TITLE
SPECS: python-wheel: Fix python spec file formatting.

### DIFF
--- a/SPECS/python-wheel/python-wheel.spec
+++ b/SPECS/python-wheel/python-wheel.spec
@@ -5,6 +5,7 @@
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
+%global srcname wheel
 # Virtual provides for the packages bundled by wheel.
 # %%{_rpmconfigdir}/pythonbundles.py src/wheel/vendored/vendor.txt --namespace 'python%%{python3_pkgversion}dist'
 %global bundled %{expand:
@@ -17,21 +18,31 @@ Release:        %autorelease
 Summary:        Built-package format for Python
 License:        MIT AND (Apache-2.0 OR BSD-2-Clause)
 URL:            https://github.com/pypa/wheel
-#!RemoteAsset
+#!RemoteAsset:  sha256:398fe0a1a609b1084bcab897c65596613544fbe6109408e505e29e4ce0c3175d
 Source:         %{url}/archive/%{version}/wheel-%{version}.tar.gz
 BuildArch:      noarch
+BuildSystem:    pyproject
 
 # Compatibility with the setuptools 75+
 # https://github.com/pypa/wheel/issues/650
 # https://github.com/pypa/wheel/commit/3028d3.patch
-Patch:          0001-3028d3.patch
+Patch0:         0001-3028d3.patch
 # Compatibility with the setuptools 78+ (PEP 639)
 # Upstream has removed this code entirely instead
 # https://github.com/pypa/wheel/pull/655
-Patch:          0002-adjusts-tests-for-setuptools-78.patch
+Patch1:         0002-adjusts-tests-for-setuptools-78.patch
 
+BuildOption(install):  -l wheel
+# Although we have setuptools, maybe include in test is a bad idea
+BuildOption(check):  -e wheel.bdist_wheel
+
+BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  expat
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%{bundled}
 
 %description
 This is a command line tool for manipulating Python wheel files,
@@ -42,38 +53,17 @@ as defined in PEP 427. It contains the following functionality:
 - Repack wheel archives.
 - Add or remove tags in existing wheel archives.
 
-%package     -n python3-wheel
-Summary:        %{summary}
-%{bundled}
-
-%description -n python3-wheel
-This is a command line tool for manipulating Python wheel files,
-as defined in PEP 427. It contains the following functionality:
-
-- Convert .egg archives into .whl.
-- Unpack wheel archives.
-- Repack wheel archives.
-- Add or remove tags in existing wheel archives.
-
-%prep
-%autosetup -n wheel-%{version} -p1
-
 %generate_buildrequires
 %pyproject_buildrequires
 
-%build
-%pyproject_wheel
-
-%install
-%pyproject_install
-%pyproject_save_files -l wheel
+%install -a
 mv %{buildroot}%{_bindir}/wheel{,-3}
 ln -s wheel-3 %{buildroot}%{_bindir}/wheel
 
-%files -n python%{python3_pkgversion}-wheel -f %{pyproject_files}
+%files -f %{pyproject_files}
 %doc README.rst
 %{_bindir}/wheel-3
 %{_bindir}/wheel
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Mainly merge the `python3-wheel` sub-package into the main package.