### PR TITLE
.github: remoteasset: Run only on .spec changes

### DIFF
--- a/.github/workflows/remoteasset.yaml
+++ b/.github/workflows/remoteasset.yaml
@@ -14,7 +14,7 @@ on:
   pull_request:
     branches: [main, ci-test]
     paths:
-     - 'SPECS/**'
+     - 'SPECS/**.spec'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-remoteasset


### PR DESCRIPTION
Filter out all non .spec changes, since those don't affect #!RemoteAsset information.

--- 

- Why is this not part of #250?

  If you merge this first, then closing and reopening pull requests affected by this bug *will not retrigger the failing check*, and you will have to rebase the affected pull requests. #250 actually fixes the check itself.