### PR TITLE
SPECS: Add tmt

### DIFF
--- a/SPECS/python-ansible-core/python-ansible-core.spec
+++ b/SPECS/python-ansible-core/python-ansible-core.spec
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname ansible-core
+%global pypi_name ansible_core
+
+Name:           python-%{srcname}
+Version:        2.20.5
+Release:        %autorelease
+Summary:        Radically simple IT automation
+License:        GPL-3.0-or-later AND Apache-2.0 AND BSD-3-Clause AND MIT AND PSF-2.0
+URL:            https://github.com/ansible/ansible
+#!RemoteAsset:  sha256:82e3049d95e6e02e5d20d4a5a8e10533a55e0cc52e878e4cf77166c45410f16f
+Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l ansible ansible_test
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(cryptography)
+BuildRequires:  python3dist(jinja2)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pyyaml)
+BuildRequires:  python3dist(resolvelib)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Ansible is a radically simple IT automation system. It handles configuration
+management, application deployment, cloud provisioning, ad-hoc task execution,
+network automation, and multi-node orchestration.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc changelogs/CHANGELOG-v2.20.rst
+%doc README.md
+%license COPYING
+%license licenses/*.txt
+%{_bindir}/ansible
+%{_bindir}/ansible-*
+
+%changelog
+%autochangelog

--- a/SPECS/python-apsw/python-apsw.spec
+++ b/SPECS/python-apsw/python-apsw.spec
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname apsw
+
+Name:           python-%{srcname}
+Version:        3.50.4.0
+Release:        %autorelease
+Summary:        Another Python SQLite Wrapper
+License:        any-OSI
+URL:            https://github.com/rogerbinns/apsw
+#!RemoteAsset:  sha256:a817c387ce2f4030ab7c3064cf21e9957911155f24f226c3ad4938df3a155e11
+Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pkgconfig(sqlite3)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+APSW is a Python wrapper for the SQLite embedded relational database engine.
+It provides a thin, low-level interface that closely mirrors the SQLite C API.
+
+%prep -a
+cat > setup.apsw << 'EOF'
+[build_ext]
+use_system_sqlite_config = true
+EOF
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+%{_bindir}/apsw
+
+%changelog
+%autochangelog

--- a/SPECS/python-array-api-strict/python-array-api-strict.spec
+++ b/SPECS/python-array-api-strict/python-array-api-strict.spec
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname array-api-strict
+%global pypi_name array_api_strict
+
+Name:           python-%{srcname}
+Version:        2.3
+Release:        %autorelease
+Summary:        A strict, minimal implementation of the Python array API standard
+License:        BSD-3-Clause
+URL:            https://github.com/data-apis/array-api-strict
+#!RemoteAsset:  sha256:6d3575ef47ac285d3472abbc7670db5308db758d2115fdecd368973531c4d8d3
+Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{pypi_name}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(hypothesis)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+A strict, minimal implementation of the Python array API standard for
+testing purposes.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-aws-xray-sdk/python-aws-xray-sdk.spec
+++ b/SPECS/python-aws-xray-sdk/python-aws-xray-sdk.spec
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname aws-xray-sdk
+%global pypi_name aws_xray_sdk
+
+Name:           python-%{srcname}
+Version:        2.15.0
+Release:        %autorelease
+Summary:        AWS X-Ray SDK for Python
+License:        Apache-2.0
+URL:            https://github.com/aws/aws-xray-sdk-python
+#!RemoteAsset:  sha256:794381b96e835314345068ae1dd3b9120bd8b4e21295066c37e8814dbb341365
+Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{pypi_name}
+# No module named 'bson'
+BuildOption(check):  -e 'aws_xray_sdk.ext.pymongo'
+BuildOption(check):  -e 'aws_xray_sdk.ext.pymongo.patch'
+# No module named 'flask_sqlalchemy'
+# incompatible with openRuyi's flask 3.x
+BuildOption(check):  -e 'aws_xray_sdk.ext.flask_sqlalchemy.query'
+# No module named 'mysql.connector'
+# mysql-connector-python uses non-standard cpydist build system
+BuildOption(check):  -e 'aws_xray_sdk.ext.mysql'
+BuildOption(check):  -e 'aws_xray_sdk.ext.mysql.patch'
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(aiobotocore)
+BuildRequires:  python3dist(aiohttp)
+BuildRequires:  python3dist(botocore)
+BuildRequires:  python3dist(bottle)
+BuildRequires:  python3dist(django)
+BuildRequires:  python3dist(flask)
+BuildRequires:  python3dist(httpx)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pg8000)
+BuildRequires:  python3dist(pymongo)
+BuildRequires:  python3dist(pymysql)
+BuildRequires:  python3dist(pynamodb)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(sqlalchemy)
+BuildRequires:  python3dist(wheel)
+BuildRequires:  python3dist(wrapt)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+The AWS X-Ray SDK for Python (the SDK) enables Python developers to record
+and emit information from within their applications to the AWS X-Ray service.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-bokeh-sampledata/python-bokeh-sampledata.spec
+++ b/SPECS/python-bokeh-sampledata/python-bokeh-sampledata.spec
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname bokeh-sampledata
+%global pypi_name bokeh_sampledata
+
+Name:           python-%{srcname}
+Version:        2025.0
+Release:        %autorelease
+Summary:        Sample datasets for Bokeh examples
+License:        BSD-3-Clause
+URL:            https://github.com/bokeh/bokeh_sampledata
+#!RemoteAsset:  sha256:6b874af5b878e70f16133695ac07e15de38642fa9fadfdf723f7d42333967af4
+Source0:        https://files.pythonhosted.org/packages/source/b/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{pypi_name}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(icalendar)
+BuildRequires:  python3dist(pandas)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+Requires:       python3dist(pandas)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Sample datasets for Bokeh examples.
+
+%prep -a
+sed -i 's/^dynamic = \["version"\]/version = "%{version}"/' pyproject.toml
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE.txt
+
+%changelog
+%autochangelog

--- a/SPECS/python-bokeh/python-bokeh.spec
+++ b/SPECS/python-bokeh/python-bokeh.spec
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname bokeh
+
+Name:           python-%{srcname}
+Version:        3.9.0
+Release:        %autorelease
+Summary:        Interactive plots and applications in the browser from Python
+License:        BSD-3-Clause
+URL:            https://bokeh.org
+VCS:            git:https://github.com/bokeh/bokeh.git
+#!RemoteAsset:  sha256:775219714a8496973ddbae16b1861606ba19fe670a421e4d43267b41148e07a3
+Source0:        https://files.pythonhosted.org/packages/source/b/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+# No module named 'selenium'
+BuildOption(check):  -e 'bokeh.io.webdriver'
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(bokeh-sampledata)
+BuildRequires:  python3dist(colorama)
+BuildRequires:  python3dist(contourpy)
+BuildRequires:  python3dist(icalendar)
+BuildRequires:  python3dist(jinja2)
+BuildRequires:  python3dist(narwhals)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pillow)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pyyaml)
+BuildRequires:  python3dist(setuptools-git-versioning)
+BuildRequires:  python3dist(sphinx)
+BuildRequires:  python3dist(toml)
+BuildRequires:  python3dist(tornado)
+BuildRequires:  python3dist(xyzservices)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Bokeh is an interactive visualization library for modern web browsers.
+It provides elegant, concise construction of versatile graphics.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE.txt
+%{python3_sitelib}/typings/
+%{_bindir}/bokeh
+
+%changelog
+%autochangelog

--- a/SPECS/python-bottle/python-bottle.spec
+++ b/SPECS/python-bottle/python-bottle.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname bottle
+
+Name:           python-%{srcname}
+Version:        0.13.4
+Release:        %autorelease
+Summary:        Fast and simple WSGI-framework for small web-applications
+License:        MIT
+URL:            https://bottlepy.org/
+VCS:            git:https://github.com/bottlepy/bottle.git
+#!RemoteAsset:  sha256:787e78327e12b227938de02248333d788cfe45987edca735f8f88e03472c3f47
+Source0:        https://files.pythonhosted.org/packages/source/b/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Bottle is a fast, simple and lightweight WSGI micro web-framework for Python.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+%{_bindir}/bottle
+%{_bindir}/bottle.py
+
+%changelog
+%autochangelog

--- a/SPECS/python-cachey/python-cachey.spec
+++ b/SPECS/python-cachey/python-cachey.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname cachey
+
+Name:           python-%{srcname}
+Version:        0.2.1
+Release:        %autorelease
+Summary:        Caching mindful of computation/storage costs
+License:        BSD-3-Clause
+URL:            https://github.com/dask/cachey
+#!RemoteAsset:  sha256:0310ba8afe52729fa7626325c8d8356a8421c434bf887ac851e58dcf7cf056a6
+Source0:        https://files.pythonhosted.org/packages/source/c/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(heapdict)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Cachey is a caching library mindful of computation and storage costs.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE.txt
+
+%changelog
+%autochangelog

--- a/SPECS/python-cftime/python-cftime.spec
+++ b/SPECS/python-cftime/python-cftime.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname cftime
+
+Name:           python-%{srcname}
+Version:        1.6.5
+Release:        %autorelease
+Summary:        Time-handling functionality from netcdf4-python
+License:        MIT
+URL:            https://github.com/Unidata/cftime
+#!RemoteAsset:  sha256:8225fed6b9b43fb87683ebab52130450fc1730011150d3092096a90e54d1e81e
+Source0:        https://files.pythonhosted.org/packages/source/c/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(cython)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+cftime is a Python library for handling time in netCDF files. It provides
+the num2date and date2num functions for converting between datetime objects
+and numeric time values.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-cysqlite/python-cysqlite.spec
+++ b/SPECS/python-cysqlite/python-cysqlite.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname cysqlite
+
+Name:           python-%{srcname}
+Version:        0.3.0
+Release:        %autorelease
+Summary:        SQLite3 binding for Python
+License:        MIT
+URL:            https://github.com/coleifer/cysqlite
+#!RemoteAsset:  sha256:aaac2707c2ec96e75af7b48cc72914f0db235ed2793155b5339aaab7ec5b9320
+Source0:        https://files.pythonhosted.org/packages/source/c/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pkgconfig(sqlite3)
+BuildRequires:  python3dist(cython)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+cysqlite is a SQLite3 binding for Python using Cython for performance.
+
+%files -f %{pyproject_files}
+%doc README.md
+
+%changelog
+%autochangelog

--- a/SPECS/python-dask/python-dask.spec
+++ b/SPECS/python-dask/python-dask.spec
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname dask
+
+Name:           python-%{srcname}
+Version:        2026.3.0
+Release:        %autorelease
+Summary:        Parallel PyData with Task Scheduling
+License:        BSD-3-Clause
+URL:            https://github.com/dask/dask
+#!RemoteAsset:  sha256:f7d96c8274e8a900d217c1ff6ea8d1bbf0b4c2c21e74a409644498d925eb8f85
+Source0:        https://files.pythonhosted.org/packages/source/d/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+# skip tests: No module named 'distributed' (circular dependency)
+BuildOption(check):  -e 'dask.tests.test_distributed'
+BuildOption(check):  -e 'dask.distributed'
+BuildOption(check):  -e 'dask.tests.test_layers'
+BuildOption(check):  -e 'dask.dataframe.dask_expr.tests.test_distributed'
+BuildOption(check):  -e 'dask.dataframe.dask_expr.io.tests.test_distributed'
+BuildOption(check):  -e 'dask.dataframe.dask_expr.tests.test_diagnostics'
+# skip tests: No module named 'cupy'
+BuildOption(check):  -e 'dask.array.tests.test_cupy*'
+# skip tests: No module named 'skimage'
+BuildOption(check):  -e 'dask.array.tests.test_image'
+# skip tests: No module named 'sparse'
+BuildOption(check):  -e 'dask.array.tests.test_sparse'
+# skip tests: No module named 'xarray' (circular dependency)
+BuildOption(check):  -e 'dask.array.tests.test_xarray'
+# skip tests: No module named 'ipycytoscape'
+BuildOption(check):  -e 'dask.tests.test_dot'
+# skip tests: No module named 'pyspark'
+BuildOption(check):  -e 'dask.tests.test_spark_compat'
+# skip tests: pyarrow ORC support not available (No module named 'pyarrow._orc')
+BuildOption(check):  -e 'dask.dataframe.io.orc.arrow'
+BuildOption(check):  -e 'dask.dataframe.io.tests.test_orc'
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(aiohttp)
+BuildRequires:  python3dist(boto3)
+BuildRequires:  python3dist(cachey)
+BuildRequires:  python3dist(click)
+BuildRequires:  python3dist(cloudpickle)
+BuildRequires:  python3dist(fastavro)
+BuildRequires:  python3dist(flask)
+BuildRequires:  python3dist(fsspec)
+BuildRequires:  python3dist(jinja2)
+BuildRequires:  python3dist(moto)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pandas)
+BuildRequires:  python3dist(partd)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pyarrow)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(pyyaml)
+BuildRequires:  python3dist(requests)
+BuildRequires:  python3dist(s3fs)
+BuildRequires:  python3dist(scipy)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm)
+BuildRequires:  python3dist(sqlalchemy)
+BuildRequires:  python3dist(toolz)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Dask is a flexible library for parallel computing in Python, providing
+parallel arrays, dataframes and task scheduling.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE.txt
+%{_bindir}/dask
+
+%changelog
+%autochangelog

--- a/SPECS/python-distributed/python-distributed.spec
+++ b/SPECS/python-distributed/python-distributed.spec
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname distributed
+
+Name:           python-%{srcname}
+Version:        2026.3.0
+Release:        %autorelease
+Summary:        Distributed scheduler for Dask
+License:        BSD-3-Clause
+URL:            https://distributed.dask.org/
+VCS:            git:https://github.com/dask/distributed.git
+#!RemoteAsset:  sha256:4a8fc6102fededfbaae45288501276da2297a054d74eb6589f01b087c7f95c26
+Source0:        https://files.pythonhosted.org/packages/source/d/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+# No module named 'distributed.bokeh'
+BuildOption(check):  -e 'distributed.bokeh'
+# No module named 'cupy'
+BuildOption(check):  -e 'distributed.protocol.cupy'
+# No module named 'keras'
+BuildOption(check):  -e 'distributed.protocol.keras'
+# No module named 'netCDF4'
+BuildOption(check):  -e 'distributed.protocol.netcdf4'
+# No module named 'numba.cuda'
+BuildOption(check):  -e 'distributed.protocol.numba'
+# No module named 'rmm'
+BuildOption(check):  -e 'distributed.protocol.rmm'
+# No module named 'sparse'
+BuildOption(check):  -e 'distributed.protocol.sparse'
+# No module named 'distributed.utils_test'
+BuildOption(check):  -e 'distributed.utils_test'
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(bokeh)
+BuildRequires:  python3dist(click)
+BuildRequires:  python3dist(cloudpickle)
+BuildRequires:  python3dist(dask)
+BuildRequires:  python3dist(h5py)
+BuildRequires:  python3dist(jinja2)
+BuildRequires:  python3dist(locket)
+BuildRequires:  python3dist(memray)
+BuildRequires:  python3dist(msgpack)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(prometheus-client)
+BuildRequires:  python3dist(psutil)
+BuildRequires:  python3dist(pyarrow)
+BuildRequires:  python3dist(pyyaml)
+BuildRequires:  python3dist(scipy)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm)
+BuildRequires:  python3dist(sortedcontainers)
+BuildRequires:  python3dist(tblib)
+BuildRequires:  python3dist(toolz)
+BuildRequires:  python3dist(torch)
+BuildRequires:  python3dist(tornado)
+BuildRequires:  python3dist(urllib3)
+BuildRequires:  python3dist(zict)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Distributed is a lightweight library for distributed computing in Python.
+It extends Dask's scheduling capabilities to clusters of machines.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE.txt
+%{_bindir}/dask-scheduler
+%{_bindir}/dask-ssh
+%{_bindir}/dask-worker
+
+%changelog
+%autochangelog

--- a/SPECS/python-flask-cors/python-flask-cors.spec
+++ b/SPECS/python-flask-cors/python-flask-cors.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname flask-cors
+%global pypi_name flask_cors
+
+Name:           python-%{srcname}
+Version:        6.0.2
+Release:        %autorelease
+Summary:        A Flask extension for handling Cross Origin Resource Sharing (CORS)
+License:        MIT
+URL:            https://github.com/corydolphin/flask-cors
+#!RemoteAsset:  sha256:6e118f3698249ae33e429760db98ce032a8bf9913638d085ca0f4c5534ad2423
+Source0:        https://files.pythonhosted.org/packages/source/f/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  %{pypi_name}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(flask)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(werkzeug)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+A Flask extension for handling Cross Origin Resource Sharing (CORS),
+making cross-origin AJAX possible.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+
+%changelog
+%autochangelog

--- a/SPECS/python-flexcache/python-flexcache.spec
+++ b/SPECS/python-flexcache/python-flexcache.spec
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname flexcache
+
+Name:           python-%{srcname}
+Version:        0.3
+Release:        %autorelease
+Summary:        Cache transformed versions of source objects
+License:        BSD-3-Clause
+URL:            https://github.com/hgrecco/flexcache
+#!RemoteAsset:  sha256:18743bd5a0621bfe2cf8d519e4c3bfdf57a269c15d1ced3fb4b64e0ff4600656
+Source0:        https://files.pythonhosted.org/packages/source/f/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm[toml])
+BuildRequires:  python3dist(typing-extensions)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+flexcache provides a small helper library for caching transformed versions of
+source objects on disk.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc CHANGES
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-flexparser/python-flexparser.spec
+++ b/SPECS/python-flexparser/python-flexparser.spec
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname flexparser
+
+Name:           python-%{srcname}
+Version:        0.4
+Release:        %autorelease
+Summary:        Parsing made fun using typing
+License:        BSD-3-Clause
+URL:            https://github.com/hgrecco/flexparser
+#!RemoteAsset:  sha256:266d98905595be2ccc5da964fe0a2c3526fbbffdc45b65b3146d75db992ef6b2
+Source0:        https://files.pythonhosted.org/packages/source/f/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm[toml])
+BuildRequires:  python3dist(typing-extensions)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+flexparser is a Python parsing helper library with a typed data model.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc CHANGES
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-fmf/python-fmf.spec
+++ b/SPECS/python-fmf/python-fmf.spec
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname fmf
+
+Name:           python-%{srcname}
+Version:        1.7.0
+Release:        %autorelease
+Summary:        Flexible Metadata Format
+License:        GPL-2.0-or-later
+URL:            https://github.com/teemtee/fmf
+#!RemoteAsset:  sha256:131b557786b912f99d49d8dcc84196e3c2f39c5ce5ffe8b78e48150afd380dc3
+Source0:        https://files.pythonhosted.org/packages/source/f/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(filelock)
+BuildRequires:  python3dist(hatch-vcs)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(jsonschema)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(ruamel-yaml)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Flexible Metadata Format is a framework and command line tool for storing
+metadata in a filesystem tree and querying it efficiently.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc examples
+%doc README.rst
+%license LICENSE
+%{_bindir}/fmf
+
+%changelog
+%autochangelog

--- a/SPECS/python-h5py/python-h5py.spec
+++ b/SPECS/python-h5py/python-h5py.spec
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname h5py
+
+Name:           python-%{srcname}
+Version:        3.16.0
+Release:        %autorelease
+Summary:        Read and write HDF5 files from Python
+License:        BSD-3-Clause
+URL:            https://www.h5py.org/
+VCS:            git:https://github.com/h5py/h5py.git
+#!RemoteAsset:  sha256:a0dbaad796840ccaa67a4c144a0d0c8080073c34c76d5a6941d6818678ef2738
+Source0:        https://files.pythonhosted.org/packages/source/h/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(hdf5)
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(cython)
+BuildRequires:  python3dist(ipython)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pkgconfig)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+The h5py package provides a Python interface to the HDF5 library.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-heapdict/python-heapdict.spec
+++ b/SPECS/python-heapdict/python-heapdict.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname heapdict
+%global pypi_name HeapDict
+
+Name:           python-%{srcname}
+Version:        1.0.1
+Release:        %autorelease
+Summary:        A heap with decrease-key and increase-key operations
+License:        BSD-3-Clause
+URL:            https://github.com/DanielStutzbach/heapdict
+#!RemoteAsset:  sha256:8495f57b3e03d8e46d5f1b2cc62ca881aca392fd5cc048dc0aa2e1a6d23ecdb6
+Source0:        https://files.pythonhosted.org/packages/source/H/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+HeapDict is a heap with decrease-key and increase-key operations.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-icalendar/python-icalendar.spec
+++ b/SPECS/python-icalendar/python-icalendar.spec
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname icalendar
+
+Name:           python-%{srcname}
+Version:        7.1.0
+Release:        %autorelease
+Summary:        RFC 5545 compatible parser and generator of iCalendar files
+License:        BSD-2-Clause
+URL:            https://icalendar.readthedocs.io
+VCS:            git:https://github.com/collective/icalendar.git
+#!RemoteAsset:  sha256:10cd223c792fcc43bee4c3ebe3149d4cf32406c85cfef146624df5a0d414260f
+Source0:        https://files.pythonhosted.org/packages/source/i/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(hatch-vcs)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(hypothesis)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(python-dateutil)
+BuildRequires:  python3dist(pytz)
+BuildRequires:  python3dist(tzdata)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+icalendar is a parser and generator of RFC 5545 compatible iCalendar
+files for Python.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE.rst
+%{_bindir}/icalendar
+
+%changelog
+%autochangelog

--- a/SPECS/python-lmdb/python-lmdb.spec
+++ b/SPECS/python-lmdb/python-lmdb.spec
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname lmdb
+
+Name:           python-%{srcname}
+Version:        2.2.0
+Release:        %autorelease
+Summary:        Universal Python binding for the LMDB Lightning Database
+License:        OLDAP-2.8
+URL:            https://github.com/jnwatson/py-lmdb
+#!RemoteAsset:  sha256:53020e20305c043ea6e68089bc242d744fba6073cdb268332299ba6dda2886d4
+Source0:        https://files.pythonhosted.org/packages/source/l/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(cffi)
+BuildRequires:  python3dist(patch-ng)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+python-lmdb is a universal Python binding for the LMDB 'Lightning' Database.
+LMDB is a tiny, lightning-fast embedded key-value store.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files
+%doc README.md
+%license LICENSE
+%{python3_sitearch}/lmdb/
+%{python3_sitearch}/lmdb-*.dist-info/
+
+%changelog
+%autochangelog

--- a/SPECS/python-locket/python-locket.spec
+++ b/SPECS/python-locket/python-locket.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname locket
+
+Name:           python-%{srcname}
+Version:        1.0.0
+Release:        %autorelease
+Summary:        File-based locks for Python on Linux and Windows
+License:        BSD-2-Clause
+URL:            https://github.com/mwilliamson/locket.py
+#!RemoteAsset:  sha256:5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632
+Source0:        https://files.pythonhosted.org/packages/source/l/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Locket is a Python package that provides file-based locking for Linux and
+Windows. It allows you to lock files for reading and writing, which is useful
+for coordinating access to shared resources.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-mdit-py-plugins/python-mdit-py-plugins.spec
+++ b/SPECS/python-mdit-py-plugins/python-mdit-py-plugins.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname mdit-py-plugins
+%global pypi_name mdit_py_plugins
+
+Name:           python-%{srcname}
+Version:        0.6.1
+Release:        %autorelease
+Summary:        Collection of plugins for markdown-it-py
+License:        MIT
+URL:            https://github.com/executablebooks/mdit-py-plugins
+#!RemoteAsset:  sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0
+Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{pypi_name}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(flit-core)
+BuildRequires:  python3dist(markdown-it-py)
+BuildRequires:  python3dist(pip)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Collection of plugins for markdown-it-py.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-memray/python-memray.spec
+++ b/SPECS/python-memray/python-memray.spec
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname memray
+
+Name:           python-%{srcname}
+Version:        1.19.3
+Release:        %autorelease
+Summary:        A memory profiler for Python applications
+License:        Apache-2.0
+URL:            https://github.com/bloomberg/memray
+#!RemoteAsset:  sha256:4e0fb29ff0a50c0ec9dc84294d8f2c83419feba561a37628b304c2ae4fe73d03
+Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(libdebuginfod)
+BuildRequires:  pkgconfig(liblz4)
+BuildRequires:  pkgconfig(libunwind)
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(cython)
+BuildRequires:  python3dist(jinja2)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pkgconfig)
+BuildRequires:  python3dist(rich)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(textual)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Memray is a memory profiler for Python applications.
+It allows developers to track and analyze memory usage.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+%{_bindir}/memray*
+
+%changelog
+%autochangelog

--- a/SPECS/python-mercantile/python-mercantile.spec
+++ b/SPECS/python-mercantile/python-mercantile.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname mercantile
+
+Name:           python-%{srcname}
+Version:        1.2.1
+Release:        %autorelease
+Summary:        Web mercator XYZ tile utilities
+License:        BSD-3-Clause
+URL:            https://github.com/mapbox/mercantile
+#!RemoteAsset:  sha256:fa3c6db15daffd58454ac198b31887519a19caccee3f9d63d17ae7ff61b3b56b
+Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(click)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Mercantile is a Python library for working with Web Mercator XYZ tile
+coordinates and spherical mercator tile coordinate systems.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE.txt
+%{_bindir}/mercantile
+
+%changelog
+%autochangelog

--- a/SPECS/python-moto/python-moto.spec
+++ b/SPECS/python-moto/python-moto.spec
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname moto
+
+Name:           python-%{srcname}
+Version:        5.2.1
+Release:        %autorelease
+Summary:        A library that allows you to easily mock out tests based on AWS infrastructure
+License:        Apache-2.0
+URL:            https://github.com/getmoto/moto
+#!RemoteAsset:  sha256:ccb2f3e1dfa82e50e054bda98b0be708d244d2668364dcc1d45e8d3de6091bde
+Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+# No module named 'openapi_spec_validator'
+BuildOption(check):  -e 'moto.apigateway*'
+BuildOption(check):  -e 'moto.cloudformation*'
+# No module named 'localstack'
+BuildOption(check):  -e 'moto.firehose*'
+BuildOption(check):  -e 'moto.stepfunctions.parser*'
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(antlr4-python3-runtime)
+BuildRequires:  python3dist(aws-xray-sdk)
+BuildRequires:  python3dist(boto3)
+BuildRequires:  python3dist(botocore)
+BuildRequires:  python3dist(cryptography)
+BuildRequires:  python3dist(flask)
+BuildRequires:  python3dist(flask-cors)
+BuildRequires:  python3dist(joserfc)
+BuildRequires:  python3dist(jsonpath-ng)
+BuildRequires:  python3dist(python-multipart)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pyparsing)
+BuildRequires:  python3dist(requests)
+BuildRequires:  python3dist(responses)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(werkzeug)
+BuildRequires:  python3dist(xmltodict)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Moto is a library that allows you to easily mock out tests based on
+AWS infrastructure.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+%{_bindir}/moto_proxy
+%{_bindir}/moto_server
+
+%changelog
+%autochangelog

--- a/SPECS/python-partd/python-partd.spec
+++ b/SPECS/python-partd/python-partd.spec
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname partd
+
+Name:           python-%{srcname}
+Version:        1.4.2
+Release:        %autorelease
+Summary:        Appendable key-value storage
+License:        BSD-3-Clause
+URL:            https://github.com/dask/partd
+#!RemoteAsset:  sha256:d022c33afbdc8405c226621b015e8067888173d85f7f5ecebb3cafed9a20f02c
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+# No module named 'zmq'
+# enable this testcase when PR merged:
+# https://github.com/openRuyi-Project/openRuyi/pull/168
+BuildOption(check):  -e 'partd.zmq'
+BuildOption(check):  -e 'partd.tests.test_zmq'
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(locket)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(pandas)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(toolz)
+BuildRequires:  python3dist(versioneer[toml])
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Partd is an appendable key-value storage. It is used by dask for shuffling
+data between workers in distributed computing.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE.txt
+
+%changelog
+%autochangelog

--- a/SPECS/python-patch-ng/python-patch-ng.spec
+++ b/SPECS/python-patch-ng/python-patch-ng.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname patch-ng
+%global pypi_name patch_ng
+
+Name:           python-%{srcname}
+Version:        1.19.1
+Release:        %autorelease
+Summary:        Library to parse and apply unified diffs
+License:        MIT
+URL:            https://github.com/techtonik/patch-ng
+#!RemoteAsset:  sha256:036a3cc00134ec53f37e92333958ee75e117f2e62a5ec2b85c7122e5e815c29e
+Source0:        https://files.pythonhosted.org/packages/source/p/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{pypi_name}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+patch-ng is a library to parse and apply unified diffs. It is a fork
+of the original patch library with Python 3 support.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-peewee/python-peewee.spec
+++ b/SPECS/python-peewee/python-peewee.spec
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname peewee
+
+Name:           python-%{srcname}
+Version:        4.0.5
+Release:        %autorelease
+Summary:        Small and expressive ORM
+License:        MIT
+URL:            https://github.com/coleifer/peewee
+#!RemoteAsset:  sha256:b43a21493f19f205a016cb4a9e29c7eca3500576d29447a89732022d193450ba
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname} playhouse pwiz
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(apsw)
+BuildRequires:  python3dist(cysqlite)
+BuildRequires:  python3dist(cython)
+BuildRequires:  python3dist(flask)
+BuildRequires:  python3dist(greenlet)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pydantic)
+BuildRequires:  python3dist(pysqlcipher3)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Peewee is a small and expressive ORM for Python applications.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%build -p
+export NO_SQLITE=1
+
+%files -f %{pyproject_files}
+%doc CHANGELOG.md
+%doc README.rst
+%license LICENSE
+%{_bindir}/pwiz
+
+%changelog
+%autochangelog

--- a/SPECS/python-pg8000/python-pg8000.spec
+++ b/SPECS/python-pg8000/python-pg8000.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pg8000
+
+Name:           python-%{srcname}
+Version:        1.31.5
+Release:        %autorelease
+Summary:        A Pure-Python PostgreSQL Driver
+License:        BSD-3-Clause
+URL:            https://github.com/tlocke/pg8000
+#!RemoteAsset:  sha256:46ebb03be52b7a77c03c725c79da2ca281d6e8f59577ca66b17c9009618cae78
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(python-dateutil)
+BuildRequires:  python3dist(scramp)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+pg8000 is a pure-Python PostgreSQL driver, compatible with the
+standard DB-API 2.0 interface.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-pint/python-pint.spec
+++ b/SPECS/python-pint/python-pint.spec
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pint
+
+Name:           python-%{srcname}
+Version:        0.25.2
+Release:        %autorelease
+Summary:        Physical quantities module
+License:        BSD-3-Clause
+URL:            https://github.com/hgrecco/pint
+#!RemoteAsset:  sha256:85a45d1da8fe9c9f7477fed8aef59ad2b939af3d6611507e1a9cbdacdcd3450a
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+# skip tests: missing python-matplotlib
+BuildOption(check):  -e 'pint.matplotlib'
+BuildOption(check):  -e 'pint.testsuite.test_matplotlib'
+# skip tests: No module named 'sparse'
+BuildOption(check):  -e 'pint.testsuite.test_compat_downcast'
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(dask)
+BuildRequires:  python3dist(distributed)
+BuildRequires:  python3dist(flexcache)
+BuildRequires:  python3dist(flexparser)
+BuildRequires:  python3dist(hatch-vcs)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(platformdirs)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(typing-extensions)
+BuildRequires:  python3dist(xarray)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Pint is a Python package to define, operate and manipulate physical quantities
+with units.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+%{_bindir}/pint-convert
+
+%changelog
+%autochangelog

--- a/SPECS/python-pynamodb/python-pynamodb.spec
+++ b/SPECS/python-pynamodb/python-pynamodb.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pynamodb
+
+Name:           python-%{srcname}
+Version:        6.1.0
+Release:        %autorelease
+Summary:        A Pythonic interface to Amazon's DynamoDB
+License:        MIT
+URL:            https://github.com/pynamodb/PynamoDB
+#!RemoteAsset:  sha256:c7d09700ace9f428e67ecf73fa867633c632de3acf402b2c7c136be695afda79
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(botocore)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+PynamoDB is a Pythonic interface to Amazon's DynamoDB.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-pysqlcipher3/0001-python313-compat.patch
+++ b/SPECS/python-pysqlcipher3/0001-python313-compat.patch
@@ -1,0 +1,609 @@
+From a0441a5a33c6875090a185336834600e6c50f23a Mon Sep 17 00:00:00 2001
+From: Milan Hauth <milahu@gmail.com>
+Date: Mon, 27 Oct 2025 14:02:46 +0100
+Subject: [PATCH 01/18] remove PyObject_AsCharBuffer for python 3.12
+
+---
+ src/python3/connection.c | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/src/python3/connection.c b/src/python3/connection.c
+index 7e5f0c7..e0decf5 100644
+--- a/src/python3/connection.c
++++ b/src/python3/connection.c
+@@ -524,17 +524,36 @@ _pysqlite_set_result(sqlite3_context* context, PyObject* py_val)
+     } else if (PyObject_CheckBuffer(py_val)) {
+         const char* buffer;
+         Py_ssize_t buflen;
++        #if PY_VERSION_HEX < 0x030C0000
++        // Python <3.12
+         if (PyObject_AsCharBuffer(py_val, &buffer, &buflen) != 0) {
+             PyErr_SetString(PyExc_ValueError,
+                             "could not convert BLOB to buffer");
+             return -1;
+         }
++        #else
++        // Python >=3.12
++        Py_buffer view;
++        if (PyObject_GetBuffer(py_val, &view, PyBUF_SIMPLE) != 0) {
++            PyErr_SetString(PyExc_ValueError,
++                            "could not convert BLOB to buffer");
++            return -1;
++        }
++        buffer = view.buf;
++        buflen = view.len;
++        #endif
++
+         if (buflen > INT_MAX) {
+             PyErr_SetString(PyExc_OverflowError,
+                             "BLOB longer than INT_MAX bytes");
+             return -1;
+         }
+         sqlite3_result_blob(context, buffer, (int)buflen, SQLITE_TRANSIENT);
++
++        #if PY_VERSION_HEX >= 0x030C0000
++        // Python >=3.12
++        PyBuffer_Release(&view);
++        #endif
+     } else {
+         return -1;
+     }
+
+From eb166c61e0ea723b615c4ca8afdedea5fc41ccab Mon Sep 17 00:00:00 2001
+From: Milan Hauth <milahu@gmail.com>
+Date: Mon, 27 Oct 2025 14:08:52 +0100
+Subject: [PATCH 02/18] remove _PyLong_AsInt for python 3.12
+
+---
+ src/python3/connection.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/python3/connection.c b/src/python3/connection.c
+index e0decf5..ae4118a 100644
+--- a/src/python3/connection.c
++++ b/src/python3/connection.c
+@@ -937,7 +937,7 @@ static int _authorizer_callback(void* user_arg, int action, const char* arg1, co
+     }
+     else {
+         if (PyLong_Check(ret)) {
+-            rc = _PyLong_AsInt(ret);
++            rc = PyLong_AsLong(ret);
+             if (rc == -1 && PyErr_Occurred()) {
+                 if (_enable_callback_tracebacks)
+                     PyErr_Print();
+
+From 23e3757d6dd12c24d7bb47c6b7bbcc4d2d7bd420 Mon Sep 17 00:00:00 2001
+From: Milan Hauth <milahu@gmail.com>
+Date: Mon, 27 Oct 2025 14:36:36 +0100
+Subject: [PATCH 03/18] remove _PyArg_NoKeywords for python 3.12
+
+---
+ src/python3/row.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/python3/row.c b/src/python3/row.c
+index ee9a908..951d033 100644
+--- a/src/python3/row.c
++++ b/src/python3/row.c
+@@ -41,8 +41,11 @@ pysqlite_row_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+ 
+     assert(type != NULL && type->tp_alloc != NULL);
+ 
+-    if (!_PyArg_NoKeywords("Row()", kwargs))
++    if (kwargs != NULL && PyDict_Check(kwargs) && PyDict_Size(kwargs) != 0) {
++        PyErr_SetString(PyExc_TypeError, "Row() takes no keyword arguments");
+         return NULL;
++    }
++
+     if (!PyArg_ParseTuple(args, "OO", &cursor, &data))
+         return NULL;
+ 
+
+From 1a60fc5c0fa8a7915e4e952725e3259afdd4ac58 Mon Sep 17 00:00:00 2001
+From: Milan Hauth <milahu@gmail.com>
+Date: Mon, 27 Oct 2025 14:40:29 +0100
+Subject: [PATCH 04/18] remove PyObject_AsCharBuffer for python 3.12
+
+---
+ src/python3/statement.c | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/src/python3/statement.c b/src/python3/statement.c
+index c007ffe..c325fbb 100644
+--- a/src/python3/statement.c
++++ b/src/python3/statement.c
+@@ -146,6 +146,8 @@ int pysqlite_statement_bind_parameter(pysqlite_Statement* self, int pos, PyObjec
+             rc = sqlite3_bind_text(self->st, pos, string, (int)buflen, SQLITE_TRANSIENT);
+             break;
+         case TYPE_BUFFER:
++            #if PY_VERSION_HEX < 0x030C0000
++            // Python <3.12
+             if (PyObject_AsCharBuffer(parameter, &buffer, &buflen) != 0) {
+                 PyErr_SetString(PyExc_ValueError, "could not convert BLOB to buffer");
+                 return -1;
+@@ -156,6 +158,22 @@ int pysqlite_statement_bind_parameter(pysqlite_Statement* self, int pos, PyObjec
+                 return -1;
+             }
+             rc = sqlite3_bind_blob(self->st, pos, buffer, buflen, SQLITE_TRANSIENT);
++            #else
++            // Python >=3.12
++            Py_buffer view;
++            if (PyObject_GetBuffer(parameter, &view, PyBUF_SIMPLE) != 0) {
++                PyErr_SetString(PyExc_ValueError, "could not convert BLOB to buffer");
++                return -1;
++            }
++            if (view.len > INT_MAX) {
++                PyBuffer_Release(&view);
++                PyErr_SetString(PyExc_OverflowError,
++                                "BLOB longer than INT_MAX bytes");
++                return -1;
++            }
++            rc = sqlite3_bind_blob(self->st, pos, view.buf, (int)view.len, SQLITE_TRANSIENT);
++            PyBuffer_Release(&view);
++            #endif
+             break;
+         case TYPE_UNKNOWN:
+             rc = -1;
+
+From a6998534d7cec132b0420c91af2d5662c58e799f Mon Sep 17 00:00:00 2001
+From: Milan Hauth <milahu@gmail.com>
+Date: Mon, 27 Oct 2025 14:46:42 +0100
+Subject: [PATCH 05/18] remove _PyLong_AsByteArray for python 3.12
+
+---
+ src/python3/util.c | 38 +++++++++++---------------------------
+ 1 file changed, 11 insertions(+), 27 deletions(-)
+
+diff --git a/src/python3/util.c b/src/python3/util.c
+index 312fe3b..6891d72 100644
+--- a/src/python3/util.c
++++ b/src/python3/util.c
+@@ -139,34 +139,18 @@ sqlite_int64
+ _pysqlite_long_as_int64(PyObject * py_val)
+ {
+     int overflow;
+-#ifdef HAVE_LONG_LONG
+-    PY_LONG_LONG value = PyLong_AsLongLongAndOverflow(py_val, &overflow);
+-#else
+-    long value = PyLong_AsLongAndOverflow(py_val, &overflow);
+-#endif
++    sqlite_int64 value;
++    #if SIZEOF_LONG_LONG >= 8
++    value = PyLong_AsLongLongAndOverflow(py_val, &overflow);
++    #else
++    value = PyLong_AsLongAndOverflow(py_val, &overflow);
++    #endif
+     if (value == -1 && PyErr_Occurred())
+         return -1;
+-    if (!overflow) {
+-#ifdef HAVE_LONG_LONG
+-# if SIZEOF_LONG_LONG > 8
+-        if (-0x8000000000000000LL <= value && value <= 0x7FFFFFFFFFFFFFFFLL)
+-# endif
+-#else
+-# if SIZEOF_LONG > 8
+-        if (-0x8000000000000000L <= value && value <= 0x7FFFFFFFFFFFFFFFL)
+-# endif
+-#endif
+-            return value;
+-    }
+-    else if (sizeof(value) < sizeof(sqlite_int64)) {
+-        sqlite_int64 int64val;
+-        if (_PyLong_AsByteArray((PyLongObject *)py_val,
+-                                (unsigned char *)&int64val, sizeof(int64val),
+-                                IS_LITTLE_ENDIAN, 1 /* signed */) >= 0) {
+-            return int64val;
+-        }
++    if (overflow != 0) {
++        PyErr_SetString(PyExc_OverflowError,
++                        "Python int too large to convert to SQLite INTEGER");
++        return -1;
+     }
+-    PyErr_SetString(PyExc_OverflowError,
+-                    "Python int too large to convert to SQLite INTEGER");
+-    return -1;
++    return value;
+ }
+
+From 5d6a5408ef62d09257ee9277d680e076ed606c97 Mon Sep 17 00:00:00 2001
+From: Milan Hauth <milahu@gmail.com>
+Date: Mon, 27 Oct 2025 14:57:08 +0100
+Subject: [PATCH 06/18] remove PyWeakref_GetObject for python 3.12
+
+---
+ src/python3/connection.c | 17 +++++++++--------
+ 1 file changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/src/python3/connection.c b/src/python3/connection.c
+index ae4118a..d219e32 100644
+--- a/src/python3/connection.c
++++ b/src/python3/connection.c
+@@ -220,15 +220,16 @@ void pysqlite_do_all_statements(pysqlite_Connection* self, int action, int reset
+ 
+     for (i = 0; i < PyList_Size(self->statements); i++) {
+         weakref = PyList_GetItem(self->statements, i);
+-        statement = PyWeakref_GetObject(weakref);
+-        if (statement != Py_None) {
+-            Py_INCREF(statement);
+-            if (action == ACTION_RESET) {
+-                (void)pysqlite_statement_reset((pysqlite_Statement*)statement);
+-            } else {
+-                (void)pysqlite_statement_finalize((pysqlite_Statement*)statement);
++        if (PyWeakref_GetRef(weakref, &statement) > 0) {
++            if (statement != Py_None) {
++                Py_INCREF(statement);
++                if (action == ACTION_RESET) {
++                    (void)pysqlite_statement_reset((pysqlite_Statement*)statement);
++                } else {
++                    (void)pysqlite_statement_finalize((pysqlite_Statement*)statement);
++                }
++                Py_DECREF(statement);
+             }
+-            Py_DECREF(statement);
+         }
+     }
+ 
+
+From 5675c6cc4835d53e5ffaeaee1cfc30964a7d1461 Mon Sep 17 00:00:00 2001
+From: Milan Hauth <milahu@gmail.com>
+Date: Mon, 27 Oct 2025 14:59:17 +0100
+Subject: [PATCH 07/18] remove PyWeakref_GetObject for python 3.12
+
+---
+ src/python3/connection.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/src/python3/connection.c b/src/python3/connection.c
+index d219e32..4b6dcbc 100644
+--- a/src/python3/connection.c
++++ b/src/python3/connection.c
+@@ -236,10 +236,16 @@ void pysqlite_do_all_statements(pysqlite_Connection* self, int action, int reset
+     if (reset_cursors) {
+         for (i = 0; i < PyList_Size(self->cursors); i++) {
+             weakref = PyList_GetItem(self->cursors, i);
+-            cursor = (pysqlite_Cursor*)PyWeakref_GetObject(weakref);
+-            if ((PyObject*)cursor != Py_None) {
++            PyObject *obj;
++            int ok = PyWeakref_GetRef(weakref, &obj);
++            if (ok > 0 && obj != Py_None) {
++                cursor = (pysqlite_Cursor*)obj;
+                 cursor->reset = 1;
++                // release the strong reference
++                Py_DECREF(obj);
+             }
++            // if ok == 0, reference is dead
++            // if ok < 0, error occurred
+         }
+     }
+ }
+
+From 036f5e081748f0b16450f4a2483ba5bde8e1e254 Mon Sep 17 00:00:00 2001
+From: Milan Hauth <milahu@gmail.com>
+Date: Mon, 27 Oct 2025 15:03:46 +0100
+Subject: [PATCH 08/18] remove PyWeakref_GetObject for python 3.12
+
+---
+ src/python3/connection.c | 18 ++++++++++++++----
+ 1 file changed, 14 insertions(+), 4 deletions(-)
+
+diff --git a/src/python3/connection.c b/src/python3/connection.c
+index 4b6dcbc..5fde4d9 100644
+--- a/src/python3/connection.c
++++ b/src/python3/connection.c
+@@ -812,12 +812,22 @@ static void _pysqlite_drop_unused_statement_references(pysqlite_Connection* self
+ 
+     for (i = 0; i < PyList_Size(self->statements); i++) {
+         weakref = PyList_GetItem(self->statements, i);
+-        if (PyWeakref_GetObject(weakref) != Py_None) {
+-            if (PyList_Append(new_list, weakref) != 0) {
+-                Py_DECREF(new_list);
+-                return;
++        PyObject *obj;
++        int ok = PyWeakref_GetRef(weakref, &obj);
++        if (ok > 0) {
++            // weakref is alive
++            if (obj != Py_None) {
++                if (PyList_Append(new_list, weakref) != 0) {
++                    Py_DECREF(obj);
++                    Py_DECREF(new_list);
++                    return;
++                }
+             }
++            // release strong reference
++            Py_DECREF(obj);
+         }
++        // ok == 0 => weakref is dead, skip
++        // ok < 0 => error occurred, could log if desired
+     }
+ 
+     Py_DECREF(self->statements);
+
+From 41059b078ed018fbbf9686d05aa8562403f25bcb Mon Sep 17 00:00:00 2001
+From: Milan Hauth <milahu@gmail.com>
+Date: Mon, 27 Oct 2025 15:05:54 +0100
+Subject: [PATCH 09/18] remove PyWeakref_GetObject for python 3.12
+
+---
+ src/python3/connection.c | 18 ++++++++++++++----
+ 1 file changed, 14 insertions(+), 4 deletions(-)
+
+diff --git a/src/python3/connection.c b/src/python3/connection.c
+index 5fde4d9..63536fc 100644
+--- a/src/python3/connection.c
++++ b/src/python3/connection.c
+@@ -854,12 +854,22 @@ static void _pysqlite_drop_unused_cursor_references(pysqlite_Connection* self)
+ 
+     for (i = 0; i < PyList_Size(self->cursors); i++) {
+         weakref = PyList_GetItem(self->cursors, i);
+-        if (PyWeakref_GetObject(weakref) != Py_None) {
+-            if (PyList_Append(new_list, weakref) != 0) {
+-                Py_DECREF(new_list);
+-                return;
++        PyObject *obj;
++        int ok = PyWeakref_GetRef(weakref, &obj);
++        if (ok > 0) {
++            // weakref is alive
++            if (obj != Py_None) {
++                if (PyList_Append(new_list, weakref) != 0) {
++                    Py_DECREF(obj);
++                    Py_DECREF(new_list);
++                    return;
++                }
+             }
++            // release strong reference
++            Py_DECREF(obj);
+         }
++        // ok == 0 => weakref is dead, skip
++        // ok < 0 => error occurred, could log if desired
+     }
+ 
+     Py_DECREF(self->cursors);
+
+From 7fe1c6879f738cd1cfd6438c0e7096bd2d97a51d Mon Sep 17 00:00:00 2001
+From: Milan Hauth <milahu@gmail.com>
+Date: Mon, 27 Oct 2025 15:09:36 +0100
+Subject: [PATCH 10/18] fix: warning: comparison of integer expressions of
+ different signedness
+
+---
+ src/python3/connection.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/python3/connection.h b/src/python3/connection.h
+index 9db8901..56cfce5 100644
+--- a/src/python3/connection.h
++++ b/src/python3/connection.h
+@@ -66,7 +66,7 @@ typedef struct
+     int initialized;
+ 
+     /* thread identification of the thread the connection was created in */
+-    long thread_ident;
++    unsigned long thread_ident;
+ 
+     pysqlite_Cache* statement_cache;
+ 
+
+From 92496e87e30717c6aed6a66f65448b92da6bb1c0 Mon Sep 17 00:00:00 2001
+From: Milan Hauth <milahu@gmail.com>
+Date: Mon, 27 Oct 2025 15:13:25 +0100
+Subject: [PATCH 11/18] remove _PyUnicode_AsString for python 3.12
+
+---
+ src/python3/connection.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/python3/connection.c b/src/python3/connection.c
+index 63536fc..3d782bc 100644
+--- a/src/python3/connection.c
++++ b/src/python3/connection.c
+@@ -1553,7 +1553,7 @@ pysqlite_connection_create_collation(pysqlite_Connection* self, PyObject* args)
+     PyObject* retval;
+     Py_ssize_t i, len;
+     _Py_IDENTIFIER(upper);
+-    char *uppercase_name_str;
++    const char *uppercase_name_str;
+     int rc;
+     unsigned int kind;
+     void *data;
+@@ -1589,7 +1589,7 @@ pysqlite_connection_create_collation(pysqlite_Connection* self, PyObject* args)
+         }
+     }
+ 
+-    uppercase_name_str = _PyUnicode_AsString(uppercase_name);
++    uppercase_name_str = PyUnicode_AsUTF8AndSize(uppercase_name, &len);
+     if (!uppercase_name_str)
+         goto finally;
+ 
+
+From 20407c04dfd4caf2ef112261280a919ca52f5647 Mon Sep 17 00:00:00 2001
+From: Milan Hauth <milahu@gmail.com>
+Date: Mon, 27 Oct 2025 15:14:50 +0100
+Subject: [PATCH 12/18] fix: warning: comparison of integer expressions of
+ different signedness
+
+---
+ src/python3/cursor.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/python3/cursor.c b/src/python3/cursor.c
+index 3a560ad..c507b17 100644
+--- a/src/python3/cursor.c
++++ b/src/python3/cursor.c
+@@ -46,7 +46,7 @@ static pysqlite_StatementKind detect_statement_type(const char* statement)
+ 
+     dst = buf;
+     *dst = 0;
+-    while (Py_ISALPHA(*src) && dst - buf < sizeof(buf) - 2) {
++    while (Py_ISALPHA(*src) && dst - buf < (ptrdiff_t)(sizeof(buf) - 2)) {
+         *dst++ = Py_TOLOWER(*src++);
+     }
+ 
+
+From 671d335beec5dd4462b42177d9f494f94da6202a Mon Sep 17 00:00:00 2001
+From: Milan Hauth <milahu@gmail.com>
+Date: Mon, 27 Oct 2025 15:17:28 +0100
+Subject: [PATCH 13/18] remove PyEval_InitThreads for python 3.7
+
+---
+ src/python3/module.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/python3/module.c b/src/python3/module.c
+index 7a7e860..7a39941 100644
+--- a/src/python3/module.c
++++ b/src/python3/module.c
+@@ -469,7 +469,10 @@ PyMODINIT_FUNC PyInit__sqlite3(void)
+      *  (see pybsddb-users mailing list post on 2002-08-07)
+      */
+ #ifdef WITH_THREAD
++    #if PY_VERSION_HEX < 0x03070000
++    // Python <3.7
+     PyEval_InitThreads();
++    #endif
+ #endif
+ 
+ error:
+
+From 2914dbb99cb20b09994cef8463e4cb6cef263a96 Mon Sep 17 00:00:00 2001
+From: Milan Hauth <milahu@gmail.com>
+Date: Mon, 27 Oct 2025 15:20:31 +0100
+Subject: [PATCH 14/18] remove _PyUnicode_AsString
+
+---
+ src/python3/row.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/python3/row.c b/src/python3/row.c
+index 951d033..1a58acb 100644
+--- a/src/python3/row.c
++++ b/src/python3/row.c
+@@ -82,7 +82,7 @@ PyObject* pysqlite_row_item(pysqlite_Row* self, Py_ssize_t idx)
+ PyObject* pysqlite_row_subscript(pysqlite_Row* self, PyObject* idx)
+ {
+     Py_ssize_t _idx;
+-    char* key;
++    const char* key;
+     Py_ssize_t nitems, i;
+     char* compare_key;
+ 
+@@ -101,7 +101,7 @@ PyObject* pysqlite_row_subscript(pysqlite_Row* self, PyObject* idx)
+         Py_XINCREF(item);
+         return item;
+     } else if (PyUnicode_Check(idx)) {
+-        key = _PyUnicode_AsString(idx);
++        key = PyUnicode_AsUTF8AndSize(idx, &i);
+         if (key == NULL)
+             return NULL;
+ 
+
+From 606cbd68163e6f540671565f0bac5f3dd2f758e0 Mon Sep 17 00:00:00 2001
+From: Milan Hauth <milahu@gmail.com>
+Date: Mon, 27 Oct 2025 15:22:19 +0100
+Subject: [PATCH 15/18] remove _PyUnicode_AsString
+
+---
+ src/python3/row.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/python3/row.c b/src/python3/row.c
+index 1a58acb..e697b62 100644
+--- a/src/python3/row.c
++++ b/src/python3/row.c
+@@ -84,7 +84,7 @@ PyObject* pysqlite_row_subscript(pysqlite_Row* self, PyObject* idx)
+     Py_ssize_t _idx;
+     const char* key;
+     Py_ssize_t nitems, i;
+-    char* compare_key;
++    const char* compare_key;
+ 
+     char* p1;
+     char* p2;
+@@ -111,7 +111,7 @@ PyObject* pysqlite_row_subscript(pysqlite_Row* self, PyObject* idx)
+             PyObject *obj;
+             obj = PyTuple_GET_ITEM(self->description, i);
+             obj = PyTuple_GET_ITEM(obj, 0);
+-            compare_key = _PyUnicode_AsString(obj);
++            compare_key = PyUnicode_AsUTF8AndSize(obj, &i);
+             if (!compare_key) {
+                 return NULL;
+             }
+
+From d387c9c2353771372b01308c6a0ba9c9be68196f Mon Sep 17 00:00:00 2001
+From: Milan Hauth <milahu@gmail.com>
+Date: Mon, 27 Oct 2025 15:23:43 +0100
+Subject: [PATCH 16/18] fix: warning: assignment discards const qualifier from
+ pointer target type
+
+---
+ src/python3/row.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/src/python3/row.c b/src/python3/row.c
+index e697b62..baff099 100644
+--- a/src/python3/row.c
++++ b/src/python3/row.c
+@@ -86,8 +86,8 @@ PyObject* pysqlite_row_subscript(pysqlite_Row* self, PyObject* idx)
+     Py_ssize_t nitems, i;
+     const char* compare_key;
+ 
+-    char* p1;
+-    char* p2;
++    const char* p1;
++    const char* p2;
+ 
+     PyObject* item;
+ 
+@@ -115,7 +115,6 @@ PyObject* pysqlite_row_subscript(pysqlite_Row* self, PyObject* idx)
+             if (!compare_key) {
+                 return NULL;
+             }
+-
+             p1 = key;
+             p2 = compare_key;
+ 
+
+From 2987839fe0f19541d4b6c6a474101e8564990894 Mon Sep 17 00:00:00 2001
+From: Milan Hauth <milahu@gmail.com>
+Date: Mon, 27 Oct 2025 15:25:34 +0100
+Subject: [PATCH 17/18] fix: warning: assignment discards const qualifier from
+ pointer target type
+
+---
+ src/python3/statement.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/python3/statement.c b/src/python3/statement.c
+index c325fbb..7bd8c31 100644
+--- a/src/python3/statement.c
++++ b/src/python3/statement.c
+@@ -95,7 +95,7 @@ int pysqlite_statement_bind_parameter(pysqlite_Statement* self, int pos, PyObjec
+ {
+     int rc = SQLITE_OK;
+     const char* buffer;
+-    char* string;
++    const char* string;
+     Py_ssize_t buflen;
+     parameter_type paramtype;
+ 
+
+From ef340612bc49751adc14ec27b3a2950dad2ebaf3 Mon Sep 17 00:00:00 2001
+From: Milan Hauth <milahu@gmail.com>
+Date: Mon, 27 Oct 2025 15:26:16 +0100
+Subject: [PATCH 18/18] fix: warning: unused variable buffer
+
+---
+ src/python3/statement.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/src/python3/statement.c b/src/python3/statement.c
+index 7bd8c31..be9c059 100644
+--- a/src/python3/statement.c
++++ b/src/python3/statement.c
+@@ -94,7 +94,6 @@ int pysqlite_statement_create(pysqlite_Statement* self, pysqlite_Connection* con
+ int pysqlite_statement_bind_parameter(pysqlite_Statement* self, int pos, PyObject* parameter)
+ {
+     int rc = SQLITE_OK;
+-    const char* buffer;
+     const char* string;
+     Py_ssize_t buflen;
+     parameter_type paramtype;

--- a/SPECS/python-pysqlcipher3/python-pysqlcipher3.spec
+++ b/SPECS/python-pysqlcipher3/python-pysqlcipher3.spec
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pysqlcipher3
+
+Name:           python-%{srcname}
+Version:        1.2.0
+Release:        %autorelease
+Summary:        DB-API 2.0 interface for SQLCIPHER 3.x
+License:        zlib-acknowledgement
+URL:            https://github.com/rigglemania/pysqlcipher3
+#!RemoteAsset:  sha256:3c8033812655947ebf29a809ac5106b2bc69be0274eaccef6b58f4580c8d06c5
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+# https://github.com/rigglemania/pysqlcipher3/pull/38
+Patch0:         0001-python313-compat.patch
+
+BuildOption(install):  -l %{srcname}
+# skip tests: test.support.TESTFN and test.support.unlink removed since python3.10
+BuildOption(check):  -e 'pysqlcipher3.test*'
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(openssl)
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pkgconfig(sqlcipher)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+pysqlcipher3 is an interface to the SQLite 3.x embedded relational database
+engine with SQLCipher encryption support. It is almost fully compliant with
+the Python database API version 2.0.
+
+%files
+%doc README.rst
+%license LICENSE
+%{python3_sitearch}/*
+
+%changelog
+%autochangelog

--- a/SPECS/python-scramp/python-scramp.spec
+++ b/SPECS/python-scramp/python-scramp.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname scramp
+
+Name:           python-%{srcname}
+Version:        1.4.5
+Release:        %autorelease
+Summary:        An implementation of the SCRAM protocol
+License:        MIT
+URL:            https://github.com/tlocke/scramp
+#!RemoteAsset:  sha256:be3fbe774ca577a7a658117dca014e5d254d158cecae3dd60332dfe33ce6d78e
+Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(asn1crypto)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(versioningit)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+A Python implementation of the SCRAM authentication protocol.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-setuptools-git-versioning/python-setuptools-git-versioning.spec
+++ b/SPECS/python-setuptools-git-versioning/python-setuptools-git-versioning.spec
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname setuptools-git-versioning
+%global pypi_name setuptools_git_versioning
+
+Name:           python-%{srcname}
+Version:        3.0.1
+Release:        %autorelease
+Summary:        Dynamic versioning based on git tags for setuptools
+License:        MIT
+URL:            https://github.com/setuptoolsuptools/setuptools-git-versioning
+#!RemoteAsset:  sha256:c8a599bacf163b5d215552b5701faf5480ffc4d65426a5711a010b802e1590eb
+Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{pypi_name}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+setuptools-git-versioning is a setuptools plugin for dynamic versioning
+based on git tags. It allows you to automatically set the version of your
+Python package based on git tags, without having to manually update the
+version in your code.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+%{_bindir}/setuptools-git-versioning
+
+%changelog
+%autochangelog

--- a/SPECS/python-testcloud/python-testcloud.spec
+++ b/SPECS/python-testcloud/python-testcloud.spec
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname testcloud
+
+Name:           python-%{srcname}
+Version:        0.11.8
+Release:        %autorelease
+Summary:        Tool to download and boot cloud images locally
+License:        GPL-2.0-or-later
+URL:            https://github.com/teemtee/testcloud
+#!RemoteAsset:  sha256:bc80571dff0f34b38eb0a8c84eff28b0f7613fead591e997baeadde5de2ba223
+Source0:        https://files.pythonhosted.org/packages/source/t/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(libvirt-python)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(peewee)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(requests)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Testcloud downloads and boots cloud images locally and provides both a command
+line interface and a Python API.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%install -a
+install -Dpm0644 manpages/testcloud.1 %{buildroot}%{_mandir}/man1/testcloud.1
+install -Dpm0644 conf/99-testcloud-nonroot-libvirt-access.rules \
+    %{buildroot}%{_udevrulesdir}/99-testcloud-nonroot-libvirt-access.rules
+
+%files -f %{pyproject_files}
+%doc conf/settings-example.py
+%doc README.md
+%license LICENSE
+%{_bindir}/testcloud
+%{_bindir}/t7d
+%{_datadir}/bash-completion/completions/%{srcname}
+%{_mandir}/man1/testcloud.1*
+%{_udevrulesdir}/99-testcloud-nonroot-libvirt-access.rules
+
+%changelog
+%autochangelog

--- a/SPECS/python-textual/2000-remove-linkify-extra.patch
+++ b/SPECS/python-textual/2000-remove-linkify-extra.patch
@@ -1,0 +1,11 @@
+--- textual-8.2.6.orig/pyproject.toml	2026-05-28 06:45:38.905136938 +0000
++++ textual-8.2.6/pyproject.toml	2026-05-28 06:45:46.179951584 +0000
+@@ -46,7 +46,7 @@
+ 
+ [tool.poetry.dependencies]
+ python = "^3.9"
+-markdown-it-py = { extras = ["linkify"], version = ">=2.1.0" }
++markdown-it-py = ">=2.1.0"
+ mdit-py-plugins = "*"
+ rich = ">=14.2.0"
+ #rich = {path="../rich", develop=true}

--- a/SPECS/python-textual/python-textual.spec
+++ b/SPECS/python-textual/python-textual.spec
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname textual
+
+Name:           python-%{srcname}
+Version:        8.2.6
+Release:        %autorelease
+Summary:        Modern Text User Interface framework
+License:        MIT
+URL:            https://github.com/Textualize/textual
+#!RemoteAsset:  sha256:cef3714498a120a99278b98d4c165c278844e73db50f1db039aaabd89f2d1b63
+Source0:        https://files.pythonhosted.org/packages/source/t/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+# missing python3dist(markdown-it-py[linkify])
+Patch2000:      2000-remove-linkify-extra.patch
+
+BuildOption(install):  -l textual
+# Windows-specific drivers, not available on Linux
+BuildOption(check):  -e 'textual.drivers.win32'
+BuildOption(check):  -e 'textual.drivers.windows_driver'
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(mdit-py-plugins)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(platformdirs)
+BuildRequires:  python3dist(poetry-core)
+BuildRequires:  python3dist(pygments)
+BuildRequires:  python3dist(rich)
+BuildRequires:  python3dist(typing-extensions)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Textual is a Text User Interface (TUI) framework for Python.
+It allows developers to build interactive terminal applications.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-tmt/python-tmt.spec
+++ b/SPECS/python-tmt/python-tmt.spec
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname tmt
+
+Name:           python-%{srcname}
+Version:        1.72.0
+Release:        %autorelease
+Summary:        Test Management Tool
+License:        MIT
+URL:            https://github.com/teemtee/tmt
+#!RemoteAsset:  sha256:df9b33cc10aae202b679b44933661dd34447ba248df8f02b5b6579334134958a
+Source0:        https://files.pythonhosted.org/packages/source/t/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(click)
+BuildRequires:  python3dist(docutils)
+BuildRequires:  python3dist(fmf)
+BuildRequires:  python3dist(hatch-vcs)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(jinja2)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pint)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pydantic)
+BuildRequires:  python3dist(pygments)
+BuildRequires:  python3dist(requests)
+BuildRequires:  python3dist(ruamel-yaml)
+BuildRequires:  python3dist(ruamel-yaml-clib)
+BuildRequires:  python3dist(urllib3)
+
+Requires:       git-core
+Requires:       libvirt-daemon-driver-qemu
+Requires:       mock
+Requires:       openssh-clients
+Requires:       podman
+Requires:       python3dist(ansible-core)
+Requires:       python3dist(libvirt-python)
+Requires:       python3dist(testcloud)
+Requires:       qemu
+Requires:       rsync
+Requires:       sshpass
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+The tmt Python module and command line tool implement the test metadata
+specification and provide test execution across multiple environments.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc examples
+%doc README.rst
+%license LICENSE
+%{_bindir}/tmt
+
+%changelog
+%autochangelog

--- a/SPECS/python-toolz/python-toolz.spec
+++ b/SPECS/python-toolz/python-toolz.spec
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname toolz
+
+Name:           python-%{srcname}
+Version:        1.1.0
+Release:        %autorelease
+Summary:        List processing tools and functional utilities
+License:        BSD-3-Clause
+URL:            https://github.com/pytoolz/toolz
+#!RemoteAsset:  sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b
+Source0:        https://files.pythonhosted.org/packages/source/t/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname} tlz
+# skip tests: toolz.compatibility raises DeprecationWarning
+BuildOption(check):  -e 'toolz.tests.test_compatibility'
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-git-versioning)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Toolz provides a set of utility functions for iterators, functions, and
+dictionaries. These functions interoperate well and form the building blocks
+of common data analytic operations. They extend the standard library modules
+itertools and functools.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE.txt
+
+%changelog
+%autochangelog

--- a/SPECS/python-tzdata/python-tzdata.spec
+++ b/SPECS/python-tzdata/python-tzdata.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname tzdata
+
+Name:           python-%{srcname}
+Version:        2026.2
+Release:        %autorelease
+Summary:        Provider of IANA time zone data
+License:        Apache-2.0
+URL:            https://github.com/python/tzdata
+#!RemoteAsset:  sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10
+Source0:        https://files.pythonhosted.org/packages/source/t/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Provider of IANA time zone data for the Python zoneinfo module.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-versioningit/python-versioningit.spec
+++ b/SPECS/python-versioningit/python-versioningit.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname versioningit
+
+Name:           python-%{srcname}
+Version:        3.3.0
+Release:        %autorelease
+Summary:        Versioning based on git tags for build systems
+License:        MIT
+URL:            https://github.com/jwodder/versioningit
+#!RemoteAsset:  sha256:b91ad7d73e73d21220e69540f20213f2b729a1f9b35c04e9e137eaf28d2214da
+Source0:        https://files.pythonhosted.org/packages/source/v/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+VersioningIt finds the version of a package based on VCS tags and
+version config files.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+%{_bindir}/versioningit
+
+%changelog
+%autochangelog

--- a/SPECS/python-xarray/python-xarray.spec
+++ b/SPECS/python-xarray/python-xarray.spec
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname xarray
+
+Name:           python-%{srcname}
+Version:        2026.4.0
+Release:        %autorelease
+Summary:        N-D labeled arrays and datasets in Python
+License:        Apache-2.0
+URL:            https://xarray.dev/
+VCS:            git:https://github.com/pydata/xarray.git
+#!RemoteAsset:  sha256:c4ac9a01a945d90d5b1628e2af045099a9d4943536d4f2ee3ae963c3b222d15b
+Source0:        https://files.pythonhosted.org/packages/source/x/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+# skip tests: No module named 'cupy'
+BuildOption(check):  -e 'xarray.tests.test_cupy'
+# skip tests: No module named 'sparse'
+BuildOption(check):  -e 'xarray.tests.test_sparse'
+# skip tests: circular dependency with python-pint
+BuildOption(check):  -e 'xarray.tests.test_units'
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(array-api-strict)
+BuildRequires:  python3dist(cftime)
+BuildRequires:  python3dist(dask)
+BuildRequires:  python3dist(distributed)
+BuildRequires:  python3dist(hypothesis)
+BuildRequires:  python3dist(jinja2)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pandas)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pyarrow)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(pytz)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+xarray is a Python package for working with labeled multi-dimensional
+arrays, providing a pandas-like API for N-dimensional data.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-xyzservices/python-xyzservices.spec
+++ b/SPECS/python-xyzservices/python-xyzservices.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname xyzservices
+
+Name:           python-%{srcname}
+Version:        2026.3.0
+Release:        %autorelease
+Summary:        Source of XYZ tiles providers
+License:        BSD-3-Clause
+URL:            https://github.com/geopandas/xyzservices
+#!RemoteAsset:  sha256:d226866a5d8e9fef337034d8da37a8298f0a1d9d1489b4018e69579eb321fea4
+Source0:        https://files.pythonhosted.org/packages/source/x/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(mercantile)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(requests)
+BuildRequires:  python3dist(setuptools-scm[toml])
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+xyzservices is a library that provides a unified API for XYZ tile providers.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+%{_datadir}/xyzservices/providers.json
+
+%changelog
+%autochangelog

--- a/SPECS/python-zict/python-zict.spec
+++ b/SPECS/python-zict/python-zict.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname zict
+
+Name:           python-%{srcname}
+Version:        3.0.0
+Release:        %autorelease
+Summary:        Mutable mapping tools
+License:        BSD-3-Clause
+URL:            https://zict.readthedocs.io/
+VCS:            git:https://github.com/dask/zict.git
+#!RemoteAsset:  sha256:e321e263b6a97aafc0790c3cfb3c04656b7066e6738c37fffcca95d803c9fba5
+Source0:        https://files.pythonhosted.org/packages/source/z/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(lmdb)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+zict provides mutable mapping tools for Python, including file-based
+mappings, LRU caches, and buffered mappings.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE.txt
+
+%changelog
+%autochangelog

--- a/SPECS/sqlcipher/sqlcipher.spec
+++ b/SPECS/sqlcipher/sqlcipher.spec
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global _test_target fuzztest
+
+Name:           sqlcipher
+Version:        4.6.1
+Release:        %autorelease
+Summary:        SQLite extension that provides 256-bit AES encryption
+License:        BSD-3-Clause
+URL:            https://github.com/sqlcipher/sqlcipher
+#!RemoteAsset:  sha256:d8f9afcbc2f4b55e316ca4ada4425daf3d0b4aab25f45e11a802ae422b9f53a3
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
+BuildSystem:    autotools
+
+BuildRequires:  pkgconfig(openssl)
+BuildRequires:  pkgconfig(tcl)
+BuildRequires:  pkgconfig(zlib)
+
+BuildOption(conf):  --enable-tempstore
+BuildOption(conf):  --enable-releasemode
+BuildOption(conf):  --disable-static
+BuildOption(conf):  --disable-tcl
+BuildOption(conf):  --enable-fts3
+BuildOption(conf):  --enable-fts4
+BuildOption(conf):  --enable-fts5
+BuildOption(conf):  --enable-rtree
+
+%description
+SQLCipher is a standalone fork of the SQLite database library that adds
+256-bit AES encryption of database files and other security features.
+
+%package        devel
+Summary:        Development files for SQLCipher
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+Header files and libraries for developing applications that use SQLCipher.
+
+%files
+%license LICENSE.md
+%{_bindir}/sqlcipher
+%{_libdir}/libsqlcipher*.so.*
+
+%files devel
+%{_includedir}/sqlcipher/
+%{_libdir}/libsqlcipher.so
+%{_libdir}/pkgconfig/sqlcipher.pc
+
+%changelog
+%autochangelog


### PR DESCRIPTION
Add tmt test framework

AIGC Declaration:  used codex gpt-5.4  for specs generated and osc build.

Depends tree:


- [x] python-tmt
	- [x] python-ansible-core
	- [x] python-fmf
	- [x] python-testcloud
		- [x] python-peewee
			- [x] python-apsw
			- [x] python-cysqlite
			- [x] python-pysqlcipher3
				- [x] sqlcipher
	- [x] python-pint
		- [x] python-flexcache
		- [x] python-flexparser
		- [x] python-dask
			- [x] python-cachey
				- [x] python-heapdict
			- [x] python-moto
				- [x] python-flask-cors
				- [x] python-aws-xray-sdk
					- [x] python-bottle
					- [x] python-pynamodb
					- [x] python-pg8000
						- [x] python-scramp
							- [x] python-versioningit
			- [x] python-partd
				- [x] python-locket
				- [x] python-toolz
			- [x] python-toolz
				- [x] python-setuptools-git-versioning
		- [x] python-distributed
			- [x] python-bokeh
				- [x] python-bokeh-sampledata
				- [x] python-icalendar
					- [x] python-tzdata
				- [x] python-xyzservices
					- [x] python-mercantile
			- [x] python-dask
			- [x] python-h5py
			- [x] python-locket
			- [x] python-memray
				- [x] python-textual
					- [x] python-mdit-py-plugins
			- [x] python-toolz
			- [x] python-zict
				- [x] python-lmdb
					- [x] python-patch-ng
		- [x] python-xarray
			- [x] python-array-api-strict
			- [x] python-cftime

