### PR TITLE
SPECS: Add grim, slurp and wl-clipboard.

### DIFF
--- a/SPECS/grim/grim.spec
+++ b/SPECS/grim/grim.spec
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Li Guan <guanli.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           grim
+Version:        1.5.0
+Release:        %autorelease
+Summary:        Grab images from a Wayland compositor
+License:        MIT
+URL:            https://gitlab.freedesktop.org/emersion/grim
+#!RemoteAsset:  sha256:99708950205d5bfd2e769519fcb6423a9f545175a29c46c7c1cf7965afc4b8eb
+Source0:        https://gitlab.freedesktop.org/emersion/grim/-/releases/v%{version}/downloads/grim-%{version}.tar.gz
+BuildSystem:    meson
+
+BuildOption(conf):  -Dbash-completions=true
+
+BuildRequires:  meson
+BuildRequires:  pkgconfig(bash-completion)
+BuildRequires:  pkgconfig(libjpeg)
+BuildRequires:  pkgconfig(libpng)
+BuildRequires:  pkgconfig(pixman-1)
+BuildRequires:  pkgconfig(wayland-client)
+BuildRequires:  pkgconfig(wayland-protocols)
+BuildRequires:  pkgconfig(wayland-scanner)
+BuildRequires:  scdoc
+
+%description
+Grab images from a Wayland compositor. Works great with slurp.
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/grim
+%{_mandir}/man1/grim.1*
+%{bash_completions_dir}/grim*
+
+%changelog
+%autochangelog

--- a/SPECS/slurp/slurp.spec
+++ b/SPECS/slurp/slurp.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Li Guan <guanli.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           slurp
+Version:        1.5.0
+Release:        %autorelease
+Summary:        Select a region in a Wayland compositor
+License:        MIT
+URL:            https://github.com/emersion/slurp
+#!RemoteAsset:  sha256:eeb282b2adc8db5614b852596340b69da6f3954cf6cfbdc4392da509c934208a
+Source0:        https://github.com/emersion/slurp/releases/download/v%{version}/slurp-%{version}.tar.gz
+BuildSystem:    meson
+
+BuildRequires:  meson
+BuildRequires:  pkgconfig(wayland-client)
+BuildRequires:  pkgconfig(wayland-cursor)
+BuildRequires:  pkgconfig(wayland-protocols)
+BuildRequires:  pkgconfig(cairo)
+BuildRequires:  pkgconfig(xkbcommon)
+BuildRequires:  scdoc
+
+%description
+Select a region in a Wayland compositor and
+print it to the standard output. Works well with grim.
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/slurp
+%{_mandir}/man1/slurp.1*
+
+%changelog
+%autochangelog

--- a/SPECS/wl-clipboard/wl-clipboard.spec
+++ b/SPECS/wl-clipboard/wl-clipboard.spec
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Li Guan <guanli.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           wl-clipboard
+Version:        2.3.0
+Release:        %autorelease
+Summary:        Command-line copy/paste utilities for Wayland
+License:        GPL-3.0-or-later
+URL:            https://github.com/bugaevc/wl-clipboard
+#!RemoteAsset:  sha256:b4dc560973f0cd74e02f817ffa2fd44ba645a4f1ea94b7b9614dacc9f895f402
+Source0:        https://github.com/bugaevc/wl-clipboard/archive/v%{version}/wl-clipboard-%{version}.tar.gz
+BuildSystem:    meson
+
+BuildRequires:  meson
+BuildRequires:  pkgconfig(wayland-protocols)
+BuildRequires:  pkgconfig(wayland-client)
+
+%description
+This project implements two command-line Wayland
+clipboard utilities, wl-copy and wl-paste, that let
+you easily copy data between the clipboard and Unix
+pipes, sockets, files and so on.
+
+%files
+%doc README.md
+%license COPYING
+%{_bindir}/wl-copy
+%{_bindir}/wl-paste
+%{_mandir}/man1/wl-clipboard.1.*
+%{_mandir}/man1/wl-copy.1.*
+%{_mandir}/man1/wl-paste.1.*
+%{_datadir}/bash-completion/completions/wl-*
+%{_datadir}/fish/vendor_completions.d/wl-*
+%{_datadir}/zsh/site-functions/_wl-*
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

**grim:** Grab images from a Wayland compositor. Works great with slurp.
**slurp:** Select a region in a Wayland compositor and print it to the standard output. Works well with grim.
**wl-clipboard:** Command-line copy/paste utilities for Wayland.