### PR TITLE
SPECS: postgresql: Update to 18.4 [security-fixes]

### DIFF
--- a/SPECS/postgresql/postgresql.spec
+++ b/SPECS/postgresql/postgresql.spec
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: (C) 2025 openRuyi Project Contributors
 # SPDX-FileContributor: sunyuechi <sunyuechi@iscas.ac.cn>
 # SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
+# SPDX-FileContributor: Li Guan <guanli.oerv@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
@@ -12,7 +13,7 @@
 %global service_name postgresql.service
 
 Name:           postgresql
-Version:        18.1
+Version:        18.4
 Release:        %autorelease
 Summary:        PostgreSQL client programs
 # The PostgreSQL license is very similar to other MIT licenses, but the OSI
@@ -20,7 +21,7 @@ Summary:        PostgreSQL client programs
 License:        PostgreSQL
 Url:            http://www.postgresql.org/
 VCS:            git:https://git.postgresql.org/git/postgresql.git
-#!RemoteAsset:  sha256:ff86675c336c46e98ac991ebb306d1b67621ece1d06787beaade312c2c915d54
+#!RemoteAsset:  sha256:81a81ec695fb0c7901407defaa1d2f7973617154cf27ba74e3a7ab8e64436094
 Source0:        https://ftp.postgresql.org/pub/source/v%{version}/postgresql-%{version}.tar.bz2
 Source1:        Makefile.regress
 Source2:        postgresql.pam


### PR DESCRIPTION
close #466

This minor release includes critical security patches (CVEs) and various
routine bug fixes across the core engine, planner, and utilities.

Security Fixes:
- Fix SQL injection vulnerabilities in pg_createsubscriber, logical 
  replication origin checks, and contrib/spi (CVE-2026-6476, 
  CVE-2026-6638, CVE-2026-6637).
- Fix integer and buffer overflows in memory allocation, ltree/intarray, 
  ts_headline, and time zone parsing (CVE-2026-6473, CVE-2026-6474).
- Prevent unbounded recursion crashes from malicious SSL/GSS requests 
  (CVE-2026-6479).
- Prevent path traversal in pg_basebackup and pg_rewind (CVE-2026-6475).
- Use timing-safe string comparisons in authentication (CVE-2026-6478).
- Mark PQfn() as unsafe in libpq to prevent memory overwrites (CVE-2026-6477).
- Fix faulty MCV stats validation and missing multirange schema privileges 
  (CVE-2026-6575, CVE-2026-6472).

Core Engine & Planner:
- Fix planner assumptions for nondeterministic collations in equality conditions.
- Fix generated columns behavior in INSERT/UPDATE and COPY FROM WHERE.
- Correctly report serialization failures for MERGE in repeatable-read mode.
- Resolve race conditions in WAL replay and free space map persistence.

Replication & Utilities:
- Prevent stuck slotsync workers from blocking standby server promotion.
- Harden tar-file parsing and fix decompression bugs in pg_basebackup.
- Fix pg_dump to correctly preserve NO INHERIT on NOT NULL constraints.
- Fix pg_upgrade protocol version selection for older source servers.
- Update time zone data files to tzdata release 2026b.