### PR TITLE
SPECS: kf6-kwindowsystem: Drop unused meson BuildRequires

### DIFF
--- a/SPECS/kf6-kwindowsystem/kf6-kwindowsystem.spec
+++ b/SPECS/kf6-kwindowsystem/kf6-kwindowsystem.spec
@@ -14,7 +14,7 @@ Summary:        KDE Access to window manager
 License:        LGPL-2.1-or-later
 URL:            https://kde.org
 VCS:            git:https://invent.kde.org/frameworks/kwindowsystem
-#!RemoteAsset
+#!RemoteAsset:  sha256:2821da92854e77d4d2accb5b6f26d189a3e62246fc0dcafbd04f1a78090e5195
 Source0:        https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
@@ -118,4 +118,4 @@ Development files.
 %{_kf6_pkgconfigdir}/KF6WindowSystem.pc
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kwindowsystem/kf6-kwindowsystem.spec
+++ b/SPECS/kf6-kwindowsystem/kf6-kwindowsystem.spec
@@ -21,7 +21,6 @@ BuildSystem:    cmake
 BuildRequires:  gcc
 BuildRequires:  gcc-c++
 BuildRequires:  cmake
-BuildRequires:  meson
 BuildRequires:  fdupes
 BuildRequires:  xz
 BuildRequires:  doxygen


### PR DESCRIPTION
- Fix kf6-kwindowsystem source metadata so the package is cleanly validated by remoteassetify.
- Drop the unused `BuildRequires: meson`; upstream kf6-kwindowsystem is CMake-based and the source tree has no Meson build path.
- AIGC Declaration: CodeX with gpt5.5 was used as coding agent.

Signed-off-by: Jingwiw <wangjingwei@iscas.ac.cn>
