### PR TITLE
SPECS: rubberband: Drop unused cmake BuildRequires

### DIFF
--- a/SPECS/rubberband/rubberband.spec
+++ b/SPECS/rubberband/rubberband.spec
@@ -23,7 +23,6 @@ BuildOption(conf):  -Dfft=fftw
 BuildOption(conf):  -Dresampler=libsamplerate
 
 BuildRequires:  meson
-BuildRequires:  cmake
 BuildRequires:  pkgconfig(fftw3)
 BuildRequires:  pkgconfig(sndfile)
 BuildRequires:  pkgconfig(samplerate)


### PR DESCRIPTION
- Drop the unused `BuildRequires: cmake`; rubberband is built with Meson and the source tree has no CMake build path.
- AIGC Declaration: CodeX with gpt5.5 was used as coding agent.

Signed-off-by: Jingwiw <wangjingwei@iscas.ac.cn>
