### PR TITLE
SPECS/llvm22: append maj_ver to python3-lldb package name

### DIFF
--- a/SPECS/llvm22/llvm22.spec
+++ b/SPECS/llvm22/llvm22.spec
@@ -118,6 +118,7 @@ BuildRequires:  python3dist(nanobind)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(psutil)
+BuildRequires:  python3dist(pexpect)
 BuildRequires:  pyproject-rpm-macros
 # for tests
 BuildRequires:  perl(Digest::MD5)
@@ -133,7 +134,7 @@ BuildRequires:  perl(Text::ParseWords)
 BuildRequires:  perl(Sys::Hostname)
 BuildRequires:  procps-ng
 
-Requires:       llvm%{maj_ver}-libs%{?_isa} = %{version}-%{release}
+Requires:       llvm%{maj_ver}-libs = %{version}-%{release}
 Provides:       llvm(major) = %{maj_ver}
 
 %description
@@ -182,7 +183,7 @@ This is for internal use by LLVM packages only.
 
 %package     -n clang%{maj_ver}
 Summary:        A C language family front-end for LLVM (%{maj_ver})
-Requires:       clang%{maj_ver}-libs%{?_isa} = %{version}-%{release}
+Requires:       clang%{maj_ver}-libs = %{version}-%{release}
 # clang requires gcc, clang++ requires libstdc++-devel
 Requires:       libstdc++-devel
 Provides:       clang(major) = %{maj_ver}
@@ -198,10 +199,10 @@ libomp-devel to enable -fopenmp.
 
 %package     -n clang%{maj_ver}-libs
 Summary:        Runtime library for clang (%{maj_ver})
-Recommends:     compiler-rt%{maj_ver}%{?_isa} = %{version}-%{release}
+Recommends:     compiler-rt%{maj_ver} = %{version}-%{release}
 Requires:       llvm%{maj_ver}-libs = %{version}-%{release}
 # atomic support is not part of compiler-rt
-Recommends:     libatomic%{?_isa}
+Recommends:     libatomic
 # libomp-devel is required, so clang can find the omp.h header when compiling
 # with -fopenmp.
 Recommends:     libomp%{maj_ver}-devel%{_isa} = %{version}-%{release}
@@ -213,11 +214,11 @@ Runtime library for clang.
 %package     -n clang%{maj_ver}-devel
 Summary:        Development header files for clang (%{maj_ver})
 Requires:       clang%{maj_ver}-libs = %{version}-%{release}
-Requires:       clang%{maj_ver}%{?_isa} = %{version}-%{release}
+Requires:       clang%{maj_ver} = %{version}-%{release}
 # The clang CMake files reference tools from clang-tools-extra.
-Requires:       clang%{maj_ver}-tools-extra%{?_isa} = %{version}-%{release}
+Requires:       clang%{maj_ver}-tools-extra = %{version}-%{release}
 # The clang cmake package depends on the LLVM cmake package.
-Requires:       llvm%{maj_ver}-devel%{?_isa} = %{version}-%{release}
+Requires:       llvm%{maj_ver}-devel = %{version}-%{release}
 Provides:       clang-devel(major) = %{maj_ver}
 
 %description -n clang%{maj_ver}-devel
@@ -225,7 +226,7 @@ Development header files for clang.
 
 %package     -n clang%{maj_ver}-static
 Summary:        Clang static libraries (%{maj_ver})
-Requires:       clang%{maj_ver}-devel%{?_isa} = %{version}-%{release}
+Requires:       clang%{maj_ver}-devel = %{version}-%{release}
 Provides:       clang-static(major) = %{maj_ver}
 
 %description -n clang%{maj_ver}-static
@@ -244,7 +245,7 @@ intended to run in tandem with a build of a project or code base.
 
 %package     -n clang%{maj_ver}-tools-extra
 Summary:        Extra tools for clang (%{maj_ver})
