### PR TITLE
.github: remoteasset: Fix handling when no .spec files changes

### DIFF
--- a/.github/workflows/remoteasset.yaml
+++ b/.github/workflows/remoteasset.yaml
@@ -35,7 +35,7 @@ jobs:
     - name: Find changed remote assets
       id: find-changed
       run: |
-        git diff --name-only HEAD^1...HEAD SPECS/ | grep '.spec$' > changed-files
+        git diff --name-only HEAD^1...HEAD 'SPECS/**/*.spec' > changed-files
 
         touch changed-remoteassets
 


### PR DESCRIPTION
If no .spec file changes, the grep exits with status 1 and fails the entire script. Use globbing in Git instead.

---

This unblocks #237. 