### PR TITLE
Add python fontmake 15pkgs

### DIFF
--- a/SPECS/python-booleanoperations/python-booleanoperations.spec
+++ b/SPECS/python-booleanoperations/python-booleanoperations.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Gui-Yue <xiangwei.riscv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname booleanoperations
+
+Name:           python-%{srcname}
+Version:        0.10.0
+Release:        %autorelease
+Summary:        Boolean operations on paths
+License:        MIT
+URL:            https://github.com/typemytype/booleanOperations
+VCS:            git:https://github.com/typemytype/booleanOperations
+#!RemoteAsset:  sha256:6d719f560d2a1dd676c812b844ecceb693c96791c76579089ab7d0f5db5cedbe
+Source0:        https://files.pythonhosted.org/packages/source/b/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l booleanOperations +auto
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(fonttools)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pyclipper)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+booleanOperations provides boolean operations on paths.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-cattrs/python-cattrs.spec
+++ b/SPECS/python-cattrs/python-cattrs.spec
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Gui-Yue <xiangwei.riscv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname cattrs
+
+Name:           python-%{srcname}
+Version:        26.1.0
+Release:        %autorelease
+Summary:        Composable class support for attrs and dataclasses
+License:        MIT
+URL:            https://github.com/python-attrs/cattrs
+VCS:            git:https://github.com/python-attrs/cattrs
+#!RemoteAsset:  sha256:fa239e0f0ec0715ba34852ce813986dfed1e12117e209b816ab87401271cdd40
+Source0:        https://files.pythonhosted.org/packages/source/c/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname} cattr +auto
+# preconf modules import optional serialization backends not required by core cattrs.
+BuildOption(check):  -e "cattrs.preconf.*"
+BuildOption(check):  -e "cattr.preconf.*"
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(attrs) >= 25.4
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(typing-extensions) >= 4.14
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+cattrs provides composable support for attrs and dataclasses classes.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README*
+%license LICENSE*
+
+%changelog
+%autochangelog

--- a/SPECS/python-cffsubr/2000-afdko-use-antlr4-archive-from-env.patch
+++ b/SPECS/python-cffsubr/2000-afdko-use-antlr4-archive-from-env.patch
@@ -1,0 +1,52 @@
+--- a/external/afdko/CMakeLists.txt
++++ b/external/afdko/CMakeLists.txt
+@@ -42,6 +42,11 @@
+ # This is a more recent commit than 4.13.2 that addresses a missing
+ # include directive needed in more recent Visual Studio releases
+ set(ANTLR4_TAG df4d68c09cdef73e023b8838a8bc7ca4dff1d1de)
++
++# Allow distro packaging to provide an offline antlr4 archive path.
++if(DEFINED ENV{ANTLR4_ZIP_REPOSITORY} AND NOT "$ENV{ANTLR4_ZIP_REPOSITORY}" STREQUAL "")
++    set(ANTLR4_ZIP_REPOSITORY "$ENV{ANTLR4_ZIP_REPOSITORY}")
++endif()
+ include(ExternalAntlr4Cpp)
+
+
+
+--- a/external/afdko/cmake/ExternalAntlr4Cpp.cmake
++++ b/external/afdko/cmake/ExternalAntlr4Cpp.cmake
+@@ -85,9 +85,17 @@
+       BUILD_COMMAND ""
+       BUILD_IN_SOURCE 1
+       SOURCE_DIR ${ANTLR4_ROOT}/runtime/Cpp  # Edited by iterumllc
++      PATCH_COMMAND
++          sed -i
++              -e "s/CMAKE_POLICY(SET CMP0045 OLD)/CMAKE_POLICY(SET CMP0045 NEW)/"
++              -e "s/CMAKE_POLICY(SET CMP0042 OLD)/CMAKE_POLICY(SET CMP0042 NEW)/"
++              -e "s/CMAKE_POLICY(SET CMP0059 OLD)/CMAKE_POLICY(SET CMP0059 NEW)/"
++              -e "s/CMAKE_POLICY(SET CMP0054 OLD)/CMAKE_POLICY(SET CMP0054 NEW)/"
++              CMakeLists.txt
+       #      SOURCE_SUBDIR runtime/Cpp  # Commented out by iterumllc
+       CMAKE_CACHE_ARGS
+           -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
++          -DCMAKE_POLICY_VERSION_MINIMUM:STRING=3.5
+           -DWITH_STATIC_CRT:BOOL=${ANTLR4_WITH_STATIC_CRT}
+           -DCMAKE_OSX_ARCHITECTURES:STRING=${CMAKE_OSX_ARCHITECTURES}
+           -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
+@@ -107,8 +115,16 @@
+       BUILD_IN_SOURCE 1
+       SOURCE_DIR ${ANTLR4_ROOT}
+       SOURCE_SUBDIR runtime/Cpp
++      PATCH_COMMAND
++          sed -i
++              -e "s/CMAKE_POLICY(SET CMP0045 OLD)/CMAKE_POLICY(SET CMP0045 NEW)/"
++              -e "s/CMAKE_POLICY(SET CMP0042 OLD)/CMAKE_POLICY(SET CMP0042 NEW)/"
++              -e "s/CMAKE_POLICY(SET CMP0059 OLD)/CMAKE_POLICY(SET CMP0059 NEW)/"
++              -e "s/CMAKE_POLICY(SET CMP0054 OLD)/CMAKE_POLICY(SET CMP0054 NEW)/"
++              runtime/Cpp/CMakeLists.txt
+       CMAKE_CACHE_ARGS
+           -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
++          -DCMAKE_POLICY_VERSION_MINIMUM:STRING=3.5
+           -DWITH_STATIC_CRT:BOOL=${ANTLR4_WITH_STATIC_CRT}
+           -DCMAKE_OSX_ARCHITECTURES:STRING=${CMAKE_OSX_ARCHITECTURES}
+           -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON

--- a/SPECS/python-cffsubr/2001-afdko-drop-python-cmake-ninja-setup-requires.patch
+++ b/SPECS/python-cffsubr/2001-afdko-drop-python-cmake-ninja-setup-requires.patch
@@ -1,0 +1,15 @@
+diff --git a/external/afdko/setup.py b/external/afdko/setup.py
+index 62b61be..9a7e2be 100644
+--- a/external/afdko/setup.py
++++ b/external/afdko/setup.py
+@@ -198,9 +198,7 @@ def main():
+           setup_requires=[
+               'wheel',
+               'setuptools_scm',
+-              'scikit-build',
+-              'cmake',
+-              'ninja'
++              'scikit-build'
+           ],
+           tests_require=[
+               'pytest',

--- a/SPECS/python-cffsubr/python-cffsubr.spec
+++ b/SPECS/python-cffsubr/python-cffsubr.spec
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Gui-Yue <xiangwei.riscv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname cffsubr
+
+Name:           python-%{srcname}
+Version:        0.4.0
+Release:        %autorelease
+Summary:        Standalone CFF subroutinizer based on AFDKO tx
+License:        Apache-2.0
+URL:            https://github.com/adobe-type-tools/cffsubr
+VCS:            git:https://github.com/adobe-type-tools/cffsubr
+#!RemoteAsset:  sha256:2c321b6807bd95856d921ed9dce8506495cf49fc7a89a63cb942e8bece13addd
+Source0:        https://files.pythonhosted.org/packages/source/c/%{srcname}/%{srcname}-%{version}.tar.gz
+#!RemoteAsset:  sha256:0ed13668906e86dbc0dcddf30fdee68c10203dea4e83852b4edb810821bee3c4
+Source1:        https://www.antlr.org/download/antlr4-cpp-runtime-4.13.2-source.zip
+BuildSystem:    pyproject
+
+# Use offline ANTLR archive and fix old CMake policy settings in bundled AFDKO.
+Patch2000:      2000-afdko-use-antlr4-archive-from-env.patch
+# Avoid pip downloading python-cmake/python-ninja from setup_requires.
+Patch2001:      2001-afdko-drop-python-cmake-ninja-setup-requires.patch
+
+BuildOption(install):  -l %{srcname} +auto
+# cffsubr custom backend injects python3dist(cmake/ninja); we keep system
+# cmake/ninja in BuildRequires and disable dynamic pyproject BR generation.
+BuildOption(generate_buildrequires):  -N
+
+BuildRequires:  cmake
+BuildRequires:  git
+BuildRequires:  ninja
+BuildRequires:  pkgconfig(libxml-2.0)
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pkgconfig(uuid)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(fonttools)
+BuildRequires:  python3dist(jinja2)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(scikit-build)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-git-ls-files)
+BuildRequires:  python3dist(setuptools-scm)
+BuildRequires:  python3dist(wheel)
+BuildRequires:  utf8cpp
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+cffsubr is a standalone CFF subroutinizer based on the AFDKO tx tool.
+
+%build -p
+export ANTLR4_ZIP_REPOSITORY=%{SOURCE1}
+export FORCE_SYSTEM_LIBXML2=1
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE NOTICE
+%{_bindir}/cffsubr
+
+%changelog
+%autochangelog

