### PR TITLE
scripts/remoteassetify.py: Change the user agent

### DIFF
--- a/scripts/remoteassetify.py
+++ b/scripts/remoteassetify.py
@@ -33,7 +33,7 @@ arg_parser.add_argument('--verbose', action='store_true', help='Generate more de
 arg_parser.add_argument('--unsafe-optional-enosys', action='store_true', help='UNSAFE: Allow running rpmspec without enosys')
 arg_parser.add_argument('--workflow', action='store_true', help='Generate some messages as workflow commands')
 
-CURL_DOWNLOAD = shlex.split("""curl --fail --location --proto '=http,https' --user-agent 'scripts/remoteassetify.py https://github.com/openRuyi-Project/openruyi' -o""")
+CURL_DOWNLOAD = shlex.split("""curl --fail --location --proto '=http,https' --user-agent 'scripts/remoteassetify.py openruyi.cn' -o""")
 
 CHECKSUM_TYPES = { 'sha256' }
 


### PR DESCRIPTION
I really do mean just "change". Apparently some servers don't like the original one because of some keyword matches. I'm not sure which ones, but hopefully this shorter one is less likely to trip one of those checks.

---

This unblocks #241. https://github.com/openRuyi-Project/openRuyi/actions/runs/25001574753/job/73334527795?pr=241

Poking around suggests that this server blocks the keyword "git" in user agent, but I don't think it's possible to know which ones exactly.