### PR TITLE
SPECS: python-hatch-fancy-pypi-readme: Rename package & Fix python spec file formatting.

### DIFF
--- a/SPECS/python-hatch-fancy-pypi-readme/python-hatch-fancy-pypi-readme.spec
+++ b/SPECS/python-hatch-fancy-pypi-readme/python-hatch-fancy-pypi-readme.spec
@@ -6,13 +6,13 @@
 
 %global srcname hatch_fancy_pypi_readme
 
-Name:           python-%{srcname}
+Name:           python-hatch-fancy-pypi-readme
 Version:        25.1.0
 Release:        %autorelease
 Summary:        Fancy PyPI READMEs with Hatch
 License:        MIT
 URL:            https://github.com/hynek/hatch-fancy-pypi-readme
-#!RemoteAsset
+#!RemoteAsset:  sha256:9c58ed3dff90d51f43414ce37009ad1d5b0f08ffc9fc216998a06380f01c0045
 Source0:        https://files.pythonhosted.org/packages/source/h/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -22,8 +22,8 @@ BuildOption(install):  -l %{srcname} +auto
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 
-Provides:       python3-%{srcname}
-%python_provide python3-%{srcname}
+Provides:       python3-hatch-fancy-pypi-readme = %{version}-%{release}
+%python_provide python3-hatch-fancy-pypi-readme
 
 %description
 This hatch plugin allows defining a project description in
@@ -37,4 +37,4 @@ parts of files defined using cut-off points or regular expressions.
 %doc README*
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
This Pull Request fixes the naming scheme described in [PEP 503](https://peps.python.org/pep-0503/#normalized-names). Also, fix these issues:

 - Correct the `#!RemoteAsset` to include the sha256 checksum value.
 - Update `%{?autochangelog}` to `%autochangelog`.
