### PR TITLE
SPECS: authselect: Add pam_unix.so nullok for openruyi local profile

### DIFF
--- a/SPECS/authselect/openruyi-local-system-auth
+++ b/SPECS/authselect/openruyi-local-system-auth
@@ -1,5 +1,5 @@
 auth        required      pam_env.so
-auth        sufficient    pam_unix.so try_first_pass
+auth        sufficient    pam_unix.so try_first_pass nullok
 auth        required      pam_deny.so
 
 account     required      pam_unix.so


### PR DESCRIPTION
Add it allow sddm login

Signed-off-by: Zheng Junjie <zhengjunjie@iscas.ac.cn>