### PR TITLE
SPECS: Use python3dist() for Python dependencies.

### DIFF
--- a/SPECS/bcc/bcc.spec
+++ b/SPECS/bcc/bcc.spec
@@ -10,7 +10,7 @@ Release:        %autorelease
 Summary:        BPF Compiler Collection (BCC)
 License:        Apache-2.0
 URL:            https://github.com/iovisor/bcc
-#!RemoteAsset
+#!RemoteAsset:  sha256:3b16f1eb6a5b90a5a68686c0f4195455f1c58da5ae40f004e931c19e98fa8d98
 Source0:        https://github.com/iovisor/bcc/archive/v%{version}/%{name}-%{version}.tar.gz
 BuildSystem:    cmake
 
@@ -27,7 +27,7 @@ BuildRequires:  cmake >= 2.8.7
 BuildRequires:  flex
 BuildRequires:  pkgconfig(libxml-2.0)
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
 BuildRequires:  pkgconfig(libelf)
 BuildRequires:  pkgconfig(libdebuginfod)
 BuildRequires:  llvm-devel
@@ -92,7 +92,7 @@ Standalone tool to run BCC tracers written in Lua
 Summary:        Command line tools for BPF Compiler Collection (BCC)
 Requires:       %{name}%{?_isa} = %{version}-%{release}
 Requires:       python3-%{name} = %{version}-%{release}
-Requires:       python3-netaddr
+Requires:       python3dist(netaddr)
 
 %description    tools
 Command line tools for BPF Compiler Collection (BCC)
@@ -188,4 +188,4 @@ rm -rf %{buildroot}%{_datadir}/%{name}/tools/old/
 %{_sbindir}/bpf-*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/bind/bind.spec
+++ b/SPECS/bind/bind.spec
@@ -16,9 +16,9 @@ Summary:        Domain Name System (DNS) Server
 License:        MPL-2.0
 URL:            https://www.isc.org/bind/
 VCS:            git:https://gitlab.isc.org/isc-projects/bind9.git
-#!RemoteAsset
+#!RemoteAsset:  sha256:d62b38fae48ba83fca6181112d0c71018d8b0f2ce285dc79dc6a0367722ccabb
 Source0:        https://downloads.isc.org/isc/bind9/%{version}/%{name}-%{version}.tar.xz
-#!RemoteAsset
+#!RemoteAsset:  sha256:2e9215f01c68734fd03b207dc1dd62fe32af79d02fe8182002529faaca6c9361
 Source1:        https://downloads.isc.org/isc/bind9/%{version}/%{name}-%{version}.tar.xz.asc
 Source2:        bind.sysusers
 Source3:        bind.tmpfiles
@@ -72,7 +72,7 @@ BuildRequires:  pkgconfig(liburcu)
 BuildRequires:  pkgconfig(libuv)
 BuildRequires:  pkgconfig(libxml-2.0)
 BuildRequires:  pkgconfig(lmdb)
-BuildRequires:  python3-dnspython
+BuildRequires:  python3dist(dnspython)
 BuildRequires:  pytest
 
 %description
@@ -232,4 +232,4 @@ install -m 644 %{SOURCE8} %{buildroot}%{_localstatedir}/named/localhost.ip6.zone
 %{_includedir}/isccfg
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/bpftool/bpftool.spec
+++ b/SPECS/bpftool/bpftool.spec
@@ -31,7 +31,7 @@ BuildRequires:  pkgconfig(libelf)
 BuildRequires:  pkgconfig(libcap)
 BuildRequires:  binutils-devel
 BuildRequires:  clang
-BuildRequires:  python3-docutils
+BuildRequires:  python3dist(docutils)
 BuildRequires:  llvm-devel
 BuildRequires:  pkgconfig(bash-completion)
 BuildRequires:  pkgconfig(libssl)

--- a/SPECS/btrfs-progs/btrfs-progs.spec
+++ b/SPECS/btrfs-progs/btrfs-progs.spec
@@ -39,8 +39,8 @@ BuildRequires:  pkgconfig(libudev)
 BuildRequires:  pkgconfig(libgcrypt) >= 1.8.0
 BuildRequires:  pkgconfig(libzstd) >= 1.0.0
 BuildRequires:  python3-devel >= 3.4
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-pip
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(pip)
 
 %description
 The btrfs-progs package provides userspace programs needed to create,

--- a/SPECS/cockpit/cockpit.spec
+++ b/SPECS/cockpit/cockpit.spec
@@ -13,7 +13,7 @@ Summary:        Web Console for Linux servers
 License:        LGPL-2.1-or-later
 URL:            https://cockpit-project.org/
 VCS:            git:https://github.com/cockpit-project/cockpit
-#!RemoteAsset
+#!RemoteAsset:  sha256:72098a51f85c4a63f2e276af119920a5faca978b57652df562b409b5941b5146
 Source:         https://github.com/cockpit-project/cockpit/releases/download/%{version}/cockpit-%{version}.tar.xz
 BuildSystem:    autotools
 
@@ -31,7 +31,7 @@ BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  pkgconfig
 BuildRequires:  appstream
-BuildRequires:  python3-pip
+BuildRequires:  python3dist(pip)
 BuildRequires:  pkgconfig(gio-unix-2.0)
 BuildRequires:  pkgconfig(json-glib-1.0)
 BuildRequires:  pkgconfig(polkit-agent-1) >= 0.105