-Requires:       clang%{maj_ver}-libs%{?_isa} = %{version}-%{release}
+Requires:       clang%{maj_ver}-libs = %{version}-%{release}
 
 %description -n clang%{maj_ver}-tools-extra
 A set of extra tools built using Clang's tooling API.
@@ -258,7 +259,7 @@ Development header files for clang tools.
 
 %package    -n python3-clang%{maj_ver}
 Summary:        Python bindings for clang (%{maj_ver})
-Requires:      clang%{maj_ver}-devel%{?_isa} = %{version}-%{release}
+Requires:      clang%{maj_ver}-devel = %{version}-%{release}
 Requires:      python3
 
 %description -n python3-clang%{maj_ver}
@@ -279,7 +280,7 @@ to provide a complete compilation solution for mixed-language projects.
 
 %package     -n flang%{maj_ver}-static
 Summary:        Flang static libraries (%{maj_ver})
-Requires:       flang%{maj_ver}%{?_isa} = %{version}-%{release}
+Requires:       flang%{maj_ver} = %{version}-%{release}
 Provides:       flang-static(major) = %{maj_ver}
 
 %description -n flang%{maj_ver}-static
@@ -299,7 +300,7 @@ instrumentation, and Blocks C language extension.
 %package     -n libomp%{maj_ver}
 Summary:        OpenMP runtime for clang (%{maj_ver})
 URL:            http://openmp.llvm.org
-Requires:       llvm%{maj_ver}-libs%{?_isa} = %{version}-%{release}
+Requires:       llvm%{maj_ver}-libs = %{version}-%{release}
 Provides:       libomp(major) = %{maj_ver}
 
 %description -n libomp%{maj_ver}
@@ -308,7 +309,7 @@ OpenMP runtime for clang.
 %package     -n libomp%{maj_ver}-devel
 Summary:        OpenMP header files (%{maj_ver})
 URL:            http://openmp.llvm.org
-Requires:       libomp%{maj_ver}%{?_isa} = %{version}-%{release}
+Requires:       libomp%{maj_ver} = %{version}-%{release}
 Provides:       libomp-devel(major) = %{maj_ver}
 
 %description  -n libomp%{maj_ver}-devel
@@ -325,7 +326,7 @@ The LLVM project linker.
 
 %package     -n lld%{maj_ver}-devel
 Summary:        Libraries and header files for LLD (%{maj_ver})
-Requires:       lld%{maj_ver}%{?_isa} = %{version}-%{release}
+Requires:       lld%{maj_ver} = %{version}-%{release}
 Provides:       lld-devel(major) = %{maj_ver}
 
 %description -n lld%{maj_ver}-devel
@@ -336,8 +337,8 @@ programs that use the LLD infrastructure.
 Summary:        Next generation high-performance debugger (%{maj_ver})
 License:        Apache-2.0 WITH LLVM-exception OR NCSA
 URL:            http://lldb.llvm.org/
-Requires:       clang%{maj_ver}-libs%{?_isa} = %{version}-%{release}
-Requires:       python3-lldb
+Requires:       clang%{maj_ver}-libs = %{version}-%{release}
+Requires:       python3-lldb%{maj_ver}
 
 %description -n lldb%{maj_ver}
 LLDB is a next generation, high-performance debugger. It is built as a set
@@ -347,16 +348,18 @@ disassembler.
 
 %package     -n lldb%{maj_ver}-devel
 Summary:        Development header files for LLDB (%{maj_ver})
-Requires:       lldb%{maj_ver}%{?_isa} = %{version}-%{release}
+Requires:       lldb%{maj_ver} = %{version}-%{release}
 
 %description -n lldb%{maj_ver}-devel
 The package contains header files for the LLDB debugger.
 
-%package     -n python3-lldb
+%package     -n python3-lldb%{maj_ver}
 Summary:        Python module for LLDB (%{maj_ver})
-Requires:       lldb%{maj_ver}%{?_isa} = %{version}-%{release}
+Requires:       lldb%{maj_ver} = %{version}-%{release}
+Obsoletes:      python3-lldb < %{version}-%{release}
+Conflicts:      python3-lldb < %{version}-%{release}
 
