### PR TITLE
SPECS: systemtap: Upgrade to 5.5 to fix error with gcc16.

### DIFF
--- a/SPECS/systemtap/systemtap.spec
+++ b/SPECS/systemtap/systemtap.spec
@@ -10,16 +10,14 @@
 %bcond dyninst 0
 
 Name:           systemtap
-Version:        5.3
+Version:        5.5
 Release:        %autorelease
 Summary:        Programmable system-wide instrumentation system
 License:        GPL-2.0-or-later
 URL:            https://sourceware.org/systemtap/
 VCS:            git:https://sourceware.org/git/systemtap.git
-#!RemoteAsset:  sha256:966a360fb73a4b65a8d0b51b389577b3c4f92a327e84aae58682103e8c65a69a
+#!RemoteAsset:  sha256:980e58887a284097b9d4c6ae6382b75787573131c27e3875c0fc94bceb8c61a8
 Source0:        https://sourceware.org/%{name}/ftp/releases/%{name}-%{version}.tar.gz
-#!RemoteAsset:  sha256:81bfd0b93d864f973942bab687713d58dd9b117a354ccfaef7747f058ba01983
-Source1:        https://sourceware.org/%{name}/ftp/releases/%{name}-%{version}.tar.gz.asc
 BuildSystem:    autotools
 
 BuildOption(conf):  --disable-docs


### PR DESCRIPTION
Current build error:
```
[  684s] tapsets.cxx: In member function ‘virtual void dwarf_derived_probe::emit_probe_local_init(systemtap_session&, translator_output*)’:
[  684s] tapsets.cxx:6207:20: error: variable ‘i’ set but not used [-Werror=unused-but-set-variable=]
[  684s]  6207 |           unsigned i = 0;
[  684s]       |                    ^
[  684s] cc1plus: all warnings being treated as errors
[  684s] make[2]: *** [Makefile:1327: stap-tapsets.o] Error 1
```

Version 5.5 can fix this error, and [release note](https://sourceware.org/git/?p=systemtap.git;a=blob;f=NEWS;h=2e3ce452c8151e6e5bbfac400f7bf7bae74b57bb;hb=83d6182bc7696f8a0c39bfdc60af984aa73c5838) shows no obvious API breakage.