### PR TITLE
SPECS: Add po4a and its dependencies.

### DIFF
--- a/SPECS/perl-MIME-Charset/perl-MIME-Charset.spec
+++ b/SPECS/perl-MIME-Charset/perl-MIME-Charset.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Suyun <ziyu.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           perl-MIME-Charset
+Version:        1.013.1
+Release:        %autorelease
+Summary:        Charset Information for MIME
+License:        GPL-2.0-only
+URL:            https://metacpan.org/dist/MIME-Charset
+VCS:            git:https://github.com/hatukanezumi/MIME-Charset.git
+#!RemoteAsset:  sha256:1bb7a6e0c0d251f23d6e60bf84c9adefc5b74eec58475bfee4d39107e60870f0
+Source0:        https://www.cpan.org/authors/id/N/NE/NEZUMI/MIME-Charset-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    perlmaker
+
+BuildOption(build):  INSTALLDIRS=vendor
+
+BuildRequires:  make
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-macros
+BuildRequires:  perl(ExtUtils::MakeMaker)
+
+%description
+MIME::Charset provides information about character sets used for MIME
+messages on Internet.
+
+%files -f %{name}.files
+%doc ARTISTIC Changes README
+
+%changelog
+%autochangelog

--- a/SPECS/perl-Text-CharWidth/perl-Text-CharWidth.spec
+++ b/SPECS/perl-Text-CharWidth/perl-Text-CharWidth.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Suyun <ziyu.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           perl-Text-CharWidth
+Version:        0.04
+Release:        %autorelease
+Summary:        Get number of occupied columns of a string on terminal
+License:        GPL-1.0-or-later OR Artistic-1.0-Perl
+URL:            https://metacpan.org/dist/Text-CharWidth
+# VCS: No VCS link available
+#!RemoteAsset:  sha256:abded5f4fdd9338e89fd2f1d8271c44989dae5bf50aece41b6179d8e230704f8
+Source0:        https://www.cpan.org/authors/id/K/KU/KUBOTA/Text-CharWidth-%{version}.tar.gz
+BuildSystem:    perlmaker
+
+BuildOption(build):  INSTALLDIRS=vendor OPTIMIZE="%{optflags}"
+
+BuildRequires:  make
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-macros
+BuildRequires:  perl(ExtUtils::MakeMaker)
+
+%description
+This module supplies features similar as wcwidth(3) and wcswidth(3) in
+C language.
+
+%files -f %{name}.files
+%doc Changes README
+
+%changelog
+%autochangelog

--- a/SPECS/perl-Text-WrapI18N/perl-Text-WrapI18N.spec
+++ b/SPECS/perl-Text-WrapI18N/perl-Text-WrapI18N.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Suyun <ziyu.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           perl-Text-WrapI18N
+Version:        0.06
+Release:        %autorelease
+Summary:        Line wrapping module with support for multibyte, fullwidth, and combining characters and languages without whitespaces between words
+License:        GPL-1.0-or-later OR Artistic-1.0-Perl
+URL:            https://metacpan.org/dist/Text-WrapI18N
+# VCS:          No VCS link available
+#!RemoteAsset:  sha256:4bd29a17f0c2c792d12c1005b3c276f2ab0fae39c00859ae1741d7941846a488
+Source0:        https://www.cpan.org/authors/id/K/KU/KUBOTA/Text-WrapI18N-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    perlmaker
+
+BuildOption(build):  INSTALLDIRS=vendor
+
+BuildRequires:  make
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-macros
+BuildRequires:  perl(ExtUtils::MakeMaker)
+BuildRequires:  perl(Text::CharWidth) >= 0.02
+
+%description
+This module intends to be a better Text::Wrap module. This module is needed
+to support multibyte character encodings such as UTF-8, EUC-JP, EUC-KR,
+GB2312, and Big5. This module also supports characters with irregular
+widths, such as combining characters (which occupy zero columns on
+terminal, like diacritical marks in UTF-8) and fullwidth characters (which
+occupy two columns on terminal, like most of east Asian characters). Also,
+minimal handling of languages which doesn't use whitespaces between words
+(like Chinese and Japanese) is supported.
+
+%files -f %{name}.files
+%doc Changes README
+
+%changelog
+%autochangelog

