### PR TITLE
SPECS: grub: Add GRUB_DISTRIBUTOR to /etc/default/grub

### DIFF
--- a/SPECS/grub/grub.default
+++ b/SPECS/grub/grub.default
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: (C) 2025 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2025 openRuyi Project Contributors
 # SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
+# SPDX-FileContributor: Xiang W <wangxiang@iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
@@ -10,3 +11,4 @@ GRUB_DEFAULT=0
 GRUB_TIMEOUT=10
 GRUB_CMDLINE_LINUX_DEFAULT="loglevel=3 quiet"
 GRUB_CMDLINE_LINUX=""
+GRUB_DISTRIBUTOR=`(. /etc/os-release && echo ${NAME})`


### PR DESCRIPTION
Previously, running `grub-install` would install `grubriscv64.efi` to `/EFI/grub`. After the fix, it will be installed to `/EFI/openruyi`.