### PR TITLE
SPECS: ruyi: Update to 0.46.0 & Fix python spec formatting.

### DIFF
--- a/SPECS/ruyi/ruyi.spec
+++ b/SPECS/ruyi/ruyi.spec
@@ -7,12 +7,12 @@
 %bcond tests 0
 
 Name:           ruyi
-Version:        0.43.0
+Version:        0.46.0
 Release:        %autorelease
 Summary:        RuyiSDK Package Manager
 License:        Apache-2.0
 URL:            https://github.com/ruyisdk/ruyi
-#!RemoteAsset
+#!RemoteAsset:  sha256:1652cb296fedcec5775149fc5592811414fbc84a9ffef33bc427855cb39c1c0b
 Source:         https://github.com/ruyisdk/ruyi/archive/refs/tags/%{version}.tar.gz
 BuildSystem:    pyproject
 
@@ -20,14 +20,14 @@ BuildOption(install):  -l ruyi -L
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-pip
-BuildRequires:  python3-poetry_core
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(poetry-core)
 %if %{with tests}
-BuildRequires:  python3-pytest
+BuildRequires:  python3dist(pytest)
 %endif
 
-Requires:       python3-requests
-Requires:       python3-rich
+Requires:       python3dist(requests)
+Requires:       python3dist(rich)
 
 %description
 RuyiSDK Package Manager, the official package manager for RuyiSDK.
@@ -35,15 +35,15 @@ RuyiSDK Package Manager, the official package manager for RuyiSDK.
 %generate_buildrequires
 %pyproject_buildrequires
 
-%check
 %if %{with tests}
+%check -a
 %pytest
 %endif
 
 %files -f %{pyproject_files}
-%license LICENSE-Apache.txt
 %doc README.md README.zh.md
+%license LICENSE-Apache.txt
 %{_bindir}/ruyi
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Based on #11. We need this update for the April release.