@@ -243,4 +243,4 @@ rm -f %{buildroot}%{_datadir}/metainfo/*selinux*
 %exclude %{_docdir}/cockpit/README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/createrepo_c/createrepo_c.spec
+++ b/SPECS/createrepo_c/createrepo_c.spec
@@ -11,7 +11,7 @@ Release:        %autorelease
 Summary:        Creates a common metadata repository
 License:        GPL-2.0-or-later
 URL:            https://github.com/rpm-software-management/createrepo_c
-#!RemoteAsset
+#!RemoteAsset:  sha256:5252911bb5ab0732922e298348a94f0e348e0891935ff0876042ac1bd8c5eeed
 Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
 BuildSystem:    cmake
 
@@ -68,7 +68,7 @@ These development files are for easy manipulation with a repodata.
 Summary:        Python bindings for the createrepo_c library
 %{?python_provide:%python_provide python3-%{name}}
 BuildRequires:  python3-devel
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
 Requires:       %{name}-libs = %{version}-%{release}
 
 %description -n python-%{name}
@@ -113,4 +113,4 @@ ln -sr %{buildroot}%{_bindir}/modifyrepo_c %{buildroot}%{_bindir}/modifyrepo
 %{python3_sitearch}/createrepo_c-*-py%{python3_version}.egg-info
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/dpdk/dpdk.spec
+++ b/SPECS/dpdk/dpdk.spec
@@ -23,7 +23,7 @@ Summary:        Set of libraries and drivers for fast packet processing
 License:        BSD-3-Clause AND GPL-2.0-only AND LGPL-2.1-only
 URL:            http://dpdk.org
 VCS:            git:https://github.com/DPDK/dpdk
-#!RemoteAsset
+#!RemoteAsset:  sha256:6886cbedc350bb8cbef347d10367d6259e36435627fbb27d578adbdc0d3b410d
 Source:         https://fast.dpdk.org/rel/dpdk-%{version}.tar.xz
 BuildSystem:    meson
 
@@ -31,7 +31,7 @@ BuildOption(prep):  -p1 -n dpdk%{version_suffix}-%{version}
 BuildOption(conf):  -Dmachine=generic
 
 BuildRequires:  meson
-BuildRequires:  python3-pyelftools
+BuildRequires:  python3dist(pyelftools)
 BuildRequires:  gcc
 BuildRequires:  linux-headers
 BuildRequires:  libpcap-devel
@@ -72,7 +72,7 @@ Requires:       %{name}%{?_isa} = %{version}-%{release}
 Requires:       kmod
 Requires:       pciutils
 Requires:       iproute2
-Requires:       python3-pyelftools
+Requires:       python3dist(pyelftools)
 
 %description    tools
 %{summary}
@@ -109,4 +109,4 @@ meson test -C %{_vpath_builddir} --num-processes %{_smp_build_ncpus} --print-err
 %{_bindir}/dpdk-*.py
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/dtc/dtc.spec
+++ b/SPECS/dtc/dtc.spec
@@ -13,9 +13,9 @@ Summary:        Device Tree Compiler
 License:        GPL-2.0-or-later
 URL:            https://devicetree.org/
 VCS:            git:https://github.com/dgibson/dtc
-#!RemoteAsset
+#!RemoteAsset:  sha256:92d8ca769805ae1f176204230438fe52808f4e1c7944053c9eec0e649b237539
 Source0:        https://www.kernel.org/pub/software/utils/%{name}/%{name}-%{version}.tar.xz
-#!RemoteAsset
+#!RemoteAsset:  sha256:76929711ac4c53bd283619037c3d853d4e97bdbfd5a793a09e11698824b7032e
 Source1:        https://www.kernel.org/pub/software/utils/%{name}/%{name}-%{version}.tar.sign
 BuildSystem:    autotools
 
@@ -35,10 +35,10 @@ BuildRequires:  flex
 BuildRequires:  bison
 BuildRequires:  swig
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-pip
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-setuptools_scm
-BuildRequires:  python3-wheel
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm)
+BuildRequires:  python3dist(wheel)
 Provides:       libfdt%{?_isa} = %{version}-%{release}
 Obsoletes:      libfdt < %{version}-%{release}
 
@@ -97,4 +97,4 @@ export SETUPTOOLS_SCM_PRETEND_VERSION=%{version}
 %{python3_sitearch}/*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/fontforge/fontforge.spec
+++ b/SPECS/fontforge/fontforge.spec
@@ -16,7 +16,7 @@ Summary:        Outline and bitmap font editor
 License:        GPL-3.0-or-later
 URL:            https://fontforge.org/
 VCS:            git:https://github.com/fontforge/fontforge
-#!RemoteAsset
+#!RemoteAsset:  sha256:69046500185a5581b58139dfad30c0b3d8128f00ebbfddc31f2fcf877e329e52
 Source0:        https://github.com/fontforge/fontforge/releases/download/%{version}/%{name}-%{version}.tar.xz
 BuildSystem:    cmake
 
@@ -53,7 +53,7 @@ BuildRequires:  pkgconfig(gtk+-3.0)
 BuildRequires:  pkgconfig(gtkmm-3.0)
 %endif
 %if %{with doc}
-BuildRequires:  python3-sphinx
+BuildRequires:  python3dist(sphinx)
 %endif
 
 %description
@@ -114,4 +114,4 @@ rm -f %{buildroot}%{_datadir}/doc/fontforge/{.buildinfo,.nojekyll}
 %endif
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/gdk-pixbuf/gdk-pixbuf.spec
+++ b/SPECS/gdk-pixbuf/gdk-pixbuf.spec
@@ -35,7 +35,7 @@ BuildRequires:  libxslt
 BuildRequires:  meson
 BuildRequires:  pkgconfig(gobject-introspection-1.0)
 BuildRequires:  shared-mime-info
-BuildRequires:  python3-docutils
+BuildRequires:  python3dist(docutils)
 
 %description
 gdk-pixbuf is an image loading library that can be extended by loadable

--- a/SPECS/glib/glib.spec
+++ b/SPECS/glib/glib.spec
@@ -30,7 +30,7 @@ Summary:        A core application building block and utility library
 License:        LGPL-2.1-or-later
 URL:            https://docs.gtk.org/glib/
 VCS:            git:https://gitlab.gnome.org/GNOME/glib.git
-#!RemoteAsset
+#!RemoteAsset:  sha256:fc2ce0f948ee163f8adc5bdde2f38612b8a3f270022aa1b0d087cb9f1f0ac5c2
 Source0:        https://download.gnome.org/sources/glib/2.87/glib-%{version}.tar.xz
 BuildSystem:    meson
 
@@ -80,7 +80,7 @@ BuildRequires:  dbus-daemon
 BuildRequires:  shared-mime-info
 %endif
 %if %{with man}
-BuildRequires:  python3-docutils
+BuildRequires:  python3dist(docutils)
 %endif
 # For %check
 BuildRequires:  systemd
@@ -249,4 +249,4 @@ glib-compile-schemas %{_datadir}/glib-2.0/schemas &> /dev/null || :
 %endif
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/go-github-pdevine-tensor/go-github-pdevine-tensor.spec
+++ b/SPECS/go-github-pdevine-tensor/go-github-pdevine-tensor.spec
@@ -15,7 +15,7 @@ Release:        %autorelease
 Summary:        package tensor provides efficient and generic n-dimensional arrays in Go that are useful for machine learning and deep learning purposes
 License:        Apache-2.0
 URL:            https://github.com/pdevine/tensor
-#!RemoteAsset
+#!RemoteAsset:  sha256:284d2f3cfb403bac5218d0142f39de8f92d5af6a820a41622d59a18190d8fd5f
 Source0:        https://github.com/pdevine/tensor/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
@@ -41,7 +41,7 @@ BuildRequires:  go(go4.org/unsafe/assume-no-moving-gc)
 BuildRequires:  go(gonum.org/v1/gonum)
 BuildRequires:  go(gorgonia.org/vecf32)
 BuildRequires:  go(gorgonia.org/vecf64)
-BuildRequires:  python3-numpy
+BuildRequires:  python3dist(numpy)
 BuildRequires:  python3
 
 Provides:       go(github.com/pdevine/tensor) = %{version}
@@ -76,4 +76,4 @@ export PYTHON_COMMAND=python3
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/gobject-introspection/gobject-introspection.spec
+++ b/SPECS/gobject-introspection/gobject-introspection.spec
@@ -19,7 +19,7 @@ Summary:        Introspection system for GObject-based libraries
 License:        GPL-2.0-or-later AND LGPL-2.0-or-later
 URL:            https://gi.readthedocs.io/
 VCS:            git:https://gitlab.gnome.org/GNOME/gobject-introspection.git
-#!RemoteAsset
+#!RemoteAsset:  sha256:920d1a3fcedeadc32acff95c2e203b319039dd4b4a08dd1a2dfd283d19c0b9ae
 Source0:        https://download.gnome.org/sources/%{name}/%{major_version}/%{name}-%{version}.tar.xz
 BuildSystem:    meson
 
@@ -33,15 +33,15 @@ BuildRequires:  gcc
 BuildRequires:  meson
 BuildRequires:  libffi-devel
 BuildRequires:  python3-devel
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
 BuildRequires:  pkgconfig(glib-2.0)
 %if %{with tests}
 BuildRequires:  pkgconfig(cairo-gobject)
 %endif
 %if %{with doc}
 BuildRequires:  gtk-doc
-BuildRequires:  python3-mako
-BuildRequires:  python3-markdown
+BuildRequires:  python3dist(mako)
+BuildRequires:  python3dist(markdown)
 %endif
 
 %description
@@ -56,7 +56,7 @@ Requires:       python(abi) = %{python3_version}
 Requires:       pkgconfig(glib-2.0) >= 2.80.0
 # The package uses distutils which is no longer part of Python 3.12+ standard library
 # https://bugzilla.redhat.com/show_bug.cgi?id=2135406
-Requires:       python3-setuptools
+Requires:       python3dist(setuptools)
 
 %description    devel
 This is the primary package for developers. It contains the essential
@@ -93,4 +93,4 @@ needed to generate introspection data for other GObject-based libraries.
 %endif
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/gtk-doc/gtk-doc.spec
+++ b/SPECS/gtk-doc/gtk-doc.spec
@@ -11,7 +11,7 @@ Release:        %autorelease
 Summary:        API documentation generation tool for GTK+ and GNOME
 License:        GPL-2.0-or-later AND GFDL-1.1-no-invariants-or-later
 URL:            https://gitlab.gnome.org/GNOME/gtk-doc/
-#!RemoteAsset
+#!RemoteAsset:  sha256:611c9f24edd6d88a8ae9a79d73ab0dc63c89b81e90ecc31d6b9005c5f05b25e2
 Source:         http://download.gnome.org/sources/gtk-doc/1.35/gtk-doc-%{version}.tar.xz
 BuildSystem:    meson
 
@@ -23,9 +23,9 @@ BuildRequires:  gcc
 BuildRequires:  gettext
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-pygments
-BuildRequires:  python3-lxml
-BuildRequires:  python3-parameterized
+BuildRequires:  python3dist(pygments)
+BuildRequires:  python3dist(lxml)
+BuildRequires:  python3dist(parameterized)
 BuildRequires:  itstool
 BuildRequires:  docbook-utils
 BuildRequires:  libxslt
@@ -34,8 +34,8 @@ BuildRequires:  docbook-xsl
 Requires:       docbook-utils
 Requires:       libxslt
 Requires:       docbook-xsl
-Requires:       python3-pygments
-Requires:       python3-lxml
+Requires:       python3dist(pygments)
+Requires:       python3dist(lxml)
 Requires:       cmake-filesystem
 
 %description
@@ -60,4 +60,4 @@ mv doc/README doc/README.docs
 %{_libdir}/cmake/GtkDoc/
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/i2c-tools/i2c-tools.spec
+++ b/SPECS/i2c-tools/i2c-tools.spec
@@ -13,9 +13,9 @@ Summary:        A heterogeneous set of I2C tools for Linux
 License:        GPL-2.0-or-later
 URL:            https://archive.kernel.org/oldwiki/i2c.wiki.kernel.org/index.php/I2C_Tools.html
 VCS:            git:https://git.kernel.org/pub/scm/utils/i2c-tools/i2c-tools.git
-#!RemoteAsset
+#!RemoteAsset:  sha256:8b15f0a880ab87280c40cfd7235cfff28134bf14d5646c07518b1ff6642a2473
 Source0:        https://www.kernel.org/pub/software/utils/i2c-tools/%{name}-%{version}.tar.xz
-#!RemoteAsset
+#!RemoteAsset:  sha256:7d37f37baf4555fc4e3bbcd2e94bafe264d64141ad49395540b8335f8cfe3694
 Source1:        https://www.kernel.org/pub/software/utils/i2c-tools/%{name}-%{version}.tar.sign
 BuildSystem:    autotools
 
@@ -30,7 +30,7 @@ BuildRequires:  make
 BuildRequires:  perl-devel
 BuildRequires:  perl-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
 
 Requires:       systemd-udev
 Requires:       kmod
@@ -161,4 +161,4 @@ exit 0
 %{_mandir}/man3/libi2c.3.*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/imath/imath.spec
+++ b/SPECS/imath/imath.spec
@@ -40,8 +40,8 @@ BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(numpy)
 %if %{with doc}
 BuildRequires:  doxygen
-BuildRequires:  python3-sphinx
-BuildRequires:  python3-breathe
+BuildRequires:  python3dist(sphinx)
+BuildRequires:  python3dist(breathe)
 %endif
 
 %description
@@ -85,4 +85,4 @@ Development files for Imath.
 %{_libdir}/libPyImath_Python*.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/iso-codes/iso-codes.spec
+++ b/SPECS/iso-codes/iso-codes.spec
@@ -21,7 +21,7 @@ BuildOption(install):  INSTALL="%{__install} -p"
 
 BuildRequires:  pkgconfig
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-lxml
+BuildRequires:  python3dist(lxml)
 
 Provides:       iso-codes-lang = %{version}
 

--- a/SPECS/itstool/itstool.spec
+++ b/SPECS/itstool/itstool.spec
@@ -12,7 +12,7 @@ Summary:        ITS-based XML translation tool
 License:        GPL-3.0-or-later
 URL:            http://itstool.org/
 VCS:            git:https://github.com/itstool/itstool
-#!RemoteAsset
+#!RemoteAsset:  sha256:6b9a7cd29a12bb95598f5750e8763cee78836a1a207f85b74d8b3275b27e87ca
 Source0:        http://files.itstool.org/itstool/%{name}-%{version}.tar.bz2
 BuildArch:      noarch
 BuildSystem:    autotools
@@ -22,13 +22,13 @@ Patch0002:      0002-Switch-from-libxml2-to-lxml.patch
 
 BuildOption(prep):  -n %{name}-%{version} -p1
 
-BuildRequires:  python3-lxml
+BuildRequires:  python3dist(lxml)
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  libtool
 
-Requires:       python3-lxml
+Requires:       python3dist(lxml)
 
 %description
 ITS Tool allows you to translate XML documents with PO files, using rules from
@@ -47,4 +47,4 @@ export PYTHON=%{__python3}
 %{_mandir}/man1/*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/json-glib/json-glib.spec
+++ b/SPECS/json-glib/json-glib.spec
@@ -12,7 +12,7 @@ Summary:        Library for JavaScript Object Notation (JSON) format
 License:        LGPL-2.1-or-later
 URL:            https://wiki.gnome.org/Projects/JsonGlib
 VCS:            git:https://gitlab.gnome.org/GNOME/json-glib
-#!RemoteAsset
+#!RemoteAsset:  sha256:55c5c141a564245b8f8fbe7698663c87a45a7333c2a2c56f06f811ab73b212dd
 Source:         https://download.gnome.org/sources/json-glib/1.10/json-glib-%{version}.tar.xz
 BuildSystem:    meson
 
@@ -25,7 +25,7 @@ BuildRequires:  gettext-devel
 BuildRequires:  gi-docgen
 BuildRequires:  pkgconfig(gio-2.0)
 BuildRequires:  pkgconfig(gobject-introspection-1.0)
-BuildRequires:  python3-docutils
+BuildRequires:  python3dist(docutils)
 
 %description
 json-glib is a library providing serialization and deserialization support
@@ -63,4 +63,4 @@ rm -rf %{buildroot}%{_datadir}/locale/*@*
 %{_mandir}/man1/json-glib-validate.1*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/jsonnet/jsonnet.spec
+++ b/SPECS/jsonnet/jsonnet.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        A data templating language based on JSON
 License:        Apache-2.0 AND MIT AND CC0-1.0
 URL:            https://github.com/google/jsonnet
-#!RemoteAsset
+#!RemoteAsset:  sha256:a12ebca72e43e7061ffe4ef910e572b95edd7778a543d6bf85f6355bd290300e
 Source0:        https://github.com/google/jsonnet/archive/refs/tags/v%{version}.tar.gz
 Source1:        jsonnet.1
 Source2:        jsonnetfmt.1
@@ -35,7 +35,7 @@ BuildRequires:  gcc
 BuildRequires:  gcc-c++
 BuildRequires:  make
 BuildRequires:  nlohmann-json
-BuildRequires:  python3-pip
+BuildRequires:  python3dist(pip)
 
 %description
 A data templating language for app and tool developers based on JSON.
@@ -85,7 +85,7 @@ install -t '%{buildroot}%{_mandir}/man1' -p -m 0644 '%{SOURCE1}' '%{SOURCE2}'
 %{_libdir}/libjsonnet.so.*
 %{_libdir}/libjsonnet++.so.*
 
-%files    devel
+%files devel
 %{_includedir}/libjsonnet*
 %{_libdir}/libjsonnet.so
 %{_libdir}/libjsonnet++.so
@@ -93,4 +93,4 @@ install -t '%{buildroot}%{_mandir}/man1' -p -m 0644 '%{SOURCE1}' '%{SOURCE2}'
 %files -n python-%{name} -f %{pyproject_files}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kea/kea.spec
+++ b/SPECS/kea/kea.spec
@@ -13,9 +13,9 @@ Summary:        DHCPv4, DHCPv6 and DDNS server from ISC
 License:        MPL-2.0 AND BSL-1.0
 URL:            http://kea.isc.org
 VCS:            git:https://gitlab.isc.org/isc-projects/kea.git
-#!RemoteAsset
+#!RemoteAsset:  sha256:a299c976c26b44a51738746fc30584c5ebb174030ef6451aeed0a2d37f9c1dad
 Source0:        https://downloads.isc.org/isc/kea/%{version}/kea-%{version}.tar.xz
-#!RemoteAsset
+#!RemoteAsset:  sha256:2478a7259b4eb1899ffc7360bd3c1de4820f543cfebf60087ff95f236adf076b
 Source1:        https://downloads.isc.org/isc/kea/%{version}/kea-%{version}.tar.xz.asc
 Source2:        kea-dhcp4.service
 Source3:        kea-dhcp6.service
@@ -53,8 +53,8 @@ BuildRequires:  flex
 BuildRequires:  systemd
 BuildRequires:  systemd-rpm-macros
 %if %{with doc}
-BuildRequires:  python3-sphinx
-BuildRequires:  python3-sphinx_rtd_theme
+BuildRequires:  python3dist(sphinx)
+BuildRequires:  python3dist(sphinx-rtd-theme)
 %endif
 
 Requires:       coreutils
@@ -173,4 +173,4 @@ fi
 %{_libdir}/kea/hooks/lib*.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kernel-hardening-checker/kernel-hardening-checker.spec
+++ b/SPECS/kernel-hardening-checker/kernel-hardening-checker.spec
@@ -13,7 +13,7 @@ Release:        %autorelease
 Summary:        Tool for checking the security hardening options of the Linux kernel
 License:        GPL-3.0-only
 URL:            https://github.com/a13xp0p0v/kernel-hardening-checker
-#!RemoteAsset
+#!RemoteAsset:  sha256:2383e851b44fe74c9a5db32919b897af05f022e676e8d1184cc53594bb9b344c
 Source0:        https://github.com/a13xp0p0v/kernel-hardening-checker/archive/refs/tags/v%{version}.tar.gz
 BuildSystem:    pyproject
 
@@ -21,9 +21,9 @@ BuildOption(install):  -l %{modname}
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-pip
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-wheel
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
 
 %description
 A tool for checking the security hardening options of the Linux kernel.
@@ -39,4 +39,4 @@ security hardening recommendations.
 %{_bindir}/kernel-hardening-checker
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kcoreaddons/kf6-kcoreaddons.spec
+++ b/SPECS/kf6-kcoreaddons/kf6-kcoreaddons.spec
@@ -18,7 +18,7 @@ Summary:        Utilities for core application functionality and accessing the O
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            https://invent.kde.org/frameworks/kcoreaddons
-#!RemoteAsset
+#!RemoteAsset:  sha256:843d27cd76ca890c4f352d6f29d2e2b8747883602b63119106b1eb229b95e649
 Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
 
 BuildRequires:  fdupes
@@ -35,9 +35,9 @@ BuildRequires:  qt6-qttools
 BuildRequires:  qt6-doctools
 BuildRequires:  qt6-linguist
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-build
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-wheel
+BuildRequires:  python3dist(build)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
 BuildRequires:  clang-devel
 BuildRequires:  cmake(Shiboken6)
 BuildRequires:  cmake(PySide6)
@@ -118,4 +118,4 @@ The package contains the PySide6 bindings library for %{name}.
 # Python bindings disabled; package intentionally empty
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kguiaddons/kf6-kguiaddons.spec
+++ b/SPECS/kf6-kguiaddons/kf6-kguiaddons.spec
@@ -19,7 +19,7 @@ Summary:        Utilities for graphical user interfaces
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kguiaddons
-#!RemoteAsset
+#!RemoteAsset:  sha256:b7652bcebebfc8c1fda2893c1aeff4136c586ee77ffc6e589e3634f0e5539eef
 Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
 
 BuildRequires:  fdupes
@@ -40,9 +40,9 @@ BuildRequires:  qt6-qttools
 BuildRequires:  qt6-doctools
 BuildRequires:  qt6-linguist
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-build
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-wheel
+BuildRequires:  python3dist(build)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
 BuildRequires:  clang-devel
 BuildRequires:  cmake(Shiboken6)
 BuildRequires:  cmake(PySide6)
@@ -106,4 +106,4 @@ of colors, fonts, text, images, keyboard input. Development files.
 %{_kf6_pkgconfigdir}/KF6GuiAddons.pc
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-knotifications/kf6-knotifications.spec
+++ b/SPECS/kf6-knotifications/kf6-knotifications.spec
@@ -18,7 +18,7 @@ Summary:        KDE Desktop notifications
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/knotifications
-#!RemoteAsset
+#!RemoteAsset:  sha256:c49aaef3ccf3dfac73ac07159b3ee0ddbf6e39696e44165d3b0a1ea02a77408c
 Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
 
 BuildRequires:  fdupes
@@ -36,9 +36,9 @@ BuildRequires:  qt6-qttools
 BuildRequires:  qt6-doctools
 BuildRequires:  qt6-linguist
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-build
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-wheel
+BuildRequires:  python3dist(build)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
 BuildRequires:  clang-devel
 BuildRequires:  cmake(Shiboken6)
 BuildRequires:  cmake(PySide6)
@@ -111,4 +111,4 @@ The package contains the PySide6 bindings library for %{name}.
 # Python bindings disabled; package intentionally empty
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kwidgetsaddons/kf6-kwidgetsaddons.spec
+++ b/SPECS/kf6-kwidgetsaddons/kf6-kwidgetsaddons.spec
@@ -18,7 +18,7 @@ Summary:        Large set of desktop widgets
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kwidgetsaddons
-#!RemoteAsset
+#!RemoteAsset:  sha256:e8832ac697054ed3241e8299ba71b8d766579b7e6cb0fd8dd176cad10aec754b
 Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
 
 BuildRequires:  fdupes
@@ -31,9 +31,9 @@ BuildRequires:  qt6-qttools
 BuildRequires:  qt6-doctools
 BuildRequires:  qt6-linguist
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-build
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-wheel
+BuildRequires:  python3dist(build)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
 BuildRequires:  clang-devel
 BuildRequires:  cmake(Shiboken6)
 BuildRequires:  cmake(PySide6)
@@ -85,4 +85,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_kf6_plugindir}/designer/kwidgetsaddons6widgets.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/libblockdev/libblockdev.spec
+++ b/SPECS/libblockdev/libblockdev.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        A library for low-level manipulation with block devices
 License:        LGPL-2.1-or-later
 URL:            https://github.com/storaged-project/libblockdev
-#!RemoteAsset
+#!RemoteAsset:  sha256:7cb0b4018600ab82d1d1f00e46c1b1d7a0cdab8f4682952dd9dba1ce7f6ebed4
 Source0:        https://github.com/storaged-project/libblockdev/archive/refs/tags/%{version}.tar.gz
 BuildSystem:    autotools
 
@@ -47,7 +47,7 @@ BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  autoconf-archive
 BuildRequires:  automake
 BuildRequires:  libtool
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
 BuildRequires:  pkgconfig(ext2fs)
 BuildRequires:  pkgconfig(e2p)
 BuildRequires:  pkgconfig(bytesize)
@@ -179,4 +179,4 @@ Python3 bindings for libblockdev.
 %{python3_sitearch}/gi/overrides/BlockDev*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/libcomps/libcomps.spec
+++ b/SPECS/libcomps/libcomps.spec
@@ -15,7 +15,7 @@ Release:        %autorelease
 Summary:        Comps XML file manipulation library
 License:        GPL-2.0-or-later
 URL:            https://github.com/rpm-software-management/libcomps
-#!RemoteAsset
+#!RemoteAsset:  sha256:0f41c042ff672ce5b30769c0bf2066c8ecc3db4b14bd26a8e5ed80a4fb0963ef
 Source:         %{url}/archive/%{version}/libcomps-%{version}.tar.gz
 BuildSystem:    cmake
 
@@ -50,7 +50,7 @@ Documentation files for libcomps library.
 %package -n python-%{name}
 Summary:        Python bindings for libcomps library
 BuildRequires:  python3-devel
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
 BuildRequires:  make
 Provides:       python3-%{srcname}
 %python_provide python3-%{srcname}
@@ -64,7 +64,7 @@ Python3 bindings for libcomps library.
 Summary:        Documentation files for python bindings libcomps library
 Requires:       %{name} = %{version}-%{release}
 BuildArch:      noarch
-BuildRequires:  python3-sphinx
+BuildRequires:  python3dist(sphinx)
 
 %description -n python-%{name}-doc
 Documentation files for python bindings libcomps library.
@@ -106,4 +106,4 @@ cp -a %{__cmake_builddir}/src/python/docs/html %{buildroot}%{_datadir}/doc/pytho
 %endif
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/libei/libei.spec
+++ b/SPECS/libei/libei.spec
@@ -10,7 +10,7 @@ Release:        %autorelease
 Summary:        Library for Emulated Input
 License:        MIT
 URL:            http://gitlab.freedesktop.org/libinput/libei
-#!RemoteAsset
+#!RemoteAsset:  sha256:da1fba92daccd0667bc46c3ee952d4ae8cfc6bdb4c0bb4d34df26528fb240618
 Source0:        https://gitlab.freedesktop.org/libinput/libei/-/archive/%{version}/libei-%{version}.tar.bz2
 BuildSystem:    meson
 
@@ -24,8 +24,8 @@ BuildRequires:  pkgconfig
 BuildRequires:  libxml2
 BuildRequires:  pkgconfig(libsystemd)
 BuildRequires:  python3-rpm-macros
-BuildRequires:  python3-attrs
-BuildRequires:  python3-jinja2
+BuildRequires:  python3dist(attrs)
+BuildRequires:  python3dist(jinja2)
 
 %description
 libei is a library to Emulate Input. It allows clients to talk to an EIS
@@ -58,4 +58,4 @@ Development files for libei.
 %{_libdir}/pkgconfig/liboeffis-1.0.pc
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/libinput/libinput.spec
+++ b/SPECS/libinput/libinput.spec
@@ -14,7 +14,7 @@ Summary:        Input device library
 License:        MIT
 URL:            http://www.freedesktop.org/wiki/Software/libinput/
 VCS:            git:https://gitlab.freedesktop.org/libinput/libinput.git
-#!RemoteAsset
+#!RemoteAsset:  sha256:594d970cab7b3738ad99218e7dafc253780f58a7600ab0823d2fcc3941a04e86
 Source:         https://gitlab.freedesktop.org/libinput/libinput/-/archive/%{version}/libinput-%{version}.tar.bz2
 BuildSystem:    meson
 
@@ -56,8 +56,8 @@ developing applications that use %{name}.
 %package        utils
 Summary:        Utilities and tools for debugging %{name}
 Requires:       %{name}%{?_isa} = %{version}-%{release}
-Requires:       python3-pyudev
-Requires:       python3-libevdev
+Requires:       python3dist(pyudev)
+Requires:       python3dist(libevdev)
 
 %description    utils
 The %{name}-utils package contains tools to debug hardware and analyze
@@ -116,4 +116,4 @@ The %{name}-utils package contains tools to debug hardware and analyze
 %{_mandir}/man1/libinput-replay.1*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/libnl/libnl.spec
+++ b/SPECS/libnl/libnl.spec
@@ -14,7 +14,7 @@ Release:        %autorelease
 Summary:        A suite of libraries for interacting with Linux Netlink sockets
 License:        LGPL-2.1-only
 URL:            https://github.com/thom311/libnl
-#!RemoteAsset
+#!RemoteAsset:  sha256:871d8f9f05b86dab080988bb994748384c1416a5d03de1f9f5e811f265094b04
 Source0:        https://github.com/thom311/libnl/archive/refs/tags/%{name}3_11_0.tar.gz#/%{name}-%{version}.tar.gz
 BuildSystem:    autotools
 
@@ -26,7 +26,7 @@ BuildRequires:  bison
 BuildRequires:  libtool
 %if %{with python}
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
 BuildRequires:  swig
 %endif
 
@@ -113,4 +113,4 @@ popd
 %{_libdir}/pkgconfig/libnl-xfrm-3.0.pc
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/libpkgmanifest/libpkgmanifest.spec
+++ b/SPECS/libpkgmanifest/libpkgmanifest.spec
@@ -14,7 +14,7 @@ Release:        %autorelease
 Summary:        Library for working with RPM manifests
 License:        LGPL-2.1-or-later
 URL:            https://github.com/rpm-software-management/libpkgmanifest
-#!RemoteAsset
+#!RemoteAsset:  sha256:7b268f9c12f06137493def0d18bb7d8f59f2af0d26c1f9c0d531dabb80ae2854
 Source0:        https://github.com/rpm-software-management/libpkgmanifest/archive/refs/tags/v%{version}.tar.gz
 BuildSystem:    cmake
 
@@ -46,7 +46,7 @@ BuildRequires:  pkgconfig(gtest)
 %endif
 %if %{with docs}
 BuildRequires:  doxygen
-BuildRequires:  python3-sphinx
+BuildRequires:  python3dist(sphinx)
 %endif
 
 %description
@@ -84,4 +84,4 @@ Python bindings for the %{name} library.
 %{python3_sitearch}/libpkgmanifest-*.dist-info/
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/libplist/libplist.spec
+++ b/SPECS/libplist/libplist.spec
@@ -12,16 +12,16 @@ Summary:        Library for manipulating Apple Binary and XML Property Lists
 License:        LGPL-2.0-or-later
 URL:            https://www.libimobiledevice.org/
 VCS:            git:https://github.com/libimobiledevice/libplist
-#!RemoteAsset
+#!RemoteAsset:  sha256:7ac42301e896b1ebe3c654634780c82baa7cb70df8554e683ff89f7c2643eb8b
 Source:         https://github.com/libimobiledevice/libplist/releases/download/%{version}/libplist-%{version}.tar.bz2
 BuildSystem:    autotools
 
 BuildOption(conf):  --disable-static
 
 BuildRequires:  gcc-c++
-BuildRequires:  python3-Cython
+BuildRequires:  python3dist(cython)
 BuildRequires:  python3-devel
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
 BuildRequires:  make
 
 %description
@@ -67,4 +67,4 @@ export PYTHON_VERSION="3"
 %{python3_sitearch}/plist.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/libpwquality/libpwquality.spec
+++ b/SPECS/libpwquality/libpwquality.spec
@@ -11,7 +11,7 @@ Release:        %autorelease
 Summary:        A library for password generation and password quality checking
 License:        BSD-3-Clause OR GPL-2.0-or-later
 URL:            https://github.com/libpwquality/libpwquality
-#!RemoteAsset
+#!RemoteAsset:  sha256:6fcf18b75d305d99d04d2e42982ed5b787a081af2842220ed63287a2d6a10988
 Source0:        https://github.com/libpwquality/libpwquality/releases/download/libpwquality-%{version}/libpwquality-%{version}.tar.bz2
 BuildSystem:    autotools
 
@@ -28,8 +28,8 @@ BuildRequires:  cracklib-devel
 BuildRequires:  gettext
 BuildRequires:  pkgconfig(pam)
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-packaging
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(packaging)
 
 %description
 This is a library for password quality checks and generation
@@ -92,4 +92,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{python3_sitearch}/*.egg-info
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/libseccomp/libseccomp.spec
+++ b/SPECS/libseccomp/libseccomp.spec
@@ -15,7 +15,7 @@ Release:        %autorelease
 Summary:        Enhanced library for the Linux syscall filtering mechanism
 License:        LGPL-2.1-only
 URL:            https://github.com/seccomp/libseccomp
-#!RemoteAsset
+#!RemoteAsset:  sha256:83b6085232d1588c379dc9b9cae47bb37407cf262e6e74993c61ba72d2a784dc
 Source0:        %{url}/releases/download/v%{version}/%{name}-%{version}.tar.gz
 BuildSystem:    autotools
 
@@ -41,7 +41,7 @@ BuildRequires:  gcc
 BuildRequires:  gperf
 %if %{with python}
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
 BuildRequires:  cython
 %endif
 
@@ -97,4 +97,4 @@ rm -f %{buildroot}%{_libdir}/libseccomp.la
 %{_mandir}/man3/*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/libselinux/libselinux.spec
+++ b/SPECS/libselinux/libselinux.spec
@@ -12,9 +12,9 @@ Release:        %autorelease
 Summary:        SELinux runtime library and utilities
 License:        LicenseRef-openRuyi-Public-Domain
 URL:            https://github.com/SELinuxProject/selinux/wiki/Releases
-#!RemoteAsset
+#!RemoteAsset:  sha256:1ef216c5b56fb7e0a51cd2909787a175a17ee391e0467894807873539ebe766b
 Source0:        https://github.com/SELinuxProject/selinux/releases/download/%{version}/%{name}-%{version}.tar.gz
-#!RemoteAsset
+#!RemoteAsset:  sha256:39dac0fe73847c0329f59ffe138d7baba193f1edf9fd6d5d226335ef4543c17d
 Source1:        https://github.com/SELinuxProject/selinux/releases/download/%{version}/%{name}-%{version}.tar.gz.asc
 Source2:        libselinux.keyring
 Source3:        selinux-ready
@@ -32,8 +32,8 @@ BuildRequires:  pkgconfig
 BuildRequires:  pkgconfig(libpcre2-8)
 BuildRequires:  python3
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-pip
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(pip)
 BuildRequires:  swig
 
 BuildOption(build):  LIBDIR="%{_libdir}" CC="%__cc"
@@ -170,4 +170,4 @@ install -m 0755 %{SOURCE3} %{buildroot}%{_sbindir}/selinux-ready
 %{python3_sitearch}/_selinux*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/libsemanage/libsemanage.spec
+++ b/SPECS/libsemanage/libsemanage.spec
@@ -15,7 +15,7 @@ Summary:        SELinux policy management library and utilities
 License:        LGPL-2.1-or-later
 URL:            https://github.com/SELinuxProject/selinux/wiki/Releases
 VCS:            git:https://github.com/SELinuxProject/selinux
-#!RemoteAsset
+#!RemoteAsset:  sha256:1978894c414769ad77438d26886eaae3fb7bb74578ef2a5ad3130c89cb5cb1fe
 Source0:        https://github.com/SELinuxProject/selinux/releases/download/%{version}/%{name}-%{version}.tar.gz
 Source1:        semanage.conf
 BuildSystem:    autotools
@@ -43,7 +43,7 @@ BuildRequires:  make
 BuildRequires:  gcc
 BuildRequires:  python3
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
 BuildRequires:  swig
 BuildRequires:  pkgconfig(cunit)
 
@@ -107,4 +107,4 @@ install -d -m 755 %{buildroot}%{_localstatedir}/lib/selinux
 %{_libexecdir}/selinux/semanage_migrate_store
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/libvirt/libvirt.spec
+++ b/SPECS/libvirt/libvirt.spec
@@ -71,7 +71,7 @@ BuildRequires:  meson
 BuildRequires:  ninja
 BuildRequires:  perl
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-docutils
+BuildRequires:  python3dist(docutils)
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  systemtap-sdt-devel
 BuildRequires:  systemtap-sdt-dtrace

--- a/SPECS/libwacom/libwacom.spec
+++ b/SPECS/libwacom/libwacom.spec
@@ -13,7 +13,7 @@ Release:        %autorelease
 Summary:        Tablet Information Client Library
 License:        HPND
 URL:            https://github.com/linuxwacom/libwacom
-#!RemoteAsset
+#!RemoteAsset:  sha256:e8654bb748a5c51f2c61d81b999760719bffa77d4b280cfeba3330de7a66388d
 Source:         https://github.com/linuxwacom/libwacom/archive/refs/tags/libwacom-%{version}.tar.gz
 BuildSystem:    meson
 
@@ -55,8 +55,8 @@ Data files describing Wacom tablets and styli.
 %package        utils
 Summary:        Utilities for %{name}
 Requires:       %{name}%{?_isa} = %{version}-%{release}
-Requires:       python3-libevdev
-Requires:       python3-pyudev
+Requires:       python3dist(libevdev)
+Requires:       python3dist(pyudev)
 
 %description    utils
 Utilities to handle and/or debug libwacom devices.
@@ -95,4 +95,4 @@ Utilities to handle and/or debug libwacom devices.
 %{_mandir}/man1/libwacom-show-stylus.1*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/linux-tools/linux-tools.spec
+++ b/SPECS/linux-tools/linux-tools.spec
@@ -47,7 +47,7 @@ BuildRequires:  pkgconfig(libdebuginfod)
 BuildRequires:  systemtap-sdt-devel
 BuildRequires:  clang
 BuildRequires:  pkgconfig(slang)
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
 BuildRequires:  llvm-devel
 BuildRequires:  pkgconfig(numa)
 BuildRequires:  systemd-rpm-macros

--- a/SPECS/lvm2/lvm2.spec
+++ b/SPECS/lvm2/lvm2.spec
@@ -21,7 +21,7 @@ Summary:        Userland logical volume management tools
 License:        LicenseRef-DMIT
 URL:            https://sourceware.org/lvm2
 VCS:            git:https://gitlab.com/lvmteam/lvm2.git
-#!RemoteAsset
+#!RemoteAsset:  sha256:ebf28b3427535e2b5abd9991cd839b61622a0dbfb8c86df0f7af1f69dcaa8371
 Source0:        https://sourceware.org/pub/lvm2/releases/LVM2.%{version}.tgz
 BuildSystem:    autotools
 
@@ -69,7 +69,7 @@ BuildRequires:  systemd-units
 BuildRequires:  pkgconfig(readline)
 %if %{with lvmdbusd}
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3-dbus
 BuildRequires:  python3-pyudev
 %endif
@@ -491,4 +491,4 @@ fi
 %{_libdir}/pkgconfig/devmapper-event.pc
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/mkosi/mkosi.spec
+++ b/SPECS/mkosi/mkosi.spec
@@ -13,17 +13,18 @@ Release:        %autorelease
 Summary:        Create bespoke OS images
 License:        LGPL-2.1-or-later
 URL:            https://github.com/systemd/mkosi
-#!RemoteAsset
+#!RemoteAsset:  sha256:5a1fb73305fe6c531e72b72deee906b1870bd3d197a5f7f1569a8bba4949b878
 Source:         https://github.com/systemd/mkosi/archive/%{commit}/mkosi-%{commit}.tar.gz
 
-BuildRequires:  python3-devel python3-pip
+BuildRequires:  python3-devel
+BuildRequires:  python3dist(pip)
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
 BuildSystem:    pyproject
 Patch0:         0001-Add-openruyi-support.patch
 
-BuildOption(prep): -n %{name}-%{commit}
-BuildOption(install): %{name} +auto
+BuildOption(prep):  -n %{name}-%{commit}
+BuildOption(install):  %{name} +auto
 
 Requires:       python3
 Requires:       coreutils
@@ -99,4 +100,4 @@ install -m 0644 -D mkosi.zsh %{buildroot}%{_datadir}/zsh/site-functions/_mkosi
 %ghost %dir %{_sysconfdir}/mkosi-addon
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/mock/mock.spec
+++ b/SPECS/mock/mock.spec
@@ -16,33 +16,33 @@ Release:        %autorelease
 Summary:        Builds packages inside chroots
 License:        GPL-2.0-or-later
 URL:            https://github.com/rpm-software-management/mock
-#!RemoteAsset
+#!RemoteAsset:  sha256:c3672842b68f0e58f331ec6280be516a830afbbb607edfdd5dee09847fbde687
 Source0:        %{url}/releases/download/%{name}-%{version}-1/%{name}-%{version}.tar.gz
 BuildArch:      noarch
 
 BuildRequires:  bash-completion
 BuildRequires:  perl
-BuildRequires:  python3-backoff
+BuildRequires:  python3dist(backoff)
 BuildRequires:  python3-devel
 BuildRequires:  python3-rpm
 BuildRequires:  python3-rpmautospec-core
-BuildRequires:  python3-argparse-manpage
-BuildRequires:  python3-requests
+BuildRequires:  python3dist(argparse-manpage)
+BuildRequires:  python3dist(requests)
 %if %{with lint}
-BuildRequires:  python3-pylint
+BuildRequires:  python3dist(pylint)
 %endif
 
 Recommends:     dnf-utils
 Recommends:     dnf5
 Recommends:     dnf5-plugins
 
-Requires:       python3-distro
-Requires:       python3-jinja2
-Requires:       python3-requests
+Requires:       python3dist(distro)
+Requires:       python3dist(jinja2)
+Requires:       python3dist(requests)
 Requires:       python3-rpm
-Requires:       python3-pyroute2
-Requires:       python3-templated-dictionary
-Requires:       python3-backoff
+Requires:       python3dist(pyroute2)
+Requires:       python3dist(templated-dictionary)
+Requires:       python3dist(backoff)
 Requires:       mock-configs
 Requires:       %{name}-filesystem = %{version}-%{release}
 Requires:       tar
@@ -219,4 +219,4 @@ getent group 'mock' >/dev/null || groupadd -f -g '135' -r 'mock' || :
 %dir %{_localstatedir}/lib/mock
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/nftables/nftables.spec
+++ b/SPECS/nftables/nftables.spec
@@ -13,7 +13,7 @@ Summary:        Netfilter Tables userspace utilities
 License:        GPL-2.0-only
 URL:            https://netfilter.org/projects/nftables/
 VCS:            git:https://git.netfilter.org/nftables
-#!RemoteAsset
+#!RemoteAsset:  sha256:1daf10f322e14fd90a017538aaf2c034d7cc1eb1cc418ded47445d714ea168d4
 Source0:        https://netfilter.org/projects/nftables/files/nftables-%{version}.tar.xz
 Source1:        nftables.service
 Source2:        nftables.conf
@@ -33,10 +33,10 @@ BuildRequires:  pkgconfig(jansson)
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  pkgconfig(readline)
 BuildRequires:  pkgconfig(libedit)
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
 BuildRequires:  make
 BuildRequires:  gcc
-BuildRequires:  python3-pip
+BuildRequires:  python3dist(pip)
 BuildRequires:  pkgconfig(libmnl) >= 1.0.4
 BuildRequires:  pkgconfig(libnftnl) >= 1.3.0
 BuildRequires:  pkgconfig(xtables) >= 1.6.1
@@ -127,4 +127,4 @@ cd py
 %{_unitdir}/nftables.service
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/ngtcp2/ngtcp2.spec
+++ b/SPECS/ngtcp2/ngtcp2.spec
@@ -14,7 +14,7 @@ Release:        %autorelease
 Summary:        Implementation of RFC 9000 QUIC protocol
 License:        MIT
 URL:            https://github.com/ngtcp2/ngtcp2
-#!RemoteAsset
+#!RemoteAsset:  sha256:367cbcecaca539f76453c49454d8e7b38ecb162acf89cd571535ac4acf82a2b4
 Source:         https://github.com/ngtcp2/ngtcp2/releases/download/v%{version}/ngtcp2-%{version}.tar.xz
 BuildSystem:    autotools
 
@@ -35,8 +35,8 @@ BuildRequires:  pkgconfig(libev)
 BuildRequires:  pkgconfig(gnutls)
 BuildRequires:  pkgconfig(openssl)
 %if %{with doc}
-BuildRequires:  python3-sphinx
-BuildRequires:  python3-sphinx_rtd_theme
+BuildRequires:  python3dist(sphinx)
+BuildRequires:  python3dist(sphinx-rtd-theme)
 %endif
 
 %description
@@ -117,4 +117,4 @@ autoreconf -fsi
 %{_includedir}/ngtcp2/ngtcp2_crypto_ossl.h
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/openvpn/openvpn.spec
+++ b/SPECS/openvpn/openvpn.spec
@@ -14,7 +14,7 @@ Summary:        A full-featured TLS VPN solution
 License:        GPL-2.0-only
 URL:            https://community.openvpn.net/
 VCS:            git:https://github.com/OpenVPN/openvpn
-#!RemoteAsset
+#!RemoteAsset:  sha256:80256bf2f9f4c912dbc72e8b00180f6c30fb40a1bb2122fb5e686e71af6a06e7
 Source0:        https://github.com/OpenVPN/openvpn/archive/refs/tags/v%{version}.tar.gz
 Source1:        roadwarrior-server.conf
 Source2:        roadwarrior-client.conf
@@ -52,7 +52,7 @@ BuildRequires:  pkgconfig(pam)
 BuildRequires:  pkgconfig(libselinux)
 BuildRequires:  pkgconfig(systemd)
 BuildRequires:  pkgconfig(cmocka)
-BuildRequires:  python3-docutils
+BuildRequires:  python3dist(docutils)
 BuildRequires:  pkgconfig(python3)
 %if %{with dco}
 BuildRequires:  pkgconfig(libnl-3.0)
@@ -154,4 +154,4 @@ rm -rf %{buildroot}%{_pkgdocdir}/contrib/cmake*
 %{_includedir}/openvpn-msg.h
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/osc/osc.spec
+++ b/SPECS/osc/osc.spec
@@ -10,27 +10,27 @@ Release:        %autorelease
 Summary:        The Command Line Interface to work with an Open Build Service
 License:        GPL-2.0-or-later
 URL:            https://github.com/openSUSE/osc
-#!RemoteAsset
+#!RemoteAsset:  sha256:6579381095a8a6675a6ffca4c894a2e5706fe19c45f2e9a18631d75e00bed051
 Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
 BuildArch:      noarch
 
-BuildRequires:  python3-argparse-manpage
-BuildRequires:  python3-cryptography
+BuildRequires:  python3dist(argparse-manpage)
+BuildRequires:  python3dist(cryptography)
 BuildRequires:  python3-devel
-BuildRequires:  python3-distro
-BuildRequires:  python3-pip
-BuildRequires:  python3-progressbar2
+BuildRequires:  python3dist(distro)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(progressbar2)
 BuildRequires:  python3-rpm
-BuildRequires:  python3-ruamel-yaml
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-urllib3
+BuildRequires:  python3dist(ruamel-yaml)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(urllib3)
 BuildRequires:  git-core
 BuildRequires:  bash-completion
 
-Requires:       python3-cryptography
+Requires:       python3dist(cryptography)
 Requires:       python3-rpm
-Requires:       python3-urllib3
-Requires:       python3-lxml
+Requires:       python3dist(urllib3)
+Requires:       python3dist(lxml)
 
 %description
 Commandline client for the Open Build Service.
@@ -122,4 +122,4 @@ sed -i '3i # PYTHON_ARGCOMPLETE_OK'  %{buildroot}%{_bindir}/git-obs
 %{_rpmconfigdir}/macros.d/macros.osc
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/pam_wrapper/pam_wrapper.spec
+++ b/SPECS/pam_wrapper/pam_wrapper.spec
@@ -12,9 +12,9 @@ Summary:        A tool to test PAM applications and PAM modules
 License:        GPL-3.0-or-later
 URL:            http://cwrap.org/
 VCS:            git:https://git.samba.org/pam_wrapper.git
-#!RemoteAsset
+#!RemoteAsset:  sha256:6549c0b3e41d1ebe0c94a1be63c25eec918191462b602ab6f47d4a5fa709c3e4
 Source0:        https://ftp.samba.org/pub/cwrap/%{name}-%{version}.tar.gz
-#!RemoteAsset
+#!RemoteAsset:  sha256:6093195d65f7e3566f38e3d9f9e0b6c3615e92774de904028937b18d941f699b
 Source1:        https://ftp.samba.org/pub/cwrap/%{name}-%{version}.tar.gz.asc
 BuildSystem:    cmake
 
@@ -25,7 +25,7 @@ BuildOption(conf):  -DPYTHON_INSTALL_SITEARCH=%{python3_sitearch}
 BuildRequires:  cmake
 BuildRequires:  cmocka-cmake
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
 BuildRequires:  pkgconfig(pam)
 
 Recommends:     cmake
@@ -114,4 +114,4 @@ sed -i -e 's/assertRaisesRegexp/assertRaisesRegex/' tests/pypamtest_test.py
 %{python3_sitearch}/pypamtest.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/pipewire/pipewire.spec
+++ b/SPECS/pipewire/pipewire.spec
@@ -14,7 +14,7 @@ Release:        %autorelease
 Summary:        Media Sharing Server
 License:        MIT
 URL:            https://gitlab.freedesktop.org/pipewire/pipewire
-#!RemoteAsset
+#!RemoteAsset:  sha256:b9d137dcf18ff228d67312f9a205e3ea8766a13d9a841a029832568ea8928efe
 Source0:        https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/%{version}/pipewire-%{version}.tar.gz
 Source1:        pipewire.sysusers
 BuildSystem:    meson
@@ -81,7 +81,7 @@ BuildRequires:  pkgconfig(sndfile)
 BuildRequires:  pkgconfig(speexdsp)
 BuildRequires:  pkgconfig(fftw3)
 BuildRequires:  doxygen
-BuildRequires:  python3-docutils
+BuildRequires:  python3dist(docutils)
 BuildRequires:  graphviz
 BuildRequires:  pkgconfig(libdrm)
 BuildRequires:  pkgconfig(vulkan)
@@ -304,4 +304,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_libdir}/pkgconfig/libspa-%{spaversion}.pc
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/policycoreutils/policycoreutils.spec
+++ b/SPECS/policycoreutils/policycoreutils.spec
@@ -14,25 +14,25 @@ Release:        %autorelease
 Summary:        SELinux policy core utilities
 License:        GPL-2.0-or-later
 URL:            https://github.com/SELinuxProject/selinux
-#!RemoteAsset
+#!RemoteAsset:  sha256:8dbd50d868acbfae9d1a972f6bbb2587f06c9ec73308d11af6acb3a401de9832
 Source0:        %{url}/releases/download/%{version}/%{name}-%{version}.tar.gz
-#!RemoteAsset
+#!RemoteAsset:  sha256:a3e175f2cc0019d1904b2cefb864d94cc2718421f1e850e733183ed4fb6e81a1
 Source1:        %{url}/releases/download/%{version}/%{name}-%{version}.tar.gz.asc
-#!RemoteAsset
+#!RemoteAsset:  sha256:5fb88e50eaf2b25f74c2022352aefe54fc24b416eef672a5ce55fae26bc79501
 Source2:        %{url}/releases/download/%{version}/selinux-dbus-%{version}.tar.gz
-#!RemoteAsset
+#!RemoteAsset:  sha256:3b29100bbb5018cd8b6a570e4d08c250f7859b3a921a3bd93d587e6e58bd8ab8
 Source3:        %{url}/releases/download/%{version}/selinux-dbus-%{version}.tar.gz.asc
-#!RemoteAsset
+#!RemoteAsset:  sha256:9d0a5b69f2fbcce8e5ccd8e0f17d56f71e6005a756386f8fb36c31f9424191a2
 Source4:        %{url}/releases/download/%{version}/selinux-python-%{version}.tar.gz
-#!RemoteAsset
+#!RemoteAsset:  sha256:d711c7ccae7b757e929bed02c681028f2cd1d11ffe842a01e4427960779769ab
 Source5:        %{url}/releases/download/%{version}/selinux-python-%{version}.tar.gz.asc
-#!RemoteAsset
+#!RemoteAsset:  sha256:4e98cf387f2e30d8f29fa58f4ff2889d07f294fade3da1216a0fceae831d8e8a
 Source6:        %{url}/releases/download/%{version}/selinux-gui-%{version}.tar.gz
-#!RemoteAsset
+#!RemoteAsset:  sha256:5cd8f2a318fe36e94993bdae834a8182ca16c910cb6b6891c75c5f6bed69f376
 Source7:        %{url}/releases/download/%{version}/selinux-gui-%{version}.tar.gz.asc
-#!RemoteAsset
+#!RemoteAsset:  sha256:1c2f14cc098cbb4d75912d131c5f747e70246e1042e72f2ab40e28f53cf45c10
 Source8:        %{url}/releases/download/%{version}/semodule-utils-%{version}.tar.gz
-#!RemoteAsset
+#!RemoteAsset:  sha256:a99dcefc28c97ed677250602bc2e40d4dbe52cc1bbeeb5f566a35b3b37085d93
 Source9:        %{url}/releases/download/%{version}/semodule-utils-%{version}.tar.gz.asc
 BuildSystem:    autotools
 
@@ -57,9 +57,9 @@ BuildRequires:  pkgconfig(libselinux)
 BuildRequires:  pkgconfig(libcap)
 BuildRequires:  pkgconfig(dbus-1)
 BuildRequires:  python3-devel
-BuildRequires:  python3-pip
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-wheel
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
 BuildRequires:  python-rpm-macros
 
 Requires:       util-linux
@@ -316,4 +316,4 @@ rm -f %{buildroot}/etc/pam.d/run_init*
 %config(noreplace) %{_sysconfdir}/pam.d/newrole
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/poppler/poppler.spec
+++ b/SPECS/poppler/poppler.spec
@@ -10,7 +10,7 @@ Release:        %autorelease
 Summary:        PDF rendering library
 License:        (GPL-2.0-only OR GPL-3.0-only) AND GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND MIT
 URL:            https://gitlab.freedesktop.org/poppler/poppler
-#!RemoteAsset
+#!RemoteAsset:  sha256:ea43da328887e99943c7939712d8bd4019e98e0c7b7156d58c057debdc5df0e6
 Source:         https://gitlab.freedesktop.org/poppler/poppler/-/archive/poppler-%{version}/poppler-poppler-%{version}.tar.gz
 BuildSystem:    cmake
 
@@ -43,7 +43,7 @@ BuildRequires:  pkgconfig(gdk-pixbuf-2.0)
 BuildRequires:  pkgconfig(gio-2.0)
 BuildRequires:  pkgconfig(gobject-2.0)
 BuildRequires:  pkgconfig(gobject-introspection-1.0)
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
 BuildRequires:  pkgconfig(lcms2)
 BuildRequires:  pkgconfig(libjpeg)
 BuildRequires:  pkgconfig(libpng)
@@ -115,4 +115,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_includedir}/poppler/cpp
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-pip/python-pip.spec
+++ b/SPECS/python-pip/python-pip.spec
@@ -55,7 +55,7 @@ BuildRequires:  pkgconfig(python3)
 # Note that the package prefix is always python3-, even if we build for 3.X
 BuildRequires:  python3-rpm-generators
 BuildRequires:  pyproject-rpm-macros
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(flit-core)
 %if %{without bash}
 BuildRequires:  bash-completion

--- a/SPECS/python-pyqt6/python-pyqt6.spec
+++ b/SPECS/python-pyqt6/python-pyqt6.spec
@@ -46,7 +46,7 @@ BuildRequires:  pkgconfig(Qt6WebSockets)
 BuildRequires:  pkgconfig(Qt6Quick3D)
 BuildRequires:  pkgconfig(Qt6RemoteObjects)
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-PyQt-builder
+BuildRequires:  python3dist(pyqt-builder)
 BuildRequires:  python3dist(dbus-python)
 BuildRequires:  python3dist(sip)
 

--- a/SPECS/qmpbackup/qmpbackup.spec
+++ b/SPECS/qmpbackup/qmpbackup.spec
@@ -10,7 +10,7 @@ Release:        %autorelease
 Summary:        Backup utility for QEMU using QMP
 License:        GPL-3.0-only
 URL:            https://github.com/abbbi/qmpbackup
-#!RemoteAsset
+#!RemoteAsset:  sha256:17374068cc83c0ac7d49fd5f6a5c671646bd34a237a8c9829246c876b3b1c60d
 Source:         https://github.com/abbbi/qmpbackup/archive/refs/tags/v%{version}.tar.gz
 BuildSystem:    pyproject
 
@@ -18,11 +18,11 @@ BuildOption(install):  -l libqmpbackup
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-pip
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-wheel
-BuildRequires:  python3-qemu-qmp
-BuildRequires:  python3-colorlog
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+BuildRequires:  python3dist(qemu-qmp)
+BuildRequires:  python3dist(colorlog)
 
 %description
 qmpbackup is a tool to create backups of QEMU virtual machines using the
@@ -39,4 +39,4 @@ It supports bitmap based incremental backups.
 %{_bindir}/qmprestore
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/qt6-qtwebengine/qt6-qtwebengine.spec
+++ b/SPECS/qt6-qtwebengine/qt6-qtwebengine.spec
@@ -91,13 +91,13 @@ BuildOption(conf):  -DQT_INSTALL_EXAMPLES_SOURCES=ON
 BuildRequires:  cmake
 BuildRequires:  gcc-c++
 BuildRequires:  python3
-BuildRequires:  python3-html5lib
+BuildRequires:  python3dist(html5lib)
 BuildRequires:  gperf
 BuildRequires:  bison
 BuildRequires:  flex
 BuildRequires:  perl
 BuildRequires:  nodejs
-BuildRequires:  python3-six
+BuildRequires:  python3dist(six)
 BuildRequires:  pkgconfig(krb5)
 BuildRequires:  qt6-macros
 BuildRequires:  qt6-qtbase-private-devel

--- a/SPECS/rdma-core/rdma-core.spec
+++ b/SPECS/rdma-core/rdma-core.spec
@@ -57,7 +57,7 @@ BuildRequires:  pkgconfig(libudev)
 BuildRequires:  pkgconfig(udev)
 %if %{with pyverbs}
 BuildRequires:  libdrm-devel
-BuildRequires:  python3-Cython
+BuildRequires:  python3dist(cython)
 BuildRequires:  pkgconfig(python3)
 %endif
 BuildRequires:  systemd-rpm-macros

--- a/SPECS/recode/recode.spec
+++ b/SPECS/recode/recode.spec
@@ -11,7 +11,7 @@ Release:        %autorelease
 Summary:        Conversion between character sets and surfaces
 License:        GPL-3.0-or-later AND LGPL-3.0-or-later AND BSD-2-Clause
 URL:            https://github.com/rrthomas/recode
-#!RemoteAsset
+#!RemoteAsset:  sha256:f590407fc51badb351973fc1333ee33111f05ec83a8f954fd8cf0c5e30439806
 Source0:        https://github.com/rrthomas/recode/releases/download/v%{version}/recode-%{version}.tar.gz
 BuildSystem:    autotools
 
@@ -31,9 +31,9 @@ BuildRequires:  gettext-devel
 BuildRequires:  libtool
 BuildRequires:  make
 BuildRequires:  texinfo
-BuildRequires:  python3-Cython
+BuildRequires:  python3dist(cython)
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
 
 %description
 The recode tool and library convert files between character sets and surfaces.
@@ -67,4 +67,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_includedir}/recodext.h
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/rpmlint/rpmlint.spec
+++ b/SPECS/rpmlint/rpmlint.spec
@@ -10,18 +10,18 @@ Release:        %autorelease
 Summary:        RPM file correctness checker
 License:        GPL-2.0-or-later
 URL:            https://github.com/rpm-software-management/rpmlint
-#!RemoteAsset
+#!RemoteAsset:  sha256:69884a3b80438698e41dc4b39658fae611b45ad6cfb31e38db76279bfb4288b1
 Source0:        https://github.com/rpm-software-management/rpmlint/archive/refs/tags/%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
 
-BuildOption(install): -l rpmlint +auto
+BuildOption(install):  -l rpmlint +auto
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  python-rpm-macros
-BuildRequires:  python3-pip
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-wheel
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
 BuildRequires:  python3-rpm
 
 Requires:       bash
@@ -31,7 +31,7 @@ Requires:       desktop-file-utils
 Requires:       file
 Requires:       findutils
 Requires:       python3-rpm
-Requires:       python3-zstandard
+Requires:       python3dist(zstandard)
 Requires:       rpm-build
 
 %description
@@ -49,4 +49,4 @@ source packages can be checked.
 %{python3_sitelib}/rpmlint*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/rrdtool/rrdtool.spec
+++ b/SPECS/rrdtool/rrdtool.spec
@@ -92,7 +92,7 @@ The Perl RRDtool bindings.
 %{?python_provide:%python_provide python3-rrdtool}
 Summary:        Python RRDtool bindings
 BuildRequires:  python3-devel
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
 %{?__python3:Requires: %{__python3}}
 Requires:       %{name}%{?_isa} = %{version}-%{release}
 

--- a/SPECS/samba/samba.spec
+++ b/SPECS/samba/samba.spec
@@ -102,12 +102,12 @@ BuildRequires:  pkgconfig(pam)
 BuildRequires:  perl(Parse::Yapp)
 BuildRequires:  perl(JSON)
 BuildRequires:  pkgconfig(popt)
-BuildRequires:  python3-cryptography
+BuildRequires:  python3dist(cryptography)
 BuildRequires:  python3-devel
-BuildRequires:  python3-dnspython
-BuildRequires:  python3-requests
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-markdown
+BuildRequires:  python3dist(dnspython)
+BuildRequires:  python3dist(requests)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(markdown)
 BuildRequires:  python3-tdb
 BuildRequires:  python3-talloc-devel
 BuildRequires:  python3-tevent

--- a/SPECS/sddm/sddm.spec
+++ b/SPECS/sddm/sddm.spec
@@ -11,7 +11,7 @@ Release:        %autorelease
 Summary:        QML-based display manager (Qt6)
 License:        GPL-2.0-or-later
 URL:            https://github.com/sddm/sddm
-#!RemoteAsset
+#!RemoteAsset:  sha256:f895de2683627e969e4849dbfbbb2b500787481ca5ba0de6d6dfdae5f1549abf
 Source0:        https://github.com/sddm/sddm/archive/refs/tags/v%{version}.tar.gz
 Source1:        sddm.conf
 Source2:        sddm-greeter.pam
@@ -46,7 +46,7 @@ BuildRequires:  gcc-c++
 BuildRequires:  pkgconfig(pam)
 BuildRequires:  pkgconfig
 BuildRequires:  shadow
-BuildRequires:  python3-docutils
+BuildRequires:  python3dist(docutils)
 BuildRequires:  qt6-macros
 BuildRequires:  cmake(Qt6Core)
 BuildRequires:  cmake(Qt6DBus)
@@ -142,4 +142,4 @@ mv %{buildroot}%{_datadir}/dbus-1/system.d/org.freedesktop.DisplayManager.conf \
 %{_datadir}/sddm/themes/maya/
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/setools/setools.spec
+++ b/SPECS/setools/setools.spec
@@ -11,7 +11,7 @@ Release:        %autorelease
 Summary:        Policy analysis tools for SELinux
 License:        GPL-2.0-only AND LGPL-2.1-only
 URL:            https://github.com/SELinuxProject/setools
-#!RemoteAsset
+#!RemoteAsset:  sha256:d143da7c0f155a67590983c7ff7f7c181c0ebaf350b37a28b34198c6b4b9a5d2
 Source0:        https://github.com/SELinuxProject/setools/archive/refs/tags/%{version}.tar.gz
 Source1:        setools.pam
 Source2:        apol.desktop
@@ -21,10 +21,10 @@ BuildOption(install):  -l setools setoolsgui
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-pip
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-wheel
-BuildRequires:  python3-Cython
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+BuildRequires:  python3dist(cython)
 BuildRequires:  gcc
 BuildRequires:  bison
 BuildRequires:  flex
@@ -34,7 +34,7 @@ BuildRequires:  swig
 # For tests.
 BuildRequires:  pytest
 BuildRequires:  checkpolicy
-BuildRequires:  python3-networkx >= 2.6
+BuildRequires:  python3dist(networkx) >= 2.6
 
 Requires:       %{name}-console = %{version}-%{release}
 Requires:       %{name}-console-analyses = %{version}-%{release}
@@ -58,7 +58,7 @@ Summary:        Policy analysis command-line tools for SELinux
 License:        GPL-2.0-only
 Requires:       python3-setools = %{version}-%{release}
 Requires:       libselinux
-Requires:       python3-networkx
+Requires:       python3dist(networkx)
 
 %description    console-analyses
 Advanced analysis tools: sedta, seinfoflow.
@@ -78,7 +78,7 @@ Summary:        Policy analysis graphical tools for SELinux
 License:        GPL-2.0-only
 Requires:       python3-setools = %{version}-%{release}
 Requires:       python3-qt6
-Requires:       python3-networkx
+Requires:       python3dist(networkx)
 
 %description    gui
 Graphical tools for SELinux policy analysis (apol).
@@ -127,4 +127,4 @@ rm -rf setools setoolsgui
 %{_mandir}/ru/man1/apol*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/sfwbar/sfwbar.spec
+++ b/SPECS/sfwbar/sfwbar.spec
@@ -20,7 +20,7 @@ BuildOption(conf):  -Dmpd=disabled
 
 BuildRequires:  meson
 BuildRequires:  gcc
-BuildRequires:  python3-docutils
+BuildRequires:  python3dist(docutils)
 BuildRequires:  pkgconfig(alsa)
 BuildRequires:  pkgconfig(gio-2.0)
 BuildRequires:  pkgconfig(gio-unix-2.0)
@@ -51,4 +51,4 @@ compositors.
 %{_mandir}/man1/*.1*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/speech-dispatcher/speech-dispatcher.spec
+++ b/SPECS/speech-dispatcher/speech-dispatcher.spec
@@ -44,7 +44,7 @@ BuildRequires:  pkgconfig(sndfile)
 BuildRequires:  pulseaudio-devel
 BuildRequires:  pkgconfig(alsa)
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
 BuildRequires:  pkgconfig(libsystemd)
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  desktop-file-utils

--- a/SPECS/sssd/sssd.spec
+++ b/SPECS/sssd/sssd.spec
@@ -13,9 +13,9 @@ Release:        %autorelease
 Summary:        System Security Services Daemon
 License:        GPL-3.0-or-later
 URL:            https://github.com/SSSD/sssd
-#!RemoteAsset
+#!RemoteAsset:  sha256:80935c9f0cffde6e74b2751398c8677c90d31644d2474dade2d336c56ab76d35
 Source0:        %{url}/releases/download/%{version}/%{name}-%{version}.tar.gz
-#!RemoteAsset
+#!RemoteAsset:  sha256:d972568557dd66dcffc43b9a3a44907f33fe796a7fb734edba3e48fd510c01b5
 Source1:        %{url}/releases/download/%{version}/%{name}-%{version}.tar.gz.asc
 Source2:        sssd.sysusers
 BuildSystem:    autotools
@@ -46,7 +46,7 @@ BuildRequires:  libxml2
 BuildRequires:  libxslt
 BuildRequires:  pkgconfig(openssl)
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  pkgconfig(augeas)
 BuildRequires:  pkgconfig(check)
@@ -582,4 +582,4 @@ fi
 %{_mandir}/*/man5/sss-certmap.5*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/systemtap/systemtap.spec
