### PR TITLE
SPECS: libproxy: Update to 0.5.12.

### DIFF
--- a/SPECS/libproxy/0001-make-use-of-meson-library.patch
+++ b/SPECS/libproxy/0001-make-use-of-meson-library.patch
@@ -1,0 +1,44 @@
+From 1f26f58960dee8dd3f39c0d071d61f70be4aba90 Mon Sep 17 00:00:00 2001
+From: Jan-Michael Brummer <jan-michael.brummer1@volkswagen.de>
+Date: Mon, 15 Dec 2025 11:41:06 +0100
+Subject: [PATCH] Make use of meson library
+
+Use meson library instead of defining shared and static library on their
+own.
+
+Fixes: https://github.com/libproxy/libproxy/issues/343
+---
+ src/libproxy/meson.build | 13 +------------
+ 1 file changed, 1 insertion(+), 12 deletions(-)
+
+diff --git a/src/libproxy/meson.build b/src/libproxy/meson.build
+index ff8d80e8..b508c33e 100644
+--- a/src/libproxy/meson.build
++++ b/src/libproxy/meson.build
+@@ -32,7 +32,7 @@ elif build_machine.system() == 'sunos'
+   endif
+ endif
+ 
+-libproxy = shared_library(
++libproxy = library(
+   'proxy',
+   libproxy_sources,
+   include_directories: px_backend_inc,
+@@ -45,17 +45,6 @@ libproxy = shared_library(
+   install_rpath: pkglibdir,
+ )
+ 
+-libproxy_static = static_library(
+-  'proxy',
+-  libproxy_sources,
+-  include_directories: px_backend_inc,
+-  dependencies: libproxy_deps,
+-  link_args : vflag,
+-  link_depends : mapfile,
+-  install: true,
+-  install_rpath: pkglibdir,
+-)
+-
+ libproxy_dep = declare_dependency (
+   include_directories: libproxy_inc,
+   link_with: libproxy,

--- a/SPECS/libproxy/libproxy.spec
+++ b/SPECS/libproxy/libproxy.spec
@@ -6,15 +6,18 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 Name:           libproxy
-Version:        0.5.11
+Version:        0.5.12
 Release:        %autorelease
 Summary:        A library for proxy configuration management
 License:        LGPL-2.1-or-later
 URL:            https://libproxy.github.io/libproxy/
 VCS:            git:https://github.com/libproxy/libproxy
-#!RemoteAsset
+#!RemoteAsset:  sha256:a1fa55991998b80a567450a9e84382421a7176a84446c95caaa8b72cf09fa86f
 Source:         https://github.com/libproxy/libproxy/archive/refs/tags/%{version}.tar.gz
 BuildSystem:    meson
+
+# https://github.com/libproxy/libproxy/pull/344
+Patch0:         0001-make-use-of-meson-library.patch
 
 BuildOption(conf):  -Dconfig-gnome=false
 BuildOption(conf):  -Dconfig-kde=false
@@ -69,4 +72,4 @@ developing applications that use libproxy.
 %{_datadir}/vala/vapi/libproxy-1.0.vapi
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
We need to update our `libproxy`, otherwise we can't build Firefox:

```
[ 3663s] 59:00.28 E ld.lld: error: undefined hidden symbol: nsUnixSystemProxySettings::GetSystemProxyDirect(bool*)
[ 3663s] 59:00.28 E >>> referenced by ld-temp.o
[ 3663s] 59:00.28 E >>>               ../../../dist/bin/libxul.so.lto.o:(vtable for nsUnixSystemProxySettings)
[ 3665s] 59:02.29 E clang++: error: linker command failed with exit code 1 (use -v to see invocation)
[ 3665s] 59:02.29 E gmake[4]: *** [/home/abuild/rpmbuild/BUILD/firefox-151.0-build/firefox-151.0/config/rules.mk:531: ../../../dist/bin/libxul.so] Error 1
```