--- a/SPECS/perl-Unicode-LineBreak/perl-Unicode-LineBreak.spec
+++ b/SPECS/perl-Unicode-LineBreak/perl-Unicode-LineBreak.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Suyun <ziyu.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           perl-Unicode-LineBreak
+Version:        2019.001
+Release:        %autorelease
+Summary:        UAX #14 Unicode Line Breaking Algorithm
+License:        GPL-1.0-or-later OR Artistic-1.0-Perl
+URL:            https://metacpan.org/dist/Unicode-LineBreak
+VCS:            git:https://github.com/hatukanezumi/Unicode-LineBreak.git
+#!RemoteAsset:  sha256:486762e4cacddcc77b13989f979a029f84630b8175e7fef17989e157d4b6318a
+Source0:        https://www.cpan.org/authors/id/N/NE/NEZUMI/Unicode-LineBreak-%{version}.tar.gz
+BuildSystem:    perlmaker
+
+BuildOption(build):  INSTALLDIRS=vendor OPTIMIZE="%{optflags}"
+
+BuildRequires:  make
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-macros
+BuildRequires:  perl >= 5.8.0
+BuildRequires:  perl(Encode) >= 1.98
+BuildRequires:  perl(ExtUtils::MakeMaker)
+BuildRequires:  perl(MIME::Charset) >= 1.6.2
+BuildRequires:  perl(Test::More) >= 0.45
+
+Requires:       perl(Encode) >= 1.98
+Requires:       perl(MIME::Charset) >= 1.6.2
+
+%description
+Unicode::LineBreak performs Line Breaking Algorithm described in Unicode
+Standard Annex #14 [UAX #14]. East_Asian_Width informative property defined
+by Annex #11 [UAX #11] will be concerned to determine breaking positions.
+
+%files -f %{name}.files
+%doc ARTISTIC Changes Changes.REL1 Makefile.PL.sombok perl-Unicode-LineBreak.spec README Todo.REL1
+
+%changelog
+%autochangelog

--- a/SPECS/po4a/po4a.spec
+++ b/SPECS/po4a/po4a.spec
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Suyun <ziyu.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           po4a
+Version:        0.74
+Release:        %autorelease
+Summary:        Tools for helping translation of documentation
+License:        GPL-2.0-or-later
+URL:            https://po4a.org/
+VCS:            git:https://github.com/mquinson/po4a.git
+#!RemoteAsset:  sha256:6e390eb7707501a86f2e648d78fddb0d211d1e8699aa1ee201176e9f966a798b
+Source0:        https://github.com/mquinson/po4a/archive/v%{version}.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  make
+BuildRequires:  perl-macros
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl >= 5.8.1
+BuildRequires:  perl(Locale::gettext) >= 1.01
+BuildRequires:  perl(Module::Build) >= 0.42
+BuildRequires:  perl(Pod::Parser)
+BuildRequires:  perl(SGMLS)
+BuildRequires:  perl(Term::ReadKey)
+BuildRequires:  perl(Text::WrapI18N)
+BuildRequires:  perl(Unicode::GCString)
+BuildRequires:  perl(Unicode::LineBreak)
+BuildRequires:  perl(YAML::Tiny)
+BuildRequires:  docbook-xsl
+BuildRequires:  libxslt
+
+%description
+po4a (PO for anything) eases the translation of documentation and other
+textual content. It converts documentation to PO files for translation,
+and then back to the original format from translated PO files.
+
+%prep
+%setup -q -n po4a-%{version}
+
+%build
+# Replace online docbook.xsl URL with local path for offline build
+sed -i 's|http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl|file://%{_datadir}/sgml/docbook/xsl-stylesheets-1.79.2/manpages/docbook.xsl|' Po4aBuilder.pm
+LC_ALL=en_US.UTF-8 perl Build.PL --installdirs=vendor
+./Build
+
+%install
+./Build install --destdir=%{buildroot} --create_packlist=0
+%perl_process_packlist
+%perl_gen_filelist
+
+%check
+./Build test
+
+%files -f %{name}.files
+%doc README* TODO changelog
+%{_mandir}/*/man1/po4a*.1*
+%{_mandir}/*/man1/msguntypot.1*
+%{_mandir}/*/man3/Locale::Po4a::*.3*
+%{_mandir}/*/man7/po4a.7*
+%{_datadir}/locale/
+
+%changelog
+%autochangelog


### PR DESCRIPTION
- Necessity: po4a (PO for anything) eases the translation of documentation and other textual content using gettext PO files, supporting formats like man, pod, tex, xml, asciidoc, markdown and more.
- AIGC Declaration: Claude Code with DeepSeek-V4-Pro was used as coding agent.