### PR TITLE
SPECS: Enhance default bootstrap flavors

### DIFF
--- a/SPECS/abseil-cpp/abseil-cpp.spec
+++ b/SPECS/abseil-cpp/abseil-cpp.spec
@@ -1,11 +1,14 @@
 # SPDX-FileCopyrightText: (C) 2025, 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2025, 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Jingwiw <wangjingwei@iscas.ac.cn>
 # SPDX-FileContributor: Xuhai Chang <xuhai.oerv@isrc.iscas.ac.cn>
 # SPDX-FileContributor: Zheng Junjie <zhengjunjie@iscas.ac.cn>
 # SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
 # SPDX-FileContributor: panglars <panghao.riscv@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
+
+%bcond tests 1
 
 Name:           abseil-cpp
 Version:        20260107.0
@@ -31,12 +34,14 @@ BuildOption(conf):  -GNinja
 BuildOption(conf):  -DABSL_USE_EXTERNAL_GOOGLETEST:BOOL=ON
 BuildOption(conf):  -DABSL_FIND_GOOGLETEST:BOOL=ON
 BuildOption(conf):  -DABSL_ENABLE_INSTALL:BOOL=ON
-BuildOption(conf):  -DABSL_BUILD_TESTING:BOOL=ON
-BuildOption(conf):  -DABSL_BUILD_TEST_HELPERS:BOOL=ON
+BuildOption(conf):  -DABSL_BUILD_TESTING:BOOL=%{?with_tests:ON}%{!?with_tests:OFF}
+BuildOption(conf):  -DABSL_BUILD_TEST_HELPERS:BOOL=%{?with_tests:ON}%{!?with_tests:OFF}
 BuildOption(conf):  -DCMAKE_BUILD_TYPE:STRING=None
 BuildOption(conf):  -DCMAKE_CXX_STANDARD:STRING=17
+%if %{with tests}
 # TODO: Exclude flaky test. https://github.com/abseil/abseil-cpp/issues/1804
 BuildOption(check):  --exclude-regex absl_failure_signal_handler_test
+%endif
 
 # The contents of absl/time/internal/cctz are derived from
 # https://github.com/google/cctz (https://src.fedoraproject.org/rpms/cctz), but
@@ -65,6 +70,7 @@ Abseil is not meant to be a competitor to the standard library; we've just
 found that many of these utilities serve a purpose within our code base,
 and we now want to provide those resources to the C++ community as a whole.
 
+%if %{with tests}
 %package        testing
 Summary:        Libraries needed for running tests on the installed %{name}
 Requires:       %{name} = %{version}-%{release}
@@ -73,11 +79,14 @@ Provides:       bundled(cctz)
 
 %description    testing
 %{summary}.
+%endif
 
 %package        devel
 Summary:        Development files for %{name}
 Requires:       %{name}%{?_isa} = %{version}-%{release}
+%if %{with tests}
 Requires:       %{name}-testing = %{version}-%{release}
+%endif
 
 # Some of the headers from CCTZ are part of the -devel subpackage. See the
 # corresponding virtual Provides in the base package for full details.
@@ -184,6 +193,7 @@ Development headers for %{name}
 %{_libdir}/libabsl_utf8_for_code_point.so.%{lib_version}
 %{_libdir}/libabsl_vlog_config_internal.so.%{lib_version}
 
+%if %{with tests}
 %files testing
 # TESTONLY libraries (that are actually installed):
 # absl/base/CMakeLists.txt
@@ -208,6 +218,7 @@ Development headers for %{name}
 %{_libdir}/libabsl_per_thread_sem_test_common.so.%{lib_version}
 # absl/time/CMakeLists.txt
 %{_libdir}/libabsl_time_internal_test_util.so.%{lib_version}
+%endif
 
 %files devel
 %{_includedir}/absl
@@ -221,7 +232,9 @@ Development headers for %{name}
 %{_libdir}/pkgconfig/absl_any.pc
 %{_libdir}/pkgconfig/absl_any_invocable.pc
 %{_libdir}/pkgconfig/absl_atomic_hook.pc
