### PR TITLE
SPECS: Add python-model-hosting-container-standards.

### DIFF
--- a/SPECS/python-model-hosting-container-standards/python-model-hosting-container-standards.spec
+++ b/SPECS/python-model-hosting-container-standards/python-model-hosting-container-standards.spec
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Zitao Zhou <zitao.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname model-hosting-container-standards
+%global pypi_name model_hosting_container_standards
+
+Name:           python-%{srcname}
+Version:        0.1.14
+Release:        %autorelease
+Summary:        Python toolkit for standardized model hosting container implementations
+License:        Apache-2.0
+URL:            https://github.com/aws/model-hosting-container-standards
+#!RemoteAsset:  sha256:b6cf4c46d88ce6acd6e543a578bb88ffd55d1179a7c09c22e61ae1d8a567c564
+Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{pypi_name}-%{version}.tar.gz
+#!RemoteAsset:  sha256:09e8a9bcec8067104652c168685ab0931e7868f9c8284b66f5ae6edae5f1130b
+Source1:        https://raw.githubusercontent.com/aws/model-hosting-container-standards/refs/tags/v%{version}/LICENSE
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{pypi_name} -L
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+A standardized Python framework for seamless integration between ML frameworks
+(TensorRT-LLM, vLLM) and Amazon SageMaker hosting. It simplifies model deployment
+by providing a unified handler system, flexible configuration, and framework
+agnostic compatibility.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%prep -a
+cp %{SOURCE1} LICENSE
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+%{_bindir}/generate-supervisor-config
+%{_bindir}/standard-supervisor
+
+%changelog
+%autochangelog

--- a/SPECS/python-supervisor/python-supervisor.spec
+++ b/SPECS/python-supervisor/python-supervisor.spec
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Zitao Zhou <zitao.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname supervisor
+
+Name:           python-%{srcname}
+Version:        4.3.0
+Release:        %autorelease
+Summary:        A system for controlling process state under UNIX
+License:        LicenseRef-openRuyi-Supervisor
+URL:            http://supervisord.org/
+VCS:            git:https://github.com/Supervisor/supervisor.git
+#!RemoteAsset:  sha256:4a2bf149adf42997e1bb44b70c43b613275ec9852c3edacca86a9166b27e945e
+Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+# python3-spew is not available in the repository
+BuildOption(check):  -e 'supervisor.tests.fixtures.spew'
+BuildOption(check):  -e 'supervisor.tests.fixtures.unkillable_spew'
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Supervisor is a client/server system that allows its users to monitor and
+control a number of processes on UNIX-like operating systems.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSES.txt
+%{_bindir}/echo_supervisord_conf
+%{_bindir}/pidproxy
+%{_bindir}/supervisorctl
+%{_bindir}/supervisord
+
+%changelog
+%autochangelog


### PR DESCRIPTION
This package provides a set of standardized interfaces and configuration specifications for hosting Python machine learning models in containers.