### PR TITLE
SPECS: qemu: update to 11.0.0 with RISC-V AIA fixes

### DIFF
--- a/SPECS/qemu/0001-target-riscv-cpu.c-remove-bare-condition-for-.profil.patch
+++ b/SPECS/qemu/0001-target-riscv-cpu.c-remove-bare-condition-for-.profil.patch
@@ -1,7 +1,7 @@
-From cd6cbe336203b3598517f578cfa0f8b13ceb1f1b Mon Sep 17 00:00:00 2001
+From a6321601e230c531bca62064d888cc3558d50882 Mon Sep 17 00:00:00 2001
 From: Daniel Henrique Barboza <dbarboza@ventanamicro.com>
 Date: Tue, 11 Nov 2025 15:29:40 -0300
-Subject: [PATCH 1/6] target/riscv/cpu.c: remove 'bare' condition for .profile
+Subject: [PATCH 1/8] target/riscv/cpu.c: remove 'bare' condition for .profile
 
 We want to configure other CPU types to use profiles as an alternative
 to adding every profile extension explicitly, i.e. a profile is nothing
@@ -18,10 +18,10 @@ Reviewed-by: Andrew Jones <ajones@ventanamicro.com>
  1 file changed, 1 deletion(-)
 
 diff --git a/target/riscv/cpu.c b/target/riscv/cpu.c
-index 73d4280d7c..975f7953e1 100644
+index 8ac935ac06..5ecb5ae57f 100644
 --- a/target/riscv/cpu.c
 +++ b/target/riscv/cpu.c