+%if %{with tests}
 %{_libdir}/pkgconfig/absl_atomic_hook_test_helper.pc
+%endif
 %{_libdir}/pkgconfig/absl_bad_any_cast.pc
 %{_libdir}/pkgconfig/absl_bad_optional_access.pc
 %{_libdir}/pkgconfig/absl_bad_variant_access.pc
@@ -232,7 +245,9 @@ Development headers for %{name}
 %{_libdir}/pkgconfig/absl_borrowed_fixup_buffer.pc
 %{_libdir}/pkgconfig/absl_bounded_utf8_length_sequence.pc
 %{_libdir}/pkgconfig/absl_btree.pc
+%if %{with tests}
 %{_libdir}/pkgconfig/absl_btree_test_common.pc
+%endif
 %{_libdir}/pkgconfig/absl_charset.pc
 %{_libdir}/pkgconfig/absl_check.pc
 %{_libdir}/pkgconfig/absl_chunked_queue.pc
@@ -249,14 +264,18 @@ Development headers for %{name}
 %{_libdir}/pkgconfig/absl_container_memory.pc
 %{_libdir}/pkgconfig/absl_cord.pc
 %{_libdir}/pkgconfig/absl_cord_internal.pc
+%if %{with tests}
 %{_libdir}/pkgconfig/absl_cord_rep_test_util.pc
 %{_libdir}/pkgconfig/absl_cord_test_helpers.pc
+%endif
 %{_libdir}/pkgconfig/absl_cordz_functions.pc
 %{_libdir}/pkgconfig/absl_cordz_handle.pc
 %{_libdir}/pkgconfig/absl_cordz_info.pc
 %{_libdir}/pkgconfig/absl_cordz_sample_token.pc
 %{_libdir}/pkgconfig/absl_cordz_statistics.pc
+%if %{with tests}
 %{_libdir}/pkgconfig/absl_cordz_test_helpers.pc
+%endif
 %{_libdir}/pkgconfig/absl_cordz_update_scope.pc
 %{_libdir}/pkgconfig/absl_cordz_update_tracker.pc
 %{_libdir}/pkgconfig/absl_core_headers.pc
@@ -274,8 +293,10 @@ Development headers for %{name}
 %{_libdir}/pkgconfig/absl_endian.pc
 %{_libdir}/pkgconfig/absl_errno_saver.pc
 %{_libdir}/pkgconfig/absl_examine_stack.pc
+%if %{with tests}
 %{_libdir}/pkgconfig/absl_exception_safety_testing.pc
 %{_libdir}/pkgconfig/absl_exception_testing.pc
+%endif
 %{_libdir}/pkgconfig/absl_exponential_biased.pc
 %{_libdir}/pkgconfig/absl_failure_signal_handler.pc
 %{_libdir}/pkgconfig/absl_fast_type_id.pc
@@ -302,10 +323,14 @@ Development headers for %{name}
 %{_libdir}/pkgconfig/absl_hash.pc
 %{_libdir}/pkgconfig/absl_hash_container_defaults.pc
 %{_libdir}/pkgconfig/absl_hash_function_defaults.pc
+%if %{with tests}
 %{_libdir}/pkgconfig/absl_hash_generator_testing.pc
 %{_libdir}/pkgconfig/absl_hash_policy_testing.pc
+%endif
 %{_libdir}/pkgconfig/absl_hash_policy_traits.pc
+%if %{with tests}
 %{_libdir}/pkgconfig/absl_hash_testing.pc
+%endif
 %{_libdir}/pkgconfig/absl_hashtable_control_bytes.pc
 %{_libdir}/pkgconfig/absl_hashtable_debug.pc
 %{_libdir}/pkgconfig/absl_hashtable_debug_hooks.pc
@@ -346,9 +371,11 @@ Development headers for %{name}
 %{_libdir}/pkgconfig/absl_log_internal_strip.pc
 %{_libdir}/pkgconfig/absl_log_internal_structured.pc
 %{_libdir}/pkgconfig/absl_log_internal_structured_proto.pc
