### PR TITLE
SPECS: talloc: python-talloc-devel should provide it's python3 variant.

### DIFF
--- a/SPECS/talloc/talloc.spec
+++ b/SPECS/talloc/talloc.spec
@@ -49,7 +49,9 @@ Requires:       %{name}%{?_isa} = %{version}-%{release}
 Python bindings and libraries for using Talloc in Python applications.
 
 %package     -n python-talloc-devel
-Summary:        Development files for python3-talloc
+Summary:        Development files for python-talloc
+Provides:       python3-talloc-devel = %{version}-%{release}
+Provides:       python3-talloc-devel%{?_isa} = %{version}-%{release}
 Requires:       python3-talloc%{?_isa} = %{version}-%{release}
 
 %description -n python-talloc-devel


### PR DESCRIPTION
`python-talloc-devel` should also provide `python3-talloc-devel`, otherwise it doesn't make sense, and samba will be unable to find build dependencies.