### PR TITLE
SPECS: python-setuptools: Merge subpackage & Fix python spec file formatting.

### DIFF
--- a/SPECS/python-setuptools/python-setuptools.spec
+++ b/SPECS/python-setuptools/python-setuptools.spec
@@ -9,62 +9,6 @@
 %global srcname setuptools
 %global python_wheel_name %{srcname}-%{version}-py3-none-any.whl
 
-# If it is set to 1, the bootstrap process will be included
-%if "%{flavor}" == "bootstrap"
-%bcond bootstrap 1
-%else
-%bcond bootstrap 0
-%endif
-
-%if %{with bootstrap}
-Name:           python-%{srcname}-bootstrap
-%else
-Name:           python-%{srcname}
-%endif
-Version:        80.9.0
-Release:        %autorelease
-Summary:        Easily build and distribute Python packages
-License:        MIT AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0) AND Python-2.0.1 AND LGPL-3.0-only
-URL:            https://pypi.python.org/pypi/setuptools
-# TODO: Use %%{pypi_source %%{srcname} %%{version}} in the future - 251
-#       Otherwise https://files.pythonhosted.org/packages/source/a/abc/%%{srcname}-%%{version}.tar.gz
-#!RemoteAsset
-Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
-BuildArch:      noarch
-
-# setuptools rewrites all shebangs to "#!python" which breaks workflows
-# where no external installers (usually rewriting this) are involved.
-# https://github.com/pypa/setuptools/issues/4883
-# - Resolution: deprecated functionality won't be fixed.
-# brp-mangle-shebang script cannot mangle this and fails for many pkgs.
-Patch0:         0001-Revert-Always-rewrite-a-Python-shebang-to-python.patch
-
-BuildRequires:  pkgconfig(python3)
-BuildRequires:  expat
-
-%if %{with bootstrap}
-BuildRequires:  unzip
-%endif
-
-# python3 bootstrap: this is built before the final build of python3, which
-# adds the dependency on python3-rpm-generators, so we require it manually
-BuildRequires:  python3-rpm-generators
-# we also use %%{_pyproject_wheeldir}, so an explicit requirement on the pyproject-macros is needed
-BuildRequires:  pyproject-rpm-macros
-
-%if %{without bootstrap}
-# Not to use the pre-generated egg-info, we use setuptools from previous build to generate it
-BuildRequires:  python3-setuptools
-%endif
-
-%description
-Setuptools is a collection of enhancements to the Python distutils that allow
-you to more easily build and distribute Python packages, especially ones that
-have dependencies on other packages.
-
-This package also contains the runtime components of setuptools, necessary to
-execute the software that requires pkg_resources.
-
 # Virtual provides for the packages bundled by setuptools.
 # Bundled packages are defined in multiple files. Generate the list with:
 # pip freeze --path setuptools/_vendor > vendored.txt
@@ -88,8 +32,53 @@ Provides: bundled(python3dist(wheel)) = 0.45.1
 Provides: bundled(python3dist(zipp)) = 3.19.2
 }
 
-%package     -n python3-setuptools
-Summary:        Easily build and distribute Python 3 packages
+# If it is set to 1, the bootstrap process will be included
+%if "%{flavor}" == "bootstrap"
+%bcond bootstrap 1
+%else
+%bcond bootstrap 0
+%endif
+
+%if %{with bootstrap}
+Name:           python-%{srcname}-bootstrap
+%else
+Name:           python-%{srcname}
+%endif
+Version:        80.9.0
+Release:        %autorelease
+Summary:        Easily build and distribute Python packages
+License:        MIT AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0) AND Python-2.0.1 AND LGPL-3.0-only
+URL:            https://pypi.python.org/pypi/setuptools
+# TODO: Use %%{pypi_source %%{srcname} %%{version}} in the future - 251
+#       Otherwise https://files.pythonhosted.org/packages/source/a/abc/%%{srcname}-%%{version}.tar.gz
+#!RemoteAsset:  sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c
+Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+
+# setuptools rewrites all shebangs to "#!python" which breaks workflows
+# where no external installers (usually rewriting this) are involved.
+# https://github.com/pypa/setuptools/issues/4883
+# - Resolution: deprecated functionality won't be fixed.
+# brp-mangle-shebang script cannot mangle this and fails for many pkgs.
+Patch0:         0001-Revert-Always-rewrite-a-Python-shebang-to-python.patch
+
+BuildRequires:  pkgconfig(python3)
+
+%if %{with bootstrap}
+BuildRequires:  unzip
+%endif
+
+# python3 bootstrap: this is built before the final build of python3, which
+# adds the dependency on python3-rpm-generators, so we require it manually
+BuildRequires:  python3-rpm-generators
+# we also use %%{_pyproject_wheeldir}, so an explicit requirement on the pyproject-macros is needed
+BuildRequires:  pyproject-rpm-macros
+
+%if %{without bootstrap}
+# Not to use the pre-generated egg-info, we use setuptools from previous build to generate it
+BuildRequires:  python3-setuptools
+%endif
+
 %{bundled}
 
 # For users who might see ModuleNotFoundError: No module named 'pkg_resoureces'
@@ -97,9 +86,9 @@ Summary:        Easily build and distribute Python 3 packages
 %py_provides    python3-pkg_resources
 %py_provides    python3-pkg-resources
 
-%description -n python3-setuptools
-Setuptools is a collection of enhancements to the Python 3 distutils that allow
-you to more easily build and distribute Python 3 packages, especially ones that
+%description
+Setuptools is a collection of enhancements to the Python distutils that allow
+you to more easily build and distribute Python packages, especially ones that
 have dependencies on other packages.
 
 This package also contains the runtime components of setuptools, necessary to
@@ -154,7 +143,7 @@ find %{buildroot}%{python3_sitelib} -name tests -print0 | xargs -0 rm -r
 mkdir -p %{buildroot}%{python_wheel_dir}
 install -p %{_pyproject_wheeldir}/%{python_wheel_name} -t %{buildroot}%{python_wheel_dir}
 
-%files -n python3-setuptools %{?!with_bootstrap:-f %{pyproject_files}}
+%files %{?!with_bootstrap:-f %{pyproject_files}}
 %doc docs/* NEWS.rst README.rst
 %{python3_sitelib}/distutils-precedence.pth
 %if %{with bootstrap}
@@ -172,4 +161,4 @@ install -p %{_pyproject_wheeldir}/%{python_wheel_name} -t %{buildroot}%{python_w
 %{python_wheel_dir}/%{python_wheel_name}
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
This Pull Request merges the `python3-setuptools` subpackage into the main package. Also, fix these issues:

 - Correct the `#!RemoteAsset` to include the sha256 checksum value.
 - Update `%{?autochangelog}` to `%autochangelog`.