+%if %{with tests}
 %{_libdir}/pkgconfig/absl_log_internal_test_actions.pc
 %{_libdir}/pkgconfig/absl_log_internal_test_helpers.pc
 %{_libdir}/pkgconfig/absl_log_internal_test_matchers.pc
+%endif
 %{_libdir}/pkgconfig/absl_log_internal_voidify.pc
 %{_libdir}/pkgconfig/absl_log_severity.pc
 %{_libdir}/pkgconfig/absl_log_sink.pc
@@ -370,10 +397,14 @@ Development headers for %{name}
 %{_libdir}/pkgconfig/absl_numeric_representation.pc
 %{_libdir}/pkgconfig/absl_optional.pc
 %{_libdir}/pkgconfig/absl_overload.pc
+%if %{with tests}
 %{_libdir}/pkgconfig/absl_per_thread_sem_test_common.pc
+%endif
 %{_libdir}/pkgconfig/absl_periodic_sampler.pc
 %{_libdir}/pkgconfig/absl_poison.pc
+%if %{with tests}
 %{_libdir}/pkgconfig/absl_pow10_helper.pc
+%endif
 %{_libdir}/pkgconfig/absl_prefetch.pc
 %{_libdir}/pkgconfig/absl_pretty_function.pc
 %{_libdir}/pkgconfig/absl_profile_builder.pc
@@ -382,14 +413,18 @@ Development headers for %{name}
 %{_libdir}/pkgconfig/absl_random_internal_distribution_caller.pc
 %{_libdir}/pkgconfig/absl_random_internal_distribution_test_util.pc
 %{_libdir}/pkgconfig/absl_random_internal_entropy_pool.pc
+%if %{with tests}
 %{_libdir}/pkgconfig/absl_random_internal_explicit_seed_seq.pc
+%endif
 %{_libdir}/pkgconfig/absl_random_internal_fast_uniform_bits.pc
 %{_libdir}/pkgconfig/absl_random_internal_fastmath.pc
 %{_libdir}/pkgconfig/absl_random_internal_generate_real.pc
 %{_libdir}/pkgconfig/absl_random_internal_iostream_state_saver.pc
 %{_libdir}/pkgconfig/absl_random_internal_mock_helpers.pc
+%if %{with tests}
 %{_libdir}/pkgconfig/absl_random_internal_mock_overload_set.pc
 %{_libdir}/pkgconfig/absl_random_internal_mock_validators.pc
+%endif
 %{_libdir}/pkgconfig/absl_random_internal_nonsecure_base.pc
 %{_libdir}/pkgconfig/absl_random_internal_pcg_engine.pc
 %{_libdir}/pkgconfig/absl_random_internal_platform.pc
@@ -400,11 +435,15 @@ Development headers for %{name}
 %{_libdir}/pkgconfig/absl_random_internal_randen_slow.pc
 %{_libdir}/pkgconfig/absl_random_internal_salted_seed_seq.pc
 %{_libdir}/pkgconfig/absl_random_internal_seed_material.pc
+%if %{with tests}
 %{_libdir}/pkgconfig/absl_random_internal_sequence_urbg.pc
+%endif
 %{_libdir}/pkgconfig/absl_random_internal_traits.pc
 %{_libdir}/pkgconfig/absl_random_internal_uniform_helper.pc
 %{_libdir}/pkgconfig/absl_random_internal_wide_multiply.pc
+%if %{with tests}
 %{_libdir}/pkgconfig/absl_random_mocking_bit_gen.pc
+%endif
 %{_libdir}/pkgconfig/absl_random_random.pc
 %{_libdir}/pkgconfig/absl_random_seed_gen_exception.pc
 %{_libdir}/pkgconfig/absl_random_seed_sequences.pc
@@ -414,16 +453,24 @@ Development headers for %{name}
 %{_libdir}/pkgconfig/absl_raw_logging_internal.pc
 %{_libdir}/pkgconfig/absl_requires_internal.pc
 %{_libdir}/pkgconfig/absl_sample_recorder.pc
+%if %{with tests}
 %{_libdir}/pkgconfig/absl_scoped_mock_log.pc
+%endif
 %{_libdir}/pkgconfig/absl_scoped_set_env.pc
 %{_libdir}/pkgconfig/absl_span.pc
