### PR TITLE
SPECS: libcerror: Drop unused doxygen BuildRequires

### DIFF
--- a/SPECS/libcerror/libcerror.spec
+++ b/SPECS/libcerror/libcerror.spec
@@ -11,10 +11,8 @@ Release:        %autorelease
 Summary:        Library for cross-platform C error functions
 License:        LGPL-3.0-or-later
 URL:            https://github.com/libyal/libcerror
-#!RemoteAsset
+#!RemoteAsset:  sha256:e42461065f4ba06f8f3116849471795d24b927c72e00cce0b5b7b8ddfe9b2806
 Source0:        %{url}/releases/download/%{version}/%{name}-beta-%{version}.tar.gz
-#!RemoteAsset
-Source1:        %{url}/releases/download/%{version}/%{name}-beta-%{version}.tar.gz.asc
 BuildSystem:    autotools
 
 BuildOption(conf):  --disable-static
@@ -49,4 +47,4 @@ applications that want to make use of libcerror.
 %{_mandir}/man3/libcerror.3*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/libcerror/libcerror.spec
+++ b/SPECS/libcerror/libcerror.spec
@@ -18,7 +18,6 @@ BuildSystem:    autotools
 BuildOption(conf):  --disable-static
 
 BuildRequires:  gcc
-BuildRequires:  doxygen
 
 %description
 libcerror is a library for cross-platform C error functions.


### PR DESCRIPTION
- Fix libcerror source metadata and remove the unused detached signature source.
- Drop the unused `BuildRequires: doxygen`; the release archive ships the manpage and the source tree has no Doxygen build path.
- AIGC Declaration: CodeX with gpt5.5 was used as coding agent.

Signed-off-by: Jingwiw <wangjingwei@iscas.ac.cn>