--- a/SPECS/python-compreffor/python-compreffor.spec
+++ b/SPECS/python-compreffor/python-compreffor.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Gui-Yue <xiangwei.riscv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname compreffor
+
+Name:           python-%{srcname}
+Version:        0.6.0
+Release:        %autorelease
+Summary:        CFF subroutinizer for fontTools
+License:        Apache-2.0
+URL:            https://github.com/googlefonts/compreffor
+VCS:            git:https://github.com/googlefonts/compreffor
+#!RemoteAsset:  sha256:7ea034a50c59cc78732f1480040eac2bb36f826ce2eb607c3029b5d38ab11ba8
+Source0:        https://files.pythonhosted.org/packages/source/c/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname} +auto
+
+BuildRequires:  gcc-c++
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(cython)
+BuildRequires:  python3dist(fonttools) >= 4
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-git-ls-files)
+BuildRequires:  python3dist(setuptools-scm)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+compreffor is a CFF subroutinizer library and CLI for fontTools.
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-fontmake/python-fontmake.spec
+++ b/SPECS/python-fontmake/python-fontmake.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Gui-Yue <xiangwei.riscv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname fontmake
+
+Name:           python-%{srcname}
+Version:        3.11.1
+Release:        %autorelease
+Summary:        Compile fonts from sources to OpenType and TrueType binaries
+License:        Apache-2.0
+URL:            https://pypi.org/project/fontmake/
+VCS:            git:https://github.com/googlei18n/fontmake
+#!RemoteAsset:  sha256:a3b958a2f6d0b978a803a5643f04c27c88c5ed9dc5af999752408aa94053d082
+Source0:        https://files.pythonhosted.org/packages/source/f/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Fontmake compiles fonts from source files such as UFO and Glyphs into binary
+fonts, including OpenType and TrueType outputs.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+%{_bindir}/fontmake
+
+%changelog
+%autochangelog

--- a/SPECS/python-fontmath/python-fontmath.spec
+++ b/SPECS/python-fontmath/python-fontmath.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Gui-Yue <xiangwei.riscv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname fontmath
+
+Name:           python-%{srcname}
+Version:        0.10.0
+Release:        %autorelease
+Summary:        Math operations on font data
+License:        MIT
+URL:            https://pypi.org/project/fontMath/
+VCS:            git:https://github.com/robotools/fontMath
+#!RemoteAsset:  sha256:7b0b39336d83d7fc03fb9dc3c662ef7d26b2c15355a34c643d1cfbd03f89fb74
+Source0:        https://files.pythonhosted.org/packages/source/f/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l fontMath +auto
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(fonttools)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm[toml])
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+fontMath provides objects for performing math operations on font data.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license License.txt
+
+%changelog
+%autochangelog

--- a/SPECS/python-fonttools/python-fonttools.spec
+++ b/SPECS/python-fonttools/python-fonttools.spec
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
 # SPDX-FileContributor: panglars <panghao.riscv@isrc.iscas.ac.cn>
+# SPDX-FileContributor: Gui-Yue <xiangwei.riscv@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
@@ -40,6 +41,8 @@ text format, and also installs utilities for subsetting and merging fonts.
 
 %generate_buildrequires
 %pyproject_buildrequires
+
+%pyproject_extras_subpkg -n python-%{srcname} all graphite interpolatable lxml pathops plot repacker symfont type1 ufo unicode woff
 
 %files -f %{pyproject_files}
 %doc README.rst NEWS.rst

