### PR TITLE
Fix python-datasets build failure

### DIFF
--- a/SPECS/python-datasets/2000-Relax-fsspec-version-requirements.patch
+++ b/SPECS/python-datasets/2000-Relax-fsspec-version-requirements.patch
@@ -1,0 +1,41 @@
+From 40772e30fdb13c97a515b189f12f89abd74a91ef Mon Sep 17 00:00:00 2001
+From: misaka00251 <liuxin@iscas.ac.cn>
+Date: Fri, 15 May 2026 13:38:07 +0800
+Subject: [PATCH] Relax fsspec version requirements
+
+https://github.com/huggingface/datasets/issues/7326
+Signed-off-by: misaka00251 <liuxin@iscas.ac.cn>
+---
+ PKG-INFO | 2 +-
+ setup.py | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/PKG-INFO b/PKG-INFO
+index 0ef17d7..b3221e4 100644
+--- a/PKG-INFO
++++ b/PKG-INFO
+@@ -35,7 +35,7 @@ Requires-Dist: httpx<1.0.0
+ Requires-Dist: tqdm>=4.66.3
+ Requires-Dist: xxhash
+ Requires-Dist: multiprocess<0.70.20
+-Requires-Dist: fsspec[http]<=2026.2.0,>=2023.1.0
++Requires-Dist: fsspec[http]<=2026.4.0,>=2023.1.0
+ Requires-Dist: huggingface-hub<2.0,>=0.25.0
+ Requires-Dist: packaging
+ Requires-Dist: pyyaml>=5.1
+diff --git a/setup.py b/setup.py
+index 4baf45b..4064eb9 100644
+--- a/setup.py
++++ b/setup.py
+@@ -127,7 +127,7 @@ REQUIRED_PKGS = [
+     "multiprocess<0.70.20",  # to align with dill<0.3.9 (see above)
+     # to save datasets locally or on any filesystem
+     # minimum 2023.1.0 to support protocol=kwargs in fsspec's `open`, `get_fs_token_paths`, etc.: see https://github.com/fsspec/filesystem_spec/pull/1143
+-    "fsspec[http]>=2023.1.0,<=2026.2.0",
++    "fsspec[http]>=2023.1.0,<=2026.4.0",
+     # To get datasets from the Datasets Hub on huggingface.co
+     "huggingface-hub>=0.25.0,<2.0",
+     # Utilities from PyPA to e.g., compare versions
+-- 
+2.54.0
+

--- a/SPECS/python-datasets/python-datasets.spec
+++ b/SPECS/python-datasets/python-datasets.spec
@@ -7,16 +7,20 @@
 %global srcname datasets
 
 Name:           python-datasets
-Version:        4.8.3
+Version:        4.8.5
 Release:        %autorelease
 Summary:        Library for accessing and sharing machine learning datasets
 License:        MIT
 URL:            https://pypi.org/project/datasets/
 VCS:            git:https://github.com/huggingface/datasets
-#!RemoteAsset:  sha256:882fb1bb514772bec17fbcad2e32985893954d0a0ecf42266e5091386be1f3b7
+#!RemoteAsset:  sha256:0f0c1c3d56ffff2c93b2f4c63c95bac94f3d7e8621aea2a2a576275233bba772
 Source0:        https://files.pythonhosted.org/packages/source/d/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
+
+# NOTE: When updating datasets, please check this URL:
+# https://github.com/huggingface/datasets/issues/7326
+Patch2000:      2000-Relax-fsspec-version-requirements.patch
 
 BuildOption(install):  -l %{srcname} +auto
 BuildOption(check):  -e datasets.io.spark -e 'datasets.packaged_modules.spark*'

--- a/SPECS/python-fsspec/python-fsspec.spec
+++ b/SPECS/python-fsspec/python-fsspec.spec
@@ -7,6 +7,7 @@
 %global srcname fsspec
 
 Name:           python-%{srcname}
+# NOTE: Please check compatibility of python-datasets when updating.
 Version:        2026.4.0
 Release:        %autorelease
 Summary:        File-system specification for Python


### PR DESCRIPTION
This Pull Request fixes #403. I added a note in the `python-fsspec` package specification file to remind users that those who want to update this package also need to verify compatibility with the `python-datasets` package.