### PR TITLE
SPECS: snappy: Honor SNAPPY_ENABLE_RTTI

### DIFF
--- a/SPECS/snappy/2000-honor-SNAPPY_ENABLE_RTTI.patch
+++ b/SPECS/snappy/2000-honor-SNAPPY_ENABLE_RTTI.patch
@@ -1,0 +1,42 @@
+From 376f14b5933e91d08ade6a503fdd657a6e01a149 Mon Sep 17 00:00:00 2001
+From: Max <tchristy001@outlook.com>
+Date: Wed, 24 Nov 2021 12:16:23 -0600
+Subject: [PATCH] add option to enable rtti, set default to current behavior
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -53,8 +53,10 @@
+   add_definitions(-D_HAS_EXCEPTIONS=0)
+ 
+   # Disable RTTI.
+-  string(REGEX REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
++  if(NOT SNAPPY_ENABLE_RTTI)
++    string(REGEX REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
++  endif(SNAPPY_ENABLE_RTTI)
+ else(MSVC)
+   # Use -Wall for clang and gcc.
+   if(NOT CMAKE_CXX_FLAGS MATCHES "-Wall")
+@@ -83,8 +85,10 @@
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
+ 
+   # Disable RTTI.
+-  string(REGEX REPLACE "-frtti" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
++  if(NOT SNAPPY_ENABLE_RTTI)
++    string(REGEX REPLACE "-frtti" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
++  endif(SNAPPY_ENABLE_RTTI)
+ endif(MSVC)
+ 
+ # BUILD_SHARED_LIBS is a standard CMake variable, but we declare it here to make
+@@ -103,6 +107,8 @@
+ 
+ option(SNAPPY_INSTALL "Install Snappy's header and library" ON)
+ 
++option(SNAPPY_ENABLE_RTTI "Enable RTTI for Snappy's library" OFF)
++
+ include(TestBigEndian)
+ test_big_endian(SNAPPY_IS_BIG_ENDIAN)
+ 

--- a/SPECS/snappy/snappy.spec
+++ b/SPECS/snappy/snappy.spec
@@ -12,9 +12,12 @@ Release:        %autorelease
 Summary:        A fast compressor/decompressor
 License:        BSD-3-Clause
 URL:            https://github.com/google/snappy
-#!RemoteAsset
+#!RemoteAsset:  sha256:90f74bc1fbf78a6c56b3c4a082a05103b3a56bb17bca1a27e052ea11723292dc
 Source0:        https://github.com/google/snappy/archive/%{version}/snappy-%{version}.tar.gz
 BuildSystem:    cmake
+
+# https://sources.debian.org/patches/snappy/1.2.2-1/add_option_to_enable_rtti.patch/
+Patch2000:      2000-honor-SNAPPY_ENABLE_RTTI.patch
 
 BuildOption(conf):  -DBUILD_SHARED_LIBS:BOOL=ON
 BuildOption(conf):  -DSNAPPY_ENABLE_RTTI:BOOL=ON
@@ -54,4 +57,4 @@ developing applications that use the Snappy library.
 %{_libdir}/cmake/Snappy/*
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Fixed dlopen failure in ceph with `undefined symbol: _ZTIN6snappy6SourceE`  (typeinfo for snappy::Source)