-@@ -2792,7 +2792,6 @@ static void riscv_cpu_class_base_init(ObjectClass *c, const void *data)
+@@ -2799,7 +2799,6 @@ static void riscv_cpu_class_base_init(ObjectClass *c, const void *data)
          mcc->def->bare |= def->bare;
          if (def->profile) {
              assert(profile_extends(def->profile, mcc->def->profile));
@@ -30,5 +30,5 @@ index 73d4280d7c..975f7953e1 100644
          }
          if (def->misa_mxl_max) {
 -- 
-2.52.0
+2.50.1 (Apple Git-155)
 

--- a/SPECS/qemu/0002-target-riscv-Add-server-platform-reference-cpu.patch
+++ b/SPECS/qemu/0002-target-riscv-Add-server-platform-reference-cpu.patch
@@ -1,7 +1,7 @@
-From 25730f4f8b0d25233044d1c484b783ab5880497d Mon Sep 17 00:00:00 2001
+From 3b67ac7e339b9996024a600b21df4a13efb0e93b Mon Sep 17 00:00:00 2001
 From: Fei Wu <wu.fei9@sanechips.com.cn>
 Date: Tue, 11 Nov 2025 15:29:41 -0300
-Subject: [PATCH 2/6] target/riscv: Add server platform reference cpu
+Subject: [PATCH 2/8] target/riscv: Add server platform reference cpu
 
 The harts requirements of RISC-V server platform [1] require RVA23 ISA
 profile support, plus Sv48, Svadu, H, Sscofmpf etc.
@@ -19,7 +19,7 @@ Signed-off-by: Daniel Henrique Barboza <dbarboza@ventanamicro.com>
  2 files changed, 15 insertions(+)
 
 diff --git a/target/riscv/cpu-qom.h b/target/riscv/cpu-qom.h
-index 75f4e43408..07e96a14ba 100644
+index 30dcdcfaae..7f0bfda0aa 100644
 --- a/target/riscv/cpu-qom.h
 +++ b/target/riscv/cpu-qom.h
 @@ -42,6 +42,7 @@
@@ -31,10 +31,10 @@ index 75f4e43408..07e96a14ba 100644
  #define TYPE_RISCV_CPU_SHAKTI_C         RISCV_CPU_TYPE_NAME("shakti-c")
  #define TYPE_RISCV_CPU_SIFIVE_E         RISCV_CPU_TYPE_NAME("sifive-e")
 diff --git a/target/riscv/cpu.c b/target/riscv/cpu.c
-index 975f7953e1..3ddb249970 100644
+index 5ecb5ae57f..65592b2bdd 100644
 --- a/target/riscv/cpu.c
 +++ b/target/riscv/cpu.c
-@@ -3305,6 +3305,20 @@ static const TypeInfo riscv_cpu_type_infos[] = {
+@@ -3312,6 +3312,20 @@ static const TypeInfo riscv_cpu_type_infos[] = {
          .cfg.max_satp_mode = VM_1_10_SV48,
      ),
  
@@ -52,9 +52,9 @@ index 975f7953e1..3ddb249970 100644
 +        .cfg.max_satp_mode = VM_1_10_SV57,
 +    ),
 +
- #if defined(CONFIG_TCG) && !defined(CONFIG_USER_ONLY)
-     DEFINE_RISCV_CPU(TYPE_RISCV_CPU_BASE128, TYPE_RISCV_DYNAMIC_CPU,
-         .cfg.max_satp_mode = VM_1_10_SV57,
+     /* https://mips.com/products/hardware/p8700/ */
+     DEFINE_RISCV_CPU(TYPE_RISCV_CPU_MIPS_P8700, TYPE_RISCV_VENDOR_CPU,
+         .misa_mxl_max = MXL_RV64,
 -- 
-2.52.0
+2.50.1 (Apple Git-155)
 

--- a/SPECS/qemu/0003-hw-riscv-experimental-server-platform-reference-mach.patch
+++ b/SPECS/qemu/0003-hw-riscv-experimental-server-platform-reference-mach.patch
@@ -1,7 +1,7 @@
-From 5d4c7e415d87a6f7ab674112f11ed6bbb0b0c564 Mon Sep 17 00:00:00 2001
+From 54ee6a320cd2e1c6eda925be64ef484c5fe8263e Mon Sep 17 00:00:00 2001
 From: Fei Wu <wu.fei9@sanechips.com.cn>
 Date: Tue, 11 Nov 2025 15:29:42 -0300
-Subject: [PATCH 3/6] hw/riscv: experimental server platform reference machine
+Subject: [PATCH 3/8] hw/riscv: experimental server platform reference machine
 
 The RISC-V Server Platform specification [1] defines a standardized set
 of hardware and software capabilities, that portable system software,
@@ -42,7 +42,7 @@ Signed-off-by: Daniel Henrique Barboza <dbarboza@ventanamicro.com>
  create mode 100644 hw/riscv/server_platform_ref.c
 
 diff --git a/configs/devices/riscv64-softmmu/default.mak b/configs/devices/riscv64-softmmu/default.mak
-index e485bbd1a3..e6075a7113 100644
+index a8e4d0ab33..9c791bb1c5 100644
 --- a/configs/devices/riscv64-softmmu/default.mak
 +++ b/configs/devices/riscv64-softmmu/default.mak
 @@ -9,6 +9,7 @@
@@ -54,7 +54,7 @@ index e485bbd1a3..e6075a7113 100644
  # CONFIG_SHAKTI_C=n
  # CONFIG_XIANGSHAN_KUNMINGHU=n
 diff --git a/hw/riscv/Kconfig b/hw/riscv/Kconfig
-index fc9c35bd98..6a5085c7a5 100644
+index 0222c93f87..b1f84fb202 100644
 --- a/hw/riscv/Kconfig
 +++ b/hw/riscv/Kconfig
 @@ -69,6 +69,20 @@ config RISCV_VIRT
@@ -79,7 +79,7 @@ index fc9c35bd98..6a5085c7a5 100644
      bool
      default y
 diff --git a/hw/riscv/meson.build b/hw/riscv/meson.build
-index 2a8d5b136c..0daf77e887 100644
+index 533472e22a..c89ea49d9f 100644
 --- a/hw/riscv/meson.build
 +++ b/hw/riscv/meson.build
 @@ -4,6 +4,7 @@ riscv_ss.add(when: 'CONFIG_RISCV_NUMA', if_true: files('numa.c'))
@@ -1373,5 +1373,5 @@ index 0000000000..ef2891a9d7
 +
 +type_init(rvsp_ref_init_register_types)
 -- 
-2.52.0
+2.50.1 (Apple Git-155)
 

--- a/SPECS/qemu/0004-hw-riscv-server_platform_ref.c-add-riscv-iommu-sys.patch
+++ b/SPECS/qemu/0004-hw-riscv-server_platform_ref.c-add-riscv-iommu-sys.patch
@@ -1,7 +1,7 @@
-From ce40aec415eccc5865b2e876ddde3302d9668674 Mon Sep 17 00:00:00 2001
+From a78e6b3ce39fa993c0b716d661341854d6df0396 Mon Sep 17 00:00:00 2001
 From: Daniel Henrique Barboza <dbarboza@ventanamicro.com>
 Date: Tue, 11 Nov 2025 15:29:43 -0300
-Subject: [PATCH 4/6] hw/riscv/server_platform_ref.c: add riscv-iommu-sys
+Subject: [PATCH 4/8] hw/riscv/server_platform_ref.c: add riscv-iommu-sys
 
 Add an always present IOMMU platform device for the rvsp-ref board.
 
@@ -16,7 +16,7 @@ Reviewed-by: Andrew Jones <ajones@ventanamicro.com>
  2 files changed, 75 insertions(+), 4 deletions(-)
 
 diff --git a/hw/riscv/Kconfig b/hw/riscv/Kconfig
-index 6a5085c7a5..4f8cbfe77f 100644
+index b1f84fb202..cf882fdc91 100644
 --- a/hw/riscv/Kconfig
 +++ b/hw/riscv/Kconfig
 @@ -82,6 +82,7 @@ config SERVER_PLATFORM_REF
@@ -179,5 +179,5 @@ index ef2891a9d7..dc6caf72a6 100644
      qemu_add_machine_init_done_notifier(&s->machine_done);
  }
 -- 
-2.52.0
+2.50.1 (Apple Git-155)
 

--- a/SPECS/qemu/0005-docs-add-rvsp-ref.rst.patch
+++ b/SPECS/qemu/0005-docs-add-rvsp-ref.rst.patch
@@ -1,7 +1,7 @@
-From c5694b67bdff830e44183d2474f91a57c19ef40d Mon Sep 17 00:00:00 2001
+From 6133be89993265af2b23da4312697f7ad8e85e11 Mon Sep 17 00:00:00 2001
 From: Daniel Henrique Barboza <dbarboza@ventanamicro.com>
 Date: Tue, 11 Nov 2025 15:29:44 -0300
-Subject: [PATCH 5/6] docs: add rvsp-ref.rst
+Subject: [PATCH 5/8] docs: add rvsp-ref.rst
 
 Add documentation on the new experimental board rvsp-ref.
 
@@ -47,10 +47,10 @@ index 0000000000..3889fce413
 +
 +.. _spec: https://github.com/riscv-non-isa/riscv-server-platform
 diff --git a/docs/system/target-riscv.rst b/docs/system/target-riscv.rst
-index 89b2cb732c..2ed337c8cf 100644
+index 3ad5d1ddaf..16350d37fb 100644
 --- a/docs/system/target-riscv.rst
 +++ b/docs/system/target-riscv.rst
-@@ -72,6 +72,7 @@ undocumented; you can get a complete list by running
+@@ -73,6 +73,7 @@ undocumented; you can get a complete list by running
     riscv/sifive_u
     riscv/virt
     riscv/xiangshan-kunminghu
@@ -59,5 +59,5 @@ index 89b2cb732c..2ed337c8cf 100644
  RISC-V CPU firmware
  -------------------
 -- 
-2.52.0
+2.50.1 (Apple Git-155)
 

--- a/SPECS/qemu/0006-target-riscv-update-satp_mode-to-SV48-for-rvsp-ref.patch
+++ b/SPECS/qemu/0006-target-riscv-update-satp_mode-to-SV48-for-rvsp-ref.patch
@@ -1,7 +1,7 @@
-From 1cb69d9dd96ac8e315e1cf97e3f4c282cd2e6de1 Mon Sep 17 00:00:00 2001
+From ce6d162eeb472e73222a599a3aca3d709ed98cd8 Mon Sep 17 00:00:00 2001
 From: Chao Liu <chao.liu.riscv@isrc.iscas.ac.cn>
 Date: Mon, 5 Jan 2026 22:23:15 +0800
-Subject: [PATCH 6/6] target/riscv: update satp_mode to SV48 for rvsp-ref
+Subject: [PATCH 6/8] target/riscv: update satp_mode to SV48 for rvsp-ref
 
 Signed-off-by: Chao Liu <chao.liu.riscv@isrc.iscas.ac.cn>
 ---
@@ -9,10 +9,10 @@ Signed-off-by: Chao Liu <chao.liu.riscv@isrc.iscas.ac.cn>
  1 file changed, 14 insertions(+), 1 deletion(-)
 
 diff --git a/target/riscv/cpu.c b/target/riscv/cpu.c
-index 3ddb249970..f62c4f1a8e 100644
+index 65592b2bdd..a49bda83dd 100644
 --- a/target/riscv/cpu.c
 +++ b/target/riscv/cpu.c
-@@ -2182,11 +2182,24 @@ static RISCVCPUProfile RVA23S64 = {
+@@ -2189,11 +2189,24 @@ static RISCVCPUProfile RVA23S64 = {
      }
  };
  
@@ -37,7 +37,7 @@ index 3ddb249970..f62c4f1a8e 100644
      NULL,
  };
  
-@@ -3307,7 +3320,7 @@ static const TypeInfo riscv_cpu_type_infos[] = {
+@@ -3314,7 +3327,7 @@ static const TypeInfo riscv_cpu_type_infos[] = {
  
      DEFINE_RISCV_CPU(TYPE_RISCV_CPU_RVSP_REF, TYPE_RISCV_BARE_CPU,
          .misa_mxl_max = MXL_RV64,
@@ -47,5 +47,5 @@ index 3ddb249970..f62c4f1a8e 100644
          /*
           * ISA extensions
 -- 
-2.52.0
+2.50.1 (Apple Git-155)
 

--- a/SPECS/qemu/0007-target-riscv-Return-virtual-fault-for-VS-AIA-stateen.patch
+++ b/SPECS/qemu/0007-target-riscv-Return-virtual-fault-for-VS-AIA-stateen.patch
@@ -1,0 +1,39 @@
+From 8596249e28dd1d913b8d84f6bf1a62acc8e87d11 Mon Sep 17 00:00:00 2001
+From: isrc-riscv-port <riscv-port@isrc.iscas.ac.cn>
+Date: Wed, 13 May 2026 03:14:49 +0000
+Subject: [PATCH 7/8] target/riscv: Return virtual fault for VS AIA stateen
+
+When a guest is running with virtualization enabled, CSR accesses made by
+VS-mode code should report a virtual instruction fault for stateen blocks
+that are controlled by the hypervisor.
+
+Handle the RISC-V AIA stateen0 bits in the mstateen check so nested guests
+see a virtual instruction fault instead of a plain illegal instruction for
+AIA, IMSIC and SVSLCT state.
+
+Signed-off-by: isrc-riscv-port <riscv-port@isrc.iscas.ac.cn>
+---
+ target/riscv/csr.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/target/riscv/csr.c b/target/riscv/csr.c
+index a75281539b..cd1bbd3739 100644
+--- a/target/riscv/csr.c
++++ b/target/riscv/csr.c
+@@ -54,6 +54,13 @@ RISCVException smstateen_acc_ok(CPURISCVState *env, int index, uint64_t bit)
+     }
+ 
+     if (!(env->mstateen[index] & bit)) {
++        if (virt && index == 0 &&
++            (bit == SMSTATEEN0_AIA ||
++             bit == SMSTATEEN0_IMSIC ||
++             bit == SMSTATEEN0_SVSLCT)) {
++            return RISCV_EXCP_VIRT_INSTRUCTION_FAULT;
++        }
++
+         return RISCV_EXCP_ILLEGAL_INST;
+     }
+ 
+-- 
+2.50.1 (Apple Git-155)
+

--- a/SPECS/qemu/0008-target-riscv-Allow-VS-AIA-stateen-checks.patch
+++ b/SPECS/qemu/0008-target-riscv-Allow-VS-AIA-stateen-checks.patch
@@ -1,0 +1,36 @@
+From 2f6af02ebcf0ab1761e364e0a10cd654f1d35939 Mon Sep 17 00:00:00 2001
+From: isrc-riscv-port <riscv-port@isrc.iscas.ac.cn>
+Date: Wed, 13 May 2026 03:14:49 +0000
+Subject: [PATCH 8/8] target/riscv: Allow VS AIA stateen checks
+
+Nested RISC-V guests can access the AIA CSR state through the VS path when
+AIA interrupt virtualization is exposed by the host. Treat the AIA, IMSIC
+and SVSLCT stateen0 bits as accessible in virtual mode so the nested guest
+can complete AIA initialization.
+
+Signed-off-by: isrc-riscv-port <riscv-port@isrc.iscas.ac.cn>
+---
+ target/riscv/csr.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/target/riscv/csr.c b/target/riscv/csr.c
+index cd1bbd3739..36979c48ff 100644
+--- a/target/riscv/csr.c
++++ b/target/riscv/csr.c
+@@ -53,6 +53,13 @@ RISCVException smstateen_acc_ok(CPURISCVState *env, int index, uint64_t bit)
+         return RISCV_EXCP_NONE;
+     }
+ 
++    if (virt && index == 0 &&
++        (bit == SMSTATEEN0_AIA ||
++         bit == SMSTATEEN0_IMSIC ||
++         bit == SMSTATEEN0_SVSLCT)) {
++        return RISCV_EXCP_NONE;
++    }
++
+     if (!(env->mstateen[index] & bit)) {
+         if (virt && index == 0 &&
+             (bit == SMSTATEEN0_AIA ||
+-- 
+2.50.1 (Apple Git-155)
+

--- a/SPECS/qemu/qemu.spec
+++ b/SPECS/qemu/qemu.spec
@@ -177,13 +177,13 @@
 %global qemudocdir %{_docdir}/%{name}
 
 Name:           qemu
-Version:        10.2.0
+Version:        11.0.0
 Release:        %autorelease
 Summary:        Machine emulator and virtualizer
 License:        BSD-2-Clause AND BSD-3-Clause AND GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later AND MIT
 URL:            http://www.qemu.org/
 VCS:            git:https://gitlab.com/qemu-project/qemu
-#!RemoteAsset:  sha256:9e30ad1b8b9f7b4463001582d1ab297f39cfccea5d08540c0ca6d6672785883a
+#!RemoteAsset:  sha256:c04ca36012653f32d11c674d370cf52a710e7d3f18c2d8b63e4932052a4854d6
 Source0:        https://download.qemu.org/%{name}-%{version}.tar.xz
 Source1:        qemu-guest-agent.service
 Source2:        qemu-ga.sysconfig
@@ -193,13 +193,16 @@ Source5:        kvm-x86.conf
 Source6:        kvm-riscv.conf
 BuildSystem:    autotools
 
-# QEMU RISC-V rvsp-ref upstream patch
+# QEMU RISC-V rvsp-ref upstream patch series refreshed for v11.0.0.
 Patch1:         0001-target-riscv-cpu.c-remove-bare-condition-for-.profil.patch
 Patch2:         0002-target-riscv-Add-server-platform-reference-cpu.patch
 Patch3:         0003-hw-riscv-experimental-server-platform-reference-mach.patch
 Patch4:         0004-hw-riscv-server_platform_ref.c-add-riscv-iommu-sys.patch
 Patch5:         0005-docs-add-rvsp-ref.rst.patch
 Patch6:         0006-target-riscv-update-satp_mode-to-SV48-for-rvsp-ref.patch
+# RISC-V nested AIA stateen fixes validated with Kata + Cloud Hypervisor.
+Patch7:         0007-target-riscv-Return-virtual-fault-for-VS-AIA-stateen.patch
+Patch8:         0008-target-riscv-Allow-VS-AIA-stateen-checks.patch
 
 BuildRequires:  hostname
 BuildRequires:  meson


### PR DESCRIPTION
## Summary

Update `qemu` to upstream baseline tag `v11.0.0` and refresh the existing
RISC-V `rvsp-ref` patch series for that baseline.

This also adds two RISC-V nested AIA stateen fixes needed by the
Kata Containers + Cloud Hypervisor validation path.

## Baseline

- Upstream source tag: `v11.0.0`
- Patch source branch: `https://git.openruyi.cn/jiayi/qemu/src/branch/riscv-nested-aia-stateen`
- Package branch commit: `47fb1e70f9fc72697aebae7b21d2651124b0e421`

## Validation

- Applied all QEMU package patches to upstream `v11.0.0` with `git apply --check`
  and `git apply`.
- Ran `git diff --check` on the prepared package branch.
- Ran `check_source_with_remoteasset.py` for the SPEC.
- Ran `remoteassetify.py --dry-run` in an openRuyi guest with RPM 4.20.1.

## AI-Assisted Contribution Disclosure

This contribution was prepared with AI assistance from Codex for SPEC formatting,
patch layout checks, command planning, and validation log consolidation. The
package changes, patch sources, checksums, branch commits, and validation
results were reviewed by the contributor. The commit message and sign-off were
set explicitly by the contributor identity.
