### PR TITLE
SPECS: rust-rpm-macros: Update to 0.4.1

### DIFF
--- a/SPECS/rust-rpm-macros/rust-rpm-macros.spec
+++ b/SPECS/rust-rpm-macros/rust-rpm-macros.spec
@@ -5,12 +5,12 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 Name:           rust-rpm-macros
-Version:        0.4
+Version:        0.4.1
 Release:        %autorelease
 Summary:        Rust macros for openRuyi packaging
 License:        MIT
 URL:            https://github.com/openRuyi-Project/rust-rpm-macros
-#!RemoteAsset:  sha256:b09e1db2b1fd8dea5567832c1090ef163bfdf5d8a1f1c6fbce0c71c01464aec2
+#!RemoteAsset:  sha256:3a57fc92361d19303bdaa7de3bf5c81c55d10cf0fd61100e35c5c61528d8be26
 Source0:        https://github.com/openRuyi-Project/rust-rpm-macros/archive/refs/tags/v%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    autotools


### PR DESCRIPTION
This update to rust-rpm-macros provides a virtual dependency for all Rust crates, which facilitates automatic dependency generation for Rust applications.