--- a/SPECS/python-glyphslib/python-glyphslib.spec
+++ b/SPECS/python-glyphslib/python-glyphslib.spec
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Gui-Yue <xiangwei.riscv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname glyphslib
+
+Name:           python-%{srcname}
+Version:        6.13.0
+Release:        %autorelease
+Summary:        Bridge from Glyphs source files to UFOs
+License:        Apache-2.0
+URL:            https://pypi.org/project/glyphsLib/
+VCS:            git:https://github.com/googlefonts/glyphsLib
+#!RemoteAsset:  sha256:7527baa1310be6c41d504ced6efec37423cccaa8ad950f8db675e54456324a1f
+Source0:        https://files.pythonhosted.org/packages/source/g/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l glyphsLib +auto
+BuildOption(check):  -e "glyphsLib.featureWriters.markFeatureWriter"
+BuildOption(check):  -e "glyphsLib.filters.cornerComponents"
+BuildOption(check):  -e "glyphsLib.filters.eraseOpenCorners"
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(fonttools)
+BuildRequires:  python3dist(openstep-plist)
+BuildRequires:  python3dist(ufolib2)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm[toml])
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+glyphsLib bridges Glyphs source files (.glyphs) to UFOs and Designspace.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-openstep-plist/python-openstep-plist.spec
+++ b/SPECS/python-openstep-plist/python-openstep-plist.spec
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Gui-Yue <xiangwei.riscv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname openstep-plist
+
+Name:           python-%{srcname}
+Version:        0.5.2
+Release:        %autorelease
+Summary:        ASCII plist parser written in Cython
+License:        MIT
+URL:            https://github.com/fonttools/openstep-plist
+VCS:            git:https://github.com/fonttools/openstep-plist
+#!RemoteAsset:  sha256:2a0d70ff7a03cce64a727062b64bb2f5c9af9fd4a636aaa4339b6aaa2cf65195
+Source0:        https://files.pythonhosted.org/packages/source/o/openstep_plist/openstep_plist-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l openstep_plist +auto
+
+BuildRequires:  gcc-c++
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(cython) >= 0.28.5
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+openstep-plist is an ASCII plist parser written in Cython.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-pyclipper/python-pyclipper.spec
+++ b/SPECS/python-pyclipper/python-pyclipper.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Gui-Yue <xiangwei.riscv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pyclipper
+
+Name:           python-%{srcname}
+Version:        1.4.0
+Release:        %autorelease
+Summary:        Cython wrapper for the Clipper library
+License:        MIT
+URL:            https://github.com/fonttools/pyclipper
+VCS:            git:https://github.com/fonttools/pyclipper
+#!RemoteAsset:  sha256:9882bd889f27da78add4dd6f881d25697efc740bf840274e749988d25496c8e1
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname} +auto
+
+BuildRequires:  gcc-c++
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(cython)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+pyclipper is a Cython wrapper for the Clipper polygon clipping library.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README*
+%license LICENSE*
+
+%changelog
+%autochangelog

--- a/SPECS/python-scikit-build/python-scikit-build.spec
+++ b/SPECS/python-scikit-build/python-scikit-build.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Gui-Yue <xiangwei.riscv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname scikit-build
+%global pypi_name scikit_build
+
+Name:           python-%{srcname}
+Version:        0.19.0
+Release:        %autorelease
+Summary:        Improved build system generator for Python C/C++ projects
+License:        MIT
+URL:            https://github.com/scikit-build/scikit-build
+VCS:            git:https://github.com/scikit-build/scikit-build
+#!RemoteAsset:  sha256:46e1b2d71343d14e4c07d7e60902e673c78defb9a2c282b70ad80fb8502ade2e
+Source0:        https://files.pythonhosted.org/packages/source/s/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l skbuild +auto
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(distro)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel) >= 0.32
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+scikit-build is an improved build system generator for Python extensions.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README*
+%license LICENSE*
+
+%changelog
+%autochangelog

--- a/SPECS/python-setuptools-git-ls-files/python-setuptools-git-ls-files.spec
+++ b/SPECS/python-setuptools-git-ls-files/python-setuptools-git-ls-files.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Gui-Yue <xiangwei.riscv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname setuptools-git-ls-files
+%global pypi_name setuptools_git_ls_files
+
+Name:           python-%{srcname}
+Version:        0.1.2
+Release:        %autorelease
+Summary:        Use git to list all files including submodules
+License:        MIT
+URL:            https://github.com/brainwane/setuptools-git-ls-files
+VCS:            git:https://github.com/brainwane/setuptools-git-ls-files
+#!RemoteAsset:  sha256:7d612087430dc912f0dca7a35c99bf791b2f86b7fa5a40c5a562192947c86efa
+Source0:        https://files.pythonhosted.org/packages/source/s/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l setuptools_git_ls_files +auto
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+setuptools-git-ls-files provides a setuptools plugin that uses git ls-files.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README*
+%license LICENSE*
+
+%changelog
+%autochangelog