+%if %{with tests}
 %{_libdir}/pkgconfig/absl_spinlock_test_common.pc
+%endif
 %{_libdir}/pkgconfig/absl_spinlock_wait.pc
+%if %{with tests}
 %{_libdir}/pkgconfig/absl_spy_hash_state.pc
 %{_libdir}/pkgconfig/absl_stack_consumption.pc
+%endif
 %{_libdir}/pkgconfig/absl_stacktrace.pc
 %{_libdir}/pkgconfig/absl_status.pc
+%if %{with tests}
 %{_libdir}/pkgconfig/absl_status_matchers.pc
+%endif
 %{_libdir}/pkgconfig/absl_statusor.pc
 %{_libdir}/pkgconfig/absl_str_format.pc
 %{_libdir}/pkgconfig/absl_str_format_internal.pc
@@ -435,16 +482,23 @@ Development headers for %{name}
 %{_libdir}/pkgconfig/absl_strings_resize_and_overwrite.pc
 %{_libdir}/pkgconfig/absl_symbolize.pc
 %{_libdir}/pkgconfig/absl_synchronization.pc
+%if %{with tests}
 %{_libdir}/pkgconfig/absl_test_allocator.pc
 %{_libdir}/pkgconfig/absl_test_instance_tracker.pc
 %{_libdir}/pkgconfig/absl_thread_pool.pc
+%endif
 %{_libdir}/pkgconfig/absl_throw_delegate.pc
 %{_libdir}/pkgconfig/absl_time.pc
+%if %{with tests}
 %{_libdir}/pkgconfig/absl_time_internal_test_util.pc
+%endif
 %{_libdir}/pkgconfig/absl_time_zone.pc
 %{_libdir}/pkgconfig/absl_tracing_internal.pc
+%if %{with tests}
 %{_libdir}/pkgconfig/absl_tracked.pc
+%endif
 %{_libdir}/pkgconfig/absl_type_traits.pc
+%if %{with tests}
 %{_libdir}/pkgconfig/absl_unordered_map_constructor_test.pc
 %{_libdir}/pkgconfig/absl_unordered_map_lookup_test.pc
 %{_libdir}/pkgconfig/absl_unordered_map_members_test.pc
@@ -453,6 +507,7 @@ Development headers for %{name}
 %{_libdir}/pkgconfig/absl_unordered_set_lookup_test.pc
 %{_libdir}/pkgconfig/absl_unordered_set_members_test.pc
 %{_libdir}/pkgconfig/absl_unordered_set_modifiers_test.pc
+%endif
 %{_libdir}/pkgconfig/absl_utf8_for_code_point.pc
 %{_libdir}/pkgconfig/absl_utility.pc
 %{_libdir}/pkgconfig/absl_variant.pc

--- a/SPECS/aide/aide.spec
+++ b/SPECS/aide/aide.spec
@@ -1,8 +1,11 @@
 # SPDX-FileCopyrightText: (C) 2025 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2025 openRuyi Project Contributors
+# SPDX-FileContributor: Jingwiw <wangjingwei@iscas.ac.cn>
 # SPDX-FileContributor: BH1SCW <kongfanjun@iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
+
+%bcond selinux 1
 
 Name:           aide
 Version:        0.19.3
@@ -25,7 +28,11 @@ BuildOption(conf):  --with-nettle
 BuildOption(conf):  --with-zlib
 BuildOption(conf):  --with-curl
 BuildOption(conf):  --with-posix-acl
+%if %{with selinux}
 BuildOption(conf):  --with-selinux
+%else
+BuildOption(conf):  --without-selinux
+%endif
 BuildOption(conf):  --with-xattr
 BuildOption(conf):  --with-e2fsattrs
 BuildOption(conf):  --with-audit
@@ -40,7 +47,9 @@ BuildRequires:  pkgconfig(nettle)
 BuildRequires:  pkgconfig(zlib)
 BuildRequires:  pkgconfig(libcurl)
 BuildRequires:  pkgconfig(libacl)
