### PR TITLE
SPECS: Add python-ruff rustcrates dependencies (part 1)

### DIFF
--- a/SPECS/rust-alloca-0.4/rust-alloca.spec
+++ b/SPECS/rust-alloca-0.4/rust-alloca.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name alloca
+%global full_version 0.4.0
+%global pkgname alloca-0.4
+
+Name:           rust-alloca-0.4
+Version:        0.4.0
+Release:        %autorelease
+Summary:        Rust crate "alloca"
+License:        MIT
+URL:            https://github.com/playXE/alloca-rs
+#!RemoteAsset:  sha256:e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(cc-1.0/default) >= 1.2.38
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/stack-clash-protection)
+
+%description
+Source code for takopackized Rust crate "alloca"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-approx-0.5/rust-approx.spec
+++ b/SPECS/rust-approx-0.5/rust-approx.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name approx
+%global full_version 0.5.1
+%global pkgname approx-0.5
+
+Name:           rust-approx-0.5
+Version:        0.5.1
+Release:        %autorelease
+Summary:        Rust crate "approx"
+License:        Apache-2.0
+URL:            https://github.com/brendanzab/approx
+#!RemoteAsset:  sha256:cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(num-traits-0.2) >= 0.2.19
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description
+Source code for takopackized Rust crate "approx"
+
+%package     -n %{name}+num-complex
+Summary:        Approximate floating point equality comparisons and assertions - feature "num-complex"
+Requires:       crate(%{pkgname})
+Requires:       crate(num-complex-0.4/default) >= 0.4.0
+Provides:       crate(%{pkgname}/num-complex)
+
+%description -n %{name}+num-complex
+This metapackage enables feature "num-complex" for the Rust approx crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-argfile-1.0/rust-argfile.spec
+++ b/SPECS/rust-argfile-1.0/rust-argfile.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name argfile
+%global full_version 1.0.0
+%global pkgname argfile-1.0
+
+Name:           rust-argfile-1.0
+Version:        1.0.0
+Release:        %autorelease
+Summary:        Rust crate "argfile"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/rust-cli/argfile
+#!RemoteAsset:  sha256:99489a733dea0d2930bfa59c243146a8513ce7b0991b9d006647687cc61f53e7
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(fs-err-3.0/default) >= 3.3.0
+Requires:       crate(os-str-bytes-7.0/default) >= 7.1.1
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "argfile"
+
+%package     -n %{name}+response
+Summary:        Load additional CLI args from file - feature "response"
+Requires:       crate(%{pkgname})
+Requires:       crate(winsplit-0.1/default) >= 0.1.0
+Provides:       crate(%{pkgname}/response)
+
+%description -n %{name}+response
+This metapackage enables feature "response" for the Rust argfile crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-assert-fs-1.0/rust-assert-fs.spec
+++ b/SPECS/rust-assert-fs-1.0/rust-assert-fs.spec
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name assert_fs
+%global full_version 1.1.3
+%global pkgname assert-fs-1.0
+
+Name:           rust-assert-fs-1.0
+Version:        1.1.3
+Release:        %autorelease
+Summary:        Rust crate "assert_fs"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/assert-rs/assert_fs
+#!RemoteAsset:  sha256:a652f6cb1f516886fcfee5e7a5c078b9ade62cfcb889524efe5a64d682dd27a9
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(anstyle-1.0/default) >= 1.0.14
+Requires:       crate(doc-comment-0.3/default) >= 0.3.3
+Requires:       crate(globwalk-0.9/default) >= 0.9.1
+Requires:       crate(predicates-3.0/diff) >= 3.1.3
+Requires:       crate(predicates-core-1.0/default) >= 1.0.9
+Requires:       crate(predicates-tree-1.0/default) >= 1.0.12
+Requires:       crate(tempfile-3.0/default) >= 3.27.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "assert_fs"
+
+%package     -n %{name}+color
+Summary:        Filesystem fixtures and assertions for testing - feature "color" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(anstream-0.6/default) >= 0.6.7
+Requires:       crate(predicates-3.0/color) >= 3.1.3
+Requires:       crate(predicates-3.0/diff) >= 3.1.3
+Provides:       crate(%{pkgname}/color)
+Provides:       crate(%{pkgname}/color-auto)
+
+%description -n %{name}+color
+This metapackage enables feature "color" for the Rust assert_fs crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "color-auto" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-attribute-derive-0.10/rust-attribute-derive.spec
+++ b/SPECS/rust-attribute-derive-0.10/rust-attribute-derive.spec
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name attribute-derive
+%global full_version 0.10.3
+%global pkgname attribute-derive-0.10
+
+Name:           rust-attribute-derive-0.10
+Version:        0.10.3
+Release:        %autorelease
+Summary:        Rust crate "attribute-derive"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/ModProg/attribute-derive
+#!RemoteAsset:  sha256:0053e96dd3bec5b4879c23a138d6ef26f2cb936c9cdc96274ac2b9ed44b5bb54
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(attribute-derive-macro-0.10/default) >= 0.10.3
+Requires:       crate(derive-where-1.0/default) >= 1.6.0
+Requires:       crate(manyhow-0.11/default) >= 0.11.4
+Requires:       crate(proc-macro2-1.0/default) >= 1.0.106
+Requires:       crate(quote-1.0/default) >= 1.0.45
+Requires:       crate(syn-2.0/default) >= 2.0.117
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "attribute-derive"
+
+%package     -n %{name}+syn-full
+Summary:        Clap like parsing for attributes in proc-macros - feature "syn-full"
+Requires:       crate(%{pkgname})
+Requires:       crate(syn-2.0/full) >= 2.0.117
+Provides:       crate(%{pkgname}/syn-full)
+
+%description -n %{name}+syn-full
+This metapackage enables feature "syn-full" for the Rust attribute-derive crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-attribute-derive-macro-0.10/rust-attribute-derive-macro.spec
+++ b/SPECS/rust-attribute-derive-macro-0.10/rust-attribute-derive-macro.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name attribute-derive-macro
+%global full_version 0.10.3
+%global pkgname attribute-derive-macro-0.10
+
+Name:           rust-attribute-derive-macro-0.10
+Version:        0.10.3
+Release:        %autorelease
+Summary:        Rust crate "attribute-derive-macro"
+License:        MIT
+URL:            https://github.com/ModProg/attribute-derive
+#!RemoteAsset:  sha256:463b53ad0fd5b460af4b1915fe045ff4d946d025fb6c4dc3337752eaa980f71b
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(collection-literals-1.0/default) >= 1.0.2
+Requires:       crate(interpolator-0.5/default) >= 0.5.0
+Requires:       crate(interpolator-0.5/iter) >= 0.5.0
+Requires:       crate(manyhow-0.11/default) >= 0.11.4
+Requires:       crate(proc-macro-utils-0.10/default) >= 0.10.0
+Requires:       crate(proc-macro2-1.0/default) >= 1.0.106
+Requires:       crate(quote-1.0/default) >= 1.0.45
+Requires:       crate(quote-use-0.8/default) >= 0.8.4
+Requires:       crate(syn-2.0/default) >= 2.0.117
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "attribute-derive-macro"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-bincode-2.0/rust-bincode.spec
+++ b/SPECS/rust-bincode-2.0/rust-bincode.spec
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name bincode
+%global full_version 2.0.1
+%global pkgname bincode-2.0
+
+Name:           rust-bincode-2.0
+Version:        2.0.1
+Release:        %autorelease
+Summary:        Rust crate "bincode"
+License:        MIT
+URL:            https://github.com/bincode-org/bincode
+#!RemoteAsset:  sha256:36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(unty-0.0.4/default) >= 0.0.4
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "bincode"
+
+%package     -n %{name}+alloc
+Summary:        Binary serialization / deserialization strategy for transforming structs into bytes and vice versa! - feature "alloc"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/alloc) >= 1.0.228
+Provides:       crate(%{pkgname}/alloc)
+
+%description -n %{name}+alloc
+This metapackage enables feature "alloc" for the Rust bincode crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+bincode-derive
+Summary:        Binary serialization / deserialization strategy for transforming structs into bytes and vice versa! - feature "bincode_derive" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(bincode-derive-2.0/default) >= 2.0.1
+Provides:       crate(%{pkgname}/bincode-derive)
+Provides:       crate(%{pkgname}/derive)
+
+%description -n %{name}+bincode-derive
+This metapackage enables feature "bincode_derive" for the Rust bincode crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "derive" feature.
+
+%package     -n %{name}+default
+Summary:        Binary serialization / deserialization strategy for transforming structs into bytes and vice versa! - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/derive)
+Requires:       crate(%{pkgname}/std)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust bincode crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+serde
+Summary:        Binary serialization / deserialization strategy for transforming structs into bytes and vice versa! - feature "serde"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0) >= 1.0.228
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust bincode crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+std
+Summary:        Binary serialization / deserialization strategy for transforming structs into bytes and vice versa! - feature "std"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/alloc)
+Requires:       crate(serde-1.0/std) >= 1.0.228
+Provides:       crate(%{pkgname}/std)
+
+%description -n %{name}+std
+This metapackage enables feature "std" for the Rust bincode crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-bincode-derive-2.0/rust-bincode-derive.spec
+++ b/SPECS/rust-bincode-derive-2.0/rust-bincode-derive.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name bincode_derive
+%global full_version 2.0.1
+%global pkgname bincode-derive-2.0
+
+Name:           rust-bincode-derive-2.0
+Version:        2.0.1
+Release:        %autorelease
+Summary:        Rust crate "bincode_derive"
+License:        MIT
+URL:            https://github.com/bincode-org/bincode
+#!RemoteAsset:  sha256:bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(virtue-0.0.18/default) >= 0.0.18
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "bincode_derive"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-bit-set-0.8/rust-bit-set.spec
+++ b/SPECS/rust-bit-set-0.8/rust-bit-set.spec
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name bit-set
+%global full_version 0.8.0
+%global pkgname bit-set-0.8
+
+Name:           rust-bit-set-0.8
+Version:        0.8.0
+Release:        %autorelease
+Summary:        Rust crate "bit-set"
+License:        Apache-2.0 OR MIT
+URL:            https://github.com/contain-rs/bit-set
+#!RemoteAsset:  sha256:08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(bit-vec-0.8) >= 0.8.0
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "bit-set"
+
+%package     -n %{name}+serde
+Summary:        Set of bits - feature "serde"
+Requires:       crate(%{pkgname})
+Requires:       crate(bit-vec-0.8/serde) >= 0.8.0
+Requires:       crate(serde-1.0/default) >= 1.0.0
+Requires:       crate(serde-1.0/derive) >= 1.0.0
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust bit-set crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+std
+Summary:        Set of bits - feature "std" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(bit-vec-0.8/std) >= 0.8.0
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description -n %{name}+std
+This metapackage enables feature "std" for the Rust bit-set crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "default" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-bit-vec-0.8/rust-bit-vec.spec
+++ b/SPECS/rust-bit-vec-0.8/rust-bit-vec.spec
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name bit-vec
+%global full_version 0.8.0
+%global pkgname bit-vec-0.8
+
+Name:           rust-bit-vec-0.8
+Version:        0.8.0
+Release:        %autorelease
+Summary:        Rust crate "bit-vec"
+License:        Apache-2.0 OR MIT
+URL:            https://github.com/contain-rs/bit-vec
+#!RemoteAsset:  sha256:5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description
+Source code for takopackized Rust crate "bit-vec"
+
+%package     -n %{name}+borsh
+Summary:        Vector of bits - feature "borsh"
+Requires:       crate(%{pkgname})
+Requires:       crate(borsh-1.0/derive) >= 1.5
+Provides:       crate(%{pkgname}/borsh)
+
+%description -n %{name}+borsh
+This metapackage enables feature "borsh" for the Rust bit-vec crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+borsh-std
+Summary:        Vector of bits - feature "borsh_std"
+Requires:       crate(%{pkgname})
+Requires:       crate(borsh-1.0/derive) >= 1.5
+Requires:       crate(borsh-1.0/std) >= 1.5
+Provides:       crate(%{pkgname}/borsh-std)
+
+%description -n %{name}+borsh-std
+This metapackage enables feature "borsh_std" for the Rust bit-vec crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+miniserde
+Summary:        Vector of bits - feature "miniserde"
+Requires:       crate(%{pkgname})
+Requires:       crate(miniserde-0.1/default) >= 0.1.0
+Provides:       crate(%{pkgname}/miniserde)
+
+%description -n %{name}+miniserde
+This metapackage enables feature "miniserde" for the Rust bit-vec crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+nanoserde
+Summary:        Vector of bits - feature "nanoserde"
+Requires:       crate(%{pkgname})
+Requires:       crate(nanoserde-0.1/default) >= 0.1.0
+Provides:       crate(%{pkgname}/nanoserde)
+
+%description -n %{name}+nanoserde
+This metapackage enables feature "nanoserde" for the Rust bit-vec crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+serde
+Summary:        Vector of bits - feature "serde"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/derive) >= 1.0.0
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust bit-vec crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+serde-no-std
+Summary:        Vector of bits - feature "serde_no_std"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/alloc) >= 1.0.0
+Requires:       crate(serde-1.0/derive) >= 1.0.0
+Provides:       crate(%{pkgname}/serde-no-std)
+
+%description -n %{name}+serde-no-std
+This metapackage enables feature "serde_no_std" for the Rust bit-vec crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+serde-std
+Summary:        Vector of bits - feature "serde_std"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/std)
+Requires:       crate(serde-1.0/derive) >= 1.0.0
+Requires:       crate(serde-1.0/std) >= 1.0.0
+Provides:       crate(%{pkgname}/serde-std)
+
+%description -n %{name}+serde-std
+This metapackage enables feature "serde_std" for the Rust bit-vec crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-bitflags-1.0/rust-bitflags.spec
+++ b/SPECS/rust-bitflags-1.0/rust-bitflags.spec
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name bitflags
+%global full_version 1.3.2
+%global pkgname bitflags-1.0
+
+Name:           rust-bitflags-1.0
+Version:        1.3.2
+Release:        %autorelease
+Summary:        Rust crate "bitflags"
+License:        MIT/Apache-2.0
+URL:            https://github.com/bitflags/bitflags
+#!RemoteAsset:  sha256:bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/example-generated)
+
+%description
+Source code for takopackized Rust crate "bitflags"
+
+%package     -n %{name}+compiler-builtins
+Summary:        Macro to generate structures which behave like bitflags - feature "compiler_builtins"
+Requires:       crate(%{pkgname})
+Requires:       crate(compiler-builtins-0.1/default) >= 0.1.2
+Provides:       crate(%{pkgname}/compiler-builtins)
+
+%description -n %{name}+compiler-builtins
+This metapackage enables feature "compiler_builtins" for the Rust bitflags crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+core
+Summary:        Macro to generate structures which behave like bitflags - feature "core"
+Requires:       crate(%{pkgname})
+Requires:       crate(rustc-std-workspace-core-1.0/default) >= 1.0.0
+Provides:       crate(%{pkgname}/core)
+
+%description -n %{name}+core
+This metapackage enables feature "core" for the Rust bitflags crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+rustc-dep-of-std
+Summary:        Macro to generate structures which behave like bitflags - feature "rustc-dep-of-std"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/compiler-builtins)
+Requires:       crate(%{pkgname}/core)
+Provides:       crate(%{pkgname}/rustc-dep-of-std)
+
+%description -n %{name}+rustc-dep-of-std
+This metapackage enables feature "rustc-dep-of-std" for the Rust bitflags crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-boxcar-0.2/rust-boxcar.spec
+++ b/SPECS/rust-boxcar-0.2/rust-boxcar.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name boxcar
+%global full_version 0.2.14
+%global pkgname boxcar-0.2
+
+Name:           rust-boxcar-0.2
+Version:        0.2.14
+Release:        %autorelease
+Summary:        Rust crate "boxcar"
+License:        MIT
+URL:            https://github.com/ibraheemdev/boxcar
+#!RemoteAsset:  sha256:36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "boxcar"
+
+%package     -n %{name}+loom
+Summary:        Concurrent, append-only vector - feature "loom"
+Requires:       crate(%{pkgname})
+Requires:       crate(loom-0.7/default) >= 0.7.0
+Provides:       crate(%{pkgname}/loom)
+
+%description -n %{name}+loom
+This metapackage enables feature "loom" for the Rust boxcar crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-cachedir-0.3/rust-cachedir.spec
+++ b/SPECS/rust-cachedir-0.3/rust-cachedir.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name cachedir
+%global full_version 0.3.1
+%global pkgname cachedir-0.3
+
+Name:           rust-cachedir-0.3
+Version:        0.3.1
+Release:        %autorelease
+Summary:        Rust crate "cachedir"
+License:        MIT
+URL:            https://github.com/jstasiak/cachedir
+#!RemoteAsset:  sha256:4703f3937077db8fa35bee3c8789343c1aec2585f0146f09d658d4ccc0e8d873
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(tempfile-3.0/default) >= 3.27.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "cachedir"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-camino-1.0/rust-camino.spec
+++ b/SPECS/rust-camino-1.0/rust-camino.spec
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name camino
+%global full_version 1.2.2
+%global pkgname camino-1.0
+
+Name:           rust-camino-1.0
+Version:        1.2.2
+Release:        %autorelease
+Summary:        Rust crate "camino"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/camino-rs/camino
+#!RemoteAsset:  sha256:e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "camino"
+
+%package     -n %{name}+proptest1
+Summary:        UTF-8 paths - feature "proptest1"
+Requires:       crate(%{pkgname})
+Requires:       crate(proptest-1.0/default) >= 1.0.0
+Provides:       crate(%{pkgname}/proptest1)
+
+%description -n %{name}+proptest1
+This metapackage enables feature "proptest1" for the Rust camino crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+serde1
+Summary:        UTF-8 paths - feature "serde1"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-core-1.0/default) >= 1.0.228
+Provides:       crate(%{pkgname}/serde1)
+
+%description -n %{name}+serde1
+This metapackage enables feature "serde1" for the Rust camino crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-castaway-0.2/rust-castaway.spec
+++ b/SPECS/rust-castaway-0.2/rust-castaway.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name castaway
+%global full_version 0.2.4
+%global pkgname castaway-0.2
+
+Name:           rust-castaway-0.2
+Version:        0.2.4
+Release:        %autorelease
+Summary:        Rust crate "castaway"
+License:        MIT
+URL:            https://github.com/sagebind/castaway
+#!RemoteAsset:  sha256:dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(rustversion-1.0/default) >= 1.0.22
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/alloc)
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description
+Source code for takopackized Rust crate "castaway"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-chacha20-0.10/rust-chacha20.spec
+++ b/SPECS/rust-chacha20-0.10/rust-chacha20.spec
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name chacha20
+%global full_version 0.10.0
+%global pkgname chacha20-0.10
+
+Name:           rust-chacha20-0.10
+Version:        0.10.0
+Release:        %autorelease
+Summary:        Rust crate "chacha20"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/RustCrypto/stream-ciphers
+#!RemoteAsset:  sha256:6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(cfg-if-1.0/default) >= 1.0.3
+Requires:       crate(cpufeatures-0.3/default) >= 0.3.0
+Provides:       crate(%{pkgname})
+
+%description
+Additionally provides the ChaCha8, ChaCha12, XChaCha20, XChaCha12 and XChaCha8 stream ciphers, and also optional rand_core-compatible RNGs based on those ciphers.
+Source code for takopackized Rust crate "chacha20"
+
+%package     -n %{name}+cipher
+Summary:        ChaCha20 stream cipher (RFC 8439) implemented in pure Rust using traits from the RustCrypto `cipher` crate, with optional architecture-specific hardware acceleration (AVX2, SSE2) - feature "cipher" and 3 more
+Requires:       crate(%{pkgname})
+Requires:       crate(cipher-0.5/default) >= 0.5.0
+Requires:       crate(cipher-0.5/stream-wrapper) >= 0.5.0
+Provides:       crate(%{pkgname}/cipher)
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/legacy)
+Provides:       crate(%{pkgname}/xchacha)
+
+%description -n %{name}+cipher
+Additionally provides the ChaCha8, ChaCha12, XChaCha20, XChaCha12 and XChaCha8 stream ciphers, and also optional rand_core-compatible RNGs based on those ciphers.
+This metapackage enables feature "cipher" for the Rust chacha20 crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "default", "legacy", and "xchacha" features.
+
+%package     -n %{name}+rng
+Summary:        ChaCha20 stream cipher (RFC 8439) implemented in pure Rust using traits from the RustCrypto `cipher` crate, with optional architecture-specific hardware acceleration (AVX2, SSE2) - feature "rng"
+Requires:       crate(%{pkgname})
+Requires:       crate(rand-core-0.10) >= 0.10.0
+Provides:       crate(%{pkgname}/rng)
+
+%description -n %{name}+rng
+Additionally provides the ChaCha8, ChaCha12, XChaCha20, XChaCha12 and XChaCha8 stream ciphers, and also optional rand_core-compatible RNGs based on those ciphers.
+This metapackage enables feature "rng" for the Rust chacha20 crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+zeroize
+Summary:        ChaCha20 stream cipher (RFC 8439) implemented in pure Rust using traits from the RustCrypto `cipher` crate, with optional architecture-specific hardware acceleration (AVX2, SSE2) - feature "zeroize"
+Requires:       crate(%{pkgname})
+Requires:       crate(zeroize-1.0) >= 1.8.1
+Provides:       crate(%{pkgname}/zeroize)
+
+%description -n %{name}+zeroize
+Additionally provides the ChaCha8, ChaCha12, XChaCha20, XChaCha12 and XChaCha8 stream ciphers, and also optional rand_core-compatible RNGs based on those ciphers.
+This metapackage enables feature "zeroize" for the Rust chacha20 crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-chrono-0.4/rust-chrono.spec
+++ b/SPECS/rust-chrono-0.4/rust-chrono.spec
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name chrono
+%global full_version 0.4.44
+%global pkgname chrono-0.4
+
+Name:           rust-chrono-0.4
+Version:        0.4.44
+Release:        %autorelease
+Summary:        Rust crate "chrono"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/chronotope/chrono
+#!RemoteAsset:  sha256:c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(num-traits-0.2) >= 0.2.19
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/internal-bench)
+Provides:       crate(%{pkgname}/alloc)
+Provides:       crate(%{pkgname}/core-error)
+Provides:       crate(%{pkgname}/libc)
+Provides:       crate(%{pkgname}/now)
+Provides:       crate(%{pkgname}/oldtime)
+Provides:       crate(%{pkgname}/std)
+
+%description
+Source code for takopackized Rust crate "chrono"
+
+%package     -n %{name}+arbitrary
+Summary:        Date and time library for Rust - feature "arbitrary"
+Requires:       crate(%{pkgname})
+Requires:       crate(arbitrary-1.0/default) >= 1.0.0
+Requires:       crate(arbitrary-1.0/derive) >= 1.0.0
+Provides:       crate(%{pkgname}/arbitrary)
+
+%description -n %{name}+arbitrary
+This metapackage enables feature "arbitrary" for the Rust chrono crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+clock
+Summary:        Date and time library for Rust - feature "clock"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/iana-time-zone)
+Requires:       crate(%{pkgname}/now)
+Requires:       crate(%{pkgname}/winapi)
+Provides:       crate(%{pkgname}/clock)
+
+%description -n %{name}+clock
+This metapackage enables feature "clock" for the Rust chrono crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+default
+Summary:        Date and time library for Rust - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/clock)
+Requires:       crate(%{pkgname}/oldtime)
+Requires:       crate(%{pkgname}/std)
+Requires:       crate(%{pkgname}/wasmbind)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust chrono crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+defmt
+Summary:        Date and time library for Rust - feature "defmt"
+Requires:       crate(%{pkgname})
+Requires:       crate(defmt-1.0/default) >= 1.0.1
+Requires:       crate(pure-rust-locales-0.8/defmt) >= 0.8.2
+Provides:       crate(%{pkgname}/defmt)
+
+%description -n %{name}+defmt
+This metapackage enables feature "defmt" for the Rust chrono crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+iana-time-zone
+Summary:        Date and time library for Rust - feature "iana-time-zone"
+Requires:       crate(%{pkgname})
+Requires:       crate(iana-time-zone-0.1/default) >= 0.1.64
+Requires:       crate(iana-time-zone-0.1/fallback) >= 0.1.64
+Provides:       crate(%{pkgname}/iana-time-zone)
+
+%description -n %{name}+iana-time-zone
+This metapackage enables feature "iana-time-zone" for the Rust chrono crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+js-sys
+Summary:        Date and time library for Rust - feature "js-sys"
+Requires:       crate(%{pkgname})
+Requires:       crate(js-sys-0.3/default) >= 0.3.0
+Provides:       crate(%{pkgname}/js-sys)
+
+%description -n %{name}+js-sys
+This metapackage enables feature "js-sys" for the Rust chrono crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+pure-rust-locales
+Summary:        Date and time library for Rust - feature "pure-rust-locales" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(pure-rust-locales-0.8/default) >= 0.8.2
+Provides:       crate(%{pkgname}/pure-rust-locales)
+Provides:       crate(%{pkgname}/unstable-locales)
+
+%description -n %{name}+pure-rust-locales
+This metapackage enables feature "pure-rust-locales" for the Rust chrono crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "unstable-locales" feature.
+
+%package     -n %{name}+rkyv
+Summary:        Date and time library for Rust - feature "rkyv" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(rkyv-0.7) >= 0.7.43
+Requires:       crate(rkyv-0.7/size-32) >= 0.7.43
+Provides:       crate(%{pkgname}/rkyv)
+Provides:       crate(%{pkgname}/rkyv-32)
+
+%description -n %{name}+rkyv
+This metapackage enables feature "rkyv" for the Rust chrono crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "rkyv-32" feature.
+
+%package     -n %{name}+rkyv-16
+Summary:        Date and time library for Rust - feature "rkyv-16"
+Requires:       crate(%{pkgname})
+Requires:       crate(rkyv-0.7) >= 0.7.43
+Requires:       crate(rkyv-0.7/size-16) >= 0.7.43
+Provides:       crate(%{pkgname}/rkyv-16)
+
+%description -n %{name}+rkyv-16
+This metapackage enables feature "rkyv-16" for the Rust chrono crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+rkyv-64
+Summary:        Date and time library for Rust - feature "rkyv-64"
+Requires:       crate(%{pkgname})
+Requires:       crate(rkyv-0.7) >= 0.7.43
+Requires:       crate(rkyv-0.7/size-64) >= 0.7.43
+Provides:       crate(%{pkgname}/rkyv-64)
+
+%description -n %{name}+rkyv-64
+This metapackage enables feature "rkyv-64" for the Rust chrono crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+rkyv-validation
+Summary:        Date and time library for Rust - feature "rkyv-validation"
+Requires:       crate(%{pkgname})
+Requires:       crate(rkyv-0.7/validation) >= 0.7.43
+Provides:       crate(%{pkgname}/rkyv-validation)
+
+%description -n %{name}+rkyv-validation
+This metapackage enables feature "rkyv-validation" for the Rust chrono crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+serde
+Summary:        Date and time library for Rust - feature "serde"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0) >= 1.0.99
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust chrono crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+wasm-bindgen
+Summary:        Date and time library for Rust - feature "wasm-bindgen"
+Requires:       crate(%{pkgname})
+Requires:       crate(wasm-bindgen-0.2/default) >= 0.2.0
+Provides:       crate(%{pkgname}/wasm-bindgen)
+
+%description -n %{name}+wasm-bindgen
+This metapackage enables feature "wasm-bindgen" for the Rust chrono crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+wasmbind
+Summary:        Date and time library for Rust - feature "wasmbind"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/js-sys)
+Requires:       crate(%{pkgname}/wasm-bindgen)
+Provides:       crate(%{pkgname}/wasmbind)
+
+%description -n %{name}+wasmbind
+This metapackage enables feature "wasmbind" for the Rust chrono crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+windows-link
+Summary:        Date and time library for Rust - feature "windows-link" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(windows-link-0.2/default) >= 0.2.0
+Provides:       crate(%{pkgname}/winapi)
+Provides:       crate(%{pkgname}/windows-link)
+
+%description -n %{name}+windows-link
+This metapackage enables feature "windows-link" for the Rust chrono crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "winapi" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-clap-complete-command-0.6/rust-clap-complete-command.spec
+++ b/SPECS/rust-clap-complete-command-0.6/rust-clap-complete-command.spec
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name clap_complete_command
+%global full_version 0.6.1
+%global pkgname clap-complete-command-0.6
+
+Name:           rust-clap-complete-command-0.6
+Version:        0.6.1
+Release:        %autorelease
+Summary:        Rust crate "clap_complete_command"
+License:        MIT
+URL:            https://github.com/nihaals/clap-complete-command
+#!RemoteAsset:  sha256:da8e198c052315686d36371e8a3c5778b7852fc75cc313e4e11eeb7a644a1b62
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(clap-4.0/default) >= 4.6.1
+Requires:       crate(clap-complete-4.0/default) >= 4.5.58
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "clap_complete_command"
+
+%package     -n %{name}+carapace
+Summary:        Reduces boilerplate for adding a shell completion command to Clap - feature "carapace"
+Requires:       crate(%{pkgname})
+Requires:       crate(carapace-spec-clap-1.0/default) >= 1.0.0
+Provides:       crate(%{pkgname}/carapace)
+
+%description -n %{name}+carapace
+This metapackage enables feature "carapace" for the Rust clap_complete_command crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+fig
+Summary:        Reduces boilerplate for adding a shell completion command to Clap - feature "fig"
+Requires:       crate(%{pkgname})
+Requires:       crate(clap-complete-fig-4.0/default) >= 4.0.0
+Provides:       crate(%{pkgname}/fig)
+
+%description -n %{name}+fig
+This metapackage enables feature "fig" for the Rust clap_complete_command crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+nushell
+Summary:        Reduces boilerplate for adding a shell completion command to Clap - feature "nushell" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(clap-complete-nushell-4.0/default) >= 4.5.8
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/nushell)
+
+%description -n %{name}+nushell
+This metapackage enables feature "nushell" for the Rust clap_complete_command crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "default" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-clap-complete-nushell-4.0/rust-clap-complete-nushell.spec
+++ b/SPECS/rust-clap-complete-nushell-4.0/rust-clap-complete-nushell.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name clap_complete_nushell
+%global full_version 4.5.8
+%global pkgname clap-complete-nushell-4.0
+
+Name:           rust-clap-complete-nushell-4.0
+Version:        4.5.8
+Release:        %autorelease
+Summary:        Rust crate "clap_complete_nushell"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/clap-rs/clap
+#!RemoteAsset:  sha256:0a0c951694691e65bf9d421d597d68416c22de9632e884c28412cb8cd8b73dce
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(clap-4.0/std) >= 4.6.1
+Requires:       crate(clap-complete-4.0/default) >= 4.5.58
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "clap_complete_nushell"
+
+%package     -n %{name}+unstable-shell-tests
+Summary:        Generator library used with clap for Nushell completion scripts - feature "unstable-shell-tests"
+Requires:       crate(%{pkgname})
+Requires:       crate(completest-0.4/default) >= 0.4.0
+Requires:       crate(completest-nu-0.4/default) >= 0.4.0
+Provides:       crate(%{pkgname}/unstable-shell-tests)
+
+%description -n %{name}+unstable-shell-tests
+This metapackage enables feature "unstable-shell-tests" for the Rust clap_complete_nushell crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-clearscreen-4.0/rust-clearscreen.spec
+++ b/SPECS/rust-clearscreen-4.0/rust-clearscreen.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name clearscreen
+%global full_version 4.0.6
+%global pkgname clearscreen-4.0
+
+Name:           rust-clearscreen-4.0
+Version:        4.0.6
+Release:        %autorelease
+Summary:        Rust crate "clearscreen"
+License:        Apache-2.0 OR MIT
+URL:            https://github.com/watchexec/clearscreen
+#!RemoteAsset:  sha256:d669bb552908e336ad5681789752033b45566b7e591aeaac7a614e58e5d6d8f2
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(nix-0.31/fs) >= 0.31.2
+Requires:       crate(nix-0.31/term) >= 0.31.2
+Requires:       crate(terminfo-0.9/default) >= 0.9.0
+Requires:       crate(thiserror-2.0/default) >= 2.0.18
+Requires:       crate(which-8.0/default) >= 8.0.2
+Requires:       crate(windows-sys-0.59/win32-foundation) >= 0.59.0
+Requires:       crate(windows-sys-0.59/win32-networkmanagement-netmanagement) >= 0.59.0
+Requires:       crate(windows-sys-0.59/win32-system-console) >= 0.59.0
+Requires:       crate(windows-sys-0.59/win32-system-systeminformation) >= 0.59.0
+Requires:       crate(windows-sys-0.59/win32-system-systemservices) >= 0.59.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/windows-console)
+
+%description
+Source code for takopackized Rust crate "clearscreen"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-codspeed-4.0/rust-codspeed.spec
+++ b/SPECS/rust-codspeed-4.0/rust-codspeed.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name codspeed
+%global full_version 4.4.1
+%global pkgname codspeed-4.0
+
+Name:           rust-codspeed-4.0
+Version:        4.4.1
+Release:        %autorelease
+Summary:        Rust crate "codspeed"
+License:        MIT OR Apache-2.0
+URL:            https://codspeed.io
+#!RemoteAsset:  sha256:b684e94583e85a5ca7e1a6454a89d76a5121240f2fb67eb564129d9bafdb9db0
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(anyhow-1.0/default) >= 1.0.102
+Requires:       crate(cc-1.0/default) >= 1.2.38
+Requires:       crate(colored-2.0/default) >= 2.2.0
+Requires:       crate(getrandom-0.2/default) >= 0.2.16
+Requires:       crate(glob-0.3/default) >= 0.3.3
+Requires:       crate(libc-0.2/default) >= 0.2.186
+Requires:       crate(nix-0.31/default) >= 0.31.2
+Requires:       crate(nix-0.31/time) >= 0.31.2
+Requires:       crate(serde-1.0/default) >= 1.0.228
+Requires:       crate(serde-1.0/derive) >= 1.0.228
+Requires:       crate(serde-json-1.0/default) >= 1.0.149
+Requires:       crate(statrs-0.18) >= 0.18.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "codspeed"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-codspeed-criterion-compat-4.0/rust-codspeed-criterion-compat.spec
+++ b/SPECS/rust-codspeed-criterion-compat-4.0/rust-codspeed-criterion-compat.spec
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name codspeed-criterion-compat
+%global full_version 4.4.1
+%global pkgname codspeed-criterion-compat-4.0
+
+Name:           rust-codspeed-criterion-compat-4.0
+Version:        4.4.1
+Release:        %autorelease
+Summary:        Rust crate "codspeed-criterion-compat"
+License:        MIT OR Apache-2.0
+URL:            https://codspeed.io
+#!RemoteAsset:  sha256:2e65444156eb73ad7f57618188f8d4a281726d133ef55b96d1dcff89528609ab
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(clap-4.0/std) >= 4.6.1
+Requires:       crate(codspeed-4.0/default) >= 4.4.1
+Requires:       crate(codspeed-criterion-compat-walltime-4.0) >= 4.4.1
+Requires:       crate(colored-2.0/default) >= 2.2.0
+Requires:       crate(regex-1.0/std) >= 1.12.3
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "codspeed-criterion-compat"
+
+%package     -n %{name}+async
+Summary:        Criterion.rs compatibility layer for CodSpeed - feature "async"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/futures)
+Requires:       crate(codspeed-criterion-compat-walltime-4.0/async) >= 4.4.1
+Provides:       crate(%{pkgname}/async)
+
+%description -n %{name}+async
+This metapackage enables feature "async" for the Rust codspeed-criterion-compat crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+async-futures
+Summary:        Criterion.rs compatibility layer for CodSpeed - feature "async_futures"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/async)
+Requires:       crate(codspeed-criterion-compat-walltime-4.0/async-futures) >= 4.4.1
+Requires:       crate(futures-0.3/executor) >= 0.3.0
+Provides:       crate(%{pkgname}/async-futures)
+
+%description -n %{name}+async-futures
+This metapackage enables feature "async_futures" for the Rust codspeed-criterion-compat crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+async-smol
+Summary:        Criterion.rs compatibility layer for CodSpeed - feature "async_smol"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/async)
+Requires:       crate(%{pkgname}/smol)
+Requires:       crate(codspeed-criterion-compat-walltime-4.0/async-smol) >= 4.4.1
+Provides:       crate(%{pkgname}/async-smol)
+
+%description -n %{name}+async-smol
+This metapackage enables feature "async_smol" for the Rust codspeed-criterion-compat crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+async-std
+Summary:        Criterion.rs compatibility layer for CodSpeed - feature "async_std"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/async)
+Requires:       crate(async-std-1.0/default) >= 1.12
+Requires:       crate(codspeed-criterion-compat-walltime-4.0/async-std) >= 4.4.1
+Provides:       crate(%{pkgname}/async-std)
+
+%description -n %{name}+async-std
+This metapackage enables feature "async_std" for the Rust codspeed-criterion-compat crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+async-tokio
+Summary:        Criterion.rs compatibility layer for CodSpeed - feature "async_tokio"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/async)
+Requires:       crate(%{pkgname}/tokio)
+Requires:       crate(codspeed-criterion-compat-walltime-4.0/async-tokio) >= 4.4.1
+Provides:       crate(%{pkgname}/async-tokio)
+
+%description -n %{name}+async-tokio
+This metapackage enables feature "async_tokio" for the Rust codspeed-criterion-compat crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+cargo-bench-support
+Summary:        Criterion.rs compatibility layer for CodSpeed - feature "cargo_bench_support"
+Requires:       crate(%{pkgname})
+Requires:       crate(codspeed-criterion-compat-walltime-4.0/cargo-bench-support) >= 4.4.1
+Provides:       crate(%{pkgname}/cargo-bench-support)
+
+%description -n %{name}+cargo-bench-support
+This metapackage enables feature "cargo_bench_support" for the Rust codspeed-criterion-compat crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+csv-output
+Summary:        Criterion.rs compatibility layer for CodSpeed - feature "csv_output"
+Requires:       crate(%{pkgname})
+Requires:       crate(codspeed-criterion-compat-walltime-4.0/csv-output) >= 4.4.1
+Provides:       crate(%{pkgname}/csv-output)
+
+%description -n %{name}+csv-output
+This metapackage enables feature "csv_output" for the Rust codspeed-criterion-compat crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+default
+Summary:        Criterion.rs compatibility layer for CodSpeed - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/cargo-bench-support)
+Requires:       crate(%{pkgname}/plotters)
+Requires:       crate(%{pkgname}/rayon)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust codspeed-criterion-compat crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+futures
+Summary:        Criterion.rs compatibility layer for CodSpeed - feature "futures"
+Requires:       crate(%{pkgname})
+Requires:       crate(futures-0.3) >= 0.3.0
+Provides:       crate(%{pkgname}/futures)
+
+%description -n %{name}+futures
+This metapackage enables feature "futures" for the Rust codspeed-criterion-compat crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+html-reports
+Summary:        Criterion.rs compatibility layer for CodSpeed - feature "html_reports"
+Requires:       crate(%{pkgname})
+Requires:       crate(codspeed-criterion-compat-walltime-4.0/html-reports) >= 4.4.1
+Provides:       crate(%{pkgname}/html-reports)
+
+%description -n %{name}+html-reports
+This metapackage enables feature "html_reports" for the Rust codspeed-criterion-compat crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+plotters
+Summary:        Criterion.rs compatibility layer for CodSpeed - feature "plotters"
+Requires:       crate(%{pkgname})
+Requires:       crate(codspeed-criterion-compat-walltime-4.0/plotters) >= 4.4.1
+Provides:       crate(%{pkgname}/plotters)
+
+%description -n %{name}+plotters
+This metapackage enables feature "plotters" for the Rust codspeed-criterion-compat crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+rayon
+Summary:        Criterion.rs compatibility layer for CodSpeed - feature "rayon"
+Requires:       crate(%{pkgname})
+Requires:       crate(codspeed-criterion-compat-walltime-4.0/rayon) >= 4.4.1
+Provides:       crate(%{pkgname}/rayon)
+
+%description -n %{name}+rayon
+This metapackage enables feature "rayon" for the Rust codspeed-criterion-compat crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+smol
+Summary:        Criterion.rs compatibility layer for CodSpeed - feature "smol"
+Requires:       crate(%{pkgname})
+Requires:       crate(smol-2.0) >= 2.0.0
+Provides:       crate(%{pkgname}/smol)
+
+%description -n %{name}+smol
+This metapackage enables feature "smol" for the Rust codspeed-criterion-compat crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+tokio
+Summary:        Criterion.rs compatibility layer for CodSpeed - feature "tokio"
+Requires:       crate(%{pkgname})
+Requires:       crate(tokio-1.0/rt) >= 1.39
+Provides:       crate(%{pkgname}/tokio)
+
+%description -n %{name}+tokio
+This metapackage enables feature "tokio" for the Rust codspeed-criterion-compat crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-codspeed-criterion-compat-walltime-4.0/rust-codspeed-criterion-compat-walltime.spec
+++ b/SPECS/rust-codspeed-criterion-compat-walltime-4.0/rust-codspeed-criterion-compat-walltime.spec
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name codspeed-criterion-compat-walltime
+%global full_version 4.4.1
+%global pkgname codspeed-criterion-compat-walltime-4.0
+
+Name:           rust-codspeed-criterion-compat-walltime-4.0
+Version:        4.4.1
+Release:        %autorelease
+Summary:        Rust crate "codspeed-criterion-compat-walltime"
+License:        Apache-2.0 OR MIT
+URL:            https://codspeed.io
+#!RemoteAsset:  sha256:96389aaa4bbb872ea4924dc0335b2bb181bcf28d6eedbe8fea29afcc5bde36a6
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(anes-0.1/default) >= 0.1.6
+Requires:       crate(cast-0.3/default) >= 0.3.0
+Requires:       crate(ciborium-0.2/default) >= 0.2.2
+Requires:       crate(clap-4.0/std) >= 4.6.1
+Requires:       crate(codspeed-4.0/default) >= 4.4.1
+Requires:       crate(criterion-plot-0.5/default) >= 0.5.0
+Requires:       crate(is-terminal-0.4/default) >= 0.4.16
+Requires:       crate(itertools-0.10/default) >= 0.10.5
+Requires:       crate(num-traits-0.2/std) >= 0.2.19
+Requires:       crate(once-cell-1.0/default) >= 1.21.3
+Requires:       crate(oorandom-11.0/default) >= 11.1.5
+Requires:       crate(regex-1.0/std) >= 1.12.3
+Requires:       crate(serde-1.0/default) >= 1.0.228
+Requires:       crate(serde-derive-1.0/default) >= 1.0.228
+Requires:       crate(serde-json-1.0/default) >= 1.0.149
+Requires:       crate(tinytemplate-1.0/default) >= 1.2.1
+Requires:       crate(walkdir-2.0/default) >= 2.5.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/cargo-bench-support)
+Provides:       crate(%{pkgname}/html-reports)
+Provides:       crate(%{pkgname}/real-blackbox)
+
+%description
+Source code for takopackized Rust crate "codspeed-criterion-compat-walltime"
+
+%package     -n %{name}+async-futures
+Summary:        Statistics-driven micro-benchmarking library - feature "async_futures"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/async)
+Requires:       crate(futures-0.3/executor) >= 0.3.0
+Provides:       crate(%{pkgname}/async-futures)
+
+%description -n %{name}+async-futures
+This metapackage enables feature "async_futures" for the Rust codspeed-criterion-compat-walltime crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+async-smol
+Summary:        Statistics-driven micro-benchmarking library - feature "async_smol"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/async)
+Requires:       crate(%{pkgname}/smol)
+Provides:       crate(%{pkgname}/async-smol)
+
+%description -n %{name}+async-smol
+This metapackage enables feature "async_smol" for the Rust codspeed-criterion-compat-walltime crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+async-std
+Summary:        Statistics-driven micro-benchmarking library - feature "async_std"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/async)
+Requires:       crate(async-std-1.0/default) >= 1.9
+Provides:       crate(%{pkgname}/async-std)
+
+%description -n %{name}+async-std
+This metapackage enables feature "async_std" for the Rust codspeed-criterion-compat-walltime crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+async-tokio
+Summary:        Statistics-driven micro-benchmarking library - feature "async_tokio"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/async)
+Requires:       crate(%{pkgname}/tokio)
+Provides:       crate(%{pkgname}/async-tokio)
+
+%description -n %{name}+async-tokio
+This metapackage enables feature "async_tokio" for the Rust codspeed-criterion-compat-walltime crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+csv
+Summary:        Statistics-driven micro-benchmarking library - feature "csv" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(csv-1.0/default) >= 1.1
+Provides:       crate(%{pkgname}/csv)
+Provides:       crate(%{pkgname}/csv-output)
+
+%description -n %{name}+csv
+This metapackage enables feature "csv" for the Rust codspeed-criterion-compat-walltime crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "csv_output" feature.
+
+%package     -n %{name}+default
+Summary:        Statistics-driven micro-benchmarking library - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/cargo-bench-support)
+Requires:       crate(%{pkgname}/plotters)
+Requires:       crate(%{pkgname}/rayon)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust codspeed-criterion-compat-walltime crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+futures
+Summary:        Statistics-driven micro-benchmarking library - feature "futures" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(futures-0.3) >= 0.3.0
+Provides:       crate(%{pkgname}/async)
+Provides:       crate(%{pkgname}/futures)
+
+%description -n %{name}+futures
+This metapackage enables feature "futures" for the Rust codspeed-criterion-compat-walltime crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "async" feature.
+
+%package     -n %{name}+plotters
+Summary:        Statistics-driven micro-benchmarking library - feature "plotters"
+Requires:       crate(%{pkgname})
+Requires:       crate(plotters-0.3/area-series) >= 0.3.1
+Requires:       crate(plotters-0.3/line-series) >= 0.3.1
+Requires:       crate(plotters-0.3/svg-backend) >= 0.3.1
+Provides:       crate(%{pkgname}/plotters)
+
+%description -n %{name}+plotters
+This metapackage enables feature "plotters" for the Rust codspeed-criterion-compat-walltime crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+rayon
+Summary:        Statistics-driven micro-benchmarking library - feature "rayon"
+Requires:       crate(%{pkgname})
+Requires:       crate(rayon-1.0/default) >= 1.3
+Provides:       crate(%{pkgname}/rayon)
+
+%description -n %{name}+rayon
+This metapackage enables feature "rayon" for the Rust codspeed-criterion-compat-walltime crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+smol
+Summary:        Statistics-driven micro-benchmarking library - feature "smol"
+Requires:       crate(%{pkgname})
+Requires:       crate(smol-1.0) >= 1.2
+Provides:       crate(%{pkgname}/smol)
+
+%description -n %{name}+smol
+This metapackage enables feature "smol" for the Rust codspeed-criterion-compat-walltime crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+stable
+Summary:        Statistics-driven micro-benchmarking library - feature "stable"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/async-futures)
+Requires:       crate(%{pkgname}/async-smol)
+Requires:       crate(%{pkgname}/async-std)
+Requires:       crate(%{pkgname}/async-tokio)
+Requires:       crate(%{pkgname}/csv-output)
+Requires:       crate(%{pkgname}/html-reports)
+Provides:       crate(%{pkgname}/stable)
+
+%description -n %{name}+stable
+This metapackage enables feature "stable" for the Rust codspeed-criterion-compat-walltime crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+tokio
+Summary:        Statistics-driven micro-benchmarking library - feature "tokio"
+Requires:       crate(%{pkgname})
+Requires:       crate(tokio-1.0/rt) >= 1.0.0
+Provides:       crate(%{pkgname}/tokio)
+
+%description -n %{name}+tokio
+This metapackage enables feature "tokio" for the Rust codspeed-criterion-compat-walltime crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-codspeed-divan-compat-4.0/rust-codspeed-divan-compat.spec
+++ b/SPECS/rust-codspeed-divan-compat-4.0/rust-codspeed-divan-compat.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name codspeed-divan-compat
+%global full_version 4.4.1
+%global pkgname codspeed-divan-compat-4.0
+
+Name:           rust-codspeed-divan-compat-4.0
+Version:        4.4.1
+Release:        %autorelease
+Summary:        Rust crate "codspeed-divan-compat"
+License:        MIT OR Apache-2.0
+URL:            https://codspeed.io
+#!RemoteAsset:  sha256:89e4bf8c7793c170fd0fcf3be97b9032b2ae39c2b9e8818aba3cc10ca0f0c6c0
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(clap-4.0/env) >= 4.6.1
+Requires:       crate(clap-4.0/std) >= 4.6.1
+Requires:       crate(codspeed-4.0/default) >= 4.4.1
+Requires:       crate(codspeed-divan-compat-macros-4.0/default) >= 4.4.1
+Requires:       crate(codspeed-divan-compat-walltime-4.0/default) >= 4.4.1
+Requires:       crate(regex-1.0/default) >= 1.12.3
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "codspeed-divan-compat"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-codspeed-divan-compat-macros-4.0/rust-codspeed-divan-compat-macros.spec
+++ b/SPECS/rust-codspeed-divan-compat-macros-4.0/rust-codspeed-divan-compat-macros.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name codspeed-divan-compat-macros
+%global full_version 4.4.1
+%global pkgname codspeed-divan-compat-macros-4.0
+
+Name:           rust-codspeed-divan-compat-macros-4.0
+Version:        4.4.1
+Release:        %autorelease
+Summary:        Rust crate "codspeed-divan-compat-macros"
+License:        MIT OR Apache-2.0
+URL:            https://codspeed.io
+#!RemoteAsset:  sha256:78aae02f2a278588e16e8ca62ea1915b8ab30f8230a09926671bba19ede801a4
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(divan-macros-0.1/default) >= 0.1.17
+Requires:       crate(itertools-0.14/default) >= 0.14.0
+Requires:       crate(proc-macro-crate-3.0/default) >= 3.4.0
+Requires:       crate(proc-macro2-1.0/default) >= 1.0.106
+Requires:       crate(quote-1.0) >= 1.0.45
+Requires:       crate(syn-2.0/clone-impls) >= 2.0.117
+Requires:       crate(syn-2.0/extra-traits) >= 2.0.117
+Requires:       crate(syn-2.0/full) >= 2.0.117
+Requires:       crate(syn-2.0/parsing) >= 2.0.117
+Requires:       crate(syn-2.0/printing) >= 2.0.117
+Requires:       crate(syn-2.0/proc-macro) >= 2.0.117
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "codspeed-divan-compat-macros"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-codspeed-divan-compat-walltime-4.0/rust-codspeed-divan-compat-walltime.spec
+++ b/SPECS/rust-codspeed-divan-compat-walltime-4.0/rust-codspeed-divan-compat-walltime.spec
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name codspeed-divan-compat-walltime
+%global full_version 4.4.1
+%global pkgname codspeed-divan-compat-walltime-4.0
+
+Name:           rust-codspeed-divan-compat-walltime-4.0
+Version:        4.4.1
+Release:        %autorelease
+Summary:        Rust crate "codspeed-divan-compat-walltime"
+License:        MIT OR Apache-2.0
+URL:            https://codspeed.io
+#!RemoteAsset:  sha256:59ffd32c0c59ab8b674b15be65ba7c59aebac047036cfa7fa1e11bc2c178b81f
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(cfg-if-1.0/default) >= 1.0.3
+Requires:       crate(clap-4.0/env) >= 4.6.1
+Requires:       crate(clap-4.0/std) >= 4.6.1
+Requires:       crate(codspeed-4.0/default) >= 4.4.1
+Requires:       crate(condtype-1.0/default) >= 1.3.0
+Requires:       crate(divan-macros-0.1/default) >= 0.1.17
+Requires:       crate(libc-0.2/default) >= 0.2.186
+Requires:       crate(regex-lite-0.1/std) >= 0.1.7
+Requires:       crate(regex-lite-0.1/string) >= 0.1.7
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/dyn-thread-local)
+Provides:       crate(%{pkgname}/internal-benches)
+
+%description
+Source code for takopackized Rust crate "codspeed-divan-compat-walltime"
+
+%package     -n %{name}+help
+Summary:        Temporary compatibility layer for CodSpeed to use Divan's walltime entrypoint - feature "help"
+Requires:       crate(%{pkgname})
+Requires:       crate(clap-4.0/env) >= 4.6.1
+Requires:       crate(clap-4.0/help) >= 4.6.1
+Requires:       crate(clap-4.0/std) >= 4.6.1
+Provides:       crate(%{pkgname}/help)
+
+%description -n %{name}+help
+This metapackage enables feature "help" for the Rust codspeed-divan-compat-walltime crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+wrap-help
+Summary:        Temporary compatibility layer for CodSpeed to use Divan's walltime entrypoint - feature "wrap_help" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/help)
+Requires:       crate(clap-4.0/env) >= 4.6.1
+Requires:       crate(clap-4.0/std) >= 4.6.1
+Requires:       crate(clap-4.0/wrap-help) >= 4.6.1
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/wrap-help)
+
+%description -n %{name}+wrap-help
+This metapackage enables feature "wrap_help" for the Rust codspeed-divan-compat-walltime crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "default" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-collection-literals-1.0/rust-collection-literals.spec
+++ b/SPECS/rust-collection-literals-1.0/rust-collection-literals.spec
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name collection_literals
+%global full_version 1.0.2
+%global pkgname collection-literals-1.0
+
+Name:           rust-collection-literals-1.0
+Version:        1.0.2
+Release:        %autorelease
+Summary:        Rust crate "collection_literals"
+License:        MIT
+URL:            https://github.com/staedoix/collection_literals
+#!RemoteAsset:  sha256:26b3f65b8fb8e88ba339f7d23a390fe1b0896217da05e2a66c584c9b29a91df8
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "collection_literals"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-colored-3.0/rust-colored.spec
+++ b/SPECS/rust-colored-3.0/rust-colored.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name colored
+%global full_version 3.1.1
+%global pkgname colored-3.0
+
+Name:           rust-colored-3.0
+Version:        3.1.1
+Release:        %autorelease
+Summary:        Rust crate "colored"
+License:        MPL-2.0
+URL:            https://github.com/mackwic/colored
+#!RemoteAsset:  sha256:faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(windows-sys-0.59/default) >= 0.59.0
+Requires:       crate(windows-sys-0.59/win32-foundation) >= 0.59.0
+Requires:       crate(windows-sys-0.59/win32-system-console) >= 0.59.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/no-color)
+
+%description
+Source code for takopackized Rust crate "colored"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-compact-str-0.9/rust-compact-str.spec
+++ b/SPECS/rust-compact-str-0.9/rust-compact-str.spec
@@ -1,0 +1,181 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name compact_str
+%global full_version 0.9.0
+%global pkgname compact-str-0.9
+
+Name:           rust-compact-str-0.9
+Version:        0.9.0
+Release:        %autorelease
+Summary:        Rust crate "compact_str"
+License:        MIT
+URL:            https://github.com/ParkMyCar/compact_str
+#!RemoteAsset:  sha256:3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(castaway-0.2/alloc) >= 0.2.4
+Requires:       crate(cfg-if-1.0/default) >= 1.0.3
+Requires:       crate(itoa-1.0/default) >= 1.0.15
+Requires:       crate(rustversion-1.0/default) >= 1.0.22
+Requires:       crate(ryu-1.0/default) >= 1.0.20
+Requires:       crate(static-assertions-1.0/default) >= 1.1.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description
+Source code for takopackized Rust crate "compact_str"
+
+%package     -n %{name}+arbitrary
+Summary:        Memory efficient string type that transparently stores strings on the stack, when possible - feature "arbitrary"
+Requires:       crate(%{pkgname})
+Requires:       crate(arbitrary-1.0) >= 1.0.0
+Provides:       crate(%{pkgname}/arbitrary)
+
+%description -n %{name}+arbitrary
+This metapackage enables feature "arbitrary" for the Rust compact_str crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+borsh
+Summary:        Memory efficient string type that transparently stores strings on the stack, when possible - feature "borsh"
+Requires:       crate(%{pkgname})
+Requires:       crate(borsh-1.0/default) >= 1.0.0
+Provides:       crate(%{pkgname}/borsh)
+
+%description -n %{name}+borsh
+This metapackage enables feature "borsh" for the Rust compact_str crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+bytes
+Summary:        Memory efficient string type that transparently stores strings on the stack, when possible - feature "bytes"
+Requires:       crate(%{pkgname})
+Requires:       crate(bytes-1.0/default) >= 1.0.0
+Provides:       crate(%{pkgname}/bytes)
+
+%description -n %{name}+bytes
+This metapackage enables feature "bytes" for the Rust compact_str crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+diesel
+Summary:        Memory efficient string type that transparently stores strings on the stack, when possible - feature "diesel"
+Requires:       crate(%{pkgname})
+Requires:       crate(diesel-2.0) >= 2.0.0
+Provides:       crate(%{pkgname}/diesel)
+
+%description -n %{name}+diesel
+This metapackage enables feature "diesel" for the Rust compact_str crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+markup
+Summary:        Memory efficient string type that transparently stores strings on the stack, when possible - feature "markup"
+Requires:       crate(%{pkgname})
+Requires:       crate(markup-0.15) >= 0.15.0
+Provides:       crate(%{pkgname}/markup)
+
+%description -n %{name}+markup
+This metapackage enables feature "markup" for the Rust compact_str crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+proptest
+Summary:        Memory efficient string type that transparently stores strings on the stack, when possible - feature "proptest"
+Requires:       crate(%{pkgname})
+Requires:       crate(proptest-1.0/std) >= 1.0.0
+Provides:       crate(%{pkgname}/proptest)
+
+%description -n %{name}+proptest
+This metapackage enables feature "proptest" for the Rust compact_str crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+quickcheck
+Summary:        Memory efficient string type that transparently stores strings on the stack, when possible - feature "quickcheck"
+Requires:       crate(%{pkgname})
+Requires:       crate(quickcheck-1.0) >= 1.0.0
+Provides:       crate(%{pkgname}/quickcheck)
+
+%description -n %{name}+quickcheck
+This metapackage enables feature "quickcheck" for the Rust compact_str crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+rkyv
+Summary:        Memory efficient string type that transparently stores strings on the stack, when possible - feature "rkyv"
+Requires:       crate(%{pkgname})
+Requires:       crate(rkyv-0.8) >= 0.8.0
+Provides:       crate(%{pkgname}/rkyv)
+
+%description -n %{name}+rkyv
+This metapackage enables feature "rkyv" for the Rust compact_str crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+serde
+Summary:        Memory efficient string type that transparently stores strings on the stack, when possible - feature "serde"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/alloc) >= 1.0.228
+Requires:       crate(serde-1.0/derive) >= 1.0.228
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust compact_str crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+smallvec
+Summary:        Memory efficient string type that transparently stores strings on the stack, when possible - feature "smallvec"
+Requires:       crate(%{pkgname})
+Requires:       crate(smallvec-1.0/default) >= 1.0.0
+Requires:       crate(smallvec-1.0/union) >= 1.0.0
+Provides:       crate(%{pkgname}/smallvec)
+
+%description -n %{name}+smallvec
+This metapackage enables feature "smallvec" for the Rust compact_str crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+sqlx
+Summary:        Memory efficient string type that transparently stores strings on the stack, when possible - feature "sqlx"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/std)
+Requires:       crate(sqlx-0.8) >= 0.8.0
+Provides:       crate(%{pkgname}/sqlx)
+
+%description -n %{name}+sqlx
+This metapackage enables feature "sqlx" for the Rust compact_str crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+sqlx-mysql
+Summary:        Memory efficient string type that transparently stores strings on the stack, when possible - feature "sqlx-mysql"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/sqlx)
+Requires:       crate(sqlx-0.8/mysql) >= 0.8.0
+Provides:       crate(%{pkgname}/sqlx-mysql)
+
+%description -n %{name}+sqlx-mysql
+This metapackage enables feature "sqlx-mysql" for the Rust compact_str crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+sqlx-postgres
+Summary:        Memory efficient string type that transparently stores strings on the stack, when possible - feature "sqlx-postgres"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/sqlx)
+Requires:       crate(sqlx-0.8/postgres) >= 0.8.0
+Provides:       crate(%{pkgname}/sqlx-postgres)
+
+%description -n %{name}+sqlx-postgres
+This metapackage enables feature "sqlx-postgres" for the Rust compact_str crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+sqlx-sqlite
+Summary:        Memory efficient string type that transparently stores strings on the stack, when possible - feature "sqlx-sqlite"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/sqlx)
+Requires:       crate(sqlx-0.8/sqlite) >= 0.8.0
+Provides:       crate(%{pkgname}/sqlx-sqlite)
+
+%description -n %{name}+sqlx-sqlite
+This metapackage enables feature "sqlx-sqlite" for the Rust compact_str crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+zeroize
+Summary:        Memory efficient string type that transparently stores strings on the stack, when possible - feature "zeroize"
+Requires:       crate(%{pkgname})
+Requires:       crate(zeroize-1.0) >= 1.0.0
+Provides:       crate(%{pkgname}/zeroize)
+
+%description -n %{name}+zeroize
+This metapackage enables feature "zeroize" for the Rust compact_str crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-condtype-1.0/rust-condtype.spec
+++ b/SPECS/rust-condtype-1.0/rust-condtype.spec
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name condtype
+%global full_version 1.3.0
+%global pkgname condtype-1.0
+
+Name:           rust-condtype-1.0
+Version:        1.3.0
+Release:        %autorelease
+Summary:        Rust crate "condtype"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/nvzqz/condtype
+#!RemoteAsset:  sha256:baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "condtype"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-console-0.16/rust-console.spec
+++ b/SPECS/rust-console-0.16/rust-console.spec
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name console
+%global full_version 0.16.1
+%global pkgname console-0.16
+
+Name:           rust-console-0.16
+Version:        0.16.1
+Release:        %autorelease
+Summary:        Rust crate "console"
+License:        MIT
+URL:            https://github.com/console-rs/console
+#!RemoteAsset:  sha256:b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(encode-unicode-1.0/default) >= 1.0.0
+Requires:       crate(windows-sys-0.61/default) >= 0.61.0
+Requires:       crate(windows-sys-0.61/win32-foundation) >= 0.61.0
+Requires:       crate(windows-sys-0.61/win32-storage-filesystem) >= 0.61.0
+Requires:       crate(windows-sys-0.61/win32-system-console) >= 0.61.0
+Requires:       crate(windows-sys-0.61/win32-ui-input-keyboardandmouse) >= 0.61.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/alloc)
+Provides:       crate(%{pkgname}/ansi-parsing)
+Provides:       crate(%{pkgname}/windows-console-colors)
+
+%description
+Source code for takopackized Rust crate "console"
+
+%package     -n %{name}+default
+Summary:        Terminal and console abstraction for Rust - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/ansi-parsing)
+Requires:       crate(%{pkgname}/std)
+Requires:       crate(%{pkgname}/unicode-width)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust console crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+std
+Summary:        Terminal and console abstraction for Rust - feature "std"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/alloc)
+Requires:       crate(libc-0.2/default) >= 0.2.186
+Requires:       crate(once-cell-1.0/default) >= 1.21.3
+Provides:       crate(%{pkgname}/std)
+
+%description -n %{name}+std
+This metapackage enables feature "std" for the Rust console crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+unicode-width
+Summary:        Terminal and console abstraction for Rust - feature "unicode-width"
+Requires:       crate(%{pkgname})
+Requires:       crate(unicode-width-0.2/default) >= 0.2.2
+Provides:       crate(%{pkgname}/unicode-width)
+
+%description -n %{name}+unicode-width
+This metapackage enables feature "unicode-width" for the Rust console crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-console-error-panic-hook-0.1/rust-console-error-panic-hook.spec
+++ b/SPECS/rust-console-error-panic-hook-0.1/rust-console-error-panic-hook.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name console_error_panic_hook
+%global full_version 0.1.7
+%global pkgname console-error-panic-hook-0.1
+
+Name:           rust-console-error-panic-hook-0.1
+Version:        0.1.7
+Release:        %autorelease
+Summary:        Rust crate "console_error_panic_hook"
+License:        Apache-2.0/MIT
+URL:            https://github.com/rustwasm/console_error_panic_hook
+#!RemoteAsset:  sha256:a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(cfg-if-1.0/default) >= 1.0.3
+Requires:       crate(wasm-bindgen-0.2/default) >= 0.2.105
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "console_error_panic_hook"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-console-log-1.0/rust-console-log.spec
+++ b/SPECS/rust-console-log-1.0/rust-console-log.spec
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name console_log
+%global full_version 1.0.0
+%global pkgname console-log-1.0
+
+Name:           rust-console-log-1.0
+Version:        1.0.0
+Release:        %autorelease
+Summary:        Rust crate "console_log"
+License:        MIT/Apache-2.0
+URL:            https://github.com/iamcodemaker/console_log
+#!RemoteAsset:  sha256:be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(log-0.4/default) >= 0.4.29
+Requires:       crate(web-sys-0.3/console) >= 0.3.82
+Requires:       crate(web-sys-0.3/default) >= 0.3.82
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "console_log"
+
+%package     -n %{name}+wasm-bindgen
+Summary:        Logging facility that routes Rust log messages to the browser's console - feature "wasm-bindgen" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(wasm-bindgen-0.2/default) >= 0.2.0
+Provides:       crate(%{pkgname}/color)
+Provides:       crate(%{pkgname}/wasm-bindgen)
+
+%description -n %{name}+wasm-bindgen
+This metapackage enables feature "wasm-bindgen" for the Rust console_log crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "color" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-countme-3.0/rust-countme.spec
+++ b/SPECS/rust-countme-3.0/rust-countme.spec
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name countme
+%global full_version 3.0.1
+%global pkgname countme-3.0
+
+Name:           rust-countme-3.0
+Version:        3.0.1
+Release:        %autorelease
+Summary:        Rust crate "countme"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/matklad/countme
+#!RemoteAsset:  sha256:7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "countme"
+
+%package     -n %{name}+dashmap
+Summary:        Counts the number of live instances of types - feature "dashmap"
+Requires:       crate(%{pkgname})
+Requires:       crate(dashmap-5.0/default) >= 5.0.0
+Provides:       crate(%{pkgname}/dashmap)
+
+%description -n %{name}+dashmap
+This metapackage enables feature "dashmap" for the Rust countme crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+enable
+Summary:        Counts the number of live instances of types - feature "enable" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/dashmap)
+Requires:       crate(%{pkgname}/once-cell)
+Requires:       crate(%{pkgname}/rustc-hash)
+Provides:       crate(%{pkgname}/enable)
+Provides:       crate(%{pkgname}/print-at-exit)
+
+%description -n %{name}+enable
+This metapackage enables feature "enable" for the Rust countme crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "print_at_exit" feature.
+
+%package     -n %{name}+once-cell
+Summary:        Counts the number of live instances of types - feature "once_cell"
+Requires:       crate(%{pkgname})
+Requires:       crate(once-cell-1.0/default) >= 1.5
+Provides:       crate(%{pkgname}/once-cell)
+
+%description -n %{name}+once-cell
+This metapackage enables feature "once_cell" for the Rust countme crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+rustc-hash
+Summary:        Counts the number of live instances of types - feature "rustc-hash"
+Requires:       crate(%{pkgname})
+Requires:       crate(rustc-hash-1.0/default) >= 1.1
+Provides:       crate(%{pkgname}/rustc-hash)
+
+%description -n %{name}+rustc-hash
+This metapackage enables feature "rustc-hash" for the Rust countme crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-criterion-0.8/rust-criterion.spec
+++ b/SPECS/rust-criterion-0.8/rust-criterion.spec
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name criterion
+%global full_version 0.8.2
+%global pkgname criterion-0.8
+
+Name:           rust-criterion-0.8
+Version:        0.8.2
+Release:        %autorelease
+Summary:        Rust crate "criterion"
+License:        Apache-2.0 OR MIT
+URL:            https://criterion-rs.github.io/book/index.html
+#!RemoteAsset:  sha256:950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(alloca-0.4/default) >= 0.4.0
+Requires:       crate(anes-0.1/default) >= 0.1.6
+Requires:       crate(cast-0.3/default) >= 0.3.0
+Requires:       crate(ciborium-0.2/default) >= 0.2.2
+Requires:       crate(clap-4.0/help) >= 4.6.1
+Requires:       crate(clap-4.0/std) >= 4.6.1
+Requires:       crate(criterion-plot-0.8/default) >= 0.8.2
+Requires:       crate(itertools-0.13/default) >= 0.13.0
+Requires:       crate(num-traits-0.2/std) >= 0.2.19
+Requires:       crate(oorandom-11.0/default) >= 11.1.5
+Requires:       crate(page-size-0.6/default) >= 0.6.0
+Requires:       crate(regex-1.0/std) >= 1.12.3
+Requires:       crate(serde-1.0/default) >= 1.0.228
+Requires:       crate(serde-1.0/derive) >= 1.0.228
+Requires:       crate(serde-json-1.0/default) >= 1.0.149
+Requires:       crate(tinytemplate-1.0/default) >= 1.2.1
+Requires:       crate(walkdir-2.0/default) >= 2.5.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/async)
+Provides:       crate(%{pkgname}/cargo-bench-support)
+Provides:       crate(%{pkgname}/html-reports)
+Provides:       crate(%{pkgname}/real-blackbox)
+
+%description
+Source code for takopackized Rust crate "criterion"
+
+%package     -n %{name}+async-futures
+Summary:        Statistics-driven micro-benchmarking library - feature "async_futures"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/async)
+Requires:       crate(futures-0.3/executor) >= 0.3.0
+Provides:       crate(%{pkgname}/async-futures)
+
+%description -n %{name}+async-futures
+This metapackage enables feature "async_futures" for the Rust criterion crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+async-smol
+Summary:        Statistics-driven micro-benchmarking library - feature "async_smol"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/async)
+Requires:       crate(smol-2.0) >= 2.0.0
+Provides:       crate(%{pkgname}/async-smol)
+
+%description -n %{name}+async-smol
+This metapackage enables feature "async_smol" for the Rust criterion crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+async-tokio
+Summary:        Statistics-driven micro-benchmarking library - feature "async_tokio"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/async)
+Requires:       crate(tokio-1.0/rt) >= 1.0.0
+Provides:       crate(%{pkgname}/async-tokio)
+
+%description -n %{name}+async-tokio
+This metapackage enables feature "async_tokio" for the Rust criterion crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+csv-output
+Summary:        Statistics-driven micro-benchmarking library - feature "csv_output"
+Requires:       crate(%{pkgname})
+Requires:       crate(csv-1.0/default) >= 1.1
+Provides:       crate(%{pkgname}/csv-output)
+
+%description -n %{name}+csv-output
+This metapackage enables feature "csv_output" for the Rust criterion crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+default
+Summary:        Statistics-driven micro-benchmarking library - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/cargo-bench-support)
+Requires:       crate(%{pkgname}/plotters)
+Requires:       crate(%{pkgname}/rayon)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust criterion crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+plotters
+Summary:        Statistics-driven micro-benchmarking library - feature "plotters"
+Requires:       crate(%{pkgname})
+Requires:       crate(plotters-0.3/area-series) >= 0.3.2
+Requires:       crate(plotters-0.3/line-series) >= 0.3.2
+Requires:       crate(plotters-0.3/svg-backend) >= 0.3.2
+Provides:       crate(%{pkgname}/plotters)
+
+%description -n %{name}+plotters
+This metapackage enables feature "plotters" for the Rust criterion crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+rayon
+Summary:        Statistics-driven micro-benchmarking library - feature "rayon"
+Requires:       crate(%{pkgname})
+Requires:       crate(rayon-1.0/default) >= 1.3
+Provides:       crate(%{pkgname}/rayon)
+
+%description -n %{name}+rayon
+This metapackage enables feature "rayon" for the Rust criterion crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+stable
+Summary:        Statistics-driven micro-benchmarking library - feature "stable"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/async-futures)
+Requires:       crate(%{pkgname}/async-smol)
+Requires:       crate(%{pkgname}/async-tokio)
+Requires:       crate(%{pkgname}/csv-output)
+Requires:       crate(%{pkgname}/html-reports)
+Provides:       crate(%{pkgname}/stable)
+
+%description -n %{name}+stable
+This metapackage enables feature "stable" for the Rust criterion crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-criterion-plot-0.8/rust-criterion-plot.spec
+++ b/SPECS/rust-criterion-plot-0.8/rust-criterion-plot.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name criterion-plot
+%global full_version 0.8.2
+%global pkgname criterion-plot-0.8
+
+Name:           rust-criterion-plot-0.8
+Version:        0.8.2
+Release:        %autorelease
+Summary:        Rust crate "criterion-plot"
+License:        Apache-2.0 OR MIT
+URL:            https://github.com/criterion-rs/criterion.rs
+#!RemoteAsset:  sha256:d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(cast-0.3/default) >= 0.3.0
+Requires:       crate(itertools-0.13/default) >= 0.13.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "criterion-plot"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-crossbeam-0.8/rust-crossbeam.spec
+++ b/SPECS/rust-crossbeam-0.8/rust-crossbeam.spec
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name crossbeam
+%global full_version 0.8.4
+%global pkgname crossbeam-0.8
+
+Name:           rust-crossbeam-0.8
+Version:        0.8.4
+Release:        %autorelease
+Summary:        Rust crate "crossbeam"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/crossbeam-rs/crossbeam
+#!RemoteAsset:  sha256:1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(crossbeam-utils-0.8) >= 0.8.21
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "crossbeam"
+
+%package     -n %{name}+alloc
+Summary:        Tools for concurrent programming - feature "alloc"
+Requires:       crate(%{pkgname})
+Requires:       crate(crossbeam-epoch-0.9/alloc) >= 0.9.18
+Requires:       crate(crossbeam-queue-0.3/alloc) >= 0.3.12
+Provides:       crate(%{pkgname}/alloc)
+
+%description -n %{name}+alloc
+This metapackage enables feature "alloc" for the Rust crossbeam crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+crossbeam-channel
+Summary:        Tools for concurrent programming - feature "crossbeam-channel"
+Requires:       crate(%{pkgname})
+Requires:       crate(crossbeam-channel-0.5) >= 0.5.15
+Provides:       crate(%{pkgname}/crossbeam-channel)
+
+%description -n %{name}+crossbeam-channel
+This metapackage enables feature "crossbeam-channel" for the Rust crossbeam crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+crossbeam-deque
+Summary:        Tools for concurrent programming - feature "crossbeam-deque"
+Requires:       crate(%{pkgname})
+Requires:       crate(crossbeam-deque-0.8) >= 0.8.6
+Provides:       crate(%{pkgname}/crossbeam-deque)
+
+%description -n %{name}+crossbeam-deque
+This metapackage enables feature "crossbeam-deque" for the Rust crossbeam crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+crossbeam-epoch
+Summary:        Tools for concurrent programming - feature "crossbeam-epoch"
+Requires:       crate(%{pkgname})
+Requires:       crate(crossbeam-epoch-0.9) >= 0.9.18
+Provides:       crate(%{pkgname}/crossbeam-epoch)
+
+%description -n %{name}+crossbeam-epoch
+This metapackage enables feature "crossbeam-epoch" for the Rust crossbeam crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+crossbeam-queue
+Summary:        Tools for concurrent programming - feature "crossbeam-queue"
+Requires:       crate(%{pkgname})
+Requires:       crate(crossbeam-queue-0.3) >= 0.3.12
+Provides:       crate(%{pkgname}/crossbeam-queue)
+
+%description -n %{name}+crossbeam-queue
+This metapackage enables feature "crossbeam-queue" for the Rust crossbeam crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+nightly
+Summary:        Tools for concurrent programming - feature "nightly"
+Requires:       crate(%{pkgname})
+Requires:       crate(crossbeam-epoch-0.9/nightly) >= 0.9.18
+Requires:       crate(crossbeam-queue-0.3/nightly) >= 0.3.12
+Requires:       crate(crossbeam-utils-0.8/nightly) >= 0.8.21
+Provides:       crate(%{pkgname}/nightly)
+
+%description -n %{name}+nightly
+This metapackage enables feature "nightly" for the Rust crossbeam crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+std
+Summary:        Tools for concurrent programming - feature "std" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/alloc)
+Requires:       crate(crossbeam-channel-0.5/std) >= 0.5.15
+Requires:       crate(crossbeam-deque-0.8/std) >= 0.8.6
+Requires:       crate(crossbeam-epoch-0.9/std) >= 0.9.18
+Requires:       crate(crossbeam-queue-0.3/std) >= 0.3.12
+Requires:       crate(crossbeam-utils-0.8/std) >= 0.8.21
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description -n %{name}+std
+This metapackage enables feature "std" for the Rust crossbeam crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "default" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-crossbeam-queue-0.3/rust-crossbeam-queue.spec
+++ b/SPECS/rust-crossbeam-queue-0.3/rust-crossbeam-queue.spec
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name crossbeam-queue
+%global full_version 0.3.12
+%global pkgname crossbeam-queue-0.3
+
+Name:           rust-crossbeam-queue-0.3
+Version:        0.3.12
+Release:        %autorelease
+Summary:        Rust crate "crossbeam-queue"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-queue
+#!RemoteAsset:  sha256:0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(crossbeam-utils-0.8) >= 0.8.21
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/alloc)
+
+%description
+Source code for takopackized Rust crate "crossbeam-queue"
+
+%package     -n %{name}+nightly
+Summary:        Concurrent queues - feature "nightly"
+Requires:       crate(%{pkgname})
+Requires:       crate(crossbeam-utils-0.8/nightly) >= 0.8.21
+Provides:       crate(%{pkgname}/nightly)
+
+%description -n %{name}+nightly
+This metapackage enables feature "nightly" for the Rust crossbeam-queue crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+std
+Summary:        Concurrent queues - feature "std" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/alloc)
+Requires:       crate(crossbeam-utils-0.8/std) >= 0.8.21
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description -n %{name}+std
+This metapackage enables feature "std" for the Rust crossbeam-queue crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "default" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-ctrlc-3.0/rust-ctrlc.spec
+++ b/SPECS/rust-ctrlc-3.0/rust-ctrlc.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name ctrlc
+%global full_version 3.5.2
+%global pkgname ctrlc-3.0
+
+Name:           rust-ctrlc-3.0
+Version:        3.5.2
+Release:        %autorelease
+Summary:        Rust crate "ctrlc"
+License:        MIT/Apache-2.0
+URL:            https://github.com/Detegr/rust-ctrlc
+#!RemoteAsset:  sha256:e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(dispatch2-0.3/default) >= 0.3.0
+Requires:       crate(nix-0.31/signal) >= 0.31.2
+Requires:       crate(windows-sys-0.61/default) >= 0.61.0
+Requires:       crate(windows-sys-0.61/win32-foundation) >= 0.61.0
+Requires:       crate(windows-sys-0.61/win32-security) >= 0.61.0
+Requires:       crate(windows-sys-0.61/win32-system-console) >= 0.61.0
+Requires:       crate(windows-sys-0.61/win32-system-threading) >= 0.61.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/termination)
+
+%description
+Source code for takopackized Rust crate "ctrlc"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-darling-0.23/rust-darling.spec
+++ b/SPECS/rust-darling-0.23/rust-darling.spec
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name darling
+%global full_version 0.23.0
+%global pkgname darling-0.23
+
+Name:           rust-darling-0.23
+Version:        0.23.0
+Release:        %autorelease
+Summary:        Rust crate "darling"
+License:        MIT
+URL:            https://github.com/TedDriggs/darling
+#!RemoteAsset:  sha256:25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(darling-core-0.23/default) >= 0.23.0
+Requires:       crate(darling-macro-0.23/default) >= 0.23.0
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "darling"
+
+%package     -n %{name}+diagnostics
+Summary:        Proc-macro library for reading attributes into structs when implementing custom derives - feature "diagnostics"
+Requires:       crate(%{pkgname})
+Requires:       crate(darling-core-0.23/diagnostics) >= 0.23.0
+Provides:       crate(%{pkgname}/diagnostics)
+
+%description -n %{name}+diagnostics
+This metapackage enables feature "diagnostics" for the Rust darling crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+serde
+Summary:        Proc-macro library for reading attributes into structs when implementing custom derives - feature "serde"
+Requires:       crate(%{pkgname})
+Requires:       crate(darling-core-0.23/serde) >= 0.23.0
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust darling crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+suggestions
+Summary:        Proc-macro library for reading attributes into structs when implementing custom derives - feature "suggestions" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(darling-core-0.23/suggestions) >= 0.23.0
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/suggestions)
+
+%description -n %{name}+suggestions
+This metapackage enables feature "suggestions" for the Rust darling crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "default" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-darling-core-0.23/rust-darling-core.spec
+++ b/SPECS/rust-darling-core-0.23/rust-darling-core.spec
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name darling_core
+%global full_version 0.23.0
+%global pkgname darling-core-0.23
+
+Name:           rust-darling-core-0.23
+Version:        0.23.0
+Release:        %autorelease
+Summary:        Rust crate "darling_core"
+License:        MIT
+URL:            https://github.com/TedDriggs/darling
+#!RemoteAsset:  sha256:9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(ident-case-1.0/default) >= 1.0.1
+Requires:       crate(proc-macro2-1.0/default) >= 1.0.106
+Requires:       crate(quote-1.0/default) >= 1.0.45
+Requires:       crate(syn-2.0/default) >= 2.0.117
+Requires:       crate(syn-2.0/extra-traits) >= 2.0.117
+Requires:       crate(syn-2.0/full) >= 2.0.117
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/diagnostics)
+
+%description
+Use https://crates.io/crates/darling in your code.
+Source code for takopackized Rust crate "darling_core"
+
+%package     -n %{name}+serde
+Summary:        Helper crate for proc-macro library for reading attributes into structs when implementing custom derives - feature "serde"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/default) >= 1.0.210
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+Use https://crates.io/crates/darling in your code.
+This metapackage enables feature "serde" for the Rust darling_core crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+strsim
+Summary:        Helper crate for proc-macro library for reading attributes into structs when implementing custom derives - feature "strsim" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(strsim-0.11/default) >= 0.11.1
+Provides:       crate(%{pkgname}/strsim)
+Provides:       crate(%{pkgname}/suggestions)
+
+%description -n %{name}+strsim
+Use https://crates.io/crates/darling in your code.
+This metapackage enables feature "strsim" for the Rust darling_core crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "suggestions" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-darling-macro-0.23/rust-darling-macro.spec
+++ b/SPECS/rust-darling-macro-0.23/rust-darling-macro.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name darling_macro
+%global full_version 0.23.0
+%global pkgname darling-macro-0.23
+
+Name:           rust-darling-macro-0.23
+Version:        0.23.0
+Release:        %autorelease
+Summary:        Rust crate "darling_macro"
+License:        MIT
+URL:            https://github.com/TedDriggs/darling
+#!RemoteAsset:  sha256:ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(darling-core-0.23/default) >= 0.23.0
+Requires:       crate(quote-1.0/default) >= 1.0.45
+Requires:       crate(syn-2.0/default) >= 2.0.117
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Use https://crates.io/crates/darling in your code.
+Source code for takopackized Rust crate "darling_macro"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-datatest-stable-0.3/rust-datatest-stable.spec
+++ b/SPECS/rust-datatest-stable-0.3/rust-datatest-stable.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name datatest-stable
+%global full_version 0.3.3
+%global pkgname datatest-stable-0.3
+
+Name:           rust-datatest-stable-0.3
+Version:        0.3.3
+Release:        %autorelease
+Summary:        Rust crate "datatest-stable"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/nextest-rs/datatest-stable
+#!RemoteAsset:  sha256:a867d7322eb69cf3a68a5426387a25b45cb3b9c5ee41023ee6cea92e2afadd82
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(camino-1.0/default) >= 1.2.2
+Requires:       crate(fancy-regex-0.14/default) >= 0.14.0
+Requires:       crate(libtest-mimic-0.8/default) >= 0.8.1
+Requires:       crate(walkdir-2.0/default) >= 2.5.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "datatest-stable"
+
+%package     -n %{name}+include-dir
+Summary:        Data-driven tests that work on stable Rust - feature "include-dir"
+Requires:       crate(%{pkgname})
+Requires:       crate(include-dir-0.7/default) >= 0.7.4
+Provides:       crate(%{pkgname}/include-dir)
+
+%description -n %{name}+include-dir
+This metapackage enables feature "include-dir" for the Rust datatest-stable crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-derive-where-1.0/rust-derive-where.spec
+++ b/SPECS/rust-derive-where-1.0/rust-derive-where.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name derive-where
+%global full_version 1.6.0
+%global pkgname derive-where-1.0
+
+Name:           rust-derive-where-1.0
+Version:        1.6.0
+Release:        %autorelease
+Summary:        Rust crate "derive-where"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/ModProg/derive-where
+#!RemoteAsset:  sha256:ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(proc-macro2-1.0/proc-macro) >= 1.0.106
+Requires:       crate(quote-1.0) >= 1.0.45
+Requires:       crate(syn-2.0/clone-impls) >= 2.0.117
+Requires:       crate(syn-2.0/derive) >= 2.0.117
+Requires:       crate(syn-2.0/extra-traits) >= 2.0.117
+Requires:       crate(syn-2.0/full) >= 2.0.117
+Requires:       crate(syn-2.0/parsing) >= 2.0.117
+Requires:       crate(syn-2.0/printing) >= 2.0.117
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/nightly)
+Provides:       crate(%{pkgname}/safe)
+Provides:       crate(%{pkgname}/serde)
+Provides:       crate(%{pkgname}/zeroize)
+Provides:       crate(%{pkgname}/zeroize-on-drop)
+
+%description
+Source code for takopackized Rust crate "derive-where"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-difflib-0.4/rust-difflib.spec
+++ b/SPECS/rust-difflib-0.4/rust-difflib.spec
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name difflib
+%global full_version 0.4.0
+%global pkgname difflib-0.4
+
+Name:           rust-difflib-0.4
+Version:        0.4.0
+Release:        %autorelease
+Summary:        Rust crate "difflib"
+License:        MIT
+URL:            https://github.com/DimaKudosh/difflib
+#!RemoteAsset:  sha256:6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "difflib"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-dirs-6.0/rust-dirs.spec
+++ b/SPECS/rust-dirs-6.0/rust-dirs.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name dirs
+%global full_version 6.0.0
+%global pkgname dirs-6.0
+
+Name:           rust-dirs-6.0
+Version:        6.0.0
+Release:        %autorelease
+Summary:        Rust crate "dirs"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/soc/dirs-rs
+#!RemoteAsset:  sha256:c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(dirs-sys-0.5/default) >= 0.5.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "dirs"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-dirs-sys-0.5/rust-dirs-sys.spec
+++ b/SPECS/rust-dirs-sys-0.5/rust-dirs-sys.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name dirs-sys
+%global full_version 0.5.0
+%global pkgname dirs-sys-0.5
+
+Name:           rust-dirs-sys-0.5
+Version:        0.5.0
+Release:        %autorelease
+Summary:        Rust crate "dirs-sys"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/dirs-dev/dirs-sys-rs
+#!RemoteAsset:  sha256:e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(libc-0.2/default) >= 0.2.186
+Requires:       crate(option-ext-0.2/default) >= 0.2.0
+Requires:       crate(redox-users-0.5) >= 0.5.2
+Requires:       crate(windows-sys-0.59/default) >= 0.59.0
+Requires:       crate(windows-sys-0.59/win32-foundation) >= 0.59.0
+Requires:       crate(windows-sys-0.59/win32-globalization) >= 0.59.0
+Requires:       crate(windows-sys-0.59/win32-system-com) >= 0.59.0
+Requires:       crate(windows-sys-0.59/win32-ui-shell) >= 0.59.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "dirs-sys"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-divan-macros-0.1/rust-divan-macros.spec
+++ b/SPECS/rust-divan-macros-0.1/rust-divan-macros.spec
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name divan-macros
+%global full_version 0.1.17
+%global pkgname divan-macros-0.1
+
+Name:           rust-divan-macros-0.1
+Version:        0.1.17
+Release:        %autorelease
+Summary:        Rust crate "divan-macros"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/nvzqz/divan
+#!RemoteAsset:  sha256:8dc51d98e636f5e3b0759a39257458b22619cac7e96d932da6eeb052891bb67c
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(proc-macro2-1.0/default) >= 1.0.106
+Requires:       crate(quote-1.0) >= 1.0.45
+Requires:       crate(syn-2.0/clone-impls) >= 2.0.117
+Requires:       crate(syn-2.0/full) >= 2.0.117
+Requires:       crate(syn-2.0/parsing) >= 2.0.117
+Requires:       crate(syn-2.0/printing) >= 2.0.117
+Requires:       crate(syn-2.0/proc-macro) >= 2.0.117
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "divan-macros"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-doc-comment-0.3/rust-doc-comment.spec
+++ b/SPECS/rust-doc-comment-0.3/rust-doc-comment.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name doc-comment
+%global full_version 0.3.3
+%global pkgname doc-comment-0.3
+
+Name:           rust-doc-comment-0.3
+Version:        0.3.3
+Release:        %autorelease
+Summary:        Rust crate "doc-comment"
+License:        MIT
+URL:            https://github.com/GuillaumeGomez/doc-comment
+#!RemoteAsset:  sha256:fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/no-core)
+Provides:       crate(%{pkgname}/old-macros)
+
+%description
+Source code for takopackized Rust crate "doc-comment"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-drop-bomb-0.1/rust-drop-bomb.spec
+++ b/SPECS/rust-drop-bomb-0.1/rust-drop-bomb.spec
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name drop_bomb
+%global full_version 0.1.5
+%global pkgname drop-bomb-0.1
+
+Name:           rust-drop-bomb-0.1
+Version:        0.1.5
+Release:        %autorelease
+Summary:        Rust crate "drop_bomb"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/matklad/drop_bomb
+#!RemoteAsset:  sha256:9bda8e21c04aca2ae33ffc2fd8c23134f3cac46db123ba97bd9d3f3b8a4a85e1
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "drop_bomb"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-dyn-clone-1.0/rust-dyn-clone.spec
+++ b/SPECS/rust-dyn-clone-1.0/rust-dyn-clone.spec
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name dyn-clone
+%global full_version 1.0.20
+%global pkgname dyn-clone-1.0
+
+Name:           rust-dyn-clone-1.0
+Version:        1.0.20
+Release:        %autorelease
+Summary:        Rust crate "dyn-clone"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/dtolnay/dyn-clone
+#!RemoteAsset:  sha256:d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "dyn-clone"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-encode-unicode-1.0/rust-encode-unicode.spec
+++ b/SPECS/rust-encode-unicode-1.0/rust-encode-unicode.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name encode_unicode
+%global full_version 1.0.0
+%global pkgname encode-unicode-1.0
+
+Name:           rust-encode-unicode-1.0
+Version:        1.0.0
+Release:        %autorelease
+Summary:        Rust crate "encode_unicode"
+License:        Apache-2.0 OR MIT
+URL:            https://github.com/tormol/encode_unicode
+#!RemoteAsset:  sha256:34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description
+Source code for takopackized Rust crate "encode_unicode"
+
+%package     -n %{name}+ascii
+Summary:        UTF-8 and UTF-16 character types, iterators and related methods for char, u8 and u16 - feature "ascii"
+Requires:       crate(%{pkgname})
+Requires:       crate(ascii-1.0) >= 1.0.0
+Provides:       crate(%{pkgname}/ascii)
+
+%description -n %{name}+ascii
+This metapackage enables feature "ascii" for the Rust encode_unicode crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-escape8259-0.5/rust-escape8259.spec
+++ b/SPECS/rust-escape8259-0.5/rust-escape8259.spec
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name escape8259
+%global full_version 0.5.3
+%global pkgname escape8259-0.5
+
+Name:           rust-escape8259-0.5
+Version:        0.5.3
+Release:        %autorelease
+Summary:        Rust crate "escape8259"
+License:        MIT
+URL:            https://github.com/ericseppanen/escape8259
+#!RemoteAsset:  sha256:5692dd7b5a1978a5aeb0ce83b7655c58ca8efdcb79d21036ea249da95afec2c6
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "escape8259"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-escargot-0.5/rust-escargot.spec
+++ b/SPECS/rust-escargot-0.5/rust-escargot.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name escargot
+%global full_version 0.5.15
+%global pkgname escargot-0.5
+
+Name:           rust-escargot-0.5
+Version:        0.5.15
+Release:        %autorelease
+Summary:        Rust crate "escargot"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/crate-ci/escargot
+#!RemoteAsset:  sha256:11c3aea32bc97b500c9ca6a72b768a26e558264303d101d3409cf6d57a9ed0cf
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(log-0.4/default) >= 0.4.29
+Requires:       crate(serde-1.0/default) >= 1.0.228
+Requires:       crate(serde-1.0/derive) >= 1.0.228
+Requires:       crate(serde-json-1.0/default) >= 1.0.149
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/cargo-unstable)
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/print)
+Provides:       crate(%{pkgname}/strict-unstable)
+Provides:       crate(%{pkgname}/test-unstable)
+
+%description
+Source code for takopackized Rust crate "escargot"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-etcetera-0.11/rust-etcetera.spec
+++ b/SPECS/rust-etcetera-0.11/rust-etcetera.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name etcetera
+%global full_version 0.11.0
+%global pkgname etcetera-0.11
+
+Name:           rust-etcetera-0.11
+Version:        0.11.0
+Release:        %autorelease
+Summary:        Rust crate "etcetera"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/lunacookies/etcetera
+#!RemoteAsset:  sha256:de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(cfg-if-1.0/default) >= 1.0.3
+Requires:       crate(windows-sys-0.61/default) >= 0.61.0
+Requires:       crate(windows-sys-0.61/win32-foundation) >= 0.61.0
+Requires:       crate(windows-sys-0.61/win32-system-com) >= 0.61.0
+Requires:       crate(windows-sys-0.61/win32-ui-shell) >= 0.61.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "etcetera"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-fancy-regex-0.14/rust-fancy-regex.spec
+++ b/SPECS/rust-fancy-regex-0.14/rust-fancy-regex.spec
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name fancy-regex
+%global full_version 0.14.0
+%global pkgname fancy-regex-0.14
+
+Name:           rust-fancy-regex-0.14
+Version:        0.14.0
+Release:        %autorelease
+Summary:        Rust crate "fancy-regex"
+License:        MIT
+URL:            https://github.com/fancy-regex/fancy-regex
+#!RemoteAsset:  sha256:6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(bit-set-0.8) >= 0.8.0
+Requires:       crate(regex-automata-0.4/alloc) >= 0.4.14
+Requires:       crate(regex-automata-0.4/dfa) >= 0.4.14
+Requires:       crate(regex-automata-0.4/hybrid) >= 0.4.14
+Requires:       crate(regex-automata-0.4/meta) >= 0.4.14
+Requires:       crate(regex-automata-0.4/nfa) >= 0.4.14
+Requires:       crate(regex-automata-0.4/syntax) >= 0.4.14
+Requires:       crate(regex-syntax-0.8) >= 0.8.10
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/track-caller)
+
+%description
+Source code for takopackized Rust crate "fancy-regex"
+
+%package     -n %{name}+default
+Summary:        Regexes, supporting a relatively rich set of features, including backreferences and look-around - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/perf)
+Requires:       crate(%{pkgname}/std)
+Requires:       crate(%{pkgname}/unicode)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust fancy-regex crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+perf
+Summary:        Regexes, supporting a relatively rich set of features, including backreferences and look-around - feature "perf"
+Requires:       crate(%{pkgname})
+Requires:       crate(regex-automata-0.4/alloc) >= 0.4.14
+Requires:       crate(regex-automata-0.4/dfa) >= 0.4.14
+Requires:       crate(regex-automata-0.4/hybrid) >= 0.4.14
+Requires:       crate(regex-automata-0.4/meta) >= 0.4.14
+Requires:       crate(regex-automata-0.4/nfa) >= 0.4.14
+Requires:       crate(regex-automata-0.4/perf) >= 0.4.14
+Requires:       crate(regex-automata-0.4/syntax) >= 0.4.14
+Provides:       crate(%{pkgname}/perf)
+
+%description -n %{name}+perf
+This metapackage enables feature "perf" for the Rust fancy-regex crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+std
+Summary:        Regexes, supporting a relatively rich set of features, including backreferences and look-around - feature "std"
+Requires:       crate(%{pkgname})
+Requires:       crate(bit-set-0.8/std) >= 0.8.0
+Requires:       crate(regex-automata-0.4/alloc) >= 0.4.14
+Requires:       crate(regex-automata-0.4/dfa) >= 0.4.14
+Requires:       crate(regex-automata-0.4/hybrid) >= 0.4.14
+Requires:       crate(regex-automata-0.4/meta) >= 0.4.14
+Requires:       crate(regex-automata-0.4/nfa) >= 0.4.14
+Requires:       crate(regex-automata-0.4/std) >= 0.4.14
+Requires:       crate(regex-automata-0.4/syntax) >= 0.4.14
+Requires:       crate(regex-syntax-0.8/std) >= 0.8.10
+Provides:       crate(%{pkgname}/std)
+
+%description -n %{name}+std
+This metapackage enables feature "std" for the Rust fancy-regex crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+unicode
+Summary:        Regexes, supporting a relatively rich set of features, including backreferences and look-around - feature "unicode"
+Requires:       crate(%{pkgname})
+Requires:       crate(regex-automata-0.4/alloc) >= 0.4.14
+Requires:       crate(regex-automata-0.4/dfa) >= 0.4.14
+Requires:       crate(regex-automata-0.4/hybrid) >= 0.4.14
+Requires:       crate(regex-automata-0.4/meta) >= 0.4.14
+Requires:       crate(regex-automata-0.4/nfa) >= 0.4.14
+Requires:       crate(regex-automata-0.4/syntax) >= 0.4.14
+Requires:       crate(regex-automata-0.4/unicode) >= 0.4.14
+Requires:       crate(regex-syntax-0.8/unicode) >= 0.8.10
+Provides:       crate(%{pkgname}/unicode)
+
+%description -n %{name}+unicode
+This metapackage enables feature "unicode" for the Rust fancy-regex crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-fern-0.7/rust-fern.spec
+++ b/SPECS/rust-fern-0.7/rust-fern.spec
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name fern
+%global full_version 0.7.1
+%global pkgname fern-0.7
+
+Name:           rust-fern-0.7
+Version:        0.7.1
+Release:        %autorelease
+Summary:        Rust crate "fern"
+License:        MIT
+URL:            https://github.com/daboross/fern
+#!RemoteAsset:  sha256:4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(log-0.4/default) >= 0.4.29
+Requires:       crate(log-0.4/std) >= 0.4.29
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/meta-logging-in-format)
+
+%description
+Source code for takopackized Rust crate "fern"
+
+%package     -n %{name}+chrono
+Summary:        Simple, efficient logging - feature "chrono" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(chrono-0.4/clock) >= 0.4.0
+Requires:       crate(chrono-0.4/std) >= 0.4.0
+Provides:       crate(%{pkgname}/chrono)
+Provides:       crate(%{pkgname}/date-based)
+
+%description -n %{name}+chrono
+This metapackage enables feature "chrono" for the Rust fern crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "date-based" feature.
+
+%package     -n %{name}+colored
+Summary:        Simple, efficient logging - feature "colored"
+Requires:       crate(%{pkgname})
+Requires:       crate(colored-2.0/default) >= 2.1.0
+Provides:       crate(%{pkgname}/colored)
+
+%description -n %{name}+colored
+This metapackage enables feature "colored" for the Rust fern crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+libc
+Summary:        Simple, efficient logging - feature "libc"
+Requires:       crate(%{pkgname})
+Requires:       crate(libc-0.2/default) >= 0.2.58
+Provides:       crate(%{pkgname}/libc)
+
+%description -n %{name}+libc
+This metapackage enables feature "libc" for the Rust fern crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+reopen-03
+Summary:        Simple, efficient logging - feature "reopen-03"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/libc)
+Requires:       crate(%{pkgname}/reopen03)
+Provides:       crate(%{pkgname}/reopen-03)
+
+%description -n %{name}+reopen-03
+This metapackage enables feature "reopen-03" for the Rust fern crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+reopen-1
+Summary:        Simple, efficient logging - feature "reopen-1"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/libc)
+Requires:       crate(%{pkgname}/reopen1)
+Provides:       crate(%{pkgname}/reopen-1)
+
+%description -n %{name}+reopen-1
+This metapackage enables feature "reopen-1" for the Rust fern crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+reopen03
+Summary:        Simple, efficient logging - feature "reopen03"
+Requires:       crate(%{pkgname})
+Requires:       crate(reopen-0.3/default) >= 0.3.0
+Provides:       crate(%{pkgname}/reopen03)
+
+%description -n %{name}+reopen03
+This metapackage enables feature "reopen03" for the Rust fern crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+reopen1
+Summary:        Simple, efficient logging - feature "reopen1"
+Requires:       crate(%{pkgname})
+Requires:       crate(reopen-1.0/default) >= 1.0.0
+Requires:       crate(reopen-1.0/signals) >= 1.0.0
+Provides:       crate(%{pkgname}/reopen1)
+
+%description -n %{name}+reopen1
+This metapackage enables feature "reopen1" for the Rust fern crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+syslog3
+Summary:        Simple, efficient logging - feature "syslog3" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(syslog-3.0/default) >= 3.0.0
+Provides:       crate(%{pkgname}/syslog-3)
+Provides:       crate(%{pkgname}/syslog3)
+
+%description -n %{name}+syslog3
+This metapackage enables feature "syslog3" for the Rust fern crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "syslog-3" feature.
+
+%package     -n %{name}+syslog4
+Summary:        Simple, efficient logging - feature "syslog4" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(syslog-4.0/default) >= 4.0.0
+Provides:       crate(%{pkgname}/syslog-4)
+Provides:       crate(%{pkgname}/syslog4)
+
+%description -n %{name}+syslog4
+This metapackage enables feature "syslog4" for the Rust fern crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "syslog-4" feature.
+
+%package     -n %{name}+syslog6
+Summary:        Simple, efficient logging - feature "syslog6" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(syslog-6.0/default) >= 6.0.0
+Provides:       crate(%{pkgname}/syslog-6)
+Provides:       crate(%{pkgname}/syslog6)
+
+%description -n %{name}+syslog6
+This metapackage enables feature "syslog6" for the Rust fern crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "syslog-6" feature.
+
+%package     -n %{name}+syslog7
+Summary:        Simple, efficient logging - feature "syslog7" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(syslog-7.0/default) >= 7.0.0
+Provides:       crate(%{pkgname}/syslog-7)
+Provides:       crate(%{pkgname}/syslog7)
+
+%description -n %{name}+syslog7
+This metapackage enables feature "syslog7" for the Rust fern crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "syslog-7" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-fs-err-3.0/rust-fs-err.spec
+++ b/SPECS/rust-fs-err-3.0/rust-fs-err.spec
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name fs-err
+%global full_version 3.3.0
+%global pkgname fs-err-3.0
+
+Name:           rust-fs-err-3.0
+Version:        3.3.0
+Release:        %autorelease
+Summary:        Rust crate "fs-err"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/andrewhickman/fs-err
+#!RemoteAsset:  sha256:73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(autocfg-1.0/default) >= 1.5.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/expose-original-error)
+
+%description
+Source code for takopackized Rust crate "fs-err"
+
+%package     -n %{name}+debug-tokio
+Summary:        Drop-in replacement for std::fs with more helpful error messages - feature "debug_tokio"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/path-facts)
+Requires:       crate(tokio-1.0/fs) >= 1.21
+Requires:       crate(tokio-1.0/rt-multi-thread) >= 1.21
+Provides:       crate(%{pkgname}/debug-tokio)
+
+%description -n %{name}+debug-tokio
+This metapackage enables feature "debug_tokio" for the Rust fs-err crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+path-facts
+Summary:        Drop-in replacement for std::fs with more helpful error messages - feature "path_facts" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(path-facts-0.2/default) >= 0.2.0
+Provides:       crate(%{pkgname}/debug)
+Provides:       crate(%{pkgname}/path-facts)
+
+%description -n %{name}+path-facts
+This metapackage enables feature "path_facts" for the Rust fs-err crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "debug" feature.
+
+%package     -n %{name}+tokio
+Summary:        Drop-in replacement for std::fs with more helpful error messages - feature "tokio"
+Requires:       crate(%{pkgname})
+Requires:       crate(tokio-1.0/fs) >= 1.21
+Provides:       crate(%{pkgname}/tokio)
+
+%description -n %{name}+tokio
+This metapackage enables feature "tokio" for the Rust fs-err crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-fsevent-sys-4.0/rust-fsevent-sys.spec
+++ b/SPECS/rust-fsevent-sys-4.0/rust-fsevent-sys.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name fsevent-sys
+%global full_version 4.1.0
+%global pkgname fsevent-sys-4.0
+
+Name:           rust-fsevent-sys-4.0
+Version:        4.1.0
+Release:        %autorelease
+Summary:        Rust crate "fsevent-sys"
+License:        MIT
+URL:            https://github.com/octplane/fsevent-rust/tree/master/fsevent-sys
+#!RemoteAsset:  sha256:76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(libc-0.2/default) >= 0.2.186
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "fsevent-sys"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-get-size-derive2-0.8/rust-get-size-derive2.spec
+++ b/SPECS/rust-get-size-derive2-0.8/rust-get-size-derive2.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name get-size-derive2
+%global full_version 0.8.0
+%global pkgname get-size-derive2-0.8
+
+Name:           rust-get-size-derive2-0.8
+Version:        0.8.0
+Release:        %autorelease
+Summary:        Rust crate "get-size-derive2"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/bircni/get-size2/tree/main/crates/get-size-derive2
+#!RemoteAsset:  sha256:dfd774e8175d3adb09c1742cb4697fb08490607fc02acfaa3b66b88254239d1d
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(attribute-derive-0.10/default) >= 0.10.3
+Requires:       crate(quote-1.0/default) >= 1.0.45
+Requires:       crate(syn-2.0/default) >= 2.0.117
+Requires:       crate(syn-2.0/derive) >= 2.0.117
+Requires:       crate(syn-2.0/parsing) >= 2.0.117
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "get-size-derive2"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-get-size2-0.8/rust-get-size2.spec
+++ b/SPECS/rust-get-size2-0.8/rust-get-size2.spec
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name get-size2
+%global full_version 0.8.0
+%global pkgname get-size2-0.8
+
+Name:           rust-get-size2-0.8
+Version:        0.8.0
+Release:        %autorelease
+Summary:        Rust crate "get-size2"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/bircni/get-size2
+#!RemoteAsset:  sha256:d5b6f7d040889b1980e31d03585f0150223f44eeada7a69c525cbb74c38266f6
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "get-size2"
+
+%package     -n %{name}+bytes
+Summary:        Determine the size in bytes an object occupies inside RAM - feature "bytes"
+Requires:       crate(%{pkgname})
+Requires:       crate(bytes-1.0) >= 1.0.0
+Provides:       crate(%{pkgname}/bytes)
+
+%description -n %{name}+bytes
+This metapackage enables feature "bytes" for the Rust get-size2 crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+chrono
+Summary:        Determine the size in bytes an object occupies inside RAM - feature "chrono"
+Requires:       crate(%{pkgname})
+Requires:       crate(chrono-0.4) >= 0.4.0
+Provides:       crate(%{pkgname}/chrono)
+
+%description -n %{name}+chrono
+This metapackage enables feature "chrono" for the Rust get-size2 crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+chrono-tz
+Summary:        Determine the size in bytes an object occupies inside RAM - feature "chrono-tz"
+Requires:       crate(%{pkgname})
+Requires:       crate(chrono-tz-0.10) >= 0.10.0
+Provides:       crate(%{pkgname}/chrono-tz)
+
+%description -n %{name}+chrono-tz
+This metapackage enables feature "chrono-tz" for the Rust get-size2 crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+compact-str
+Summary:        Determine the size in bytes an object occupies inside RAM - feature "compact-str"
+Requires:       crate(%{pkgname})
+Requires:       crate(compact-str-0.9) >= 0.9.0
+Provides:       crate(%{pkgname}/compact-str)
+
+%description -n %{name}+compact-str
+This metapackage enables feature "compact-str" for the Rust get-size2 crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+get-size-derive2
+Summary:        Determine the size in bytes an object occupies inside RAM - feature "get-size-derive2" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(get-size-derive2-0.8/default) >= 0.8.0
+Provides:       crate(%{pkgname}/derive)
+Provides:       crate(%{pkgname}/get-size-derive2)
+
+%description -n %{name}+get-size-derive2
+This metapackage enables feature "get-size-derive2" for the Rust get-size2 crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "derive" feature.
+
+%package     -n %{name}+hashbrown
+Summary:        Determine the size in bytes an object occupies inside RAM - feature "hashbrown"
+Requires:       crate(%{pkgname})
+Requires:       crate(hashbrown-0.17) >= 0.17.0
+Provides:       crate(%{pkgname}/hashbrown)
+
+%description -n %{name}+hashbrown
+This metapackage enables feature "hashbrown" for the Rust get-size2 crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+indexmap
+Summary:        Determine the size in bytes an object occupies inside RAM - feature "indexmap"
+Requires:       crate(%{pkgname})
+Requires:       crate(indexmap-2.0) >= 2.14.0
+Provides:       crate(%{pkgname}/indexmap)
+
+%description -n %{name}+indexmap
+This metapackage enables feature "indexmap" for the Rust get-size2 crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+ordermap
+Summary:        Determine the size in bytes an object occupies inside RAM - feature "ordermap"
+Requires:       crate(%{pkgname})
+Requires:       crate(ordermap-1.0) >= 1.2.0
+Provides:       crate(%{pkgname}/ordermap)
+
+%description -n %{name}+ordermap
+This metapackage enables feature "ordermap" for the Rust get-size2 crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+smallvec
+Summary:        Determine the size in bytes an object occupies inside RAM - feature "smallvec"
+Requires:       crate(%{pkgname})
+Requires:       crate(smallvec-1.0) >= 1.15.1
+Provides:       crate(%{pkgname}/smallvec)
+
+%description -n %{name}+smallvec
+This metapackage enables feature "smallvec" for the Rust get-size2 crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+thin-vec
+Summary:        Determine the size in bytes an object occupies inside RAM - feature "thin-vec"
+Requires:       crate(%{pkgname})
+Requires:       crate(thin-vec-0.2) >= 0.2.0
+Provides:       crate(%{pkgname}/thin-vec)
+
+%description -n %{name}+thin-vec
+This metapackage enables feature "thin-vec" for the Rust get-size2 crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+url
+Summary:        Determine the size in bytes an object occupies inside RAM - feature "url"
+Requires:       crate(%{pkgname})
+Requires:       crate(url-2.0) >= 2.0.0
+Provides:       crate(%{pkgname}/url)
+
+%description -n %{name}+url
+This metapackage enables feature "url" for the Rust get-size2 crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-getopts-0.2/rust-getopts.spec
+++ b/SPECS/rust-getopts-0.2/rust-getopts.spec
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name getopts
+%global full_version 0.2.24
+%global pkgname getopts-0.2
+
+Name:           rust-getopts-0.2
+Version:        0.2.24
+Release:        %autorelease
+Summary:        Rust crate "getopts"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/rust-lang/getopts
+#!RemoteAsset:  sha256:cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "getopts"
+
+%package     -n %{name}+core
+Summary:        Getopts-like option parsing - feature "core"
+Requires:       crate(%{pkgname})
+Requires:       crate(rustc-std-workspace-core-1.0/default) >= 1.0.0
+Provides:       crate(%{pkgname}/core)
+
+%description -n %{name}+core
+This metapackage enables feature "core" for the Rust getopts crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+rustc-dep-of-std
+Summary:        Getopts-like option parsing - feature "rustc-dep-of-std"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/core)
+Requires:       crate(%{pkgname}/std)
+Provides:       crate(%{pkgname}/rustc-dep-of-std)
+
+%description -n %{name}+rustc-dep-of-std
+This metapackage enables feature "rustc-dep-of-std" for the Rust getopts crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+std
+Summary:        Getopts-like option parsing - feature "std"
+Requires:       crate(%{pkgname})
+Requires:       crate(rustc-std-workspace-std-1.0/default) >= 1.0.0
+Provides:       crate(%{pkgname}/std)
+
+%description -n %{name}+std
+This metapackage enables feature "std" for the Rust getopts crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+unicode
+Summary:        Getopts-like option parsing - feature "unicode" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(unicode-width-0.2/default) >= 0.2.2
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/unicode)
+
+%description -n %{name}+unicode
+This metapackage enables feature "unicode" for the Rust getopts crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "default" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-globwalk-0.9/rust-globwalk.spec
+++ b/SPECS/rust-globwalk-0.9/rust-globwalk.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name globwalk
+%global full_version 0.9.1
+%global pkgname globwalk-0.9
+
+Name:           rust-globwalk-0.9
+Version:        0.9.1
+Release:        %autorelease
+Summary:        Rust crate "globwalk"
+License:        MIT
+URL:            https://github.com/gilnaa/globwalk
+#!RemoteAsset:  sha256:0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(bitflags-2.0/default) >= 2.11.1
+Requires:       crate(ignore-0.4/default) >= 0.4.25
+Requires:       crate(walkdir-2.0/default) >= 2.5.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "globwalk"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-iana-time-zone-0.1/rust-iana-time-zone.spec
+++ b/SPECS/rust-iana-time-zone-0.1/rust-iana-time-zone.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name iana-time-zone
+%global full_version 0.1.64
+%global pkgname iana-time-zone-0.1
+
+Name:           rust-iana-time-zone-0.1
+Version:        0.1.64
+Release:        %autorelease
+Summary:        Rust crate "iana-time-zone"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/strawlab/iana-time-zone
+#!RemoteAsset:  sha256:33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(android-system-properties-0.1/default) >= 0.1.5
+Requires:       crate(core-foundation-sys-0.8/default) >= 0.8.7
+Requires:       crate(iana-time-zone-haiku-0.1/default) >= 0.1.2
+Requires:       crate(js-sys-0.3/default) >= 0.3.82
+Requires:       crate(log-0.4/default) >= 0.4.29
+Requires:       crate(wasm-bindgen-0.2/default) >= 0.2.105
+Requires:       crate(windows-core-0.62/default) >= 0.62.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/fallback)
+
+%description
+Source code for takopackized Rust crate "iana-time-zone"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-iana-time-zone-haiku-0.1/rust-iana-time-zone-haiku.spec
+++ b/SPECS/rust-iana-time-zone-haiku-0.1/rust-iana-time-zone-haiku.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name iana-time-zone-haiku
+%global full_version 0.1.2
+%global pkgname iana-time-zone-haiku-0.1
+
+Name:           rust-iana-time-zone-haiku-0.1
+Version:        0.1.2
+Release:        %autorelease
+Summary:        Rust crate "iana-time-zone-haiku"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/strawlab/iana-time-zone
+#!RemoteAsset:  sha256:f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(cc-1.0/default) >= 1.2.38
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "iana-time-zone-haiku"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-ident-case-1.0/rust-ident-case.spec
+++ b/SPECS/rust-ident-case-1.0/rust-ident-case.spec
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name ident_case
+%global full_version 1.0.1
+%global pkgname ident-case-1.0
+
+Name:           rust-ident-case-1.0
+Version:        1.0.1
+Release:        %autorelease
+Summary:        Rust crate "ident_case"
+License:        MIT/Apache-2.0
+URL:            https://github.com/TedDriggs/ident_case
+#!RemoteAsset:  sha256:b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "ident_case"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-imara-diff-0.2/rust-imara-diff.spec
+++ b/SPECS/rust-imara-diff-0.2/rust-imara-diff.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name imara-diff
+%global full_version 0.2.0
+%global pkgname imara-diff-0.2
+
+Name:           rust-imara-diff-0.2
+Version:        0.2.0
+Release:        %autorelease
+Summary:        Rust crate "imara-diff"
+License:        Apache-2.0
+URL:            https://github.com/pascalkuthe/imara-diff
+#!RemoteAsset:  sha256:2f01d462f766df78ab820dd06f5eb700233c51f0f4c2e846520eaf4ba6aa5c5c
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(hashbrown-0.15/default-hasher) >= 0.15.5
+Requires:       crate(hashbrown-0.15/inline-more) >= 0.15.5
+Requires:       crate(memchr-2.0/default) >= 2.8.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/unified-diff)
+
+%description
+Source code for takopackized Rust crate "imara-diff"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-imperative-1.0/rust-imperative.spec
+++ b/SPECS/rust-imperative-1.0/rust-imperative.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name imperative
+%global full_version 1.0.7
+%global pkgname imperative-1.0
+
+Name:           rust-imperative-1.0
+Version:        1.0.7
+Release:        %autorelease
+Summary:        Rust crate "imperative"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/crate-ci/imperative
+#!RemoteAsset:  sha256:35e1d0bd9c575c52e59aad8e122a11786e852a154678d0c86e9e243d55273970
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(phf-0.13/default) >= 0.13.1
+Requires:       crate(rust-stemmers-1.0/default) >= 1.2.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "imperative"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-indicatif-0.18/rust-indicatif.spec
+++ b/SPECS/rust-indicatif-0.18/rust-indicatif.spec
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name indicatif
+%global full_version 0.18.4
+%global pkgname indicatif-0.18
+
+Name:           rust-indicatif-0.18
+Version:        0.18.4
+Release:        %autorelease
+Summary:        Rust crate "indicatif"
+License:        MIT
+URL:            https://github.com/console-rs/indicatif
+#!RemoteAsset:  sha256:25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(console-0.16/ansi-parsing) >= 0.16.1
+Requires:       crate(console-0.16/std) >= 0.16.1
+Requires:       crate(portable-atomic-1.0/default) >= 1.13.1
+Requires:       crate(unit-prefix-0.5/default) >= 0.5.1
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "indicatif"
+
+%package     -n %{name}+default
+Summary:        Progress bar and cli reporting library for Rust - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/unicode-width)
+Requires:       crate(%{pkgname}/wasmbind)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust indicatif crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+futures
+Summary:        Progress bar and cli reporting library for Rust - feature "futures"
+Requires:       crate(%{pkgname})
+Requires:       crate(futures-core-0.3) >= 0.3.0
+Provides:       crate(%{pkgname}/futures)
+
+%description -n %{name}+futures
+This metapackage enables feature "futures" for the Rust indicatif crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+improved-unicode
+Summary:        Progress bar and cli reporting library for Rust - feature "improved_unicode"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/unicode-segmentation)
+Requires:       crate(%{pkgname}/unicode-width)
+Provides:       crate(%{pkgname}/improved-unicode)
+
+%description -n %{name}+improved-unicode
+This metapackage enables feature "improved_unicode" for the Rust indicatif crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+rayon
+Summary:        Progress bar and cli reporting library for Rust - feature "rayon"
+Requires:       crate(%{pkgname})
+Requires:       crate(rayon-1.0/default) >= 1.1
+Provides:       crate(%{pkgname}/rayon)
+
+%description -n %{name}+rayon
+This metapackage enables feature "rayon" for the Rust indicatif crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+tokio
+Summary:        Progress bar and cli reporting library for Rust - feature "tokio"
+Requires:       crate(%{pkgname})
+Requires:       crate(tokio-1.0/default) >= 1.0.0
+Requires:       crate(tokio-1.0/io-util) >= 1.0.0
+Provides:       crate(%{pkgname}/tokio)
+
+%description -n %{name}+tokio
+This metapackage enables feature "tokio" for the Rust indicatif crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+unicode-segmentation
+Summary:        Progress bar and cli reporting library for Rust - feature "unicode-segmentation"
+Requires:       crate(%{pkgname})
+Requires:       crate(unicode-segmentation-1.0/default) >= 1.0.0
+Provides:       crate(%{pkgname}/unicode-segmentation)
+
+%description -n %{name}+unicode-segmentation
+This metapackage enables feature "unicode-segmentation" for the Rust indicatif crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+unicode-width
+Summary:        Progress bar and cli reporting library for Rust - feature "unicode-width"
+Requires:       crate(%{pkgname})
+Requires:       crate(console-0.16/ansi-parsing) >= 0.16.1
+Requires:       crate(console-0.16/std) >= 0.16.1
+Requires:       crate(console-0.16/unicode-width) >= 0.16.1
+Requires:       crate(unicode-width-0.2/default) >= 0.2.2
+Provides:       crate(%{pkgname}/unicode-width)
+
+%description -n %{name}+unicode-width
+This metapackage enables feature "unicode-width" for the Rust indicatif crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+vt100
+Summary:        Progress bar and cli reporting library for Rust - feature "vt100" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(vt100-0.16/default) >= 0.16.2
+Provides:       crate(%{pkgname}/in-memory)
+Provides:       crate(%{pkgname}/vt100)
+
+%description -n %{name}+vt100
+This metapackage enables feature "vt100" for the Rust indicatif crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "in_memory" feature.
+
+%package     -n %{name}+wasmbind
+Summary:        Progress bar and cli reporting library for Rust - feature "wasmbind"
+Requires:       crate(%{pkgname})
+Requires:       crate(web-time-1.0/default) >= 1.1.0
+Provides:       crate(%{pkgname}/wasmbind)
+
+%description -n %{name}+wasmbind
+This metapackage enables feature "wasmbind" for the Rust indicatif crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-inotify-0.11/rust-inotify.spec
+++ b/SPECS/rust-inotify-0.11/rust-inotify.spec
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name inotify
+%global full_version 0.11.0
+%global pkgname inotify-0.11
+
+Name:           rust-inotify-0.11
+Version:        0.11.0
+Release:        %autorelease
+Summary:        Rust crate "inotify"
+License:        ISC
+URL:            https://github.com/hannobraun/inotify
+#!RemoteAsset:  sha256:f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(bitflags-2.0/default) >= 2.11.1
+Requires:       crate(inotify-sys-0.1/default) >= 0.1.5
+Requires:       crate(libc-0.2/default) >= 0.2.186
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "inotify"
+
+%package     -n %{name}+futures-core
+Summary:        Idiomatic wrapper for inotify - feature "futures-core"
+Requires:       crate(%{pkgname})
+Requires:       crate(futures-core-0.3/default) >= 0.3.1
+Provides:       crate(%{pkgname}/futures-core)
+
+%description -n %{name}+futures-core
+This metapackage enables feature "futures-core" for the Rust inotify crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+stream
+Summary:        Idiomatic wrapper for inotify - feature "stream" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/futures-core)
+Requires:       crate(%{pkgname}/tokio)
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/stream)
+
+%description -n %{name}+stream
+This metapackage enables feature "stream" for the Rust inotify crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "default" feature.
+
+%package     -n %{name}+tokio
+Summary:        Idiomatic wrapper for inotify - feature "tokio"
+Requires:       crate(%{pkgname})
+Requires:       crate(tokio-1.0/default) >= 1.0.1
+Requires:       crate(tokio-1.0/net) >= 1.0.1
+Provides:       crate(%{pkgname}/tokio)
+
+%description -n %{name}+tokio
+This metapackage enables feature "tokio" for the Rust inotify crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog


### PR DESCRIPTION
necessity: a bunch of rustcrates used by python-ruff, which are packages useful for AI stack.

Generated by TakoPack.

AI declaration: organized by GPT-5.5, reviewed by human