### PR TITLE
SPECS: kata-containers: add 3.29.0 for Cloud Hypervisor

### DIFF
--- a/SPECS/kata-containers/0001-agent-poll-sysfs-while-waiting-for-PCI-net-devices.patch
+++ b/SPECS/kata-containers/0001-agent-poll-sysfs-while-waiting-for-PCI-net-devices.patch
@@ -1,0 +1,102 @@
+From 921d0917bd12c9faaed9af27dc04aa8bf6a34a0a Mon Sep 17 00:00:00 2001
+From: isrc-riscv-port <riscv-port@isrc.iscas.ac.cn>
+Date: Wed, 13 May 2026 03:15:54 +0000
+Subject: [PATCH 1/4] agent: poll sysfs while waiting for PCI net devices
+
+Signed-off-by: isrc-riscv-port <riscv-port@isrc.iscas.ac.cn>
+---
+ .../src/device/network_device_handler.rs      | 43 ++++++++++++++++---
+ 1 file changed, 36 insertions(+), 7 deletions(-)
+
+diff --git a/src/agent/src/device/network_device_handler.rs b/src/agent/src/device/network_device_handler.rs
+index 54504d487..a0148a654 100644
+--- a/src/agent/src/device/network_device_handler.rs
++++ b/src/agent/src/device/network_device_handler.rs
+@@ -5,18 +5,26 @@
+ //
+ #[cfg(target_arch = "s390x")]
+ use crate::ccw;
++#[cfg(not(target_arch = "s390x"))]
++use crate::AGENT_CONFIG;
+ use crate::linux_abi::*;
+ use crate::sandbox::Sandbox;
+-use crate::uevent::{wait_for_uevent, Uevent, UeventMatcher};
++#[cfg(target_arch = "s390x")]
++use crate::uevent::wait_for_uevent;
++use crate::uevent::{Uevent, UeventMatcher};
+ #[cfg(not(target_arch = "s390x"))]
+ use crate::{device::pcipath_to_sysfs, pci};
+ use anyhow::{anyhow, Result};
+ use regex::Regex;
+ use std::fs;
+ use std::sync::Arc;
++#[cfg(not(target_arch = "s390x"))]
++use std::time::Duration;
+ use tokio::sync::Mutex;
++#[cfg(not(target_arch = "s390x"))]
++use tokio::time::{sleep, Instant};
+ 
+-fn check_existing(re: Regex) -> Result<bool> {
++fn check_existing(re: &Regex) -> Result<bool> {
+     // Check if the interface is already added in case network is cold-plugged
+     // or the uevent loop is started before network is added.
+     // We check for the device in the sysfs directory for network devices.
+@@ -37,7 +45,7 @@ fn check_existing(re: Regex) -> Result<bool> {
+ 
+ #[cfg(not(target_arch = "s390x"))]
+ pub async fn wait_for_pci_net_interface(
+-    sandbox: &Arc<Mutex<Sandbox>>,
++    _sandbox: &Arc<Mutex<Sandbox>>,
+     root_complex: &str,
+     pcipath: &pci::Path,
+ ) -> Result<()> {
+@@ -49,13 +57,34 @@ pub async fn wait_for_pci_net_interface(
+         matcher.devpath.as_str()
+     );
+     let re = Regex::new(&pattern).expect("BUG: Failed to compile regex for NetPciMatcher");
+-    if check_existing(re)? {
++    if check_existing(&re)? {
+         return Ok(());
+     }
+ 
+-    let _uev = wait_for_uevent(sandbox, matcher).await?;
++    // Some virtual PCI network devices can be visible in sysfs without a net
++    // uevent reaching the agent watcher. Poll the same sysfs symlink pattern
++    // used for cold-plug detection so UpdateInterface can still proceed.
++    let timeout = AGENT_CONFIG.hotplug_timeout;
++    let deadline = Instant::now() + timeout;
++    let interval = Duration::from_millis(100);
+ 
+-    Ok(())
++    loop {
++        if check_existing(&re)? {
++            return Ok(());
++        }
++
++        if Instant::now() >= deadline {
++            break;
++        }
++
++        sleep(interval).await;
++    }
++
++    Err(anyhow!(
++        "Timeout after {:?} waiting for net interface {:?}",
++        timeout,
++        matcher
++    ))
+ }
+ 
+ #[cfg(not(target_arch = "s390x"))]
+@@ -91,7 +120,7 @@ pub async fn wait_for_ccw_net_interface(
+     device: &ccw::Device,
+ ) -> Result<()> {
+     let matcher = NetCcwMatcher::new(CCW_ROOT_BUS_PATH, device);
+-    if check_existing(matcher.re.clone())? {
++    if check_existing(&matcher.re)? {
+         return Ok(());
+     }
+     let _uev = wait_for_uevent(sandbox, matcher).await?;
+-- 
+2.50.1 (Apple Git-155)
+

--- a/SPECS/kata-containers/0002-agent-resolve-RISC-V-platform-PCI-root-bus-path.patch
+++ b/SPECS/kata-containers/0002-agent-resolve-RISC-V-platform-PCI-root-bus-path.patch
@@ -1,0 +1,69 @@
+From 3e8fe90bd2e95b57436d468492e262a669247a01 Mon Sep 17 00:00:00 2001
+From: isrc-riscv-port <riscv-port@isrc.iscas.ac.cn>
+Date: Wed, 13 May 2026 03:15:55 +0000
+Subject: [PATCH 2/4] agent: resolve RISC-V platform PCI root bus path
+
+Signed-off-by: isrc-riscv-port <riscv-port@isrc.iscas.ac.cn>
+---
+ src/agent/src/linux_abi.rs | 33 +++++++++++++++++++++++++++++++--
+ 1 file changed, 31 insertions(+), 2 deletions(-)
+
+diff --git a/src/agent/src/linux_abi.rs b/src/agent/src/linux_abi.rs
+index cb5c6bc3f..4991259ed 100644
+--- a/src/agent/src/linux_abi.rs
++++ b/src/agent/src/linux_abi.rs
+@@ -9,13 +9,12 @@ use cfg_if::cfg_if;
+ use std::str::FromStr;
+ // Linux ABI related constants.
+ 
+-#[cfg(target_arch = "aarch64")]
++#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+ use std::fs;
+ 
+ pub const SYSFS_DIR: &str = "/sys";
+ #[cfg(any(
+     all(target_arch = "powerpc64", target_endian = "little"),
+-    target_arch = "riscv64",
+     target_arch = "s390x",
+     target_arch = "x86_64",
+     target_arch = "x86"
+@@ -26,6 +25,36 @@ pub fn create_pci_root_bus_path(root_complex: &str) -> String {
+     format!("/devices/pci0000:{root_complex}")
+ }
+ 
++#[cfg(target_arch = "riscv64")]
++pub fn create_pci_root_bus_path(root_complex: &str) -> String {
++    let acpi_root_bus_path = format!("/devices/pci0000:{root_complex}");
++    let acpi_sysfs_dir = format!("{SYSFS_DIR}{acpi_root_bus_path}");
++    if fs::metadata(acpi_sysfs_dir).is_ok() {
++        return acpi_root_bus_path;
++    }
++
++    let fallback = format!("/devices/platform/30000000.pci/pci0000:{root_complex}");
++    let platform_sysfs_dir = format!("{SYSFS_DIR}/devices/platform");
++    let entries = match fs::read_dir(platform_sysfs_dir) {
++        Ok(entries) => entries,
++        Err(_) => return fallback,
++    };
++
++    for entry in entries.flatten() {
++        let dir_name = entry.file_name();
++        let root_bus_path = format!(
++            "/devices/platform/{}/pci0000:{root_complex}",
++            dir_name.to_string_lossy()
++        );
++        let sysfs_dir = format!("{SYSFS_DIR}{root_bus_path}");
++        if fs::metadata(sysfs_dir).is_ok() {
++            return root_bus_path;
++        }
++    }
++
++    fallback
++}
++
+ // This is used in several modules, let's create a helper function to parse the
+ // qom path and switch easily once the shim sends us the full NUMA path
+ pub fn pcipath_from_dev_tree_path(dev_tree_path: &str) -> Result<(&str, pci::Path)> {
+-- 
+2.50.1 (Apple Git-155)
+

--- a/SPECS/kata-containers/0003-virtcontainers-extend-Cloud-Hypervisor-boot-timeout-.patch
+++ b/SPECS/kata-containers/0003-virtcontainers-extend-Cloud-Hypervisor-boot-timeout-.patch
@@ -1,0 +1,64 @@
+From 8c32a6a33446233db7d5251f8c8b3347594441e2 Mon Sep 17 00:00:00 2001
+From: isrc-riscv-port <riscv-port@isrc.iscas.ac.cn>
+Date: Wed, 13 May 2026 03:15:56 +0000
+Subject: [PATCH 3/4] virtcontainers: extend Cloud Hypervisor boot timeout on
+ RISC-V
+
+Signed-off-by: isrc-riscv-port <riscv-port@isrc.iscas.ac.cn>
+---
+ src/runtime/virtcontainers/clh.go | 24 ++++++++++++++++++------
+ 1 file changed, 18 insertions(+), 6 deletions(-)
+
+diff --git a/src/runtime/virtcontainers/clh.go b/src/runtime/virtcontainers/clh.go
+index 51e3577ab..c9a4020e2 100644
+--- a/src/runtime/virtcontainers/clh.go
++++ b/src/runtime/virtcontainers/clh.go
+@@ -76,9 +76,10 @@ const (
+ 	clhTimeout                     = 10
+ 	clhAPITimeout                  = 1
+ 	clhAPITimeoutConfidentialGuest = 20
+-	// Minimum timout for calling CreateVM followed by BootVM. Executing these two APIs
++	// Minimum timeout for calling CreateVM followed by BootVM. Executing these two APIs
+ 	// might take longer than the value returned by getClhAPITimeout().
+-	clhCreateAndBootVMMinimumTimeout = 10
++	clhCreateAndBootVMMinimumTimeout        = 10
++	clhRiscv64CreateAndBootVMMinimumTimeout = 60
+ 	// Timeout for hot-plug - hotplug devices can take more time, than usual API calls
+ 	// Use longer time timeout for it.
+ 	clhHotPlugAPITimeout                   = 5
+@@ -318,6 +319,20 @@ func (clh *cloudHypervisor) getClhAPITimeout() time.Duration {
+ 	return clhAPITimeout
+ }
+ 
++func (clh *cloudHypervisor) getClhCreateAndBootVMTimeout() time.Duration {
++	minimumTimeout := time.Duration(clhCreateAndBootVMMinimumTimeout)
++	if runtime.GOARCH == "riscv64" {
++		minimumTimeout = time.Duration(clhRiscv64CreateAndBootVMMinimumTimeout)
++	}
++
++	apiTimeout := clh.getClhAPITimeout()
++	if apiTimeout < minimumTimeout {
++		return minimumTimeout
++	}
++
++	return apiTimeout
++}
++
+ func (clh *cloudHypervisor) getClhStopSandboxTimeout() time.Duration {
+ 	// Increase the StopSandboxTimeout when dealing with a Confidential Guest.
+ 	// The value has been chosen based on tests using `ctr`, and hopefully
+@@ -764,10 +779,7 @@ func (clh *cloudHypervisor) StartVM(ctx context.Context, timeout int) error {
+ 		return fmt.Errorf("failed to launch cloud-hypervisor: %q", err)
+ 	}
+ 
+-	bootTimeout := clh.getClhAPITimeout()
+-	if bootTimeout < clhCreateAndBootVMMinimumTimeout {
+-		bootTimeout = clhCreateAndBootVMMinimumTimeout
+-	}
++	bootTimeout := clh.getClhCreateAndBootVMTimeout()
+ 	ctx, cancel := context.WithTimeout(ctx, bootTimeout*time.Second)
+ 	defer cancel()
+ 
+-- 
+2.50.1 (Apple Git-155)
+

--- a/SPECS/kata-containers/0004-runtime-enable-Cloud-Hypervisor-config-on-RISC-V.patch
+++ b/SPECS/kata-containers/0004-runtime-enable-Cloud-Hypervisor-config-on-RISC-V.patch
@@ -1,0 +1,22 @@
+From ba05fe8cd6f7f7c8512a58f07c9a2318e4662a6b Mon Sep 17 00:00:00 2001
+From: isrc-riscv-port <riscv-port@isrc.iscas.ac.cn>
+Date: Thu, 14 May 2026 19:37:00 +0800
+Subject: [PATCH 4/4] runtime: enable Cloud Hypervisor config on RISC-V
+
+Signed-off-by: isrc-riscv-port <riscv-port@isrc.iscas.ac.cn>
+---
+ src/runtime/arch/riscv64-options.mk | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/runtime/arch/riscv64-options.mk b/src/runtime/arch/riscv64-options.mk
+index 55ba9da80..347642f3c 100644
+--- a/src/runtime/arch/riscv64-options.mk
++++ b/src/runtime/arch/riscv64-options.mk
+@@ -11,3 +11,4 @@ MACHINEACCELERATORS :=
+ CPUFEATURES :=
+ 
+ QEMUCMD := qemu-system-riscv64
++CLHCMD := cloud-hypervisor
+-- 
+2.50.1 (Apple Git-155)
+

--- a/SPECS/kata-containers/kata-containers.spec
+++ b/SPECS/kata-containers/kata-containers.spec
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: isrc-riscv-port <riscv-port@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%ifarch x86_64
+%global rust_def_target x86_64-unknown-linux-gnu
+%endif
+
+%ifarch riscv64
+%global rust_def_target riscv64gc-unknown-linux-gnu
+%endif
+
+Name:           kata-containers
+Version:        3.29.0
+Release:        %autorelease
+Summary:        Secure container runtime with lightweight virtual machines
+License:        Apache-2.0
+URL:            https://github.com/kata-containers/kata-containers
+#!RemoteAsset:  sha256:8dab047ee17d2cd2fc8cdb01d2530c65cd2235e48e964c95a9a3a9275f721078
+Source0:        %{url}/archive/refs/tags/%{version}.tar.gz#/%{name}-%{version}.tar.gz
+# Kata combines a Go runtime and Rust agent behind upstream custom Makefiles.
+# The available declarative build systems do not cover this mixed build yet.
+BuildSystem:
+
+BuildRequires:  cargo >= 1.92.0
+BuildRequires:  git
+BuildRequires:  go >= 1.25.9
+BuildRequires:  go-rpm-macros
+BuildRequires:  make
+BuildRequires:  rust >= 1.92.0
+BuildRequires:  rust-rpm-macros
+
+Requires:       cloud-hypervisor
+Requires:       virtiofsd
+
+%patchlist
+# Poll sysfs while waiting for PCI network devices so Cloud Hypervisor hotplug
+# does not stall when the uevent watcher misses an already-created netdev.
+0001-agent-poll-sysfs-while-waiting-for-PCI-net-devices.patch
+# Resolve the platform PCI root bus path used by RISC-V virt machines without
+# ACPI, falling back to /devices/platform/.../pci0000:* when needed.
+0002-agent-resolve-RISC-V-platform-PCI-root-bus-path.patch
+# Increase the Cloud Hypervisor CreateVM and BootVM timeout on riscv64, where
+# nested virtualization under QEMU/TCG boots more slowly during validation.
+0003-virtcontainers-extend-Cloud-Hypervisor-boot-timeout-.patch
+# Register Cloud Hypervisor as an available riscv64 hypervisor in Kata's
+# architecture options so DEFAULT_HYPERVISOR=cloud-hypervisor is accepted.
+0004-runtime-enable-Cloud-Hypervisor-config-on-RISC-V.patch
+
+%description
+Kata Containers provides a secure container runtime using lightweight virtual
+machines. It integrates with OCI and CRI runtimes while improving workload
+isolation with a dedicated guest kernel and agent.
+
+%prep
+%autosetup -p1
+mkdir -p .cargo
+cat > .cargo/config.toml <<EOF
+[source.crates-io]
+replace-with = "system-registry"
+
+[source.system-registry]
+directory = "/usr/share/cargo/registry"
+
+[net]
+offline = true
+EOF
+
+%build
+export GOFLAGS="-mod=vendor"
+make -C src/runtime \
+    PREFIX=%{_prefix} \
+    LIBEXECDIR=%{_libexecdir} \
+    DEFAULT_HYPERVISOR=cloud-hypervisor
+
+make -C src/agent \
+    BUILD_TYPE=release \
+    TRIPLE=%{rust_def_target} \
+    optimize
+
+%install
+export GOFLAGS="-mod=vendor"
+make -C src/runtime \
+    DESTDIR=%{buildroot} \
+    PREFIX=%{_prefix} \
+    LIBEXECDIR=%{_libexecdir} \
+    DEFAULT_HYPERVISOR=cloud-hypervisor \
+    install
+
+install -Dpm0755 target/%{rust_def_target}/release/kata-agent \
+    %{buildroot}%{_datadir}/kata-containers/kata-agent
+
+%check
+# Upstream tests require nested virtualization, container runtime state, or
+# privileged kernel features that are unavailable in a normal package chroot.
+
+%files
+%doc README.md VERSION
+%license LICENSE
+%{_bindir}/kata-runtime
+%{_bindir}/containerd-shim-kata-v2
+%{_bindir}/kata-monitor
+%{_bindir}/kata-collect-data.sh
+%{_datadir}/bash-completion/completions/kata-runtime
+%{_datadir}/defaults/kata-containers/
+%{_datadir}/kata-containers/kata-agent
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

Add `kata-containers` version `3.29.0` packaging for openRuyi with Cloud
Hypervisor as the default hypervisor.

The package uses upstream source, vendored Rust crates for the agent build, and
vendored Go modules for the runtime build. The patch series contains the
RISC-V network hotplug fixes and the RISC-V Cloud Hypervisor build enablement
needed for this validation path.

## Baseline

- Upstream source tag: `3.29.0`
- Patch source branch: `https://git.openruyi.cn/jiayi/kata-containers/src/branch/riscv-kata-cloud-hypervisor`
- Package branch commit: `975bba6e387351203ec404e40b7689bb3eca7c1d`

## Validation

- Applied all Kata package patches to upstream `3.29.0` with `git apply --check`
  and `git apply`.
- Ran `git diff --check` on the prepared package branch.
- Ran `check_source_with_remoteasset.py` for the SPEC.
- Ran `remoteassetify.py --dry-run` in an openRuyi guest with RPM 4.20.1.
- Verified the uploaded Go vendor archive download URL and SHA-256:
  `14b863b184e3d44a5de16ace24224267dc5aa5e6e91b7f3fb750f0495f7f0f03`.

## AI-Assisted Contribution Disclosure

This contribution was prepared with AI assistance from Codex for SPEC formatting,
patch layout checks, command planning, and validation log consolidation. The
package changes, patch sources, checksums, branch commits, and validation
results were reviewed by the contributor. The commit message and sign-off were
set explicitly by the contributor identity.
