### PR TITLE
SPECS: Add python-tensorboard.spec

### DIFF
--- a/SPECS/python-tensorboard/python-tensorboard.spec
+++ b/SPECS/python-tensorboard/python-tensorboard.spec
@@ -20,8 +20,18 @@ BuildRequires:  bazel
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
-BuildRequires:  python3dist(virtualenv)
 BuildRequires:  python3dist(wheel)
+
+Requires:       python3dist(absl-py) >= 0.4
+Requires:       python3dist(grpcio) >= 1.48.2
+Requires:       python3dist(markdown) >= 2.6.8
+Requires:       python3dist(numpy) >= 1.12.0
+Requires:       python3dist(packaging)
+Requires:       python3dist(pillow)
+Requires:       python3dist(protobuf) >= 3.19.6
+Requires:       python3dist(setuptools) >= 41.0.0
+Requires:       python3dist(tensorboard-data-server) >= 0.7.0
+Requires:       python3dist(werkzeug) >= 1.0.1
 
 Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
@@ -33,21 +43,52 @@ your TensorFlow runs and graphs.
 %prep
 %autosetup -n %{srcname}-%{version}
 
-perl -pi \
-  -e 's/virtualenv -q -p python3 venv/virtualenv -q --system-site-packages -p python3 venv/;' \
-  -e 's/^[ \t]*pip\s+install\s+.*/  python -c "import setuptools, wheel"/;' \
-  tensorboard/pip_package/build_pip_package.sh
-
 %build
-mkdir -p dist
-bazel build //tensorboard/pip_package:pip_package
-tar -xzf bazel-bin/tensorboard/pip_package/pip_packages.tar.gz -C dist
+bazel build //tensorboard/pip_package:build_pip_package
+
+RUNFILES=bazel-bin/tensorboard/pip_package/build_pip_package.runfiles
+rm -rf pip-src
+mkdir -p pip-src
+
+cp -LR "${RUNFILES}/org_tensorflow_tensorboard/tensorboard" pip-src/
+mv -f pip-src/tensorboard/pip_package/LICENSE pip-src/
+mv -f pip-src/tensorboard/pip_package/MANIFEST.in pip-src/
+mv -f pip-src/tensorboard/pip_package/README.rst pip-src/
+mv -f pip-src/tensorboard/pip_package/requirements.txt pip-src/
+mv -f pip-src/tensorboard/pip_package/setup.cfg pip-src/
+mv -f pip-src/tensorboard/pip_package/setup.py pip-src/
+rm -rf pip-src/tensorboard/pip_package
+rm -f pip-src/tensorboard/tensorboard
+
+chmod -x pip-src/LICENSE
+find pip-src -name __init__.py -exec chmod -x {} +
+
+mkdir -p pip-src/tensorboard/_vendor
+touch pip-src/tensorboard/_vendor/__init__.py
+cp -LR "${RUNFILES}/org_mozilla_bleach/bleach" pip-src/tensorboard/_vendor/
+cp -LR "${RUNFILES}/org_pythonhosted_webencodings/webencodings" pip-src/tensorboard/_vendor/
+
+chmod -R u+w,go+r pip-src
+find pip-src/tensorboard -name '*.py' -exec perl -pi -e '
+    s/^import bleach$/from tensorboard._vendor import bleach/;
+    s/^from bleach/from tensorboard._vendor.bleach/;
+    s/^import webencodings$/from tensorboard._vendor import webencodings/;
+    s/^from webencodings/from tensorboard._vendor.webencodings/;
+  ' {} +
+
+pushd pip-src
+%{python3} -m pip wheel --no-build-isolation --no-deps -w dist .
+popd
 
 %install
-%py3_install_wheel %{srcname}-%{version}-py3-none-any.whl
+pushd pip-src
+%{python3} -m pip install --no-build-isolation --no-deps \
+    --root %{buildroot} --prefix %{_prefix} \
+    dist/*.whl
+popd
 
 %files
-%license %{python3_sitelib}/%{srcname}-%{version}.dist-info/licenses/LICENSE
+%license pip-src/LICENSE
 %{_bindir}/%{srcname}
 %{python3_sitelib}/%{srcname}/
 %{python3_sitelib}/%{srcname}-%{version}.dist-info/

--- a/SPECS/python-tensorboard/python-tensorboard.spec
+++ b/SPECS/python-tensorboard/python-tensorboard.spec
@@ -33,8 +33,6 @@ your TensorFlow runs and graphs.
 %prep
 %autosetup -n %{srcname}-%{version}
 
-# The upstream pip-package helper creates a virtualenv and tries to upgrade
-# build tools from PyPI. Use RPM-provided Python build tools instead.
 perl -pi \
   -e 's/virtualenv -q -p python3 venv/virtualenv -q --system-site-packages -p python3 venv/;' \
   -e 's/^[ \t]*pip\s+install\s+.*/  python -c "import setuptools, wheel"/;' \