+++ b/SPECS/systemtap/systemtap.spec
@@ -16,9 +16,9 @@ Summary:        Programmable system-wide instrumentation system
 License:        GPL-2.0-or-later
 URL:            https://sourceware.org/systemtap/
 VCS:            git:https://sourceware.org/git/systemtap.git
-#!RemoteAsset
+#!RemoteAsset:  sha256:966a360fb73a4b65a8d0b51b389577b3c4f92a327e84aae58682103e8c65a69a
 Source0:        https://sourceware.org/%{name}/ftp/releases/%{name}-%{version}.tar.gz
-#!RemoteAsset
+#!RemoteAsset:  sha256:81bfd0b93d864f973942bab687713d58dd9b117a354ccfaef7747f058ba01983
 Source1:        https://sourceware.org/%{name}/ftp/releases/%{name}-%{version}.tar.gz.asc
 BuildSystem:    autotools
 
@@ -44,7 +44,7 @@ BuildRequires:  sqlite-devel
 BuildRequires:  pkgconfig(systemd)
 BuildRequires:  python3
 BuildRequires:  python3-devel
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
 
 Requires:       %{name}-client = %{version}-%{release}
 Requires:       %{name}-devel = %{version}-%{release}
@@ -148,7 +148,7 @@ instrumentation compiled into userspace programs.
 Summary:        Static probe support dtrace tool
 License:        GPL-2.0-or-later AND CC0-1.0
 Provides:       dtrace = %{version}-%{release}
