### PR TITLE
SPECS: openblas: Default to LP64, build ILP64 as openblas64

### DIFF
--- a/SPECS/openblas/openblas.spec
+++ b/SPECS/openblas/openblas.spec
@@ -21,7 +21,7 @@ Source0:        https://github.com/OpenMathLib/OpenBLAS/releases/download/v%{ver
 BuildSystem:    autotools
 
 BuildOption(build):  BINARY=64
-BuildOption(build):  INTERFACE64=1
+BuildOption(build):  INTERFACE64=0
 BuildOption(build):  USE_THREAD=1
 BuildOption(build):  USE_OPENMP=0
 BuildOption(build):  NO_STATIC=1
@@ -52,6 +52,26 @@ This package contains the development headers and libraries for OpenBLAS.
 # No configure
 %conf
 
+# Parallel ILP64 build for consumers that BR pkgconfig(openblas64).
+%prep -a
+cp -al . ../ilp64
+
+%build -a
+%make_build -C ../ilp64 \
+%ifarch riscv64
+  TARGET=RISCV64_GENERIC \
+%endif
+  BINARY=64 INTERFACE64=1 LIBNAMESUFFIX=64 \
+  USE_THREAD=1 USE_OPENMP=0 NO_STATIC=1 DYNAMIC_ARCH=1 NO_TEST=1
+
+%install -a
+%make_install -C ../ilp64 \
+  PREFIX=%{_prefix} \
+  OPENBLAS_LIBRARY_DIR=%{_libdir} \
+  OPENBLAS_INCLUDE_DIR=%{_includedir}/openblas64 \
+  OPENBLAS_CMAKE_DIR=%{_libdir}/cmake/openblas64 \
+  INTERFACE64=1 LIBNAMESUFFIX=64 NO_STATIC=1
+
 %files
 %license LICENSE
 %doc Changelog.txt GotoBLAS_01Readme.txt
@@ -60,8 +80,10 @@ This package contains the development headers and libraries for OpenBLAS.
 %files devel
 %{_includedir}/*
 %{_libdir}/libopenblas*.so
+%{_libdir}/pkgconfig/openblas.pc
 %{_libdir}/pkgconfig/openblas64.pc
 %{_libdir}/cmake/openblas/
+%{_libdir}/cmake/openblas64/
 
 %changelog
 %autochangelog


### PR DESCRIPTION
ceph's scipy build wants `pkg-config openblas` , Build LP64 alongside ILP64

Build succeeded on RISC-V