### PR TITLE
SPECS: update wlroots and libdrm

### DIFF
--- a/SPECS/libdrm/libdrm.spec
+++ b/SPECS/libdrm/libdrm.spec
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: (C) 2025 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2025 openRuyi Project Contributors
+# SPDX-FileContributer: Jingkun Zheng <zhengjingkun@iscas.ac.cn>
 # SPDX-FileContributor: Zheng Junjie <zhengjunjie@iscas.ac.cn>
 # SPDX-FileContributor: yyjeqhc <jialin.oerv@isrc.iscas.ac.cn>
 # SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
@@ -7,13 +8,13 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 Name:           libdrm
-Version:        2.4.125
+Version:        2.4.131
 Release:        %autorelease
 License:        MIT
 Summary:        Library for Direct Rendering Manager
 URL:            https://dri.freedesktop.org
 VCS:            git:https://gitlab.freedesktop.org/mesa/libdrm
-#!RemoteAsset
+#!RemoteAsset:  sha256:45ba9983b51c896406a3d654de81d313b953b76e6391e2797073d543c5f617d5
 Source0:        https://dri.freedesktop.org/libdrm/%{name}-%{version}.tar.xz
 Source1:        91-drm-modeset.rules
 BuildSystem:    meson
@@ -69,4 +70,4 @@ install -D -m0644 -t %{buildroot}%{_udevrulesdir} %{SOURCE1}
 %{_libdir}/pkgconfig/libdrm_vc4.pc
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/wlroots/wlroots.spec
+++ b/SPECS/wlroots/wlroots.spec
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: (C) 2025 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2025 openRuyi Project Contributors
+# SPDX-FileContributor: Jingkun Zheng <zhengjingkun@iscas.ac.cn>
 # SPDX-FileContributor: yyjeqhc <jialin.oerv@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
@@ -7,12 +8,12 @@
 %bcond xwayland 0
 
 Name:           wlroots
-Version:        0.19.2
+Version:        0.19.3
 Release:        %autorelease
 Summary:        A modular Wayland compositor library
 License:        MIT
 URL:            https://gitlab.freedesktop.org/wlroots/wlroots
-#!RemoteAsset:  sha256:f0530ecaa8739d15f97bd1e1edddb77e281d57e42d4263fccb67157f71730d17
+#!RemoteAsset:  sha256:a6ff89b64ea15e424d1b0db4a22145fccf5ec2ff2e7b8af0fa35e2ac8975986f
 Source0:        https://gitlab.freedesktop.org/wlroots/wlroots/-/archive/%{version}/wlroots-%{version}.tar.gz
 BuildSystem:    meson
 


### PR DESCRIPTION
Update `wlroots` to 0.19.3 to resolve FTBFS.

`libdrm` is updated to 2.4.131 as a dependency of `wlroots` (newer versions of wlroots, like 0.20.0, will require `libdrm >= 2.4.129` while currently we have 2.4.125).