-Requires:       python3-pyparsing
+Requires:       python3dist(pyparsing)
 
 %description    sdt-dtrace
 This package includes the dtrace-compatibility preprocessor
@@ -325,4 +325,4 @@ install -D -m 644 macros.systemtap %{buildroot}%{_rpmmacrodir}/macros.systemtap
 %{_mandir}/man1/dtrace.1*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/udisks2/udisks2.spec
+++ b/SPECS/udisks2/udisks2.spec
@@ -14,7 +14,7 @@ Release:        %autorelease
 Summary:        Disk Manager
 License:        GPL-2.0-or-later
 URL:            https://github.com/storaged-project/udisks
-#!RemoteAsset
+#!RemoteAsset:  sha256:0bf30151fe8d9d2fb59b57f6630739dfbbd16417dee69ec57d43b37335bd649a
 Source0:        https://github.com/storaged-project/udisks/releases/download/udisks-%{version}/udisks-%{version}.tar.bz2
 BuildSystem:    autotools
 
@@ -41,7 +41,7 @@ BuildOption(conf):  --disable-lsm
 
 BuildRequires:  make
 BuildRequires:  gcc
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(gobject-introspection-1.0)
 BuildRequires:  pkgconfig(gudev-1.0)
@@ -165,4 +165,4 @@ fi
 %endif
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/volume_key/volume_key.spec
+++ b/SPECS/volume_key/volume_key.spec
@@ -11,7 +11,7 @@ Summary:        An utility for manipulating storage encryption keys and passphra
 License:        GPL-2.0-only AND (MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later)
 URL:            https://pagure.io/volume_key/
 VCS:            git:https://pagure.io/volume_key.git
