### PR TITLE
SPECS: p11-kit: Drop unused cmake BuildRequires

### DIFF
--- a/SPECS/p11-kit/p11-kit.spec
+++ b/SPECS/p11-kit/p11-kit.spec
@@ -24,7 +24,6 @@ BuildOption(conf):  -Dman=false
 
 BuildRequires:  meson
 BuildRequires:  python3
-BuildRequires:  cmake
 BuildRequires:  pkgconfig
 BuildRequires:  pkgconfig(libffi) >= 3.0.0
 BuildRequires:  pkgconfig(libsystemd)

--- a/SPECS/p11-kit/p11-kit.spec
+++ b/SPECS/p11-kit/p11-kit.spec
@@ -13,7 +13,7 @@ Summary:        Library and tools for working with PKCS#11 modules
 License:        BSD-3-Clause
 URL:            https://p11-glue.freedesktop.org/p11-kit.html
 VCS:            git:https://github.com/p11-glue/p11-kit
-#!RemoteAsset
+#!RemoteAsset:  sha256:04d0a86450cdb1be018f26af6699857171a188ac6d5b8c90786a60854e1198e5
 Source:         https://github.com/p11-glue/%{name}/releases/download/%{version}/%{name}-%{version}.tar.xz
 BuildSystem:    meson
 
@@ -75,4 +75,4 @@ rm -f %{buildroot}%{_sysconfdir}/pkcs11/pkcs11.conf.example
 %{_libdir}/pkgconfig/p11-kit-1.pc
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
- Fix p11-kit source metadata so the package is cleanly validated by remoteassetify.
- Drop the unused `BuildRequires: cmake`; upstream p11-kit uses Meson and the source tree has no CMake build path.
- AIGC Declaration: CodeX with gpt5.5 was used as coding agent.

Signed-off-by: Jingwiw <wangjingwei@iscas.ac.cn>
