### PR TITLE
SPECS: binutils: fix RISC-V testsuite failures

### DIFF
--- a/SPECS/binutils/2000-ld-riscv-data-reloc-allow-textrels-in-tests.patch
+++ b/SPECS/binutils/2000-ld-riscv-data-reloc-allow-textrels-in-tests.patch
@@ -1,0 +1,72 @@
+diff --git a/ld/testsuite/ld-riscv-elf/data-reloc-rv32-pic.d b/ld/testsuite/ld-riscv-elf/data-reloc-rv32-pic.d
+index 5bf85b9..ea96835 100644
+--- a/ld/testsuite/ld-riscv-elf/data-reloc-rv32-pic.d
++++ b/ld/testsuite/ld-riscv-elf/data-reloc-rv32-pic.d
+@@ -1,6 +1,6 @@
+ #source: data-reloc.s
+ #as: -march=rv32i -mabi=ilp32 -defsym __abs__=1 -defsym __addr__=1 -defsym __undef__=1
+-#ld: -m[riscv_choose_ilp32_emul] -Ttext 0x8000 --defsym _start=0x0 --defsym abs=0x100 --defsym abs_local=0x200 -shared
++#ld: -m[riscv_choose_ilp32_emul] -Ttext 0x8000 --defsym _start=0x0 --defsym abs=0x100 --defsym abs_local=0x200 -shared -z notext
+ #objdump: -dR
+ 
+ .*:[ 	]+file format .*
+diff --git a/ld/testsuite/ld-riscv-elf/data-reloc-rv32-pie.d b/ld/testsuite/ld-riscv-elf/data-reloc-rv32-pie.d
+index 4ed7f28..8a3b5d8 100644
+--- a/ld/testsuite/ld-riscv-elf/data-reloc-rv32-pie.d
++++ b/ld/testsuite/ld-riscv-elf/data-reloc-rv32-pie.d
+@@ -1,6 +1,6 @@
+ #source: data-reloc.s
+ #as: -march=rv32i -mabi=ilp32 -defsym __abs__=1 -defsym __addr__=1
+-#ld: -m[riscv_choose_ilp32_emul] -Ttext 0x8000 --defsym _start=0x0 --defsym abs=0x100 --defsym abs_local=0x200 -pie
++#ld: -m[riscv_choose_ilp32_emul] -Ttext 0x8000 --defsym _start=0x0 --defsym abs=0x100 --defsym abs_local=0x200 -pie -z notext
+ #objdump: -dR
+ 
+ .*:[ 	]+file format .*
+diff --git a/ld/testsuite/ld-riscv-elf/data-reloc-rv32-symbolic.d b/ld/testsuite/ld-riscv-elf/data-reloc-rv32-symbolic.d
+index 4f8a1a1..0a16656 100644
+--- a/ld/testsuite/ld-riscv-elf/data-reloc-rv32-symbolic.d
++++ b/ld/testsuite/ld-riscv-elf/data-reloc-rv32-symbolic.d
+@@ -1,6 +1,6 @@
+ #source: data-reloc.s
+ #as: -march=rv32i -mabi=ilp32 -defsym __abs__=1 -defsym __addr__=1 -defsym __undef__=1
+-#ld: -m[riscv_choose_ilp32_emul] -Ttext 0x8000 --defsym _start=0x0 --defsym abs=0x100 --defsym abs_local=0x200 -shared -Bsymbolic
++#ld: -m[riscv_choose_ilp32_emul] -Ttext 0x8000 --defsym _start=0x0 --defsym abs=0x100 --defsym abs_local=0x200 -shared -Bsymbolic -z notext
+ #objdump: -dR
+ 
+ .*:[ 	]+file format .*
+diff --git a/ld/testsuite/ld-riscv-elf/data-reloc-rv64-pic.d b/ld/testsuite/ld-riscv-elf/data-reloc-rv64-pic.d
+index f77be5a..a65fc00 100644
+--- a/ld/testsuite/ld-riscv-elf/data-reloc-rv64-pic.d
++++ b/ld/testsuite/ld-riscv-elf/data-reloc-rv64-pic.d
+@@ -1,6 +1,6 @@
+ #source: data-reloc.s
+ #as: -march=rv64i -mabi=lp64 -defsym __64_bit__=1 -defsym __abs__=1 -defsym __addr__=1 -defsym __undef__=1
+-#ld: -m[riscv_choose_lp64_emul] -Ttext 0x8000 --defsym _start=0x0 --defsym abs=0x100 --defsym abs_local=0x200 -shared
++#ld: -m[riscv_choose_lp64_emul] -Ttext 0x8000 --defsym _start=0x0 --defsym abs=0x100 --defsym abs_local=0x200 -shared -z notext
+ #objdump: -dR
+ 
+ .*:[ 	]+file format .*
+diff --git a/ld/testsuite/ld-riscv-elf/data-reloc-rv64-pie.d b/ld/testsuite/ld-riscv-elf/data-reloc-rv64-pie.d
+index f85c323..a0f8233 100644
+--- a/ld/testsuite/ld-riscv-elf/data-reloc-rv64-pie.d
++++ b/ld/testsuite/ld-riscv-elf/data-reloc-rv64-pie.d
+@@ -1,6 +1,6 @@
+ #source: data-reloc.s
+ #as: -march=rv64i -mabi=lp64 -defsym __64_bit__=1 -defsym __abs__=1 -defsym __addr__=1
+-#ld: -m[riscv_choose_lp64_emul] -Ttext 0x8000 --defsym _start=0x0 --defsym abs=0x100 --defsym abs_local=0x200 -pie
++#ld: -m[riscv_choose_lp64_emul] -Ttext 0x8000 --defsym _start=0x0 --defsym abs=0x100 --defsym abs_local=0x200 -pie -z notext
+ #objdump: -dR
+ 
+ .*:[ 	]+file format .*
+diff --git a/ld/testsuite/ld-riscv-elf/data-reloc-rv64-symbolic.d b/ld/testsuite/ld-riscv-elf/data-reloc-rv64-symbolic.d
+index 0c3ce86..b6b797a 100644
+--- a/ld/testsuite/ld-riscv-elf/data-reloc-rv64-symbolic.d
++++ b/ld/testsuite/ld-riscv-elf/data-reloc-rv64-symbolic.d
+@@ -1,6 +1,6 @@
+ #source: data-reloc.s
+ #as: -march=rv64i -mabi=lp64 -defsym __64_bit__=1 -defsym __abs__=1 -defsym __addr__=1 -defsym __undef__=1
+-#ld: -m[riscv_choose_lp64_emul] -Ttext 0x8000 --defsym _start=0x0 --defsym abs=0x100 --defsym abs_local=0x200 -shared -Bsymbolic
++#ld: -m[riscv_choose_lp64_emul] -Ttext 0x8000 --defsym _start=0x0 --defsym abs=0x100 --defsym abs_local=0x200 -shared -Bsymbolic -z notext
+ #objdump: -dR
+ 
+ .*:[ 	]+file format .*

