### PR TITLE
SPECS: jsoncpp: Enable string_view symbols

### DIFF
--- a/SPECS/jsoncpp/jsoncpp.spec
+++ b/SPECS/jsoncpp/jsoncpp.spec
@@ -16,6 +16,8 @@ URL:            https://github.com/open-source-parsers/jsoncpp
 Source0:        https://github.com/open-source-parsers/%{name}/archive/refs/tags/%{version}.tar.gz#/%{name}-%{version}.tar.gz
 BuildSystem:    meson
 
+BuildOption(conf):  -Dcpp_std=c++17
+
 BuildRequires:  gcc-c++
 BuildRequires:  meson
 BuildRequires:  pkgconfig


### PR DESCRIPTION
Build jsoncpp with C++17 so libjsoncpp exports the std::string_view
overloads declared by its headers. This fixes link failures in C++20
consumers such as waybar.
This fixed waybar.