+%if %{with selinux}
 BuildRequires:  pkgconfig(libselinux)
+%endif
 BuildRequires:  pkgconfig(libattr)
 BuildRequires:  pkgconfig(e2p)
 BuildRequires:  pkgconfig(audit)

--- a/SPECS/alsa-lib/alsa-lib.spec
+++ b/SPECS/alsa-lib/alsa-lib.spec
@@ -1,11 +1,20 @@
 # SPDX-FileCopyrightText: (C) 2025 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2025 openRuyi Project Contributors
+# SPDX-FileContributor: Jingwiw <wangjingwei@iscas.ac.cn>
 # SPDX-FileContributor: Dingli Zhang <dingli@iscas.ac.cn>
 # SPDX-FileContributor: Zheng Junjie <zhengjunjie@iscas.ac.cn>
 # SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
 # SPDX-FileContributor: corestudy <2760018909@qq.com>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
+
+%bcond docs 1
+%bcond lto 1
+
+%if %{with lto}
+# Needed for symbol versioning.
+%global _lto_cflags -flto -ffat-lto-objects -flto-partition=none
+%endif
 
 Name:           alsa-lib
 Version:        1.2.15.3
@@ -27,7 +36,9 @@ BuildOption(conf):  --disable-alisp
 BuildOption(build):  V=1
 BuildOption(install):  DESTDIR=%{buildroot}
 
+%if %{with docs}
 BuildRequires:  doxygen
+%endif
 BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  libtool
@@ -61,15 +72,14 @@ against the ALSA libraries and interfaces.
 autoreconf -vif
 
 %build -p
-# Set custom LTO flags (needed for symbol versioning)
-%define _lto_cflags -flto -ffat-lto-objects -flto-partition=none
-
 # fix libtool rpath
 sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool || :
 sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool || :
 
 %build -a
+%if %{with docs}
 %make_build doc
+%endif
 
 %install -a
 # Install global configuration files
@@ -100,7 +110,10 @@ rm -f %{buildroot}%{_includedir}/asoundlib.h
 %{_prefix}/lib/modprobe.d/dist-*
 
 %files devel
-%doc TODO doc/doxygen/
+%doc TODO
+%if %{with docs}
+%doc doc/doxygen/
+%endif
 %{_includedir}/alsa/
 %{_includedir}/sys/asoundlib.h
 %{_libdir}/libasound.so

--- a/SPECS/audit/audit.spec
+++ b/SPECS/audit/audit.spec
@@ -7,6 +7,8 @@
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
+%bcond golang 1
+
 Name:           audit
 Version:        4.1.4
 Release:        %autorelease
@@ -26,6 +28,9 @@ BuildOption(conf):  --with-apparmor
 BuildOption(conf):  --with-libcap-ng=no
 BuildOption(conf):  --disable-static
 BuildOption(conf):  --with-python3=no
+%if %{without golang}
+BuildOption(conf):  --with-golang=no
+%endif
 BuildOption(conf):  --disable-zos-remote
 
 BuildRequires:  autoconf >= 2.12

--- a/SPECS/autoconf/autoconf.spec
+++ b/SPECS/autoconf/autoconf.spec
@@ -1,9 +1,12 @@
 # SPDX-FileCopyrightText: (C) 2025 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2025 openRuyi Project Contributors
+# SPDX-FileContributor: Jingwiw <wangjingwei@iscas.ac.cn>
 # SPDX-FileContributor: Zheng Junjie <zhengjunjie@iscas.ac.cn>
 # SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
+
+%bcond manpages 1
 
 Name:           autoconf
 Version:        2.72
@@ -12,16 +15,16 @@ Summary:        A GNU Tool for Automatically Configuring Source Code
 License:        GPL-3.0-or-later
 URL:            https://www.gnu.org/software/autoconf
 VCS:            git:https://git.savannah.gnu.org/git/autoconf.git
-#!RemoteAsset
+#!RemoteAsset:  sha256:ba885c1319578d6c94d46e9b0dceb4014caafe2490e437a0dbca3f270a223f5a
 Source0:        https://ftpmirror.gnu.org/gnu/autoconf/autoconf-%{version}.tar.xz
