### PR TITLE
SEPCS: python-mako: Enable mako.ext.linguaplugin 

### DIFF
--- a/SPECS/python-chameleon/python-chameleon.spec
+++ b/SPECS/python-chameleon/python-chameleon.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname chameleon
+%global pypi_name Chameleon
+
+Name:           python-%{srcname}
+Version:        4.6.0
+Release:        %autorelease
+Summary:        Fast HTML/XML template compiler
+License:        BSD-3-Clause AND BSD-4-Clause AND Python-2.0 AND ZPL-2.1
+URL:            https://chameleon.readthedocs.io
+VCS:            git:https://github.com/malthe/chameleon.git
+#!RemoteAsset:  sha256:910cd729f6f7f38adad132ee51faa4f3ccc8344a6721aac31aa51a31f5781c1b
+Source0:        https://files.pythonhosted.org/packages/source/C/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+BuildRequires:  python3dist(pytest)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Chameleon is an HTML/XML template engine for Python. It uses the page templates
+language.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc CHANGES.rst COPYRIGHT.txt README.rst
+%license LICENSE.txt
+
+%changelog
+%autochangelog

--- a/SPECS/python-lingua/python-lingua.spec
+++ b/SPECS/python-lingua/python-lingua.spec
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname lingua
+
+Name:           python-%{srcname}
+Version:        4.16.2
+Release:        %autorelease
+Summary:        Translation toolset
+License:        BSD-3-Clause
+URL:            https://github.com/wichert/lingua
+VCS:            git:https://github.com/wichert/lingua.git
+#!RemoteAsset:  sha256:b1e5cbbbecd40afd39ef3d4fcb40e4e3fc9b96bc0e043e708844a6d226ee54bd
+Source0:        https://files.pythonhosted.org/packages/source/l/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(chameleon)
+BuildRequires:  python3dist(click)
+BuildRequires:  python3dist(polib)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+Requires:       python3dist(chameleon)
+Requires:       python3dist(click)
+Requires:       python3dist(polib)
+
+%description
+Lingua is a package with tools to extract translatable texts from your code,
+and to check existing translations. It replaces the use of the xgettext command
+from gettext, or pybabel from Babel.
+
+%prep -a
+# Replace uv_build backend with hatchling (compatible, uv_build not packaged)
+sed -i 's/requires = \["uv_build>=0.10.5,<0.11.0"\]/requires = ["hatchling"]/' pyproject.toml
+sed -i 's/build-backend = "uv_build"/build-backend = "hatchling.build"/' pyproject.toml
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+%{_bindir}/polint
+%{_bindir}/pot-create
+
+%changelog
+%autochangelog

--- a/SPECS/python-mako/python-mako.spec
+++ b/SPECS/python-mako/python-mako.spec
@@ -19,13 +19,12 @@ BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  %{srcname}
-# We don't have python-lingua
-BuildOption(check):  -e mako.ext.linguaplugin
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(markupsafe)
+BuildRequires:  python3dist(lingua)
 # For tests
 BuildRequires:  python3dist(babel)
 BuildRequires:  python3dist(pygments)
@@ -35,6 +34,7 @@ Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
 
 Requires:       python3dist(six)
+Requires:       python3dist(lingua)
 
 %description
 Mako is a template library written in Python. It provides a familiar, non-XML
@@ -59,8 +59,8 @@ ln -s ./mako-render-%{python3_version} %{buildroot}/%{_bindir}/mako-render-3
 ln -s ./mako-render-%{python3_version} %{buildroot}/%{_bindir}/mako-render
 
 %files -f %{pyproject_files}
-%license LICENSE
 %doc CHANGES README.rst examples
+%license LICENSE
 %{_bindir}/mako-render
 %{_bindir}/mako-render-3
 %{_bindir}/mako-render-%{python3_version}

--- a/SPECS/python-polib/python-polib.spec
+++ b/SPECS/python-polib/python-polib.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname polib
+
+Name:           python-%{srcname}
+Version:        1.2.0
+Release:        %autorelease
+Summary:        Library to manipulate gettext files
+License:        MIT
+URL:            https://github.com/izimobil/polib/
+VCS:            git:https://github.com/izimobil/polib.git
+#!RemoteAsset:  sha256:f3ef94aefed6e183e342a8a269ae1fc4742ba193186ad76f175938621dbfc26b
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+polib is a library to manipulate, create, and modify gettext files such as
+POT, PO, and MO files.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst CHANGELOG
+%license LICENSE
+
+%changelog
+%autochangelog


### PR DESCRIPTION
`python-lingua` is a Python library for detecting the language of a given text. It can identify whether a string is written in English, Chinese, Japanese, French, German, and many other languages. It is especially useful for short-text language detection in multilingual applications, such as chat systems, translation tools, and text-processing pipelines. One of `python-mako`’s features depends on `python-lingua` for language detection. In addition, `python-chameleon` and `python-polib` are dependencies of `python-lingua`; without these two packages, `python-lingua` cannot run properly.