### PR TITLE
SPECS: qt6-qtdeclarative: Use Ninja generator

### DIFF
--- a/SPECS/qt6-qtdeclarative/qt6-qtdeclarative.spec
+++ b/SPECS/qt6-qtdeclarative/qt6-qtdeclarative.spec
@@ -26,9 +26,11 @@ Patch0:         qtdeclarative-quickshapes-make-module-public.patch
 
 BuildOption(conf):  -DQT_BUILD_EXAMPLES:BOOL=ON
 BuildOption(conf):  -DQT_INSTALL_EXAMPLES_SOURCES:BOOL=ON
+BuildOption(conf):  -GNinja
 
 BuildRequires:  cmake
 BuildRequires:  gcc-c++
+BuildRequires:  ninja
 BuildRequires:  qt6-macros
 BuildRequires:  pkgconfig(Qt6Core)
 BuildRequires:  qt6-qtbase-private-devel


### PR DESCRIPTION
 qt6-qtdeclarative 6.10.1 was failing under the default CMake Makefiles generator around
 generated QML registration sources. Switching this package to Ninja addresses the build
 ordering/generator issue without touching Qt sources or unrelated Qt packages.

 Signed-off-by: Jingwiw <wangjingwei@iscas.ac.cn>