--- a/SPECS/binutils/2001-ld-riscv-relax-tests-accept-signed-immediates.patch
+++ b/SPECS/binutils/2001-ld-riscv-relax-tests-accept-signed-immediates.patch
@@ -1,0 +1,41 @@
+diff --git a/ld/testsuite/ld-riscv-elf/pcgp-relax-01-norelaxgp.d b/ld/testsuite/ld-riscv-elf/pcgp-relax-01-norelaxgp.d
+index 9099641..3272f46 100644
+--- a/ld/testsuite/ld-riscv-elf/pcgp-relax-01-norelaxgp.d
++++ b/ld/testsuite/ld-riscv-elf/pcgp-relax-01-norelaxgp.d
+@@ -9,10 +9,10 @@
+ Disassembly of section \.text:
+ 
+ 0+[0-9a-f]+ <_start>:
+-.*:[ 	]+[0-9a-f]+[ 	]+addi[ 	]+a0,a0,[0-9]+
++.*:[ 	]+[0-9a-f]+[ 	]+addi[ 	]+a0,a0,[-]?[0-9]+
+ .*:[ 	]+[0-9a-f]+[ 	]+jal[ 	        ]+ra,[0-9a-f]+ <_start>
+ .*:[ 	]+[0-9a-f]+[ 	]+auipc[ 	]+a1,0x[0-9a-f]+
+-.*:[ 	]+[0-9a-f]+[ 	]+addi[ 	]+a1,a1,[0-9]+ # [0-9a-f]+ <data_g>
++.*:[ 	]+[0-9a-f]+[ 	]+addi[ 	]+a1,a1,[-]?[0-9]+ # [0-9a-f]+ <data_g>
+ .*:[ 	]+[0-9a-f]+[ 	]+lui[ 	        ]+a2,0x[0-9a-f]+
+ .*:[ 	]+[0-9a-f]+[ 	]+addi[ 	]+a2,a2,[0-9]+ # [0-9a-f]+ <data_g>
+ .*:[ 	]+[0-9a-f]+[ 	]+addi[ 	]+a3,tp,0 # 0 <data_t>
+diff --git a/ld/testsuite/ld-riscv-elf/pcgp-relax-01.d b/ld/testsuite/ld-riscv-elf/pcgp-relax-01.d
+index 5cc3a53..cc7f80b 100644
+--- a/ld/testsuite/ld-riscv-elf/pcgp-relax-01.d
++++ b/ld/testsuite/ld-riscv-elf/pcgp-relax-01.d
+@@ -9,7 +9,7 @@
+ Disassembly of section \.text:
+ 
+ 0+[0-9a-f]+ <_start>:
+-.*:[ 	]+[0-9a-f]+[ 	]+addi[ 	]+a0,a0,[0-9]+
++.*:[ 	]+[0-9a-f]+[ 	]+addi[ 	]+a0,a0,[-]?[0-9]+
+ .*:[ 	]+[0-9a-f]+[ 	]+jal[ 	]+ra,[0-9a-f]+ <_start>
+ .*:[ 	]+[0-9a-f]+[ 	]+addi[ 	]+a1,gp,\-[0-9]+ # [0-9a-f]+ <data_g>
+ .*:[ 	]+[0-9a-f]+[ 	]+addi[ 	]+a2,gp,\-[0-9]+ # [0-9a-f]+ <data_g>
+diff --git a/ld/testsuite/ld-riscv-elf/pcgp-relax-02.d b/ld/testsuite/ld-riscv-elf/pcgp-relax-02.d
+index 513a126..e586844 100644
+--- a/ld/testsuite/ld-riscv-elf/pcgp-relax-02.d
++++ b/ld/testsuite/ld-riscv-elf/pcgp-relax-02.d
+@@ -11,5 +11,5 @@ Disassembly of section .text:
+ [0-9a-f]+ <_start>:
+ .*:[ 	]+[0-9a-f]+[ 	]+auipc[ 	]+a1.*
+ .*:[ 	]+[0-9a-f]+[ 	]+addi[ 	]+a0,gp.*<data_a>
+-.*:[ 	]+[0-9a-f]+[ 	]+addi[ 	]+a1,a1.*<data_b>
++.*:[ 	]+[0-9a-f]+[ 	]+(mv[ 	]+a1,a1|addi[ 	]+a1,a1,[-]?[0-9]+( # [0-9a-f]+ <data_b>)?)
+ #pass

--- a/SPECS/binutils/2002-ld-riscv-zicfilp-accept-variable-plt-offset.patch
+++ b/SPECS/binutils/2002-ld-riscv-zicfilp-accept-variable-plt-offset.patch
@@ -1,0 +1,12 @@
+diff --git a/ld/testsuite/ld-riscv-elf/zicfilp-unlabeled-plt.d b/ld/testsuite/ld-riscv-elf/zicfilp-unlabeled-plt.d
+index a0181af..5556739 100644
+--- a/ld/testsuite/ld-riscv-elf/zicfilp-unlabeled-plt.d
++++ b/ld/testsuite/ld-riscv-elf/zicfilp-unlabeled-plt.d
+@@ -30,6 +30,6 @@ Disassembly of section \.plt:
+ 
+ [0-9a-f]+ <bar@plt>:
+ .*:[ 	]+[0-9a-f]+[ 	]+lpad[ 	]+0x0
+-.*:[ 	]+[0-9a-f]+[ 	]+auipc[ 	]+t3,0x1
++.*:[ 	]+[0-9a-f]+[ 	]+auipc[ 	]+t3,0x[0-9a-f]+
+ .*:[ 	]+[0-9a-f]+[ 	]+ld[ 	]+t3,[0-9]+\(t3\) # [0-9a-f]+ <bar>
+ .*:[ 	]+[0-9a-f]+[ 	]+jalr[ 	]+t1,t3

--- a/SPECS/binutils/2003-binutils-riscv-xfail-strip-annotation-symbol-tests.patch
+++ b/SPECS/binutils/2003-binutils-riscv-xfail-strip-annotation-symbol-tests.patch
@@ -1,0 +1,14 @@
+diff --git a/binutils/testsuite/binutils-all/objcopy.exp b/binutils/testsuite/binutils-all/objcopy.exp
+index eed6658..d7a5f78 100644
+--- a/binutils/testsuite/binutils-all/objcopy.exp
++++ b/binutils/testsuite/binutils-all/objcopy.exp
+@@ -613,6 +613,9 @@ proc strip_test { } {
+     set exec_output [binutils_run $NM "-a $NMFLAGS $objfile"]
+     set exec_output [prune_warnings $exec_output]
+     if ![string match "*: no symbols*" $exec_output] {
++	# RISC-V annotation symbols can remain after stripping.
++	setup_xfail riscv*-*-*
++
+ 	fail $test
+ 	return
+     }

--- a/SPECS/binutils/2004-ld-elf-dwarf3-accept-riscv-pie-output.patch
+++ b/SPECS/binutils/2004-ld-elf-dwarf3-accept-riscv-pie-output.patch
@@ -1,0 +1,9 @@
+diff --git a/ld/testsuite/ld-elf/dwarf3.err b/ld/testsuite/ld-elf/dwarf3.err
+index 8d1f0d5..a76c83a 100644
+--- a/ld/testsuite/ld-elf/dwarf3.err
++++ b/ld/testsuite/ld-elf/dwarf3.err
+@@ -1,4 +1,3 @@
+ .*/dwarf3\.o: in function `main':
+ .*\(\.text.*\+0x[0-9a-f]+\): undefined reference to `bar'
+-.*\(\.text.*\+0x[0-9a-f]+\): undefined reference to `bar'
+ #...

--- a/SPECS/binutils/binutils.spec
+++ b/SPECS/binutils/binutils.spec
@@ -30,6 +30,8 @@ BuildSystem:    autotools
 Patch2000:      2000-ld-riscv-data-reloc-allow-textrels-in-tests.patch
 # a8edbcb: accept signed RISC-V relaxation immediates without full wildcarding
 Patch2001:      2001-ld-riscv-relax-tests-accept-signed-immediates.patch
+# f6c1766: accept layout-dependent RISC-V Zicfilp PLT offsets
+Patch2002:      2002-ld-riscv-zicfilp-accept-variable-plt-offset.patch
 %endif
 
 BuildOption(build):  -C build-dir

--- a/SPECS/binutils/binutils.spec
+++ b/SPECS/binutils/binutils.spec
@@ -23,22 +23,20 @@ VCS:            git:https://sourceware.org/git/binutils-gdb.git
 Source0:        https://ftpmirror.gnu.org/gnu/binutils/binutils-%{version}.tar.bz2
 BuildSystem:    autotools
 
-%ifarch riscv64
 # Backports from Fedora f44 binutils-riscv-testsuite-fixes.patch:
 # https://src.fedoraproject.org/rpms/binutils/blob/f44/f/binutils-riscv-testsuite-fixes.patch
-# f3398aab: allow data-reloc tests when text relocations are rejected
+# https://src.fedoraproject.org/rpms/binutils/c/f3398aab: allow data-reloc tests when text relocations are rejected
 Patch2000:      2000-ld-riscv-data-reloc-allow-textrels-in-tests.patch
-# a8edbcb: accept signed RISC-V relaxation immediates without full wildcarding
+# https://src.fedoraproject.org/rpms/binutils/c/a8edbcb: accept signed RISC-V relaxation immediates without full wildcarding
 Patch2001:      2001-ld-riscv-relax-tests-accept-signed-immediates.patch
-# f6c1766: accept layout-dependent RISC-V Zicfilp PLT offsets
+# https://src.fedoraproject.org/rpms/binutils/c/f6c1766: accept layout-dependent RISC-V Zicfilp PLT offsets
 Patch2002:      2002-ld-riscv-zicfilp-accept-variable-plt-offset.patch
-# 9e81b24: xfail RISC-V strip test where annotation symbols remain
+# https://src.fedoraproject.org/rpms/binutils/c/9e81b24: xfail RISC-V strip test where annotation symbols remain
 Patch2003:      2003-binutils-riscv-xfail-strip-annotation-symbol-tests.patch
 # openRuyi: default PIE on RISC-V emits this diagnostic before the second
 # undefined reference expected by upstream:
 # relocation R_RISCV_CALL_PLT against `bar' which may bind externally can not be used when making a shared object; recompile with -fPIC
 Patch2004:      2004-ld-elf-dwarf3-accept-riscv-pie-output.patch
-%endif
 
 BuildOption(build):  -C build-dir
 
@@ -123,13 +121,23 @@ cd ..
 %find_lang %{name} --all-name --generate-subpackages
 
 %check
-# Delete upsteam known failure. https://sourceware.org/bugzilla//show_bug.cgi?id=32983
+# Drop upstream-known pr19719 tests pending ld/32983.
+# https://sourceware.org/bugzilla/show_bug.cgi?id=32983
 sed -i '/"pr19719/d' ld/testsuite/ld-elf/shared.exp
 
 cd build-dir
 
-# Increase timeout to fit slow qemu-system builder.
-make RUNTESTFLAGS='TEST_TIMEOUT=600' check
+# Keep successful builds quiet, but print concise DejaGnu context on failure.
+make RUNTESTFLAGS='TEST_TIMEOUT=600' check || {
+  rc=$?
+  dejagnu_sum_regex='^(FAIL|XPASS|ERROR|UNRESOLVED):'
+  dejagnu_log_regex='^(FAIL|XPASS|ERROR|UNRESOLVED):|^expected:|^actual:|^output is|^returned with:|ld\.messages has'
+  echo "===== DejaGnu unexpected results ====="
+  find . -name '*.sum' -exec grep -HnE "$dejagnu_sum_regex" {} + || :
+  echo "===== DejaGnu failure context ====="
+  find . -name '*.log' -exec grep -HnE -C 5 "$dejagnu_log_regex" {} + || :
+  exit $rc
+}
 
 %post
 if [ "$1" = 1 ]; then

--- a/SPECS/binutils/binutils.spec
+++ b/SPECS/binutils/binutils.spec
@@ -34,6 +34,10 @@ Patch2001:      2001-ld-riscv-relax-tests-accept-signed-immediates.patch
 Patch2002:      2002-ld-riscv-zicfilp-accept-variable-plt-offset.patch
 # 9e81b24: xfail RISC-V strip test where annotation symbols remain
 Patch2003:      2003-binutils-riscv-xfail-strip-annotation-symbol-tests.patch
+# openRuyi: default PIE on RISC-V emits this diagnostic before the second
+# undefined reference expected by upstream:
+# relocation R_RISCV_CALL_PLT against `bar' which may bind externally can not be used when making a shared object; recompile with -fPIC
+Patch2004:      2004-ld-elf-dwarf3-accept-riscv-pie-output.patch
 %endif
 
 BuildOption(build):  -C build-dir

--- a/SPECS/binutils/binutils.spec
+++ b/SPECS/binutils/binutils.spec
@@ -23,6 +23,13 @@ VCS:            git:https://sourceware.org/git/binutils-gdb.git
 Source0:        https://ftpmirror.gnu.org/gnu/binutils/binutils-%{version}.tar.bz2
 BuildSystem:    autotools
 
+%ifarch riscv64
+# Backports from Fedora f44 binutils-riscv-testsuite-fixes.patch:
+# https://src.fedoraproject.org/rpms/binutils/blob/f44/f/binutils-riscv-testsuite-fixes.patch
+# f3398aab: allow data-reloc tests when text relocations are rejected
+Patch2000:      2000-ld-riscv-data-reloc-allow-textrels-in-tests.patch
+%endif
+
 BuildOption(build):  -C build-dir
 
 BuildRequires:  gcc-c++

--- a/SPECS/binutils/binutils.spec
+++ b/SPECS/binutils/binutils.spec
@@ -32,6 +32,8 @@ Patch2000:      2000-ld-riscv-data-reloc-allow-textrels-in-tests.patch
 Patch2001:      2001-ld-riscv-relax-tests-accept-signed-immediates.patch
 # f6c1766: accept layout-dependent RISC-V Zicfilp PLT offsets
 Patch2002:      2002-ld-riscv-zicfilp-accept-variable-plt-offset.patch
+# 9e81b24: xfail RISC-V strip test where annotation symbols remain
+Patch2003:      2003-binutils-riscv-xfail-strip-annotation-symbol-tests.patch
 %endif
 
 BuildOption(build):  -C build-dir

--- a/SPECS/binutils/binutils.spec
+++ b/SPECS/binutils/binutils.spec
@@ -28,6 +28,8 @@ BuildSystem:    autotools
 # https://src.fedoraproject.org/rpms/binutils/blob/f44/f/binutils-riscv-testsuite-fixes.patch
 # f3398aab: allow data-reloc tests when text relocations are rejected
 Patch2000:      2000-ld-riscv-data-reloc-allow-textrels-in-tests.patch
+# a8edbcb: accept signed RISC-V relaxation immediates without full wildcarding
+Patch2001:      2001-ld-riscv-relax-tests-accept-signed-immediates.patch
 %endif
 
 BuildOption(build):  -C build-dir


### PR DESCRIPTION
Signed-off-by: Jingwiw <wangjingwei@iscas.ac.cn>

Backport Fedora RISC-V binutils testsuite fixes and add one openRuyi-specific adjustment
for the no-DWARF diagnostic test under default PIE toolchains.