-%description -n python3-lldb
+%description -n python3-lldb%{maj_ver}
 The package contains the LLDB Python module.
 
 %package     -n mlir%{maj_ver}
@@ -374,15 +377,15 @@ existing compilers together.
 
 %package     -n mlir%{maj_ver}-static
 Summary:        MLIR static files (%{maj_ver})
-Requires:       mlir%{maj_ver}%{?_isa} = %{version}-%{release}
+Requires:       mlir%{maj_ver} = %{version}-%{release}
 
 %description -n mlir%{maj_ver}-static
 MLIR static files.
 
 %package     -n mlir%{maj_ver}-devel
 Summary:        MLIR development files (%{maj_ver})
-Requires:       mlir%{maj_ver}%{?_isa} = %{version}-%{release}
-Requires:       mlir%{maj_ver}-static%{?_isa} = %{version}-%{release}
+Requires:       mlir%{maj_ver} = %{version}-%{release}
+Requires:       mlir%{maj_ver}-static = %{version}-%{release}
 
 %description -n mlir%{maj_ver}-devel
 MLIR development files.
@@ -399,7 +402,7 @@ MLIR python bindings.
 Summary:        C++ standard library targeting C++11 (LLVM %{maj_ver})
 License:        Apache-2.0 WITH LLVM-exception OR MIT OR NCSA
 URL:            http://libcxx.llvm.org/
-Requires:       libcxxabi%{maj_ver}%{?_isa} = %{version}-%{release}
+Requires:       libcxxabi%{maj_ver} = %{version}-%{release}
 
 %description -n libcxx%{maj_ver}
 libc++ is a new implementation of the C++ standard library, targeting C++11 and above.
@@ -407,7 +410,7 @@ This package contains LLVM version %{maj_ver}.
 
 %package     -n libcxx%{maj_ver}-devel
 Summary:        Headers and libraries for libcxx%{maj_ver} development
-Requires:       libcxx%{maj_ver}%{?_isa} = %{version}-%{release}
+Requires:       libcxx%{maj_ver} = %{version}-%{release}
 Requires:       libcxxabi%{maj_ver}-devel
 
 %description -n libcxx%{maj_ver}-devel
@@ -430,7 +433,7 @@ This package contains LLVM version %{maj_ver}.
 
 %package     -n libcxxabi%{maj_ver}-devel
 Summary:        Headers and libraries for libcxxabi%{maj_ver} development
-Requires:       libcxxabi%{maj_ver}%{?_isa} = %{version}-%{release}
+Requires:       libcxxabi%{maj_ver} = %{version}-%{release}
 
 %description -n libcxxabi%{maj_ver}-devel
 Headers and libraries for libcxxabi%{maj_ver} development.
@@ -457,7 +460,7 @@ This package contains LLVM version %{maj_ver}.
 %package     -n llvm-libunwind%{maj_ver}-devel
 Summary:        LLVM libunwind development files (version %{maj_ver})
 Provides:       llvm-libunwind(major) = %{maj_ver}
-Requires:       llvm-libunwind%{maj_ver}%{?_isa} = %{version}-%{release}
+Requires:       llvm-libunwind%{maj_ver} = %{version}-%{release}
 
 %description -n llvm-libunwind%{maj_ver}-devel
 Development files for LLVM libunwind version %{maj_ver}.
@@ -568,7 +571,9 @@ OLD_CWD="$PWD"
     -DLLVM_BUILD_DOCS:BOOL=OFF
 
 # lldb options
-%global cmake_config_args %{cmake_config_args} -DLLDB_ENFORCE_STRICT_TEST_REQUIREMENTS:BOOL=ON
+%global cmake_config_args %{cmake_config_args} \\\
+    -DLLDB_ENFORCE_STRICT_TEST_REQUIREMENTS:BOOL=ON \\\
+    -DLLDB_PYTHON_RELATIVE_PATH=lib/python%{python3_version}/site-packages
 
 # libcxx options
 %global cmake_config_args %{cmake_config_args}  \\\
