### PR TITLE
SPECS: labwc: add dependency xkeyboard-config

### DIFF
--- a/SPECS/labwc/labwc.spec
+++ b/SPECS/labwc/labwc.spec
@@ -34,6 +34,7 @@ BuildRequires:  pkgconfig(xcb)
 BuildRequires:  pkgconfig(xkbcommon)
 
 Requires:       xdg-desktop-portal-wlr
+Requires:       xkeyboard-config
 
 %description
 Labwc is a wlroots-based window-stacking compositor for wayland, inspired by


### PR DESCRIPTION
Otherwise labwc doesn't start because of failing to find keymaps.