### PR TITLE
SPECS: openruyi-minimal: Add systemd subpackage

### DIFF
--- a/SPECS/openruyi-minimal/openruyi-minimal.spec
+++ b/SPECS/openruyi-minimal/openruyi-minimal.spec
@@ -43,6 +43,18 @@ Requires:       nano
 %description
 This meta package provides the minimal environment for openRuyi.
 
+%package        systemd
+Summary:        Meta package for minimal openRuyi environment, with systemd
+Requires:       systemd
+Requires:       systemd-udev
+# for udevd System call
+Requires:       libseccomp
+# for udevd auto modprobe
+Requires:       kmod-libs
+
+%description    systemd
+This meta package provides the minimal environment with systemd for openRuyi.
+
 %prep
 
 %build
@@ -51,5 +63,7 @@ This meta package provides the minimal environment for openRuyi.
 
 %files
 
+%files systemd
+
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Make dnf select systemd-udev, not libudev-zero

Signed-off-by: Zheng Junjie <zhengjunjie@iscas.ac.cn>