### PR TITLE
SPECS: linux-tools: Update to 7.0.10 and add new patch for const qualifier fix.

### DIFF
--- a/SPECS/linux-tools/0001-perf-riscv-Fix-discarded-const-qualifier-in-_get_.patch
+++ b/SPECS/linux-tools/0001-perf-riscv-Fix-discarded-const-qualifier-in-_get_.patch
@@ -1,0 +1,43 @@
+From 7378b6656aa46fda56f2743d5a7c1f619c2f6f9b Mon Sep 17 00:00:00 2001
+From: Li Guan <guanli.oerv@isrc.iscas.ac.cn>
+Date: Thu, 14 May 2026 02:07:21 +0800
+Subject: perf riscv: Fix discarded const qualifier in _get_field()
+
+The assignment of strrchr() return values to non-const char * variables
+triggers a -Werror=discarded-qualifiers warning when building with GCC
+14.
+
+This happens because in newer glibc versions, strrchr() returns a 'const
+char *' if the input string is const.
+
+Properly declare 'line2' and 'nl' as const char * to match the glibc
+function signature and ensure type safety. This avoids the need for
+explicit type casting and aligns with the design pattern of not
+modifying read-only memory in the perf tool.
+
+Reviewed-by: Ian Rogers <irogers@google.com>
+Signed-off-by: Li Guan <guanli.oerv@isrc.iscas.ac.cn>
+Cc: Adrian Hunter <adrian.hunter@intel.com>
+Cc: Namhyung Kim <namhyung@kernel.org>
+Cc: Palmer Dabbelt <palmer@dabbelt.com>
+Cc: Paul Walmsley <pjw@kernel.org>
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+---
+ tools/perf/arch/riscv/util/header.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/perf/arch/riscv/util/header.c b/tools/perf/arch/riscv/util/header.c
+index 4b839203d4a54..891984e909bd8 100644
+--- a/tools/perf/arch/riscv/util/header.c
++++ b/tools/perf/arch/riscv/util/header.c
+@@ -19,7 +19,7 @@
+ 
+ static char *_get_field(const char *line)
+ {
+-	char *line2, *nl;
++	const char *line2, *nl;
+ 
+ 	line2 = strrchr(line, ' ');
+ 	if (!line2)
+-- 
+cgit 1.3-korg

--- a/SPECS/linux-tools/linux-tools.spec
+++ b/SPECS/linux-tools/linux-tools.spec
@@ -1,19 +1,22 @@
 # SPDX-FileCopyrightText: (C) 2025 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2025 openRuyi Project Contributors
 # SPDX-FileContributor: Yafen Fang <yafen@iscas.ac.cn>
+# SPDX-FileContributor: Li Guan <guanli.oerv@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 %bcond doc 0
 
 Name:           linux-tools
-Version:        7.0.9
+Version:        7.0.10
 Release:        %autorelease
 Summary:        Set of tools for the Linux kernel
 License:        GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-only
 URL:            https://www.kernel.org/
 VCS:            git:https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
-#!RemoteAsset:  sha256:ac07acdf76cf4621cc5187a2670270a1a699533c8a6b225e4878c416ad83f1c4
+#!RemoteAsset:  sha256:094977eb62c20e3d1939fe81a92958a1f987f339446e532fa86963b2804e32dc
 Source0:        https://cdn.kernel.org/pub/linux/kernel/v7.x/linux-%{version}.tar.xz
+
+Patch0001:      0001-perf-riscv-Fix-discarded-const-qualifier-in-_get_.patch
 
 %if %{with doc}
 BuildRequires:  asciidoc


### PR DESCRIPTION
The patch has been merged by the upstream team, but has not yet been released into the latest version, so the patch file is named 0001.

https://git.kernel.org/pub/scm/linux/kernel/git/perf/perf-tools-next.git/commit/?h=perf-tools-next&id=7378b6656aa46fda56f2743d5a7c1f619c2f6f9b


----
The assignment of strrchr() return values to non-const char * variables triggers a -Werror=discarded-qualifiers warning when building with GCC 14.

This happens because in newer glibc versions, strrchr() returns a const char * if the input string is const.

Properly declare 'line2' and 'nl' as const char * to match the glibc function signature and ensure type safety. This avoids the need for explicit type casting and aligns with the design pattern of not modifying read-only memory in the perf tool.