-#!RemoteAsset
+#!RemoteAsset:  sha256:6ca3748fc1dad22c450bbf6601d4e706cb11c5e662d11bb4aeb473a9cd77309b
 Source0:        https://releases.pagure.org/volume_key/volume_key-%{version}.tar.xz
 BuildSystem:    autotools
 
@@ -30,7 +30,7 @@ BuildRequires:  pkgconfig(gpgme)
 BuildRequires:  pkgconfig(blkid)
 BuildRequires:  pkgconfig(nss)
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3-setuptools
+BuildRequires:  python3dist(setuptools)
 
 %description
 The main goal of the software is to allow restoring access to an encrypted
@@ -83,4 +83,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{python3_sitearch}/__pycache__/volume_key.*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/xdg-desktop-portal/xdg-desktop-portal.spec
+++ b/SPECS/xdg-desktop-portal/xdg-desktop-portal.spec
@@ -15,7 +15,7 @@ Release:        %autorelease
 Summary:        Portal frontend service to flatpak
 License:        LGPL-2.1-or-later
 URL:            https://github.com/flatpak/xdg-desktop-portal
-#!RemoteAsset
+#!RemoteAsset:  sha256:4bfb164937f59107eb1a3cc21abaa948d903c76f3b99fac210cea38ce1da9edc
 Source0:        https://github.com/flatpak/xdg-desktop-portal/releases/download/%{version}/xdg-desktop-portal-%{version}.tar.xz
 BuildSystem:    meson
 
@@ -52,9 +52,9 @@ BuildRequires:  pkgconfig(libpipewire-0.3)
 BuildRequires:  pkgconfig(umockdev-1.0)
 %endif
 %if %{with docs}
-BuildRequires:  python3-furo
-BuildRequires:  python3-sphinx-copybutton
-BuildRequires:  python3-sphinxext-opengraph
+BuildRequires:  python3dist(furo)
+BuildRequires:  python3dist(sphinx-copybutton)
+BuildRequires:  python3dist(sphinxext-opengraph)
 BuildRequires:  /usr/bin/sphinx-build
 BuildRequires:  /usr/bin/rst2man
 %endif
@@ -118,4 +118,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_datadir}/pkgconfig/xdg-desktop-portal.pc
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Most changes are purely normalization, though a few also resolve unresolvable issues such as cython.