### PR TITLE
SPECS: jsoncpp: Use cpp17

### DIFF
--- a/SPECS/jsoncpp/jsoncpp.spec
+++ b/SPECS/jsoncpp/jsoncpp.spec
@@ -16,6 +16,8 @@ URL:            https://github.com/open-source-parsers/jsoncpp
 Source0:        https://github.com/open-source-parsers/%{name}/archive/refs/tags/%{version}.tar.gz#/%{name}-%{version}.tar.gz
 BuildSystem:    meson
 
+BuildOption(conf):  -Dcpp_std=c++17
+
 BuildRequires:  gcc-c++
 BuildRequires:  meson
 BuildRequires:  pkgconfig


### PR DESCRIPTION
Fixes a jsoncpp ABI mismatch exposed by C++17/C++20 consumers such as waybar