--- a/SPECS/python-tensorboard/python-tensorboard.spec
+++ b/SPECS/python-tensorboard/python-tensorboard.spec
@@ -12,13 +12,16 @@ Release:        %autorelease
 Summary:        TensorBoard lets you watch Tensors Flow
 License:        Apache-2.0
 URL:            https://github.com/tensorflow/tensorboard
-# PyPI does not publish an sdist for 2.20.0, so use the upstream wheel.
-#!RemoteAsset:  sha256:9dc9f978cb84c0723acf9a345d96c184f0293d18f166bb8d59ee098e6cfaaba6
-Source0:        https://files.pythonhosted.org/packages/9c/d9/a5db55f88f258ac669a92858b70a714bbbd5acd993820b41ec4a96a4d77f/%{srcname}-%{version}-py3-none-any.whl
+#!RemoteAsset:  sha256:7a3b3bb111a9734fd051bd34e763ae90b0a76a2549e74ec75ebcba752ba5a21a
+Source0:        https://github.com/tensorflow/tensorboard/archive/refs/tags/%{version}.tar.gz#/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 
+BuildRequires:  bazel
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(virtualenv)
+BuildRequires:  python3dist(wheel)
 
 Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
@@ -28,10 +31,19 @@ TensorBoard is a suite of web applications for inspecting and understanding
 your TensorFlow runs and graphs.
 
 %prep
+%autosetup -n %{srcname}-%{version}
+
+# The upstream pip-package helper creates a virtualenv and tries to upgrade
+# build tools from PyPI. Use RPM-provided Python build tools instead.
+perl -pi \
+  -e 's/virtualenv -q -p python3 venv/virtualenv -q --system-site-packages -p python3 venv/;' \
+  -e 's/^[ \t]*pip\s+install\s+.*/  python -c "import setuptools, wheel"/;' \
+  tensorboard/pip_package/build_pip_package.sh
 
 %build
 mkdir -p dist
-cp %{SOURCE0} dist/
+bazel build //tensorboard/pip_package:pip_package
+tar -xzf bazel-bin/tensorboard/pip_package/pip_packages.tar.gz -C dist
 
 %install
 %py3_install_wheel %{srcname}-%{version}-py3-none-any.whl

--- a/SPECS/python-tensorboard/python-tensorboard.spec
+++ b/SPECS/python-tensorboard/python-tensorboard.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Zitao Zhou <zitao.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname tensorboard
+
+Name:           python-%{srcname}
+Version:        2.20.0
+Release:        %autorelease
+Summary:        TensorBoard lets you watch Tensors Flow
+License:        Apache-2.0
+URL:            https://github.com/tensorflow/tensorboard
+# PyPI does not publish an sdist for 2.20.0, so use the upstream wheel.
+#!RemoteAsset:  sha256:9dc9f978cb84c0723acf9a345d96c184f0293d18f166bb8d59ee098e6cfaaba6
+Source0:        https://files.pythonhosted.org/packages/9c/d9/a5db55f88f258ac669a92858b70a714bbbd5acd993820b41ec4a96a4d77f/%{srcname}-%{version}-py3-none-any.whl
+BuildArch:      noarch
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(pip)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+TensorBoard is a suite of web applications for inspecting and understanding
+your TensorFlow runs and graphs.
+
+%prep
+
+%build
+mkdir -p dist
+cp %{SOURCE0} dist/
+
+%install
+%py3_install_wheel %{srcname}-%{version}-py3-none-any.whl
+
+%files
+%license %{python3_sitelib}/%{srcname}-%{version}.dist-info/licenses/LICENSE
+%{_bindir}/%{srcname}
+%{python3_sitelib}/%{srcname}/
+%{python3_sitelib}/%{srcname}-%{version}.dist-info/
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary
- add a new `python-tensorboard` spec
- package TensorBoard 2.20.0 from the upstream wheel because PyPI does not publish an sdist for this release

## Validation
- ran `spec-formatter --config /Users/catherina/Documents/OERV/spec-formatter/config.yaml SPECS/python-tensorboard/python-tensorboard.spec`
- verified the PR branch contains only the TensorBoard commit on top of `origin/main`
- re-signed the commit with the work GPG key and work email
