### PR TITLE
SPECS: ruby: only run bootstraptest in riscv64

### DIFF
--- a/SPECS/ruby/ruby.spec
+++ b/SPECS/ruby/ruby.spec
@@ -6,21 +6,21 @@
 
 %global ruby_api_version 4.0.0
 %global ruby_soversion 4.0
-%global rubygems_version 4.0.6
+%global rubygems_version 4.0.10
 %global ruby_arch %{_arch}-linux
 %global ruby_librubydir %{_libdir}/ruby/%{ruby_api_version}
 %global ruby_gemdir %{_libdir}/ruby/gems/%{ruby_api_version}
 %global ruby_gemextdir %{ruby_gemdir}/extensions/%{ruby_arch}/%{ruby_api_version}
 
 Name:           ruby
-Version:        4.0.2
+Version:        4.0.3
 Release:        %autorelease
 Summary:        Ruby programming language interpreter
 License:        (Ruby OR BSD-2-Clause) AND MIT
 URL:            https://www.ruby-lang.org/
 VCS:            git:https://github.com/ruby/ruby.git
-#!RemoteAsset:  sha256:4618db85bb9ec04d8152d0099db488694a3d3c4f52106625e4ad547f1318db87
-Source0:        https://cache.ruby-lang.org/pub/ruby/4.0/ruby-%{version}.tar.xz
+#!RemoteAsset:  sha256:77964acc370d5c8375b9502e5ba6c13c03ef91ab9eb9f521c84fb42b9c9a6b0f
+Source0:        https://cache.ruby-lang.org/pub/ruby/4.0/ruby-%{version}.tar.gz
 BuildSystem:    autotools
 
 BuildOption(conf):  --libdir=%{_libdir}
@@ -94,8 +94,13 @@ rm -rf %{buildroot}%{ruby_gemdir}/cache
 find %{buildroot} -type f -name '*.pem' -delete
 
 %check
+%ifarch riscv64
+# Ruby test-all currently times out or aborts in upstream tests on riscv64.
+%make_build test
+%else
 # only run offline test suite
 %make_build test test-all
+%endif
 
 %files
 %license BSDL COPYING GPL LEGAL


### PR DESCRIPTION
- only run bootstraptest in riscv64,now ruby test-all currently times out or aborts in upstream tests on riscv64
- update to 4.0.3 to fix [CVE-2026-41316](https://www.ruby-lang.org/en/news/2026/04/21/erb-cve-2026-41316/)