-#!RemoteAsset
-Source1:        https://ftpmirror.gnu.org/gnu/autoconf/autoconf-%{version}.tar.xz.sig
 BuildArch:      noarch
 BuildSystem:    autotools
 
 Patch0:         autoreconf-ltdl.diff
 
+%if %{with manpages}
 BuildRequires:  help2man
+%endif
 BuildRequires:  m4 >= 1.4.16
 BuildRequires:  perl >= 5.10
 
@@ -41,6 +44,12 @@ Note that the autoconf package is not required for the end user who may
 be configuring software with an autoconf-generated script; autoconf is
 only required for the generation of the scripts, not their use.
 
+%build -p
+%if %{without manpages}
+# Release tarballs already carry these generated pages.
+touch man/*.1
+%endif
+
 %files
 %doc AUTHORS NEWS README TODO
 %license COPYING
@@ -50,4 +59,4 @@ only required for the generation of the scripts, not their use.
 %{_mandir}/man1/*.gz
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/bdftopcf/bdftopcf.spec
+++ b/SPECS/bdftopcf/bdftopcf.spec
@@ -1,8 +1,11 @@
 # SPDX-FileCopyrightText: (C) 2025 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2025 openRuyi Project Contributors
+# SPDX-FileContributor: Jingwiw <wangjingwei@iscas.ac.cn>
 # SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
+
+%bcond autoreconf 1
 
 Name:           bdftopcf
 Version:        1.1.2
@@ -11,18 +14,18 @@ Summary:        Font compiler for the X server and font server
 License:        MIT
 URL:            https://www.x.org/wiki/
 VCS:            git:https://gitlab.freedesktop.org/xorg/util/bdftopcf
-#!RemoteAsset
+#!RemoteAsset:  sha256:bc60be5904330faaa3ddd2aed7874bee2f29e4387c245d6787552f067eb0523a
 Source0:        http://xorg.freedesktop.org/releases/individual/util/bdftopcf-%{version}.tar.xz
-#!RemoteAsset
-Source1:        http://xorg.freedesktop.org/releases/individual/util/bdftopcf-%{version}.tar.xz.sig
 BuildSystem:    autotools
 
 BuildRequires:  make
+%if %{with autoreconf}
 BuildRequires:  libtool
 BuildRequires:  autoconf
 BuildRequires:  automake
-BuildRequires:  pkgconfig(xfont2)
 BuildRequires:  pkgconfig(xorg-macros)
+%endif
+BuildRequires:  pkgconfig(xfont2)
 
 %description
 bdftopcf is a font compiler for the X server and font server. Fonts
@@ -33,7 +36,9 @@ appropriate machine, but the files are still portable (but read more
 slowly) on other machines.
 
 %conf -p
+%if %{with autoreconf}
 autoreconf -fiv
+%endif
 
 %files
 %license COPYING
@@ -41,4 +46,4 @@ autoreconf -fiv
 %{_mandir}/man1/bdftopcf.1*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/grep/grep.spec
+++ b/SPECS/grep/grep.spec
@@ -1,9 +1,12 @@
 # SPDX-FileCopyrightText: (C) 2025 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2025 openRuyi Project Contributors
+# SPDX-FileContributor: Jingwiw <wangjingwei@iscas.ac.cn>
 # SPDX-FileContributor: Zheng Junjie <zhengjunjie@iscas.ac.cn>
 # SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
+
+%bcond pcre 1
 
 Name:           grep
 Version:        3.12
@@ -12,18 +15,21 @@ Summary:        Print lines matching a pattern
 License:        GPL-3.0-or-later
 URL:            https://www.gnu.org/software/grep/
 VCS:            git:https://https.git.savannah.gnu.org/git/grep.git
-#!RemoteAsset
+#!RemoteAsset:  sha256:2649b27c0e90e632eadcd757be06c6e9a4f48d941de51e7c0f83ff76408a07b9
 Source0:        https://ftpmirror.gnu.org/gnu/%{name}/%{name}-%{version}.tar.xz
-#!RemoteAsset
-Source2:        https://ftpmirror.gnu.org/gnu/%{name}/%{name}-%{version}.tar.xz.sig
-Buildsystem:    autotools
+BuildSystem:    autotools
 
 BuildOption(conf):  --disable-silent-rules
 BuildOption(conf):  CONFIG_SHELL=/bin/sh
+%if %{without pcre}
+BuildOption(conf):  --disable-perl-regexp
+%endif
 
 BuildRequires:  glibc-locale
 BuildRequires:  texinfo
+%if %{with pcre}
 BuildRequires:  pkgconfig(libpcre2-8)
+%endif
 
 Provides:       base:%{_bindir}/grep
 
@@ -44,4 +50,4 @@ match to a specified pattern.  By default, grep prints the matching lines.
 %{_infodir}/grep.info%{?ext_info}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/linux-headers/linux-headers.spec
+++ b/SPECS/linux-headers/linux-headers.spec
@@ -7,6 +7,8 @@
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
+%bcond bootstrap 0
+
 %ifarch riscv64
 %global archdir riscv
 %endif
@@ -24,7 +26,9 @@ VCS:            git:https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/lin
 #!RemoteAsset:  sha256:f4855f382c1b735c84072bdef36db5bcd5dc7b0c37e42f5104317149a0a486ef
 Source0:        https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-%{version}.tar.xz
 
+%if %{without bootstrap}
 BuildRequires:  rsync
+%endif
 
 %description
 Linux-headers includes the C header files that specify the stable API
@@ -34,11 +38,18 @@ interface between the Linux kernel and userspace libraries and programs.
 %autosetup -p1 -n linux-%{version}
 
 %install
+%if %{with bootstrap}
+%make_build ARCH=%{archdir} headers
+mkdir -p %{buildroot}%{_prefix}
+cp -a usr/include %{buildroot}%{_prefix}/
+rm -f %{buildroot}%{_includedir}/.gitignore
+%else
 %make_build ARCH=%{archdir} headers_install INSTALL_HDR_PATH=%{buildroot}%{_prefix}
+%endif
 
 %files
 %license COPYING
 %{_includedir}/*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/sed/sed.spec
+++ b/SPECS/sed/sed.spec
@@ -1,9 +1,13 @@
 # SPDX-FileCopyrightText: (C) 2025 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2025 openRuyi Project Contributors
+# SPDX-FileContributor: Jingwiw <wangjingwei@iscas.ac.cn>
 # SPDX-FileContributor: Zheng Junjie <zhengjunjie@iscas.ac.cn>
 # SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
+
+%bcond acl 1
+%bcond selinux 1
 
 Name:           sed
 Version:        4.9
@@ -12,16 +16,24 @@ Summary:        A Stream-Oriented Non-Interactive Text Editor
 License:        GPL-3.0-or-later
 URL:            https://www.gnu.org/software/sed/
 VCS:            git:https://https.git.savannah.gnu.org/git/sed.git
-#!RemoteAsset
+#!RemoteAsset:  sha256:6e226b732e1cd739464ad6862bd1a1aba42d7982922da7a53519631d24975181
 Source0:        https://ftpmirror.gnu.org/gnu/sed/%{name}-%{version}.tar.xz
-#!RemoteAsset
-Source1:        https://ftpmirror.gnu.org/gnu/sed/%{name}-%{version}.tar.xz.sig
 BuildSystem:    autotools
 
 BuildOption(conf):  --without-included-regex
+%if %{without acl}
+BuildOption(conf):  --disable-acl
+%endif
+%if %{without selinux}
+BuildOption(conf):  --without-selinux
+%endif
 
+%if %{with acl}
 BuildRequires:  pkgconfig(libacl)
+%endif
+%if %{with selinux}
 BuildRequires:  pkgconfig(libselinux)
+%endif
 
 Provides:       base:/bin/sed
 
@@ -42,4 +54,4 @@ occurrences of a string within a file.
 %{_infodir}/sed.info*%{ext_info}
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Add optional build flavors for packages that can expose bootstrap-friendly
configuration without changing the default full build.

Signed-off-by: Jingwiw <wangjingwei@iscas.ac.cn>