### PR TITLE
scripts/update-package: Push .changes file to track commit; associated fixes

### DIFF
--- a/scripts/update-package
+++ b/scripts/update-package
@@ -4,6 +4,7 @@ export REPO=openruyi
 export OSC="$DRYRUN osc"
 export BEFORE_COMMIT=$1
 export AFTER_COMMIT=$2
+export DATE="$(LC_ALL=en_US.UTF-8 date --utc '+%a %b %_d %T %Z %Y')"
 for P in $(git diff --no-renames --max-depth=1 --name-only $BEFORE_COMMIT..$AFTER_COMMIT --diff-filter=AM -- SPECS/)
 do
 PKG=$(basename $P)
@@ -13,6 +14,19 @@ $OSC api -X PUT /source/$REPO/$PKG/_meta -d "<?xml version=\"1.0\" encoding=\"UT
 <title/>
 <description/>
 </package>
+"
+$OSC api -X PUT /source/$REPO/$PKG/$PKG.changes -d \
+"----------------------------------------
+$DATE - openRuyi <update-package-v1@noreply.openruyi.cn>
+
+Automatic update from Git repository
+
+See changes at https://github.com/openRuyi-Project/openRuyi/commits/$AFTER_COMMIT/$P
+
+[metadata]
+version=1
+commit=$AFTER_COMMIT
+subdir=$P
 "
 $OSC api -X PUT /source/$REPO/$PKG/_service -d \
 "<services>

--- a/scripts/update-package
+++ b/scripts/update-package
@@ -4,11 +4,10 @@ export REPO=openruyi
 export OSC="$DRYRUN osc"
 export BEFORE_COMMIT=$1
 export AFTER_COMMIT=$2
-for I in $(git diff --no-renames --name-only $BEFORE_COMMIT..$AFTER_COMMIT --diff-filter=A -- SPECS/ | grep .spec$ | awk -F/ '!seen[$0]++')
+for P in $(git diff --no-renames --max-depth=1 --name-only $BEFORE_COMMIT..$AFTER_COMMIT --diff-filter=AM -- SPECS/)
 do
-P=$(dirname $I)
 PKG=$(basename $P)
-echo "do Add type change $P $PKG"
+echo "do Add/Modify type change $P $PKG"
 $OSC api -X PUT /source/$REPO/$PKG/_meta -d "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
 <package name=\"$PKG\" project=\"$REPO\">
 <title/>
@@ -20,7 +19,7 @@ $OSC api -X PUT /source/$REPO/$PKG/_service -d \
     <service name=\"obs_scm\" mode=\"trylocal\">
       <param name=\"scm\">git</param>
       <param name=\"url\">https://github.com/openRuyi-project/openruyi/</param>
-      <param name=\"revision\">main</param>
+      <param name=\"revision\">$AFTER_COMMIT</param>
       <param name=\"exclude\">*</param>
       <param name=\"extract\">$P/*</param>
     </service>
@@ -29,18 +28,8 @@ $OSC api -X PUT /source/$REPO/$PKG/_service -d \
 "
 done
 
-for I in $(git diff --no-renames --name-only $BEFORE_COMMIT..$AFTER_COMMIT --diff-filter=M -- SPECS/| awk -F/ '!seen[$0]++')
+for P in $(git diff --no-renames --max-depth=1 --name-only $BEFORE_COMMIT..$AFTER_COMMIT --diff-filter=D -- SPECS/)
 do
-P=$(dirname $I)
-PKG=$(basename $P)
-echo "do Modify type change $P $PKG"
-$OSC service rr $REPO $PKG
-done
-
-
-for I in $(git diff --no-renames --name-only $BEFORE_COMMIT..$AFTER_COMMIT --diff-filter=D -- SPECS/|grep .spec$ | awk -F/ '!seen[$0]++')
-do
-P=$(dirname $I)
 PKG=$(basename $P)
 echo "do Delete type change $P $PKG"
 echo "<package name=\"$PKG\" project=\"$REPO\">


### PR DESCRIPTION
Push a .changes file to track the commit and directory used, which should end up showing up in the RPM changelog.

This allows RPM packages to be traced back to the exact Git commit in our monorepo.