@@ -707,8 +712,6 @@ done
 popd
 
 mkdir -p %{buildroot}/%{install_python3mod}
-#FIXME: why lldb install python mod here?
-mv -f %{buildroot}/%{install_prefix}/lib64/python%{python3_version}/site-packages/* %{buildroot}/%{install_python3mod}
 cp -a clang/bindings/python/clang %{buildroot}/%{install_python3mod}
 mv -f %{buildroot}/%{install_prefix}/python_packages/mlir_core/mlir %{buildroot}/%{install_python3mod}
 
@@ -1101,7 +1104,7 @@ fi
     yaml2macho-core
 }}
 
-%files -n python3-lldb
+%files -n python3-lldb%{maj_ver}
 %{install_python3mod}/lldb
 
 %files -n mlir%{maj_ver}

--- a/SPECS/llvm22/llvm22.spec
+++ b/SPECS/llvm22/llvm22.spec
@@ -134,7 +134,7 @@ BuildRequires:  perl(Text::ParseWords)
 BuildRequires:  perl(Sys::Hostname)
 BuildRequires:  procps-ng
 
-Requires:       llvm%{maj_ver}-libs = %{version}-%{release}
+Requires:       llvm%{maj_ver}-libs%{?_isa} = %{version}-%{release}
 Provides:       llvm(major) = %{maj_ver}
 
 %description
@@ -145,8 +145,8 @@ tools as well as libraries with equivalent functionality.
 
 %package     -n llvm%{maj_ver}-devel
 Summary:        Libraries and header files for LLVM (%{maj_ver})
-Requires:       llvm%{maj_ver} = %{version}-%{release}
-Requires:       llvm%{maj_ver}-libs = %{version}-%{release}
+Requires:       llvm%{maj_ver}%{?_isa} = %{version}-%{release}
+Requires:       llvm%{maj_ver}-libs%{?_isa} = %{version}-%{release}
 # The installed LLVM cmake files will add -ledit to the linker flags for any
 # app that requires the libLLVMLineEditor, so we need to make sure
 # libedit-devel is available.
@@ -154,7 +154,7 @@ Requires:       pkgconfig(libedit)
 Requires:       pkgconfig(libzstd)
 # The installed cmake files reference binaries from llvm-test, llvm-static, and
 # llvm-gtest.
-Requires:       llvm%{maj_ver}-static = %{version}-%{release}
+Requires:       llvm%{maj_ver}-static%{?_isa} = %{version}-%{release}
 Provides:       llvm-devel(major) = %{maj_ver}
 
 %description -n llvm%{maj_ver}-devel
@@ -183,9 +183,9 @@ This is for internal use by LLVM packages only.
 
 %package     -n clang%{maj_ver}
 Summary:        A C language family front-end for LLVM (%{maj_ver})
-Requires:       clang%{maj_ver}-libs = %{version}-%{release}
+Requires:       clang%{maj_ver}-libs%{?_isa} = %{version}-%{release}
 # clang requires gcc, clang++ requires libstdc++-devel
-Requires:       libstdc++-devel
+Requires:       libstdc++-devel%{?_isa}
 Provides:       clang(major) = %{maj_ver}
 
 %description -n clang%{maj_ver}
@@ -199,10 +199,10 @@ libomp-devel to enable -fopenmp.
 
 %package     -n clang%{maj_ver}-libs
 Summary:        Runtime library for clang (%{maj_ver})
-Recommends:     compiler-rt%{maj_ver} = %{version}-%{release}
+Recommends:     compiler-rt%{maj_ver}%{?_isa} = %{version}-%{release}
 Requires:       llvm%{maj_ver}-libs = %{version}-%{release}
 # atomic support is not part of compiler-rt
-Recommends:     libatomic
+Recommends:     libatomic%{?_isa}
 # libomp-devel is required, so clang can find the omp.h header when compiling
 # with -fopenmp.
 Recommends:     libomp%{maj_ver}-devel%{_isa} = %{version}-%{release}
@@ -213,12 +213,12 @@ Runtime library for clang.
 
 %package     -n clang%{maj_ver}-devel
 Summary:        Development header files for clang (%{maj_ver})
-Requires:       clang%{maj_ver}-libs = %{version}-%{release}
-Requires:       clang%{maj_ver} = %{version}-%{release}
+Requires:       clang%{maj_ver}-libs%{?_isa} = %{version}-%{release}
+Requires:       clang%{maj_ver}%{?_isa} = %{version}-%{release}
 # The clang CMake files reference tools from clang-tools-extra.
-Requires:       clang%{maj_ver}-tools-extra = %{version}-%{release}
+Requires:       clang%{maj_ver}-tools-extra%{?_isa} = %{version}-%{release}
 # The clang cmake package depends on the LLVM cmake package.
-Requires:       llvm%{maj_ver}-devel = %{version}-%{release}
+Requires:       llvm%{maj_ver}-devel%{?_isa} = %{version}-%{release}
 Provides:       clang-devel(major) = %{maj_ver}
 
 %description -n clang%{maj_ver}-devel
@@ -226,7 +226,7 @@ Development header files for clang.
 
 %package     -n clang%{maj_ver}-static
 Summary:        Clang static libraries (%{maj_ver})
-Requires:       clang%{maj_ver}-devel = %{version}-%{release}
+Requires:       clang%{maj_ver}-devel%{?_isa} = %{version}-%{release}
 Provides:       clang-static(major) = %{maj_ver}
 
 %description -n clang%{maj_ver}-static
@@ -235,7 +235,7 @@ Static libraries for Clang.
 %package     -n clang%{maj_ver}-analyzer
 Summary:        A source code analysis framework (%{maj_ver})
 License:        Apache-2.0 WITH LLVM-exception OR NCSA OR MIT
-Requires:       clang%{maj_ver} = %{version}-%{release}
+Requires:       clang%{maj_ver}%{?_isa} = %{version}-%{release}
 
 %description -n clang%{maj_ver}-analyzer
 The Clang Static Analyzer consists of both a source code analysis
@@ -245,21 +245,21 @@ intended to run in tandem with a build of a project or code base.
 
 %package     -n clang%{maj_ver}-tools-extra
 Summary:        Extra tools for clang (%{maj_ver})
-Requires:       clang%{maj_ver}-libs = %{version}-%{release}
+Requires:       clang%{maj_ver}-libs%{?_isa} = %{version}-%{release}
 
 %description -n clang%{maj_ver}-tools-extra
 A set of extra tools built using Clang's tooling API.
 
 %package     -n clang%{maj_ver}-tools-extra-devel
 Summary:        Development header files for clang tools (%{maj_ver})
-Requires:       clang%{maj_ver}-tools-extra = %{version}-%{release}
+Requires:       clang%{maj_ver}-tools-extra%{?_isa} = %{version}-%{release}
 
 %description -n clang%{maj_ver}-tools-extra-devel
 Development header files for clang tools.
 
 %package    -n python3-clang%{maj_ver}
 Summary:        Python bindings for clang (%{maj_ver})
-Requires:      clang%{maj_ver}-devel = %{version}-%{release}
+Requires:      clang%{maj_ver}-devel%{?_isa} = %{version}-%{release}
 Requires:      python3
 
 %description -n python3-clang%{maj_ver}
@@ -280,7 +280,7 @@ to provide a complete compilation solution for mixed-language projects.
 
 %package     -n flang%{maj_ver}-static
 Summary:        Flang static libraries (%{maj_ver})
-Requires:       flang%{maj_ver} = %{version}-%{release}
+Requires:       flang%{maj_ver}%{?_isa} = %{version}-%{release}
 Provides:       flang-static(major) = %{maj_ver}
 
 %description -n flang%{maj_ver}-static
@@ -300,7 +300,7 @@ instrumentation, and Blocks C language extension.
 %package     -n libomp%{maj_ver}
 Summary:        OpenMP runtime for clang (%{maj_ver})
 URL:            http://openmp.llvm.org
-Requires:       llvm%{maj_ver}-libs = %{version}-%{release}
+Requires:       llvm%{maj_ver}-libs%{?_isa} = %{version}-%{release}
 Provides:       libomp(major) = %{maj_ver}
 
 %description -n libomp%{maj_ver}
@@ -309,7 +309,7 @@ OpenMP runtime for clang.
 %package     -n libomp%{maj_ver}-devel
 Summary:        OpenMP header files (%{maj_ver})
 URL:            http://openmp.llvm.org
-Requires:       libomp%{maj_ver} = %{version}-%{release}
+Requires:       libomp%{maj_ver}%{?_isa} = %{version}-%{release}
 Provides:       libomp-devel(major) = %{maj_ver}
 
 %description  -n libomp%{maj_ver}-devel
@@ -317,8 +317,6 @@ OpenMP header files.
 
 %package      -n lld%{maj_ver}
 Summary:        The LLVM Linker (%{maj_ver})
-Requires(post):  chkconfig
-Requires(preun): chkconfig
 Provides:        lld(major) = %{maj_ver}
 
 %description -n lld%{maj_ver}
@@ -326,7 +324,7 @@ The LLVM project linker.
 
 %package     -n lld%{maj_ver}-devel
 Summary:        Libraries and header files for LLD (%{maj_ver})
-Requires:       lld%{maj_ver} = %{version}-%{release}
+Requires:       lld%{maj_ver}%{?_isa} = %{version}-%{release}
 Provides:       lld-devel(major) = %{maj_ver}
 
 %description -n lld%{maj_ver}-devel
@@ -337,8 +335,8 @@ programs that use the LLD infrastructure.
 Summary:        Next generation high-performance debugger (%{maj_ver})
 License:        Apache-2.0 WITH LLVM-exception OR NCSA
 URL:            http://lldb.llvm.org/
-Requires:       clang%{maj_ver}-libs = %{version}-%{release}
-Requires:       python3-lldb%{maj_ver}
+Requires:       clang%{maj_ver}-libs%{?_isa} = %{version}-%{release}
+Recommends:     python3-lldb%{maj_ver}%{?_isa} = %{version}-%{release}
 
 %description -n lldb%{maj_ver}
 LLDB is a next generation, high-performance debugger. It is built as a set
@@ -348,14 +346,14 @@ disassembler.
 
 %package     -n lldb%{maj_ver}-devel
 Summary:        Development header files for LLDB (%{maj_ver})
-Requires:       lldb%{maj_ver} = %{version}-%{release}
+Requires:       lldb%{maj_ver}%{?_isa} = %{version}-%{release}
 
 %description -n lldb%{maj_ver}-devel
 The package contains header files for the LLDB debugger.
 
 %package     -n python3-lldb%{maj_ver}
 Summary:        Python module for LLDB (%{maj_ver})
-Requires:       lldb%{maj_ver} = %{version}-%{release}
+Requires:       lldb%{maj_ver}%{?_isa} = %{version}-%{release}
 Obsoletes:      python3-lldb < %{version}-%{release}
 Conflicts:      python3-lldb < %{version}-%{release}
 
@@ -366,7 +364,7 @@ The package contains the LLDB Python module.
 Summary:        Multi-Level Intermediate Representation Overview (%{maj_ver})
 License:        Apache-2.0 WITH LLVM-exception
 URL:            http://mlir.llvm.org
-Requires:       llvm%{maj_ver}-libs = %{version}-%{release}
+Requires:       llvm%{maj_ver}-libs%{?_isa} = %{version}-%{release}
 
 %description -n mlir%{maj_ver}
 The MLIR project is a novel approach to building reusable and extensible
@@ -377,15 +375,15 @@ existing compilers together.
 
 %package     -n mlir%{maj_ver}-static
 Summary:        MLIR static files (%{maj_ver})
-Requires:       mlir%{maj_ver} = %{version}-%{release}
+Requires:       mlir%{maj_ver}%{?_isa} = %{version}-%{release}
 
 %description -n mlir%{maj_ver}-static
 MLIR static files.
 
 %package     -n mlir%{maj_ver}-devel
 Summary:        MLIR development files (%{maj_ver})
-Requires:       mlir%{maj_ver} = %{version}-%{release}
-Requires:       mlir%{maj_ver}-static = %{version}-%{release}
+Requires:       mlir%{maj_ver}%{?_isa} = %{version}-%{release}
+Requires:       mlir%{maj_ver}-static%{?_isa} = %{version}-%{release}
 
 %description -n mlir%{maj_ver}-devel
 MLIR development files.
@@ -402,7 +400,7 @@ MLIR python bindings.
 Summary:        C++ standard library targeting C++11 (LLVM %{maj_ver})
 License:        Apache-2.0 WITH LLVM-exception OR MIT OR NCSA
 URL:            http://libcxx.llvm.org/
-Requires:       libcxxabi%{maj_ver} = %{version}-%{release}
+Requires:       libcxxabi%{maj_ver}%{?_isa} = %{version}-%{release}
 
 %description -n libcxx%{maj_ver}
 libc++ is a new implementation of the C++ standard library, targeting C++11 and above.
@@ -410,8 +408,8 @@ This package contains LLVM version %{maj_ver}.
 
 %package     -n libcxx%{maj_ver}-devel
 Summary:        Headers and libraries for libcxx%{maj_ver} development
-Requires:       libcxx%{maj_ver} = %{version}-%{release}
-Requires:       libcxxabi%{maj_ver}-devel
+Requires:       libcxx%{maj_ver}%{?_isa} = %{version}-%{release}
+Requires:       libcxxabi%{maj_ver}-devel%{?_isa}
 
 %description -n libcxx%{maj_ver}-devel
 Headers and libraries for libcxx%{maj_ver} development.
@@ -433,7 +431,7 @@ This package contains LLVM version %{maj_ver}.
 
 %package     -n libcxxabi%{maj_ver}-devel
 Summary:        Headers and libraries for libcxxabi%{maj_ver} development
-Requires:       libcxxabi%{maj_ver} = %{version}-%{release}
+Requires:       libcxxabi%{maj_ver}%{?_isa} = %{version}-%{release}
 
 %description -n libcxxabi%{maj_ver}-devel
 Headers and libraries for libcxxabi%{maj_ver} development.
@@ -459,8 +457,8 @@ This package contains LLVM version %{maj_ver}.
 
 %package     -n llvm-libunwind%{maj_ver}-devel
 Summary:        LLVM libunwind development files (version %{maj_ver})
+Requires:       llvm-libunwind%{maj_ver}%{?_isa} = %{version}-%{release}
 Provides:       llvm-libunwind(major) = %{maj_ver}
-Requires:       llvm-libunwind%{maj_ver} = %{version}-%{release}
 
 %description -n llvm-libunwind%{maj_ver}-devel
 Development files for LLVM libunwind version %{maj_ver}.
@@ -722,14 +720,6 @@ rm -f %{buildroot}/%{install_libdir}/libllvm_gtest*
 
 %check
 # it takes days to complete the testing. Let's just disable it for now.
-
-%post -n lld%{maj_ver}
-update-alternatives --install %{_bindir}/ld ld %{_bindir}/ld.lld 1
-
-%postun -n lld%{maj_ver}
-if [ $1 -eq 0 ] ; then
-  update-alternatives --remove ld %{_bindir}/ld.lld
-fi
 
 %define expand_bins() %{lua:
   local bindir = rpm.expand("%{_bindir}")


### PR DESCRIPTION
This is missing in the previous version.

We also remove update-alternative from this package, it should be in llvm-default package.