### PR TITLE
SPECS: add fzf and its dependencies

### DIFF
--- a/SPECS/fzf/fzf.spec
+++ b/SPECS/fzf/fzf.spec
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: panglars <panghao.riscv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define go_import_path  github.com/junegunn/fzf
+
+Name:           fzf
+Version:        0.72.0
+Release:        %autorelease
+Summary:        Command-line fuzzy finder
+License:        MIT
+URL:            https://github.com/junegunn/fzf
+#!RemoteAsset:  sha256:ca5ce083cec5187503ceb96d837c20d8efde85f03e62bba3a8890f8da526f2fc
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
+BuildSystem:    autotools
+
+BuildOption(build):  -C %{_builddir}/go/src/%{go_import_path}
+BuildOption(build):  FZF_VERSION=%{version}
+BuildOption(build):  FZF_REVISION=tarball
+BuildOption(build):  install
+
+BuildRequires:  go >= 1.23
+BuildRequires:  go-rpm-macros
+BuildRequires:  make
+BuildRequires:  go(github.com/charlievieth/fastwalk)
+BuildRequires:  go(github.com/gdamore/encoding)
+BuildRequires:  go(github.com/gdamore/tcell/v2)
+BuildRequires:  go(github.com/junegunn/go-shellwords)
+BuildRequires:  go(github.com/lucasb-eyer/go-colorful)
+BuildRequires:  go(github.com/mattn/go-isatty)
+BuildRequires:  go(github.com/mattn/go-runewidth)
+BuildRequires:  go(github.com/rivo/uniseg)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(golang.org/x/term)
+BuildRequires:  go(golang.org/x/text)
+
+Requires:       bash
+Recommends:     tmux
+
+%description
+fzf is a general-purpose command-line fuzzy finder. It can interactively filter
+files, command history, processes, host names, bookmarks, git commits, and other
+line-oriented input.
+
+%conf
+# No configuration needed.
+
+%build -p
+%go_common
+export GOFLAGS="-buildmode=pie -trimpath -buildvcs=false"
+mkdir -p %{_builddir}/go/src/github.com/junegunn
+# GOPATH mode lets the build use packaged Go dependency sources
+ln -snf "$(pwd)" %{_builddir}/go/src/%{go_import_path}
+
+# upstream %install only install bin/fzf
+%install
+install -D -m 0755 bin/fzf %{buildroot}%{_bindir}/fzf
+install -D -m 0755 bin/fzf-preview.sh %{buildroot}%{_bindir}/fzf-preview.sh
+install -D -m 0755 bin/fzf-tmux %{buildroot}%{_bindir}/fzf-tmux
+install -D -m 0644 man/man1/fzf.1 %{buildroot}%{_mandir}/man1/fzf.1
+install -D -m 0644 man/man1/fzf-tmux.1 %{buildroot}%{_mandir}/man1/fzf-tmux.1
+
+%check
+%go_common
+export GOFLAGS="-buildmode=pie -trimpath -buildvcs=false"
+%__make -C %{_builddir}/go/src/%{go_import_path} FZF_VERSION=%{version} FZF_REVISION=tarball test
+
+%files
+%doc ADVANCED.md BUILD.md CHANGELOG.md README.md README-VIM.md doc/fzf.txt
+%license LICENSE
+%{_bindir}/fzf
+%{_bindir}/fzf-preview.sh
+%{_bindir}/fzf-tmux
+%{_mandir}/man1/fzf.1*
+%{_mandir}/man1/fzf-tmux.1*
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-charlievieth-fastwalk/go-github-charlievieth-fastwalk.spec
+++ b/SPECS/go-github-charlievieth-fastwalk/go-github-charlievieth-fastwalk.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: panglars <panghao.riscv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           fastwalk
+%define go_import_path  github.com/charlievieth/fastwalk
+
+Name:           go-github-charlievieth-fastwalk
+Version:        1.0.14
+Release:        %autorelease
+Summary:        Fast parallel directory traversal for Go
+License:        MIT
+URL:            https://github.com/charlievieth/fastwalk
+#!RemoteAsset:  sha256:e5bba50b0239b74113a218cb11db00fc3dbaf81fdb155cb7e1573cdbd82d9f86
+Source0:        https://github.com/charlievieth/fastwalk/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{_name}-%{version}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/charlievieth/fastwalk) = %{version}
+
+%description
+Package fastwalk provides a fast parallel version of filepath.WalkDir with
+support for concurrent traversal and optional symbolic link handling.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-gdamore-encoding/go-github-gdamore-encoding.spec
+++ b/SPECS/go-github-gdamore-encoding/go-github-gdamore-encoding.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: panglars <panghao.riscv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           encoding
+%define go_import_path  github.com/gdamore/encoding
+
+Name:           go-github-gdamore-encoding
+Version:        1.0.1
+Release:        %autorelease
+Summary:        Character map encodings missing from the Go standard library
+License:        Apache-2.0
+URL:            https://github.com/gdamore/encoding
+#!RemoteAsset:  sha256:fc14f9f1d10d60a5888536df5a08e9e0fd7dad3412b9051a370edfe4cccf538d
+Source0:        https://github.com/gdamore/encoding/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{_name}-%{version}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(golang.org/x/text)
+
+Provides:       go(github.com/gdamore/encoding) = %{version}
+
+Requires:       go(golang.org/x/text)
+
+%description
+Package encoding provides character encodings that are useful for dealing with
+I/O streams from non-UTF friendly sources.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-gdamore-tcell-v2/go-github-gdamore-tcell-v2.spec
+++ b/SPECS/go-github-gdamore-tcell-v2/go-github-gdamore-tcell-v2.spec
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: panglars <panghao.riscv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           tcell
+%define go_import_path  github.com/gdamore/tcell/v2
+
+Name:           go-github-gdamore-tcell-v2
+Version:        2.9.0
+Release:        %autorelease
+Summary:        Cell-based terminal package for Go
+License:        Apache-2.0
+URL:            https://github.com/gdamore/tcell
+#!RemoteAsset:  sha256:54f215174a8bcdf78b25283eb818aa3ad1ac16d35a1a0f1687cd95848de2b72a
+Source0:        https://github.com/gdamore/tcell/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{_name}-%{version}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/gdamore/encoding)
+BuildRequires:  go(github.com/lucasb-eyer/go-colorful)
+BuildRequires:  go(github.com/mattn/go-runewidth)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(golang.org/x/term)
+BuildRequires:  go(golang.org/x/text)
+
+Provides:       go(github.com/gdamore/tcell/v2) = %{version}
+
+Requires:       go(github.com/gdamore/encoding)
+Requires:       go(github.com/lucasb-eyer/go-colorful)
+Requires:       go(github.com/mattn/go-runewidth)
+Requires:       go(golang.org/x/sys)
+Requires:       go(golang.org/x/term)
+Requires:       go(golang.org/x/text)
+
+%description
+Tcell provides a cell-based view for text terminals, with support for colors,
+Unicode, keyboard input, and mouse events.
+
+%files
+%doc README* TUTORIAL*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-junegunn-go-shellwords/go-github-junegunn-go-shellwords.spec
+++ b/SPECS/go-github-junegunn-go-shellwords/go-github-junegunn-go-shellwords.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: panglars <panghao.riscv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-shellwords
+%define go_import_path  github.com/junegunn/go-shellwords
+%define commit_id       2aa3b3277741a6ad31883f223d770221a85e9dd0
+
+Name:           go-github-junegunn-go-shellwords
+Version:        0+git20250127.2aa3b32
+Release:        %autorelease
+Summary:        Parse command lines into shell words
+License:        MIT
+URL:            https://github.com/junegunn/go-shellwords
+#!RemoteAsset:  sha256:5b7a6c2c25b305b83cf55309358833708fbd4555c0c1a47a0a5c20030abd0fba
+Source0:        https://github.com/junegunn/go-shellwords/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{_name}-%{commit_id}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/junegunn/go-shellwords) = %{version}
+
+%description
+Package go-shellwords parses command lines into shell-style words and optional
+environment assignments.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog


### PR DESCRIPTION
fzf is a general-purpose command-line fuzzy finder. It can interactively filter
files, command history, processes, host names, bookmarks, git commits, and other
line-oriented input

go module generated by go2sepc, fzf use gpt-5.5 to assist, reviewed by human