### PR TITLE
SPECS: accounts-qml-module: Use pkgconfig BuildRequires

### DIFF
--- a/SPECS/accounts-qml-module/accounts-qml-module.spec
+++ b/SPECS/accounts-qml-module/accounts-qml-module.spec
@@ -58,4 +58,4 @@ rm %{buildroot}%{_bindir}/tst_plugin
 %doc %{_datadir}/accounts-qml-module/
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/accounts-qml-module/accounts-qml-module.spec
+++ b/SPECS/accounts-qml-module/accounts-qml-module.spec
@@ -21,7 +21,6 @@ BuildSystem:    autotools
 BuildOption(install):  INSTALL_ROOT=%{buildroot}
 
 BuildRequires:  make
-BuildRequires:  cmake
 BuildRequires:  gcc-c++
 BuildRequires:  qt6-macros
 BuildRequires:  cmake(AccountsQt6)

--- a/SPECS/accounts-qml-module/accounts-qml-module.spec
+++ b/SPECS/accounts-qml-module/accounts-qml-module.spec
@@ -23,9 +23,9 @@ BuildOption(install):  INSTALL_ROOT=%{buildroot}
 BuildRequires:  make
 BuildRequires:  gcc-c++
 BuildRequires:  qt6-macros
-BuildRequires:  cmake(AccountsQt6)
-BuildRequires:  cmake(Qt6Qml)
-BuildRequires:  cmake(SignOnQt6)
+BuildRequires:  pkgconfig(accounts-qt6)
+BuildRequires:  pkgconfig(Qt6Qml)
+BuildRequires:  pkgconfig(libsignon-qt6)
 BuildRequires:  qt6-doctools
 
 %description


### PR DESCRIPTION
- Fix the changelog macro to the current `%autochangelog` form.
- Drop the unused naked `BuildRequires: cmake`.
- Replace CMake virtual BuildRequires with the pkg-config names used by the qmake project: `accounts-qt6`, `Qt6Qml`, and `libsignon-qt6`.
- AIGC Declaration: CodeX with gpt5.5 was used as coding agent.

Signed-off-by: Jingwiw <wangjingwei@iscas.ac.cn>