--- a/SPECS/python-ufo2ft/python-ufo2ft.spec
+++ b/SPECS/python-ufo2ft/python-ufo2ft.spec
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Gui-Yue <xiangwei.riscv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname ufo2ft
+
+Name:           python-%{srcname}
+Version:        3.7.0
+Release:        %autorelease
+Summary:        Bridge between UFOs and FontTools
+License:        MIT
+URL:            https://github.com/googlefonts/ufo2ft
+VCS:            git:https://github.com/googlefonts/ufo2ft
+#!RemoteAsset:  sha256:e467db380d42774d4a6016a13879987d76f921c5d62cc3cc78960da019f1e80e
+Source0:        https://files.pythonhosted.org/packages/source/u/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l ufo2ft +auto
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(booleanoperations) >= 0.9
+BuildRequires:  python3dist(cffsubr) >= 0.3
+BuildRequires:  python3dist(fontmath) >= 0.9.4
+BuildRequires:  python3dist(fonttools) >= 4.61.1
+BuildRequires:  python3dist(fonttools[ufo]) >= 4.61.1
+BuildRequires:  python3dist(ufolib2) >= 0.18.1
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%pyproject_extras_subpkg -n python-%{srcname} cffsubr compreffor pathops
+
+%description
+ufo2ft is a bridge between UFOs and FontTools.
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-ufolib2/python-ufolib2.spec
+++ b/SPECS/python-ufolib2/python-ufolib2.spec
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Gui-Yue <xiangwei.riscv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname ufolib2
+
+Name:           python-%{srcname}
+Version:        0.18.1
+Release:        %autorelease
+Summary:        UFO font processing library
+License:        Apache-2.0
+URL:            https://github.com/fonttools/ufoLib2
+VCS:            git:https://github.com/fonttools/ufoLib2
+#!RemoteAsset:  sha256:7de0efcc361c573f2537ee7ceabdb3bc64b19b61304cfa25e828caa7db8ae1a4
+Source0:        https://files.pythonhosted.org/packages/source/u/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l ufoLib2 +auto
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(attrs)
+BuildRequires:  python3dist(cattrs)
+BuildRequires:  python3dist(fonttools)
+BuildRequires:  python3dist(msgpack)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm[toml])
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+ufoLib2 is a UFO font processing library for fast batch manipulation.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-unicodedata2/python-unicodedata2.spec
+++ b/SPECS/python-unicodedata2/python-unicodedata2.spec
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Gui-Yue <xiangwei.riscv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname unicodedata2
+
+Name:           python-%{srcname}
+Version:        17.0.1
+Release:        %autorelease
+Summary:        Unicodedata backport updated to the latest Unicode version
+License:        Apache-2.0
+URL:            https://github.com/fonttools/unicodedata2
+VCS:            git:https://github.com/fonttools/unicodedata2
+#!RemoteAsset:  sha256:d79943d153f5f6bfbe3f55a5ec611985184bda37fcedb3ecc75322d82ae6ad3b
+Source0:        https://files.pythonhosted.org/packages/source/u/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname} +auto
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+unicodedata2 is a unicodedata backport updated to the latest Unicode version.
+
+%files -f %{pyproject_files}
+%doc CHANGELOG.md README.md
+%license LICENSE
+
+%changelog
+%autochangelog


### PR DESCRIPTION
Replaces #30. The previous PR accumulated too much conversation history, so this is a clean resubmission with the same package intent and a clearer description.

Changes:
- Add `python-fontmake` and its missing Python dependency packages.
- Keep one package action per commit so each package remains reviewable and revertible independently.

Notes for `python-fonttools`:
- Preserves the existing spec content, including the original `SPDX-FileContributor: panglars <panghao.riscv@isrc.iscas.ac.cn>` line.
- Adds `SPDX-FileContributor: Gui-Yue <xiangwei.riscv@isrc.iscas.ac.cn>` without removing existing attribution.
- Only adds `%pyproject_extras_subpkg -n python-%{srcname} ...`; existing BuildOption, BuildRequires, description, and `%files` entries are unchanged.
