### PR TITLE
SPECS: Add python-ruff rustcrates dependencies (part 2)

### DIFF
--- a/SPECS/rust-inotify-sys-0.1/rust-inotify-sys.spec
+++ b/SPECS/rust-inotify-sys-0.1/rust-inotify-sys.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name inotify-sys
+%global full_version 0.1.5
+%global pkgname inotify-sys-0.1
+
+Name:           rust-inotify-sys-0.1
+Version:        0.1.5
+Release:        %autorelease
+Summary:        Rust crate "inotify-sys"
+License:        ISC
+URL:            https://github.com/hannobraun/inotify-sys
+#!RemoteAsset:  sha256:e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(libc-0.2/default) >= 0.2.186
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "inotify-sys"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-insta-1.0/rust-insta.spec
+++ b/SPECS/rust-insta-1.0/rust-insta.spec
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name insta
+%global full_version 1.47.2
+%global pkgname insta-1.0
+
+Name:           rust-insta-1.0
+Version:        1.47.2
+Release:        %autorelease
+Summary:        Rust crate "insta"
+License:        Apache-2.0
+URL:            https://insta.rs/
+#!RemoteAsset:  sha256:7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(once-cell-1.0/default) >= 1.21.3
+Requires:       crate(similar-2.0/default) >= 2.7.0
+Requires:       crate(similar-2.0/inline) >= 2.7.0
+Requires:       crate(tempfile-3.0/default) >= 3.27.0
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "insta"
+
+%package     -n %{name}+clap
+Summary:        Snapshot testing library for Rust - feature "clap" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(clap-4.0/default) >= 4.1
+Requires:       crate(clap-4.0/derive) >= 4.1
+Requires:       crate(clap-4.0/env) >= 4.1
+Provides:       crate(%{pkgname}/cargo-insta-internal)
+Provides:       crate(%{pkgname}/clap)
+
+%description -n %{name}+clap
+This metapackage enables feature "clap" for the Rust insta crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "_cargo_insta_internal" feature.
+
+%package     -n %{name}+console
+Summary:        Snapshot testing library for Rust - feature "console" and 2 more
+Requires:       crate(%{pkgname})
+Requires:       crate(console-0.16/std) >= 0.16.1
+Provides:       crate(%{pkgname}/colors)
+Provides:       crate(%{pkgname}/console)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+console
+This metapackage enables feature "console" for the Rust insta crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "colors", and "default" features.
+
+%package     -n %{name}+csv
+Summary:        Snapshot testing library for Rust - feature "csv"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/serde)
+Requires:       crate(csv-1.0/default) >= 1.1.6
+Provides:       crate(%{pkgname}/csv)
+
+%description -n %{name}+csv
+This metapackage enables feature "csv" for the Rust insta crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+glob
+Summary:        Snapshot testing library for Rust - feature "glob"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/globset)
+Requires:       crate(%{pkgname}/walkdir)
+Provides:       crate(%{pkgname}/glob)
+
+%description -n %{name}+glob
+This metapackage enables feature "glob" for the Rust insta crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+globset
+Summary:        Snapshot testing library for Rust - feature "globset"
+Requires:       crate(%{pkgname})
+Requires:       crate(globset-0.4/default) >= 0.4.6
+Provides:       crate(%{pkgname}/globset)
+
+%description -n %{name}+globset
+This metapackage enables feature "globset" for the Rust insta crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+pest
+Summary:        Snapshot testing library for Rust - feature "pest"
+Requires:       crate(%{pkgname})
+Requires:       crate(pest-2.0/default) >= 2.8.2
+Provides:       crate(%{pkgname}/pest)
+
+%description -n %{name}+pest
+This metapackage enables feature "pest" for the Rust insta crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+pest-derive
+Summary:        Snapshot testing library for Rust - feature "pest_derive"
+Requires:       crate(%{pkgname})
+Requires:       crate(pest-derive-2.0/default) >= 2.8.2
+Provides:       crate(%{pkgname}/pest-derive)
+
+%description -n %{name}+pest-derive
+This metapackage enables feature "pest_derive" for the Rust insta crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+redactions
+Summary:        Snapshot testing library for Rust - feature "redactions"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/pest)
+Requires:       crate(%{pkgname}/pest-derive)
+Requires:       crate(%{pkgname}/serde)
+Provides:       crate(%{pkgname}/redactions)
+
+%description -n %{name}+redactions
+This metapackage enables feature "redactions" for the Rust insta crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+regex
+Summary:        Snapshot testing library for Rust - feature "regex" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(regex-1.0/std) >= 1.12.3
+Requires:       crate(regex-1.0/unicode) >= 1.12.3
+Provides:       crate(%{pkgname}/filters)
+Provides:       crate(%{pkgname}/regex)
+
+%description -n %{name}+regex
+This metapackage enables feature "regex" for the Rust insta crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "filters" feature.
+
+%package     -n %{name}+ron
+Summary:        Snapshot testing library for Rust - feature "ron"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/serde)
+Requires:       crate(ron-0.12/default) >= 0.12.0
+Provides:       crate(%{pkgname}/ron)
+
+%description -n %{name}+ron
+This metapackage enables feature "ron" for the Rust insta crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+serde
+Summary:        Snapshot testing library for Rust - feature "serde" and 2 more
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/default) >= 1.0.228
+Provides:       crate(%{pkgname}/json)
+Provides:       crate(%{pkgname}/serde)
+Provides:       crate(%{pkgname}/yaml)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust insta crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "json", and "yaml" features.
+
+%package     -n %{name}+toml
+Summary:        Snapshot testing library for Rust - feature "toml"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/serde)
+Requires:       crate(toml-edit-0.25/default) >= 0.25.0
+Requires:       crate(toml-edit-0.25/display) >= 0.25.0
+Requires:       crate(toml-edit-0.25/parse) >= 0.25.0
+Requires:       crate(toml-edit-0.25/serde) >= 0.25.0
+Requires:       crate(toml-writer-1.0/default) >= 1.0.0
+Provides:       crate(%{pkgname}/toml)
+
+%description -n %{name}+toml
+This metapackage enables feature "toml" for the Rust insta crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+walkdir
+Summary:        Snapshot testing library for Rust - feature "walkdir"
+Requires:       crate(%{pkgname})
+Requires:       crate(walkdir-2.0/default) >= 2.3.1
+Provides:       crate(%{pkgname}/walkdir)
+
+%description -n %{name}+walkdir
+This metapackage enables feature "walkdir" for the Rust insta crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-insta-cmd-0.6/rust-insta-cmd.spec
+++ b/SPECS/rust-insta-cmd-0.6/rust-insta-cmd.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name insta-cmd
+%global full_version 0.6.0
+%global pkgname insta-cmd-0.6
+
+Name:           rust-insta-cmd-0.6
+Version:        0.6.0
+Release:        %autorelease
+Summary:        Rust crate "insta-cmd"
+License:        Apache-2.0
+URL:            https://insta.rs/
+#!RemoteAsset:  sha256:ffeeefa927925cced49ccb01bf3e57c9d4cd132df21e576eb9415baeab2d3de6
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(insta-1.0/default) >= 1.47.2
+Requires:       crate(insta-1.0/serde) >= 1.47.2
+Requires:       crate(serde-1.0/default) >= 1.0.228
+Requires:       crate(serde-1.0/derive) >= 1.0.228
+Requires:       crate(serde-json-1.0/default) >= 1.0.149
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "insta-cmd"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-interpolator-0.5/rust-interpolator.spec
+++ b/SPECS/rust-interpolator-0.5/rust-interpolator.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name interpolator
+%global full_version 0.5.0
+%global pkgname interpolator-0.5
+
+Name:           rust-interpolator-0.5
+Version:        0.5.0
+Release:        %autorelease
+Summary:        Rust crate "interpolator"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/ModProg/interpolator
+#!RemoteAsset:  sha256:71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/debug)
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/iter)
+Provides:       crate(%{pkgname}/number)
+Provides:       crate(%{pkgname}/pointer)
+
+%description
+Source code for takopackized Rust crate "interpolator"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-intrusive-collections-0.9/rust-intrusive-collections.spec
+++ b/SPECS/rust-intrusive-collections-0.9/rust-intrusive-collections.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name intrusive-collections
+%global full_version 0.9.7
+%global pkgname intrusive-collections-0.9
+
+Name:           rust-intrusive-collections-0.9
+Version:        0.9.7
+Release:        %autorelease
+Summary:        Rust crate "intrusive-collections"
+License:        Apache-2.0/MIT
+URL:            https://github.com/Amanieu/intrusive-rs
+#!RemoteAsset:  sha256:189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(memoffset-0.9/default) >= 0.9.1
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/alloc)
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/nightly)
+
+%description
+Source code for takopackized Rust crate "intrusive-collections"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-inventory-0.3/rust-inventory.spec
+++ b/SPECS/rust-inventory-0.3/rust-inventory.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name inventory
+%global full_version 0.3.24
+%global pkgname inventory-0.3
+
+Name:           rust-inventory-0.3
+Version:        0.3.24
+Release:        %autorelease
+Summary:        Rust crate "inventory"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/dtolnay/inventory
+#!RemoteAsset:  sha256:a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(rustversion-1.0/default) >= 1.0.22
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "inventory"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-is-macro-0.3/rust-is-macro.spec
+++ b/SPECS/rust-is-macro-0.3/rust-is-macro.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name is-macro
+%global full_version 0.3.7
+%global pkgname is-macro-0.3
+
+Name:           rust-is-macro-0.3
+Version:        0.3.7
+Release:        %autorelease
+Summary:        Rust crate "is-macro"
+License:        Apache-2.0
+URL:            https://github.com/dudykr/ddbase.git
+#!RemoteAsset:  sha256:1d57a3e447e24c22647738e4607f1df1e0ec6f72e16182c4cd199f647cdfb0e4
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(heck-0.5/default) >= 0.5.0
+Requires:       crate(proc-macro2-1.0/default) >= 1.0.106
+Requires:       crate(quote-1.0/default) >= 1.0.45
+Requires:       crate(syn-2.0/default) >= 2.0.117
+Requires:       crate(syn-2.0/derive) >= 2.0.117
+Requires:       crate(syn-2.0/extra-traits) >= 2.0.117
+Requires:       crate(syn-2.0/fold) >= 2.0.117
+Requires:       crate(syn-2.0/full) >= 2.0.117
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "is-macro"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-jod-thread-1.0/rust-jod-thread.spec
+++ b/SPECS/rust-jod-thread-1.0/rust-jod-thread.spec
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name jod-thread
+%global full_version 1.0.0
+%global pkgname jod-thread-1.0
+
+Name:           rust-jod-thread-1.0
+Version:        1.0.0
+Release:        %autorelease
+Summary:        Rust crate "jod-thread"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/matklad/jod-thread
+#!RemoteAsset:  sha256:a037eddb7d28de1d0fc42411f501b53b75838d313908078d6698d064f3029b24
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "jod-thread"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-kqueue-1.0/rust-kqueue.spec
+++ b/SPECS/rust-kqueue-1.0/rust-kqueue.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name kqueue
+%global full_version 1.1.1
+%global pkgname kqueue-1.0
+
+Name:           rust-kqueue-1.0
+Version:        1.1.1
+Release:        %autorelease
+Summary:        Rust crate "kqueue"
+License:        MIT
+URL:            https://gitlab.com/rust-kqueue/rust-kqueue
+#!RemoteAsset:  sha256:eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(kqueue-sys-1.0/default) >= 1.0.4
+Requires:       crate(libc-0.2/default) >= 0.2.186
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "kqueue"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-kqueue-sys-1.0/rust-kqueue-sys.spec
+++ b/SPECS/rust-kqueue-sys-1.0/rust-kqueue-sys.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name kqueue-sys
+%global full_version 1.0.4
+%global pkgname kqueue-sys-1.0
+
+Name:           rust-kqueue-sys-1.0
+Version:        1.0.4
+Release:        %autorelease
+Summary:        Rust crate "kqueue-sys"
+License:        MIT
+URL:            https://gitlab.com/rust-kqueue/rust-kqueue-sys
+#!RemoteAsset:  sha256:ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(bitflags-1.0/default) >= 1.3.2
+Requires:       crate(libc-0.2/default) >= 0.2.186
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "kqueue-sys"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-libcst-1.0/rust-libcst.spec
+++ b/SPECS/rust-libcst-1.0/rust-libcst.spec
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name libcst
+%global full_version 1.8.6
+%global pkgname libcst-1.0
+
+Name:           rust-libcst-1.0
+Version:        1.8.6
+Release:        %autorelease
+Summary:        Rust crate "libcst"
+License:        MIT AND (MIT AND PSF-2.0)
+URL:            https://github.com/Instagram/LibCST
+#!RemoteAsset:  sha256:6aea7143e4a0ed59b87a1ee71e198500889f8b005311136be15e84c97a6fcd8d
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(annotate-snippets-0.11/default) >= 0.11.5
+Requires:       crate(libcst-derive-1.0/default) >= 1.8.6
+Requires:       crate(memchr-2.0/default) >= 2.8.0
+Requires:       crate(paste-1.0/default) >= 1.0.15
+Requires:       crate(peg-0.8/default) >= 0.8.5
+Requires:       crate(regex-1.0/default) >= 1.12.3
+Requires:       crate(thiserror-2.0/default) >= 2.0.18
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "libcst"
+
+%package     -n %{name}+py
+Summary:        Python parser and Concrete Syntax Tree library - feature "py" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/pyo3)
+Requires:       crate(pyo3-0.26/extension-module) >= 0.26.0
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/py)
+
+%description -n %{name}+py
+This metapackage enables feature "py" for the Rust libcst crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "default" feature.
+
+%package     -n %{name}+pyo3
+Summary:        Python parser and Concrete Syntax Tree library - feature "pyo3"
+Requires:       crate(%{pkgname})
+Requires:       crate(pyo3-0.26/default) >= 0.26.0
+Provides:       crate(%{pkgname}/pyo3)
+
+%description -n %{name}+pyo3
+This metapackage enables feature "pyo3" for the Rust libcst crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+trace
+Summary:        Python parser and Concrete Syntax Tree library - feature "trace"
+Requires:       crate(%{pkgname})
+Requires:       crate(peg-0.8/trace) >= 0.8.5
+Provides:       crate(%{pkgname}/trace)
+
+%description -n %{name}+trace
+This metapackage enables feature "trace" for the Rust libcst crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-libcst-derive-1.0/rust-libcst-derive.spec
+++ b/SPECS/rust-libcst-derive-1.0/rust-libcst-derive.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name libcst_derive
+%global full_version 1.8.6
+%global pkgname libcst-derive-1.0
+
+Name:           rust-libcst-derive-1.0
+Version:        1.8.6
+Release:        %autorelease
+Summary:        Rust crate "libcst_derive"
+License:        MIT
+URL:            https://github.com/Instagram/LibCST
+#!RemoteAsset:  sha256:0903173ea316c34a44d0497161e04d9210af44f5f5e89bf2f55d9a254c9a0e8d
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(quote-1.0/default) >= 1.0.45
+Requires:       crate(syn-2.0/default) >= 2.0.117
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "libcst_derive"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-libmimalloc-sys-0.1/rust-libmimalloc-sys.spec
+++ b/SPECS/rust-libmimalloc-sys-0.1/rust-libmimalloc-sys.spec
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name libmimalloc-sys
+%global full_version 0.1.47
+%global pkgname libmimalloc-sys-0.1
+
+Name:           rust-libmimalloc-sys-0.1
+Version:        0.1.47
+Release:        %autorelease
+Summary:        Rust crate "libmimalloc-sys"
+License:        MIT
+URL:            https://github.com/purpleprotocol/mimalloc_rust/tree/master/libmimalloc-sys
+#!RemoteAsset:  sha256:2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(cc-1.0/default) >= 1.2.38
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/arena)
+Provides:       crate(%{pkgname}/debug)
+Provides:       crate(%{pkgname}/debug-in-debug)
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/local-dynamic-tls)
+Provides:       crate(%{pkgname}/no-thp)
+Provides:       crate(%{pkgname}/override)
+Provides:       crate(%{pkgname}/secure)
+Provides:       crate(%{pkgname}/v2)
+
+%description
+Source code for takopackized Rust crate "libmimalloc-sys"
+
+%package     -n %{name}+cty
+Summary:        Sys crate wrapping the mimalloc allocator - feature "cty" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(cty-0.2/default) >= 0.2.0
+Provides:       crate(%{pkgname}/cty)
+Provides:       crate(%{pkgname}/extended)
+
+%description -n %{name}+cty
+This metapackage enables feature "cty" for the Rust libmimalloc-sys crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "extended" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-libtest-mimic-0.7/rust-libtest-mimic.spec
+++ b/SPECS/rust-libtest-mimic-0.7/rust-libtest-mimic.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name libtest-mimic
+%global full_version 0.7.3
+%global pkgname libtest-mimic-0.7
+
+Name:           rust-libtest-mimic-0.7
+Version:        0.7.3
+Release:        %autorelease
+Summary:        Rust crate "libtest-mimic"
+License:        MIT/Apache-2.0
+URL:            https://github.com/LukasKalbertodt/libtest-mimic
+#!RemoteAsset:  sha256:cc0bda45ed5b3a2904262c1bb91e526127aa70e7ef3758aba2ef93cf896b9b58
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(clap-4.0/default) >= 4.6.1
+Requires:       crate(clap-4.0/derive) >= 4.6.1
+Requires:       crate(escape8259-0.5/default) >= 0.5.3
+Requires:       crate(termcolor-1.0/default) >= 1.4.1
+Requires:       crate(threadpool-1.0/default) >= 1.8.1
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "libtest-mimic"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-libtest-mimic-0.8/rust-libtest-mimic.spec
+++ b/SPECS/rust-libtest-mimic-0.8/rust-libtest-mimic.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name libtest-mimic
+%global full_version 0.8.1
+%global pkgname libtest-mimic-0.8
+
+Name:           rust-libtest-mimic-0.8
+Version:        0.8.1
+Release:        %autorelease
+Summary:        Rust crate "libtest-mimic"
+License:        MIT/Apache-2.0
+URL:            https://github.com/LukasKalbertodt/libtest-mimic
+#!RemoteAsset:  sha256:5297962ef19edda4ce33aaa484386e0a5b3d7f2f4e037cbeee00503ef6b29d33
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(anstream-0.6/default) >= 0.6.21
+Requires:       crate(anstyle-1.0/default) >= 1.0.14
+Requires:       crate(clap-4.0/default) >= 4.6.1
+Requires:       crate(clap-4.0/derive) >= 4.6.1
+Requires:       crate(escape8259-0.5/default) >= 0.5.3
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "libtest-mimic"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-lsp-server-0.7/rust-lsp-server.spec
+++ b/SPECS/rust-lsp-server-0.7/rust-lsp-server.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name lsp-server
+%global full_version 0.7.9
+%global pkgname lsp-server-0.7
+
+Name:           rust-lsp-server-0.7
+Version:        0.7.9
+Release:        %autorelease
+Summary:        Rust crate "lsp-server"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/rust-lang/rust-analyzer/tree/master/lib/lsp-server
+#!RemoteAsset:  sha256:7d6ada348dbc2703cbe7637b2dda05cff84d3da2819c24abcb305dd613e0ba2e
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(crossbeam-channel-0.5/default) >= 0.5.15
+Requires:       crate(log-0.4/default) >= 0.4.29
+Requires:       crate(serde-1.0/default) >= 1.0.228
+Requires:       crate(serde-derive-1.0/default) >= 1.0.228
+Requires:       crate(serde-json-1.0/default) >= 1.0.149
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "lsp-server"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-manyhow-0.11/rust-manyhow.spec
+++ b/SPECS/rust-manyhow-0.11/rust-manyhow.spec
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name manyhow
+%global full_version 0.11.4
+%global pkgname manyhow-0.11
+
+Name:           rust-manyhow-0.11
+Version:        0.11.4
+Release:        %autorelease
+Summary:        Rust crate "manyhow"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/ModProg/manyhow
+#!RemoteAsset:  sha256:b33efb3ca6d3b07393750d4030418d594ab1139cee518f0dc88db70fec873587
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(proc-macro2-1.0/default) >= 1.0.106
+Requires:       crate(quote-1.0/default) >= 1.0.45
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "manyhow"
+
+%package     -n %{name}+darling-core
+Summary:        Proc macro error handling à la anyhow x proc-macro-error - feature "darling_core" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(darling-core-0.20/default) >= 0.20.1
+Provides:       crate(%{pkgname}/darling)
+Provides:       crate(%{pkgname}/darling-core)
+
+%description -n %{name}+darling-core
+This metapackage enables feature "darling_core" for the Rust manyhow crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "darling" feature.
+
+%package     -n %{name}+default
+Summary:        Proc macro error handling à la anyhow x proc-macro-error - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/macros)
+Requires:       crate(%{pkgname}/syn)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust manyhow crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+macros
+Summary:        Proc macro error handling à la anyhow x proc-macro-error - feature "macros"
+Requires:       crate(%{pkgname})
+Requires:       crate(manyhow-macros-0.11/default) >= 0.11.4
+Provides:       crate(%{pkgname}/macros)
+
+%description -n %{name}+macros
+This metapackage enables feature "macros" for the Rust manyhow crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+syn1
+Summary:        Proc macro error handling à la anyhow x proc-macro-error - feature "syn1"
+Requires:       crate(%{pkgname})
+Requires:       crate(syn-2.0/printing) >= 2.0.117
+Provides:       crate(%{pkgname}/syn1)
+
+%description -n %{name}+syn1
+This metapackage enables feature "syn1" for the Rust manyhow crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+syn2
+Summary:        Proc macro error handling à la anyhow x proc-macro-error - feature "syn2" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(syn-2.0/parsing) >= 2.0.117
+Requires:       crate(syn-2.0/printing) >= 2.0.117
+Provides:       crate(%{pkgname}/syn)
+Provides:       crate(%{pkgname}/syn2)
+
+%description -n %{name}+syn2
+This metapackage enables feature "syn2" for the Rust manyhow crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "syn" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-manyhow-macros-0.11/rust-manyhow-macros.spec
+++ b/SPECS/rust-manyhow-macros-0.11/rust-manyhow-macros.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name manyhow-macros
+%global full_version 0.11.4
+%global pkgname manyhow-macros-0.11
+
+Name:           rust-manyhow-macros-0.11
+Version:        0.11.4
+Release:        %autorelease
+Summary:        Rust crate "manyhow-macros"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/ModProg/manyhow
+#!RemoteAsset:  sha256:46fce34d199b78b6e6073abf984c9cf5fd3e9330145a93ee0738a7443e371495
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(proc-macro-utils-0.10/default) >= 0.10.0
+Requires:       crate(proc-macro2-1.0/default) >= 1.0.106
+Requires:       crate(quote-1.0/default) >= 1.0.45
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "manyhow-macros"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-markdown-1.0/rust-markdown.spec
+++ b/SPECS/rust-markdown-1.0/rust-markdown.spec
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name markdown
+%global full_version 1.0.0
+%global pkgname markdown-1.0
+
+Name:           rust-markdown-1.0
+Version:        1.0.0
+Release:        %autorelease
+Summary:        Rust crate "markdown"
+License:        MIT
+URL:            https://github.com/wooorm/markdown-rs
+#!RemoteAsset:  sha256:a5cab8f2cadc416a82d2e783a1946388b31654d391d1c7d92cc1f03e295b1deb
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(unicode-id-0.3/default) >= 0.3.6
+Requires:       crate(unicode-id-0.3/no-std) >= 0.3.6
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "markdown"
+
+%package     -n %{name}+log
+Summary:        CommonMark compliant markdown parser in Rust with ASTs and extensions - feature "log"
+Requires:       crate(%{pkgname})
+Requires:       crate(log-0.4/default) >= 0.4.0
+Provides:       crate(%{pkgname}/log)
+
+%description -n %{name}+log
+This metapackage enables feature "log" for the Rust markdown crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+serde
+Summary:        CommonMark compliant markdown parser in Rust with ASTs and extensions - feature "serde" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/default) >= 1.0.0
+Requires:       crate(serde-1.0/derive) >= 1.0.0
+Provides:       crate(%{pkgname}/json)
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust markdown crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "json" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-matchit-0.9/rust-matchit.spec
+++ b/SPECS/rust-matchit-0.9/rust-matchit.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name matchit
+%global full_version 0.9.2
+%global pkgname matchit-0.9
+
+Name:           rust-matchit-0.9
+Version:        0.9.2
+Release:        %autorelease
+Summary:        Rust crate "matchit"
+License:        MIT AND BSD-3-Clause
+URL:            https://github.com/ibraheemdev/matchit
+#!RemoteAsset:  sha256:8863b587001c1b9a8a4e36008cebc6b3612cb1226fe2de94858e06092687b608
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/test-helpers)
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "matchit"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-mimalloc-0.1/rust-mimalloc.spec
+++ b/SPECS/rust-mimalloc-0.1/rust-mimalloc.spec
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name mimalloc
+%global full_version 0.1.50
+%global pkgname mimalloc-0.1
+
+Name:           rust-mimalloc-0.1
+Version:        0.1.50
+Release:        %autorelease
+Summary:        Rust crate "mimalloc"
+License:        MIT
+URL:            https://github.com/purpleprotocol/mimalloc_rust
+#!RemoteAsset:  sha256:b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(libmimalloc-sys-0.1) >= 0.1.47
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "mimalloc"
+
+%package     -n %{name}+debug
+Summary:        Performance and security oriented drop-in allocator - feature "debug"
+Requires:       crate(%{pkgname})
+Requires:       crate(libmimalloc-sys-0.1/debug) >= 0.1.47
+Provides:       crate(%{pkgname}/debug)
+
+%description -n %{name}+debug
+This metapackage enables feature "debug" for the Rust mimalloc crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+debug-in-debug
+Summary:        Performance and security oriented drop-in allocator - feature "debug_in_debug"
+Requires:       crate(%{pkgname})
+Requires:       crate(libmimalloc-sys-0.1/debug-in-debug) >= 0.1.47
+Provides:       crate(%{pkgname}/debug-in-debug)
+
+%description -n %{name}+debug-in-debug
+This metapackage enables feature "debug_in_debug" for the Rust mimalloc crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+extended
+Summary:        Performance and security oriented drop-in allocator - feature "extended"
+Requires:       crate(%{pkgname})
+Requires:       crate(libmimalloc-sys-0.1/extended) >= 0.1.47
+Provides:       crate(%{pkgname}/extended)
+
+%description -n %{name}+extended
+This metapackage enables feature "extended" for the Rust mimalloc crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+local-dynamic-tls
+Summary:        Performance and security oriented drop-in allocator - feature "local_dynamic_tls"
+Requires:       crate(%{pkgname})
+Requires:       crate(libmimalloc-sys-0.1/local-dynamic-tls) >= 0.1.47
+Provides:       crate(%{pkgname}/local-dynamic-tls)
+
+%description -n %{name}+local-dynamic-tls
+This metapackage enables feature "local_dynamic_tls" for the Rust mimalloc crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+no-thp
+Summary:        Performance and security oriented drop-in allocator - feature "no_thp"
+Requires:       crate(%{pkgname})
+Requires:       crate(libmimalloc-sys-0.1/no-thp) >= 0.1.47
+Provides:       crate(%{pkgname}/no-thp)
+
+%description -n %{name}+no-thp
+This metapackage enables feature "no_thp" for the Rust mimalloc crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+override
+Summary:        Performance and security oriented drop-in allocator - feature "override"
+Requires:       crate(%{pkgname})
+Requires:       crate(libmimalloc-sys-0.1/override) >= 0.1.47
+Provides:       crate(%{pkgname}/override)
+
+%description -n %{name}+override
+This metapackage enables feature "override" for the Rust mimalloc crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+secure
+Summary:        Performance and security oriented drop-in allocator - feature "secure"
+Requires:       crate(%{pkgname})
+Requires:       crate(libmimalloc-sys-0.1/secure) >= 0.1.47
+Provides:       crate(%{pkgname}/secure)
+
+%description -n %{name}+secure
+This metapackage enables feature "secure" for the Rust mimalloc crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+v2
+Summary:        Performance and security oriented drop-in allocator - feature "v2"
+Requires:       crate(%{pkgname})
+Requires:       crate(libmimalloc-sys-0.1/v2) >= 0.1.47
+Provides:       crate(%{pkgname}/v2)
+
+%description -n %{name}+v2
+This metapackage enables feature "v2" for the Rust mimalloc crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-minicov-0.3/rust-minicov.spec
+++ b/SPECS/rust-minicov-0.3/rust-minicov.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name minicov
+%global full_version 0.3.7
+%global pkgname minicov-0.3
+
+Name:           rust-minicov-0.3
+Version:        0.3.7
+Release:        %autorelease
+Summary:        Rust crate "minicov"
+License:        Apache-2.0/MIT
+URL:            https://github.com/Amanieu/minicov
+#!RemoteAsset:  sha256:f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(cc-1.0/default) >= 1.2.38
+Requires:       crate(walkdir-2.0/default) >= 2.5.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/alloc)
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "minicov"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-natord-1.0/rust-natord.spec
+++ b/SPECS/rust-natord-1.0/rust-natord.spec
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name natord
+%global full_version 1.0.9
+%global pkgname natord-1.0
+
+Name:           rust-natord-1.0
+Version:        1.0.9
+Release:        %autorelease
+Summary:        Rust crate "natord"
+License:        MIT
+URL:            https://github.com/lifthrasiir/rust-natord
+#!RemoteAsset:  sha256:308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "natord"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-newtype-uuid-1.0/rust-newtype-uuid.spec
+++ b/SPECS/rust-newtype-uuid-1.0/rust-newtype-uuid.spec
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name newtype-uuid
+%global full_version 1.3.2
+%global pkgname newtype-uuid-1.0
+
+Name:           rust-newtype-uuid-1.0
+Version:        1.3.2
+Release:        %autorelease
+Summary:        Rust crate "newtype-uuid"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/oxidecomputer/newtype-uuid
+#!RemoteAsset:  sha256:5c012d14ef788ab066a347d19e3dda699916c92293b05b85ba2c76b8c82d2830
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(uuid-1.0) >= 1.23.1
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/alloc)
+
+%description
+Source code for takopackized Rust crate "newtype-uuid"
+
+%package     -n %{name}+default
+Summary:        Newtype wrapper around UUIDs - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/std)
+Requires:       crate(uuid-1.0/default) >= 1.23.1
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust newtype-uuid crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+proptest1
+Summary:        Newtype wrapper around UUIDs - feature "proptest1"
+Requires:       crate(%{pkgname})
+Requires:       crate(proptest-1.0/std) >= 1.7.0
+Provides:       crate(%{pkgname}/proptest1)
+
+%description -n %{name}+proptest1
+This metapackage enables feature "proptest1" for the Rust newtype-uuid crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+schemars08
+Summary:        Newtype wrapper around UUIDs - feature "schemars08"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/std)
+Requires:       crate(schemars-0.8/default) >= 0.8.17
+Requires:       crate(schemars-0.8/uuid1) >= 0.8.17
+Requires:       crate(serde-json-1.0/default) >= 1.0.140
+Provides:       crate(%{pkgname}/schemars08)
+
+%description -n %{name}+schemars08
+This metapackage enables feature "schemars08" for the Rust newtype-uuid crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+serde
+Summary:        Newtype wrapper around UUIDs - feature "serde"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/default) >= 1.0.0
+Requires:       crate(serde-1.0/derive) >= 1.0.0
+Requires:       crate(uuid-1.0/serde) >= 1.23.1
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust newtype-uuid crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+std
+Summary:        Newtype wrapper around UUIDs - feature "std"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/alloc)
+Requires:       crate(uuid-1.0/std) >= 1.23.1
+Provides:       crate(%{pkgname}/std)
+
+%description -n %{name}+std
+This metapackage enables feature "std" for the Rust newtype-uuid crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+v4
+Summary:        Newtype wrapper around UUIDs - feature "v4"
+Requires:       crate(%{pkgname})
+Requires:       crate(uuid-1.0/v4) >= 1.23.1
+Provides:       crate(%{pkgname}/v4)
+
+%description -n %{name}+v4
+This metapackage enables feature "v4" for the Rust newtype-uuid crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+v7
+Summary:        Newtype wrapper around UUIDs - feature "v7"
+Requires:       crate(%{pkgname})
+Requires:       crate(uuid-1.0/v7) >= 1.23.1
+Provides:       crate(%{pkgname}/v7)
+
+%description -n %{name}+v7
+This metapackage enables feature "v7" for the Rust newtype-uuid crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-nix-0.31/rust-nix.spec
+++ b/SPECS/rust-nix-0.31/rust-nix.spec
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name nix
+%global full_version 0.31.2
+%global pkgname nix-0.31
+
+Name:           rust-nix-0.31
+Version:        0.31.2
+Release:        %autorelease
+Summary:        Rust crate "nix"
+License:        MIT
+URL:            https://github.com/nix-rust/nix
+#!RemoteAsset:  sha256:5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(bitflags-2.0/default) >= 2.11.1
+Requires:       crate(cfg-aliases-0.2/default) >= 0.2.1
+Requires:       crate(cfg-if-1.0/default) >= 1.0.3
+Requires:       crate(libc-0.2/default) >= 0.2.186
+Requires:       crate(libc-0.2/extra-traits) >= 0.2.186
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/acct)
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/dir)
+Provides:       crate(%{pkgname}/env)
+Provides:       crate(%{pkgname}/event)
+Provides:       crate(%{pkgname}/fanotify)
+Provides:       crate(%{pkgname}/feature)
+Provides:       crate(%{pkgname}/fs)
+Provides:       crate(%{pkgname}/hostname)
+Provides:       crate(%{pkgname}/inotify)
+Provides:       crate(%{pkgname}/ioctl)
+Provides:       crate(%{pkgname}/kmod)
+Provides:       crate(%{pkgname}/mman)
+Provides:       crate(%{pkgname}/mount)
+Provides:       crate(%{pkgname}/mqueue)
+Provides:       crate(%{pkgname}/personality)
+Provides:       crate(%{pkgname}/poll)
+Provides:       crate(%{pkgname}/process)
+Provides:       crate(%{pkgname}/pthread)
+Provides:       crate(%{pkgname}/ptrace)
+Provides:       crate(%{pkgname}/quota)
+Provides:       crate(%{pkgname}/reboot)
+Provides:       crate(%{pkgname}/resource)
+Provides:       crate(%{pkgname}/sched)
+Provides:       crate(%{pkgname}/signal)
+Provides:       crate(%{pkgname}/syslog)
+Provides:       crate(%{pkgname}/term)
+Provides:       crate(%{pkgname}/time)
+Provides:       crate(%{pkgname}/ucontext)
+Provides:       crate(%{pkgname}/uio)
+Provides:       crate(%{pkgname}/user)
+
+%description
+Source code for takopackized Rust crate "nix"
+
+%package     -n %{name}+memoffset
+Summary:        Rust friendly bindings to *nix APIs - feature "memoffset" and 2 more
+Requires:       crate(%{pkgname})
+Requires:       crate(memoffset-0.9/default) >= 0.9.0
+Provides:       crate(%{pkgname}/memoffset)
+Provides:       crate(%{pkgname}/net)
+Provides:       crate(%{pkgname}/socket)
+
+%description -n %{name}+memoffset
+This metapackage enables feature "memoffset" for the Rust nix crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "net", and "socket" features.
+
+%package     -n %{name}+pin-utils
+Summary:        Rust friendly bindings to *nix APIs - feature "pin-utils" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(pin-utils-0.1/default) >= 0.1.0
+Provides:       crate(%{pkgname}/aio)
+Provides:       crate(%{pkgname}/pin-utils)
+
+%description -n %{name}+pin-utils
+This metapackage enables feature "pin-utils" for the Rust nix crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "aio" feature.
+
+%package     -n %{name}+zerocopy
+Summary:        Rust friendly bindings to *nix APIs - feature "zerocopy"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/fs)
+Requires:       crate(%{pkgname}/uio)
+Provides:       crate(%{pkgname}/zerocopy)
+
+%description -n %{name}+zerocopy
+This metapackage enables feature "zerocopy" for the Rust nix crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-notify-8.0/rust-notify.spec
+++ b/SPECS/rust-notify-8.0/rust-notify.spec
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name notify
+%global full_version 8.2.0
+%global pkgname notify-8.0
+
+Name:           rust-notify-8.0
+Version:        8.2.0
+Release:        %autorelease
+Summary:        Rust crate "notify"
+License:        CC0-1.0
+URL:            https://github.com/notify-rs/notify
+#!RemoteAsset:  sha256:4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(bitflags-2.0/default) >= 2.11.1
+Requires:       crate(inotify-0.11) >= 0.11.0
+Requires:       crate(kqueue-1.0/default) >= 1.1.1
+Requires:       crate(libc-0.2/default) >= 0.2.186
+Requires:       crate(log-0.4/default) >= 0.4.29
+Requires:       crate(mio-1.0/default) >= 1.0.4
+Requires:       crate(mio-1.0/os-ext) >= 1.0.4
+Requires:       crate(notify-types-2.0/default) >= 2.0.0
+Requires:       crate(walkdir-2.0/default) >= 2.5.0
+Requires:       crate(windows-sys-0.60/default) >= 0.60.2
+Requires:       crate(windows-sys-0.60/win32-foundation) >= 0.60.2
+Requires:       crate(windows-sys-0.60/win32-security) >= 0.60.2
+Requires:       crate(windows-sys-0.60/win32-storage-filesystem) >= 0.60.2
+Requires:       crate(windows-sys-0.60/win32-system-io) >= 0.60.2
+Requires:       crate(windows-sys-0.60/win32-system-threading) >= 0.60.2
+Requires:       crate(windows-sys-0.60/win32-system-windowsprogramming) >= 0.60.2
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "notify"
+
+%package     -n %{name}+crossbeam-channel
+Summary:        Cross-platform filesystem notification library - feature "crossbeam-channel"
+Requires:       crate(%{pkgname})
+Requires:       crate(crossbeam-channel-0.5/default) >= 0.5.0
+Provides:       crate(%{pkgname}/crossbeam-channel)
+
+%description -n %{name}+crossbeam-channel
+This metapackage enables feature "crossbeam-channel" for the Rust notify crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+flume
+Summary:        Cross-platform filesystem notification library - feature "flume"
+Requires:       crate(%{pkgname})
+Requires:       crate(flume-0.11/default) >= 0.11.1
+Provides:       crate(%{pkgname}/flume)
+
+%description -n %{name}+flume
+This metapackage enables feature "flume" for the Rust notify crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+fsevent-sys
+Summary:        Cross-platform filesystem notification library - feature "fsevent-sys" and 2 more
+Requires:       crate(%{pkgname})
+Requires:       crate(fsevent-sys-4.0/default) >= 4.1.0
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/fsevent-sys)
+Provides:       crate(%{pkgname}/macos-fsevent)
+
+%description -n %{name}+fsevent-sys
+This metapackage enables feature "fsevent-sys" for the Rust notify crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "default", and "macos_fsevent" features.
+
+%package     -n %{name}+kqueue
+Summary:        Cross-platform filesystem notification library - feature "kqueue"
+Requires:       crate(%{pkgname})
+Requires:       crate(kqueue-1.0/default) >= 1.1.1
+Provides:       crate(%{pkgname}/kqueue)
+
+%description -n %{name}+kqueue
+This metapackage enables feature "kqueue" for the Rust notify crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+macos-kqueue
+Summary:        Cross-platform filesystem notification library - feature "macos_kqueue"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/kqueue)
+Requires:       crate(%{pkgname}/mio)
+Provides:       crate(%{pkgname}/macos-kqueue)
+
+%description -n %{name}+macos-kqueue
+This metapackage enables feature "macos_kqueue" for the Rust notify crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+mio
+Summary:        Cross-platform filesystem notification library - feature "mio"
+Requires:       crate(%{pkgname})
+Requires:       crate(mio-1.0/default) >= 1.0.4
+Requires:       crate(mio-1.0/os-ext) >= 1.0.4
+Provides:       crate(%{pkgname}/mio)
+
+%description -n %{name}+mio
+This metapackage enables feature "mio" for the Rust notify crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+serde
+Summary:        Cross-platform filesystem notification library - feature "serde"
+Requires:       crate(%{pkgname})
+Requires:       crate(notify-types-2.0/serde) >= 2.0.0
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust notify crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+serialization-compat-6
+Summary:        Cross-platform filesystem notification library - feature "serialization-compat-6"
+Requires:       crate(%{pkgname})
+Requires:       crate(notify-types-2.0/serialization-compat-6) >= 2.0.0
+Provides:       crate(%{pkgname}/serialization-compat-6)
+
+%description -n %{name}+serialization-compat-6
+This metapackage enables feature "serialization-compat-6" for the Rust notify crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-notify-types-2.0/rust-notify-types.spec
+++ b/SPECS/rust-notify-types-2.0/rust-notify-types.spec
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name notify-types
+%global full_version 2.0.0
+%global pkgname notify-types-2.0
+
+Name:           rust-notify-types-2.0
+Version:        2.0.0
+Release:        %autorelease
+Summary:        Rust crate "notify-types"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/notify-rs/notify
+#!RemoteAsset:  sha256:5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/serialization-compat-6)
+
+%description
+Source code for takopackized Rust crate "notify-types"
+
+%package     -n %{name}+serde
+Summary:        Types used by the notify crate - feature "serde"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/default) >= 1.0.89
+Requires:       crate(serde-1.0/derive) >= 1.0.89
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust notify-types crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+web-time
+Summary:        Types used by the notify crate - feature "web-time"
+Requires:       crate(%{pkgname})
+Requires:       crate(web-time-1.0/default) >= 1.1.0
+Provides:       crate(%{pkgname}/web-time)
+
+%description -n %{name}+web-time
+This metapackage enables feature "web-time" for the Rust notify-types crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-num-cpus-1.0/rust-num-cpus.spec
+++ b/SPECS/rust-num-cpus-1.0/rust-num-cpus.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name num_cpus
+%global full_version 1.17.0
+%global pkgname num-cpus-1.0
+
+Name:           rust-num-cpus-1.0
+Version:        1.17.0
+Release:        %autorelease
+Summary:        Rust crate "num_cpus"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/seanmonstar/num_cpus
+#!RemoteAsset:  sha256:91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(hermit-abi-0.5/default) >= 0.5.2
+Requires:       crate(libc-0.2/default) >= 0.2.186
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "num_cpus"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-option-ext-0.2/rust-option-ext.spec
+++ b/SPECS/rust-option-ext-0.2/rust-option-ext.spec
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name option-ext
+%global full_version 0.2.0
+%global pkgname option-ext-0.2
+
+Name:           rust-option-ext-0.2
+Version:        0.2.0
+Release:        %autorelease
+Summary:        Rust crate "option-ext"
+License:        MPL-2.0
+URL:            https://github.com/soc/option-ext
+#!RemoteAsset:  sha256:04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "option-ext"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-ordermap-1.0/rust-ordermap.spec
+++ b/SPECS/rust-ordermap-1.0/rust-ordermap.spec
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name ordermap
+%global full_version 1.2.0
+%global pkgname ordermap-1.0
+
+Name:           rust-ordermap-1.0
+Version:        1.2.0
+Release:        %autorelease
+Summary:        Rust crate "ordermap"
+License:        Apache-2.0 OR MIT
+URL:            https://github.com/indexmap-rs/ordermap
+#!RemoteAsset:  sha256:7f7476a5b122ff1fce7208e7ee9dccd0a516e835f5b8b19b8f3c98a34cf757c1
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(indexmap-2.0) >= 2.14.0
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "ordermap"
+
+%package     -n %{name}+arbitrary
+Summary:        Hash table with consistent order and fast iteration - feature "arbitrary"
+Requires:       crate(%{pkgname})
+Requires:       crate(arbitrary-1.0) >= 1.0.0
+Requires:       crate(indexmap-2.0/arbitrary) >= 2.14.0
+Provides:       crate(%{pkgname}/arbitrary)
+
+%description -n %{name}+arbitrary
+This metapackage enables feature "arbitrary" for the Rust ordermap crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+borsh
+Summary:        Hash table with consistent order and fast iteration - feature "borsh"
+Requires:       crate(%{pkgname})
+Requires:       crate(borsh-1.0) >= 1.5.6
+Requires:       crate(borsh-1.0/indexmap) >= 1.5.6
+Provides:       crate(%{pkgname}/borsh)
+
+%description -n %{name}+borsh
+This metapackage enables feature "borsh" for the Rust ordermap crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+quickcheck
+Summary:        Hash table with consistent order and fast iteration - feature "quickcheck"
+Requires:       crate(%{pkgname})
+Requires:       crate(indexmap-2.0/quickcheck) >= 2.14.0
+Requires:       crate(quickcheck-1.0) >= 1.0.0
+Provides:       crate(%{pkgname}/quickcheck)
+
+%description -n %{name}+quickcheck
+This metapackage enables feature "quickcheck" for the Rust ordermap crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+rayon
+Summary:        Hash table with consistent order and fast iteration - feature "rayon"
+Requires:       crate(%{pkgname})
+Requires:       crate(indexmap-2.0/rayon) >= 2.14.0
+Requires:       crate(rayon-1.0/default) >= 1.9
+Provides:       crate(%{pkgname}/rayon)
+
+%description -n %{name}+rayon
+This metapackage enables feature "rayon" for the Rust ordermap crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+serde
+Summary:        Hash table with consistent order and fast iteration - feature "serde"
+Requires:       crate(%{pkgname})
+Requires:       crate(indexmap-2.0/serde) >= 2.14.0
+Requires:       crate(serde-1.0) >= 1.0.228
+Requires:       crate(serde-core-1.0) >= 1.0.228
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust ordermap crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+std
+Summary:        Hash table with consistent order and fast iteration - feature "std" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(indexmap-2.0/std) >= 2.14.0
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description -n %{name}+std
+This metapackage enables feature "std" for the Rust ordermap crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "default" feature.
+
+%package     -n %{name}+sval
+Summary:        Hash table with consistent order and fast iteration - feature "sval"
+Requires:       crate(%{pkgname})
+Requires:       crate(indexmap-2.0/sval) >= 2.14.0
+Requires:       crate(sval-2.0) >= 2.0.0
+Provides:       crate(%{pkgname}/sval)
+
+%description -n %{name}+sval
+This metapackage enables feature "sval" for the Rust ordermap crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-os-pipe-1.0/rust-os-pipe.spec
+++ b/SPECS/rust-os-pipe-1.0/rust-os-pipe.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name os_pipe
+%global full_version 1.2.2
+%global pkgname os-pipe-1.0
+
+Name:           rust-os-pipe-1.0
+Version:        1.2.2
+Release:        %autorelease
+Summary:        Rust crate "os_pipe"
+License:        MIT
+URL:            https://github.com/oconnor663/os_pipe.rs
+#!RemoteAsset:  sha256:db335f4760b14ead6290116f2427bf33a14d4f0617d49f78a246de10c1831224
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(libc-0.2/default) >= 0.2.186
+Requires:       crate(windows-sys-0.59/default) >= 0.59.0
+Requires:       crate(windows-sys-0.59/win32-foundation) >= 0.59.0
+Requires:       crate(windows-sys-0.59/win32-security) >= 0.59.0
+Requires:       crate(windows-sys-0.59/win32-system-pipes) >= 0.59.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/io-safety)
+
+%description
+Source code for takopackized Rust crate "os_pipe"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-os-str-bytes-7.0/rust-os-str-bytes.spec
+++ b/SPECS/rust-os-str-bytes-7.0/rust-os-str-bytes.spec
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name os_str_bytes
+%global full_version 7.1.1
+%global pkgname os-str-bytes-7.0
+
+Name:           rust-os-str-bytes-7.0
+Version:        7.1.1
+Release:        %autorelease
+Summary:        Rust crate "os_str_bytes"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/dylni/os_str_bytes
+#!RemoteAsset:  sha256:63eceb7b5d757011a87d08eb2123db15d87fb0c281f65d101ce30a1e96c3ad5c
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/checked-conversions)
+Provides:       crate(%{pkgname}/conversions)
+Provides:       crate(%{pkgname}/raw-os-str)
+
+%description
+Source code for takopackized Rust crate "os_str_bytes"
+
+%package     -n %{name}+default
+Summary:        Lossless functionality for platform-native strings - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/memchr)
+Requires:       crate(%{pkgname}/raw-os-str)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust os_str_bytes crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+memchr
+Summary:        Lossless functionality for platform-native strings - feature "memchr"
+Requires:       crate(%{pkgname})
+Requires:       crate(memchr-2.0/default) >= 2.8.0
+Provides:       crate(%{pkgname}/memchr)
+
+%description -n %{name}+memchr
+This metapackage enables feature "memchr" for the Rust os_str_bytes crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-page-size-0.6/rust-page-size.spec
+++ b/SPECS/rust-page-size-0.6/rust-page-size.spec
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name page_size
+%global full_version 0.6.0
+%global pkgname page-size-0.6
+
+Name:           rust-page-size-0.6
+Version:        0.6.0
+Release:        %autorelease
+Summary:        Rust crate "page_size"
+License:        MIT/Apache-2.0
+URL:            https://github.com/Elzair/page_size_rs
+#!RemoteAsset:  sha256:30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(libc-0.2/default) >= 0.2.186
+Requires:       crate(winapi-0.3/default) >= 0.3.9
+Requires:       crate(winapi-0.3/sysinfoapi) >= 0.3.9
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "page_size"
+
+%package     -n %{name}+spin
+Summary:        Provides an easy, fast, cross-platform way to retrieve the memory page size - feature "spin" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(spin-0.9/default) >= 0.9.8
+Provides:       crate(%{pkgname}/no-std)
+Provides:       crate(%{pkgname}/spin)
+
+%description -n %{name}+spin
+This metapackage enables feature "spin" for the Rust page_size crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "no_std" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-path-absolutize-3.0/rust-path-absolutize.spec
+++ b/SPECS/rust-path-absolutize-3.0/rust-path-absolutize.spec
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name path-absolutize
+%global full_version 3.1.1
+%global pkgname path-absolutize-3.0
+
+Name:           rust-path-absolutize-3.0
+Version:        3.1.1
+Release:        %autorelease
+Summary:        Rust crate "path-absolutize"
+License:        MIT
+URL:            https://magiclen.org/path-absolutize
+#!RemoteAsset:  sha256:e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(path-dedot-3.0/default) >= 3.1.1
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "path-absolutize"
+
+%package     -n %{name}+lazy-static-cache
+Summary:        Extending `Path` and `PathBuf` in order to get an absolute path and remove the containing dots - feature "lazy_static_cache"
+Requires:       crate(%{pkgname})
+Requires:       crate(path-dedot-3.0/lazy-static-cache) >= 3.1.1
+Provides:       crate(%{pkgname}/lazy-static-cache)
+
+%description -n %{name}+lazy-static-cache
+This metapackage enables feature "lazy_static_cache" for the Rust path-absolutize crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+once-cell-cache
+Summary:        Extending `Path` and `PathBuf` in order to get an absolute path and remove the containing dots - feature "once_cell_cache"
+Requires:       crate(%{pkgname})
+Requires:       crate(path-dedot-3.0/once-cell-cache) >= 3.1.1
+Provides:       crate(%{pkgname}/once-cell-cache)
+
+%description -n %{name}+once-cell-cache
+This metapackage enables feature "once_cell_cache" for the Rust path-absolutize crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+unsafe-cache
+Summary:        Extending `Path` and `PathBuf` in order to get an absolute path and remove the containing dots - feature "unsafe_cache"
+Requires:       crate(%{pkgname})
+Requires:       crate(path-dedot-3.0/unsafe-cache) >= 3.1.1
+Provides:       crate(%{pkgname}/unsafe-cache)
+
+%description -n %{name}+unsafe-cache
+This metapackage enables feature "unsafe_cache" for the Rust path-absolutize crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+use-unix-paths-on-wasm
+Summary:        Extending `Path` and `PathBuf` in order to get an absolute path and remove the containing dots - feature "use_unix_paths_on_wasm"
+Requires:       crate(%{pkgname})
+Requires:       crate(path-dedot-3.0/use-unix-paths-on-wasm) >= 3.1.1
+Provides:       crate(%{pkgname}/use-unix-paths-on-wasm)
+
+%description -n %{name}+use-unix-paths-on-wasm
+This metapackage enables feature "use_unix_paths_on_wasm" for the Rust path-absolutize crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-path-dedot-3.0/rust-path-dedot.spec
+++ b/SPECS/rust-path-dedot-3.0/rust-path-dedot.spec
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name path-dedot
+%global full_version 3.1.1
+%global pkgname path-dedot-3.0
+
+Name:           rust-path-dedot-3.0
+Version:        3.1.1
+Release:        %autorelease
+Summary:        Rust crate "path-dedot"
+License:        MIT
+URL:            https://magiclen.org/path-dedot
+#!RemoteAsset:  sha256:07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(once-cell-1.0/default) >= 1.21.3
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/once-cell-cache)
+Provides:       crate(%{pkgname}/unsafe-cache)
+Provides:       crate(%{pkgname}/use-unix-paths-on-wasm)
+
+%description
+Source code for takopackized Rust crate "path-dedot"
+
+%package     -n %{name}+lazy-static
+Summary:        Extending `Path` and `PathBuf` in order to parse the path which contains dots - feature "lazy_static" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(lazy-static-1.0/default) >= 1.4
+Provides:       crate(%{pkgname}/lazy-static)
+Provides:       crate(%{pkgname}/lazy-static-cache)
+
+%description -n %{name}+lazy-static
+This metapackage enables feature "lazy_static" for the Rust path-dedot crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "lazy_static_cache" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-path-slash-0.2/rust-path-slash.spec
+++ b/SPECS/rust-path-slash-0.2/rust-path-slash.spec
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name path-slash
+%global full_version 0.2.1
+%global pkgname path-slash-0.2
+
+Name:           rust-path-slash-0.2
+Version:        0.2.1
+Release:        %autorelease
+Summary:        Rust crate "path-slash"
+License:        MIT
+URL:            https://github.com/rhysd/path-slash
+#!RemoteAsset:  sha256:1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "path-slash"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-peg-0.8/rust-peg.spec
+++ b/SPECS/rust-peg-0.8/rust-peg.spec
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name peg
+%global full_version 0.8.5
+%global pkgname peg-0.8
+
+Name:           rust-peg-0.8
+Version:        0.8.5
+Release:        %autorelease
+Summary:        Rust crate "peg"
+License:        MIT
+URL:            https://github.com/kevinmehall/rust-peg
+#!RemoteAsset:  sha256:9928cfca101b36ec5163e70049ee5368a8a1c3c6efc9ca9c5f9cc2f816152477
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(peg-macros-0.8/default) >= 0.8.5
+Requires:       crate(peg-runtime-0.8/default) >= 0.8.5
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "peg"
+
+%package     -n %{name}+std
+Summary:        Simple Parsing Expression Grammar (PEG) parser generator - feature "std" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(peg-runtime-0.8/std) >= 0.8.5
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description -n %{name}+std
+This metapackage enables feature "std" for the Rust peg crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "default" feature.
+
+%package     -n %{name}+trace
+Summary:        Simple Parsing Expression Grammar (PEG) parser generator - feature "trace"
+Requires:       crate(%{pkgname})
+Requires:       crate(peg-macros-0.8/trace) >= 0.8.5
+Provides:       crate(%{pkgname}/trace)
+
+%description -n %{name}+trace
+This metapackage enables feature "trace" for the Rust peg crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+unstable
+Summary:        Simple Parsing Expression Grammar (PEG) parser generator - feature "unstable"
+Requires:       crate(%{pkgname})
+Requires:       crate(peg-runtime-0.8/unstable) >= 0.8.5
+Provides:       crate(%{pkgname}/unstable)
+
+%description -n %{name}+unstable
+This metapackage enables feature "unstable" for the Rust peg crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-peg-macros-0.8/rust-peg-macros.spec
+++ b/SPECS/rust-peg-macros-0.8/rust-peg-macros.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name peg-macros
+%global full_version 0.8.5
+%global pkgname peg-macros-0.8
+
+Name:           rust-peg-macros-0.8
+Version:        0.8.5
+Release:        %autorelease
+Summary:        Rust crate "peg-macros"
+License:        MIT
+URL:            https://github.com/kevinmehall/rust-peg
+#!RemoteAsset:  sha256:6298ab04c202fa5b5d52ba03269fb7b74550b150323038878fe6c372d8280f71
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(peg-runtime-0.8/default) >= 0.8.5
+Requires:       crate(proc-macro2-1.0/default) >= 1.0.106
+Requires:       crate(quote-1.0/default) >= 1.0.45
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/trace)
+
+%description
+To use rust-peg, see the `peg` crate.
+Source code for takopackized Rust crate "peg-macros"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-peg-runtime-0.8/rust-peg-runtime.spec
+++ b/SPECS/rust-peg-runtime-0.8/rust-peg-runtime.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name peg-runtime
+%global full_version 0.8.5
+%global pkgname peg-runtime-0.8
+
+Name:           rust-peg-runtime-0.8
+Version:        0.8.5
+Release:        %autorelease
+Summary:        Rust crate "peg-runtime"
+License:        MIT
+URL:            https://github.com/kevinmehall/rust-peg
+#!RemoteAsset:  sha256:132dca9b868d927b35b5dd728167b2dee150eb1ad686008fc71ccb298b776fca
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+Provides:       crate(%{pkgname}/unstable)
+
+%description
+To use rust-peg, see the `peg` crate.
+Source code for takopackized Rust crate "peg-runtime"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-pep440-rs-0.7/rust-pep440-rs.spec
+++ b/SPECS/rust-pep440-rs-0.7/rust-pep440-rs.spec
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name pep440_rs
+%global full_version 0.7.3
+%global pkgname pep440-rs-0.7
+
+Name:           rust-pep440-rs-0.7
+Version:        0.7.3
+Release:        %autorelease
+Summary:        Rust crate "pep440_rs"
+License:        Apache-2.0 OR BSD-2-Clause
+URL:            https://github.com/konstin/pep440-rs
+#!RemoteAsset:  sha256:31095ca1f396e3de32745f42b20deef7bc09077f918b085307e8eab6ddd8fb9c
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(once-cell-1.0/default) >= 1.21.3
+Requires:       crate(serde-1.0/default) >= 1.0.228
+Requires:       crate(serde-1.0/derive) >= 1.0.228
+Requires:       crate(unicode-width-0.2/default) >= 0.2.2
+Requires:       crate(unscanny-0.1/default) >= 0.1.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "pep440_rs"
+
+%package     -n %{name}+rkyv
+Summary:        Python version numbers and specifiers, implementing PEP 440 - feature "rkyv"
+Requires:       crate(%{pkgname})
+Requires:       crate(rkyv-0.8/default) >= 0.8.9
+Provides:       crate(%{pkgname}/rkyv)
+
+%description -n %{name}+rkyv
+This metapackage enables feature "rkyv" for the Rust pep440_rs crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+tracing
+Summary:        Python version numbers and specifiers, implementing PEP 440 - feature "tracing"
+Requires:       crate(%{pkgname})
+Requires:       crate(tracing-0.1/default) >= 0.1.40
+Provides:       crate(%{pkgname}/tracing)
+
+%description -n %{name}+tracing
+This metapackage enables feature "tracing" for the Rust pep440_rs crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+version-ranges
+Summary:        Python version numbers and specifiers, implementing PEP 440 - feature "version-ranges"
+Requires:       crate(%{pkgname})
+Requires:       crate(version-ranges-0.1/default) >= 0.1.1
+Provides:       crate(%{pkgname}/version-ranges)
+
+%description -n %{name}+version-ranges
+This metapackage enables feature "version-ranges" for the Rust pep440_rs crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-pep508-rs-0.9/rust-pep508-rs.spec
+++ b/SPECS/rust-pep508-rs-0.9/rust-pep508-rs.spec
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name pep508_rs
+%global full_version 0.9.2
+%global pkgname pep508-rs-0.9
+
+Name:           rust-pep508-rs-0.9
+Version:        0.9.2
+Release:        %autorelease
+Summary:        Rust crate "pep508_rs"
+License:        Apache-2.0 OR BSD-2-Clause
+URL:            https://github.com/konstin/pep508_rs
+#!RemoteAsset:  sha256:faee7227064121fcadcd2ff788ea26f0d8f2bd23a0574da11eca23bc935bcc05
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(boxcar-0.2/default) >= 0.2.14
+Requires:       crate(indexmap-2.0/default) >= 2.14.0
+Requires:       crate(itertools-0.13/default) >= 0.13.0
+Requires:       crate(once-cell-1.0/default) >= 1.21.3
+Requires:       crate(pep440-rs-0.7/default) >= 0.7.3
+Requires:       crate(pep440-rs-0.7/version-ranges) >= 0.7.3
+Requires:       crate(regex-1.0/default) >= 1.12.3
+Requires:       crate(rustc-hash-2.0/default) >= 2.1.2
+Requires:       crate(serde-1.0/default) >= 1.0.228
+Requires:       crate(serde-1.0/derive) >= 1.0.228
+Requires:       crate(serde-1.0/rc) >= 1.0.228
+Requires:       crate(smallvec-1.0/default) >= 1.15.1
+Requires:       crate(thiserror-1.0/default) >= 1.0.69
+Requires:       crate(unicode-width-0.2/default) >= 0.2.2
+Requires:       crate(url-2.0/default) >= 2.5.8
+Requires:       crate(url-2.0/serde) >= 2.5.8
+Requires:       crate(urlencoding-2.0/default) >= 2.1.3
+Requires:       crate(version-ranges-0.1/default) >= 0.1.1
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/non-pep508-extensions)
+
+%description
+Source code for takopackized Rust crate "pep508_rs"
+
+%package     -n %{name}+schemars
+Summary:        Python dependency specifiers, better known as PEP 508 - feature "schemars"
+Requires:       crate(%{pkgname})
+Requires:       crate(schemars-0.8/default) >= 0.8.21
+Provides:       crate(%{pkgname}/schemars)
+
+%description -n %{name}+schemars
+This metapackage enables feature "schemars" for the Rust pep508_rs crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+tracing
+Summary:        Python dependency specifiers, better known as PEP 508 - feature "tracing"
+Requires:       crate(%{pkgname})
+Requires:       crate(pep440-rs-0.7/tracing) >= 0.7.3
+Requires:       crate(pep440-rs-0.7/version-ranges) >= 0.7.3
+Requires:       crate(tracing-0.1/default) >= 0.1.40
+Provides:       crate(%{pkgname}/tracing)
+
+%description -n %{name}+tracing
+This metapackage enables feature "tracing" for the Rust pep508_rs crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-pest-2.0/rust-pest.spec
+++ b/SPECS/rust-pest-2.0/rust-pest.spec
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name pest
+%global full_version 2.8.2
+%global pkgname pest-2.0
+
+Name:           rust-pest-2.0
+Version:        2.8.2
+Release:        %autorelease
+Summary:        Rust crate "pest"
+License:        MIT OR Apache-2.0
+URL:            https://pest.rs/
+#!RemoteAsset:  sha256:21e0a3a33733faeaf8651dfee72dd0f388f0c8e5ad496a3478fa5a922f49cfa8
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(ucd-trie-0.1) >= 0.1.7
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/const-prec-climber)
+
+%description
+Source code for takopackized Rust crate "pest"
+
+%package     -n %{name}+default
+Summary:        Elegant Parser - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/memchr)
+Requires:       crate(%{pkgname}/std)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust pest crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+memchr
+Summary:        Elegant Parser - feature "memchr"
+Requires:       crate(%{pkgname})
+Requires:       crate(memchr-2.0/default) >= 2.8.0
+Provides:       crate(%{pkgname}/memchr)
+
+%description -n %{name}+memchr
+This metapackage enables feature "memchr" for the Rust pest crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+miette-error
+Summary:        Elegant Parser - feature "miette-error"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/pretty-print)
+Requires:       crate(%{pkgname}/std)
+Requires:       crate(miette-7.0/default) >= 7.2.0
+Requires:       crate(miette-7.0/fancy) >= 7.2.0
+Requires:       crate(thiserror-2.0/default) >= 2.0.18
+Provides:       crate(%{pkgname}/miette-error)
+
+%description -n %{name}+miette-error
+This metapackage enables feature "miette-error" for the Rust pest crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+pretty-print
+Summary:        Elegant Parser - feature "pretty-print"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/default) >= 1.0.145
+Requires:       crate(serde-json-1.0/default) >= 1.0.85
+Provides:       crate(%{pkgname}/pretty-print)
+
+%description -n %{name}+pretty-print
+This metapackage enables feature "pretty-print" for the Rust pest crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+std
+Summary:        Elegant Parser - feature "std"
+Requires:       crate(%{pkgname})
+Requires:       crate(thiserror-2.0/default) >= 2.0.18
+Requires:       crate(ucd-trie-0.1/std) >= 0.1.7
+Provides:       crate(%{pkgname}/std)
+
+%description -n %{name}+std
+This metapackage enables feature "std" for the Rust pest crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-pest-derive-2.0/rust-pest-derive.spec
+++ b/SPECS/rust-pest-derive-2.0/rust-pest-derive.spec
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name pest_derive
+%global full_version 2.8.2
+%global pkgname pest-derive-2.0
+
+Name:           rust-pest-derive-2.0
+Version:        2.8.2
+Release:        %autorelease
+Summary:        Rust crate "pest_derive"
+License:        MIT OR Apache-2.0
+URL:            https://pest.rs/
+#!RemoteAsset:  sha256:bc58706f770acb1dbd0973e6530a3cff4746fb721207feb3a8a6064cd0b6c663
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(pest-2.0) >= 2.8.2
+Requires:       crate(pest-generator-2.0) >= 2.8.2
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "pest_derive"
+
+%package     -n %{name}+grammar-extras
+Summary:        Pest's derive macro - feature "grammar-extras"
+Requires:       crate(%{pkgname})
+Requires:       crate(pest-generator-2.0/grammar-extras) >= 2.8.2
+Provides:       crate(%{pkgname}/grammar-extras)
+
+%description -n %{name}+grammar-extras
+This metapackage enables feature "grammar-extras" for the Rust pest_derive crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+not-bootstrap-in-src
+Summary:        Pest's derive macro - feature "not-bootstrap-in-src"
+Requires:       crate(%{pkgname})
+Requires:       crate(pest-generator-2.0/not-bootstrap-in-src) >= 2.8.2
+Provides:       crate(%{pkgname}/not-bootstrap-in-src)
+
+%description -n %{name}+not-bootstrap-in-src
+This metapackage enables feature "not-bootstrap-in-src" for the Rust pest_derive crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+std
+Summary:        Pest's derive macro - feature "std" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(pest-2.0/std) >= 2.8.2
+Requires:       crate(pest-generator-2.0/std) >= 2.8.2
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description -n %{name}+std
+This metapackage enables feature "std" for the Rust pest_derive crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "default" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-pest-generator-2.0/rust-pest-generator.spec
+++ b/SPECS/rust-pest-generator-2.0/rust-pest-generator.spec
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name pest_generator
+%global full_version 2.8.2
+%global pkgname pest-generator-2.0
+
+Name:           rust-pest-generator-2.0
+Version:        2.8.2
+Release:        %autorelease
+Summary:        Rust crate "pest_generator"
+License:        MIT OR Apache-2.0
+URL:            https://pest.rs/
+#!RemoteAsset:  sha256:6d4f36811dfe07f7b8573462465d5cb8965fffc2e71ae377a33aecf14c2c9a2f
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(pest-2.0) >= 2.8.2
+Requires:       crate(pest-meta-2.0/default) >= 2.8.2
+Requires:       crate(proc-macro2-1.0/default) >= 1.0.106
+Requires:       crate(quote-1.0/default) >= 1.0.45
+Requires:       crate(syn-2.0/default) >= 2.0.117
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/export-internal)
+
+%description
+Source code for takopackized Rust crate "pest_generator"
+
+%package     -n %{name}+grammar-extras
+Summary:        Pest code generator - feature "grammar-extras"
+Requires:       crate(%{pkgname})
+Requires:       crate(pest-meta-2.0/grammar-extras) >= 2.8.2
+Provides:       crate(%{pkgname}/grammar-extras)
+
+%description -n %{name}+grammar-extras
+This metapackage enables feature "grammar-extras" for the Rust pest_generator crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+not-bootstrap-in-src
+Summary:        Pest code generator - feature "not-bootstrap-in-src"
+Requires:       crate(%{pkgname})
+Requires:       crate(pest-meta-2.0/not-bootstrap-in-src) >= 2.8.2
+Provides:       crate(%{pkgname}/not-bootstrap-in-src)
+
+%description -n %{name}+not-bootstrap-in-src
+This metapackage enables feature "not-bootstrap-in-src" for the Rust pest_generator crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+std
+Summary:        Pest code generator - feature "std" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(pest-2.0/std) >= 2.8.2
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description -n %{name}+std
+This metapackage enables feature "std" for the Rust pest_generator crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "default" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-pest-meta-2.0/rust-pest-meta.spec
+++ b/SPECS/rust-pest-meta-2.0/rust-pest-meta.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name pest_meta
+%global full_version 2.8.2
+%global pkgname pest-meta-2.0
+
+Name:           rust-pest-meta-2.0
+Version:        2.8.2
+Release:        %autorelease
+Summary:        Rust crate "pest_meta"
+License:        MIT OR Apache-2.0
+URL:            https://pest.rs/
+#!RemoteAsset:  sha256:42919b05089acbd0a5dcd5405fb304d17d1053847b81163d09c4ad18ce8e8420
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(pest-2.0/default) >= 2.8.2
+Requires:       crate(sha2-0.10) >= 0.10.9
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/grammar-extras)
+
+%description
+Source code for takopackized Rust crate "pest_meta"
+
+%package     -n %{name}+not-bootstrap-in-src
+Summary:        Pest meta language parser and validator - feature "not-bootstrap-in-src"
+Requires:       crate(%{pkgname})
+Requires:       crate(cargo-0.81/default) >= 0.81.0
+Provides:       crate(%{pkgname}/not-bootstrap-in-src)
+
+%description -n %{name}+not-bootstrap-in-src
+This metapackage enables feature "not-bootstrap-in-src" for the Rust pest_meta crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-phf-0.11/rust-phf.spec
+++ b/SPECS/rust-phf-0.11/rust-phf.spec
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name phf
+%global full_version 0.11.3
+%global pkgname phf-0.11
+
+Name:           rust-phf-0.11
+Version:        0.11.3
+Release:        %autorelease
+Summary:        Rust crate "phf"
+License:        MIT
+URL:            https://github.com/rust-phf/rust-phf
+#!RemoteAsset:  sha256:1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(phf-shared-0.11) >= 0.11.3
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "phf"
+
+%package     -n %{name}+phf-macros
+Summary:        Runtime support for perfect hash function data structures - feature "phf_macros" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(phf-macros-0.11/default) >= 0.11.3
+Provides:       crate(%{pkgname}/macros)
+Provides:       crate(%{pkgname}/phf-macros)
+
+%description -n %{name}+phf-macros
+This metapackage enables feature "phf_macros" for the Rust phf crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "macros" feature.
+
+%package     -n %{name}+serde
+Summary:        Runtime support for perfect hash function data structures - feature "serde"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/default) >= 1.0.0
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust phf crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+std
+Summary:        Runtime support for perfect hash function data structures - feature "std" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(phf-shared-0.11/std) >= 0.11.3
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description -n %{name}+std
+This metapackage enables feature "std" for the Rust phf crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "default" feature.
+
+%package     -n %{name}+uncased
+Summary:        Runtime support for perfect hash function data structures - feature "uncased"
+Requires:       crate(%{pkgname})
+Requires:       crate(phf-shared-0.11/uncased) >= 0.11.3
+Provides:       crate(%{pkgname}/uncased)
+
+%description -n %{name}+uncased
+This metapackage enables feature "uncased" for the Rust phf crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+unicase
+Summary:        Runtime support for perfect hash function data structures - feature "unicase"
+Requires:       crate(%{pkgname})
+Requires:       crate(phf-macros-0.11/unicase) >= 0.11.3
+Requires:       crate(phf-shared-0.11/unicase) >= 0.11.3
+Provides:       crate(%{pkgname}/unicase)
+
+%description -n %{name}+unicase
+This metapackage enables feature "unicase" for the Rust phf crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-phf-0.13/rust-phf.spec
+++ b/SPECS/rust-phf-0.13/rust-phf.spec
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name phf
+%global full_version 0.13.1
+%global pkgname phf-0.13
+
+Name:           rust-phf-0.13
+Version:        0.13.1
+Release:        %autorelease
+Summary:        Rust crate "phf"
+License:        MIT
+URL:            https://github.com/rust-phf/rust-phf
+#!RemoteAsset:  sha256:c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(phf-shared-0.13) >= 0.13.1
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "phf"
+
+%package     -n %{name}+phf-macros
+Summary:        Runtime support for perfect hash function data structures - feature "phf_macros" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(phf-macros-0.13/default) >= 0.13.1
+Provides:       crate(%{pkgname}/macros)
+Provides:       crate(%{pkgname}/phf-macros)
+
+%description -n %{name}+phf-macros
+This metapackage enables feature "phf_macros" for the Rust phf crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "macros" feature.
+
+%package     -n %{name}+serde
+Summary:        Runtime support for perfect hash function data structures - feature "serde"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0) >= 1.0.228
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust phf crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+std
+Summary:        Runtime support for perfect hash function data structures - feature "std" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(phf-shared-0.13/std) >= 0.13.1
+Requires:       crate(serde-1.0/std) >= 1.0.228
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description -n %{name}+std
+This metapackage enables feature "std" for the Rust phf crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "default" feature.
+
+%package     -n %{name}+uncased
+Summary:        Runtime support for perfect hash function data structures - feature "uncased"
+Requires:       crate(%{pkgname})
+Requires:       crate(phf-macros-0.13/uncased) >= 0.13.1
+Requires:       crate(phf-shared-0.13/uncased) >= 0.13.1
+Provides:       crate(%{pkgname}/uncased)
+
+%description -n %{name}+uncased
+This metapackage enables feature "uncased" for the Rust phf crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+unicase
+Summary:        Runtime support for perfect hash function data structures - feature "unicase"
+Requires:       crate(%{pkgname})
+Requires:       crate(phf-macros-0.13/unicase) >= 0.13.1
+Requires:       crate(phf-shared-0.13/unicase) >= 0.13.1
+Provides:       crate(%{pkgname}/unicase)
+
+%description -n %{name}+unicase
+This metapackage enables feature "unicase" for the Rust phf crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-phf-codegen-0.11/rust-phf-codegen.spec
+++ b/SPECS/rust-phf-codegen-0.11/rust-phf-codegen.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name phf_codegen
+%global full_version 0.11.3
+%global pkgname phf-codegen-0.11
+
+Name:           rust-phf-codegen-0.11
+Version:        0.11.3
+Release:        %autorelease
+Summary:        Rust crate "phf_codegen"
+License:        MIT
+URL:            https://github.com/rust-phf/rust-phf
+#!RemoteAsset:  sha256:aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(phf-generator-0.11/default) >= 0.11.3
+Requires:       crate(phf-shared-0.11/default) >= 0.11.3
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "phf_codegen"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-phf-generator-0.11/rust-phf-generator.spec
+++ b/SPECS/rust-phf-generator-0.11/rust-phf-generator.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name phf_generator
+%global full_version 0.11.3
+%global pkgname phf-generator-0.11
+
+Name:           rust-phf-generator-0.11
+Version:        0.11.3
+Release:        %autorelease
+Summary:        Rust crate "phf_generator"
+License:        MIT
+URL:            https://github.com/rust-phf/rust-phf
+#!RemoteAsset:  sha256:3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(phf-shared-0.11) >= 0.11.3
+Requires:       crate(rand-0.8/small-rng) >= 0.8.5
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "phf_generator"
+
+%package     -n %{name}+criterion
+Summary:        PHF generation logic - feature "criterion"
+Requires:       crate(%{pkgname})
+Requires:       crate(criterion-0.3/default) >= 0.3.6
+Provides:       crate(%{pkgname}/criterion)
+
+%description -n %{name}+criterion
+This metapackage enables feature "criterion" for the Rust phf_generator crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-phf-shared-0.11/rust-phf-shared.spec
+++ b/SPECS/rust-phf-shared-0.11/rust-phf-shared.spec
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name phf_shared
+%global full_version 0.11.3
+%global pkgname phf-shared-0.11
+
+Name:           rust-phf-shared-0.11
+Version:        0.11.3
+Release:        %autorelease
+Summary:        Rust crate "phf_shared"
+License:        MIT
+URL:            https://github.com/rust-phf/rust-phf
+#!RemoteAsset:  sha256:67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(siphasher-1.0/default) >= 1.0.1
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description
+Source code for takopackized Rust crate "phf_shared"
+
+%package     -n %{name}+uncased
+Summary:        Support code shared by PHF libraries - feature "uncased"
+Requires:       crate(%{pkgname})
+Requires:       crate(uncased-0.9) >= 0.9.9
+Provides:       crate(%{pkgname}/uncased)
+
+%description -n %{name}+uncased
+This metapackage enables feature "uncased" for the Rust phf_shared crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+unicase
+Summary:        Support code shared by PHF libraries - feature "unicase"
+Requires:       crate(%{pkgname})
+Requires:       crate(unicase-2.0/default) >= 2.4.0
+Provides:       crate(%{pkgname}/unicase)
+
+%description -n %{name}+unicase
+This metapackage enables feature "unicase" for the Rust phf_shared crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-phf-shared-0.13/rust-phf-shared.spec
+++ b/SPECS/rust-phf-shared-0.13/rust-phf-shared.spec
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name phf_shared
+%global full_version 0.13.1
+%global pkgname phf-shared-0.13
+
+Name:           rust-phf-shared-0.13
+Version:        0.13.1
+Release:        %autorelease
+Summary:        Rust crate "phf_shared"
+License:        MIT
+URL:            https://github.com/rust-phf/rust-phf
+#!RemoteAsset:  sha256:e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(siphasher-1.0/default) >= 1.0.1
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description
+Source code for takopackized Rust crate "phf_shared"
+
+%package     -n %{name}+uncased
+Summary:        Support code shared by PHF libraries - feature "uncased"
+Requires:       crate(%{pkgname})
+Requires:       crate(uncased-0.9) >= 0.9.9
+Provides:       crate(%{pkgname}/uncased)
+
+%description -n %{name}+uncased
+This metapackage enables feature "uncased" for the Rust phf_shared crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+unicase
+Summary:        Support code shared by PHF libraries - feature "unicase"
+Requires:       crate(%{pkgname})
+Requires:       crate(unicase-2.0/default) >= 2.4.0
+Provides:       crate(%{pkgname}/unicase)
+
+%description -n %{name}+unicase
+This metapackage enables feature "unicase" for the Rust phf_shared crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-predicates-3.0/rust-predicates.spec
+++ b/SPECS/rust-predicates-3.0/rust-predicates.spec
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name predicates
+%global full_version 3.1.3
+%global pkgname predicates-3.0
+
+Name:           rust-predicates-3.0
+Version:        3.1.3
+Release:        %autorelease
+Summary:        Rust crate "predicates"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/assert-rs/predicates-rs
+#!RemoteAsset:  sha256:a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(anstyle-1.0/default) >= 1.0.14
+Requires:       crate(predicates-core-1.0/default) >= 1.0.9
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/color)
+Provides:       crate(%{pkgname}/unstable)
+
+%description
+Source code for takopackized Rust crate "predicates"
+
+%package     -n %{name}+default
+Summary:        Boolean-valued predicate functions - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/color)
+Requires:       crate(%{pkgname}/diff)
+Requires:       crate(%{pkgname}/float-cmp)
+Requires:       crate(%{pkgname}/normalize-line-endings)
+Requires:       crate(%{pkgname}/regex)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust predicates crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+diff
+Summary:        Boolean-valued predicate functions - feature "diff"
+Requires:       crate(%{pkgname})
+Requires:       crate(difflib-0.4/default) >= 0.4.0
+Provides:       crate(%{pkgname}/diff)
+
+%description -n %{name}+diff
+This metapackage enables feature "diff" for the Rust predicates crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+float-cmp
+Summary:        Boolean-valued predicate functions - feature "float-cmp"
+Requires:       crate(%{pkgname})
+Requires:       crate(float-cmp-0.10/default) >= 0.10.0
+Provides:       crate(%{pkgname}/float-cmp)
+
+%description -n %{name}+float-cmp
+This metapackage enables feature "float-cmp" for the Rust predicates crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+normalize-line-endings
+Summary:        Boolean-valued predicate functions - feature "normalize-line-endings"
+Requires:       crate(%{pkgname})
+Requires:       crate(normalize-line-endings-0.3/default) >= 0.3.0
+Provides:       crate(%{pkgname}/normalize-line-endings)
+
+%description -n %{name}+normalize-line-endings
+This metapackage enables feature "normalize-line-endings" for the Rust predicates crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+regex
+Summary:        Boolean-valued predicate functions - feature "regex"
+Requires:       crate(%{pkgname})
+Requires:       crate(regex-1.0/default) >= 1.0.0
+Provides:       crate(%{pkgname}/regex)
+
+%description -n %{name}+regex
+This metapackage enables feature "regex" for the Rust predicates crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-predicates-core-1.0/rust-predicates-core.spec
+++ b/SPECS/rust-predicates-core-1.0/rust-predicates-core.spec
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name predicates-core
+%global full_version 1.0.9
+%global pkgname predicates-core-1.0
+
+Name:           rust-predicates-core-1.0
+Version:        1.0.9
+Release:        %autorelease
+Summary:        Rust crate "predicates-core"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/assert-rs/predicates-rs/tree/master/crates/core
+#!RemoteAsset:  sha256:727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "predicates-core"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-predicates-tree-1.0/rust-predicates-tree.spec
+++ b/SPECS/rust-predicates-tree-1.0/rust-predicates-tree.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name predicates-tree
+%global full_version 1.0.12
+%global pkgname predicates-tree-1.0
+
+Name:           rust-predicates-tree-1.0
+Version:        1.0.12
+Release:        %autorelease
+Summary:        Rust crate "predicates-tree"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/assert-rs/predicates-rs/tree/master/crates/tree
+#!RemoteAsset:  sha256:72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(predicates-core-1.0/default) >= 1.0.9
+Requires:       crate(termtree-0.5/default) >= 0.5.1
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "predicates-tree"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-proc-macro-crate-3.0/rust-proc-macro-crate.spec
+++ b/SPECS/rust-proc-macro-crate-3.0/rust-proc-macro-crate.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name proc-macro-crate
+%global full_version 3.4.0
+%global pkgname proc-macro-crate-3.0
+
+Name:           rust-proc-macro-crate-3.0
+Version:        3.4.0
+Release:        %autorelease
+Summary:        Rust crate "proc-macro-crate"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/bkchr/proc-macro-crate
+#!RemoteAsset:  sha256:219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(toml-edit-0.23/parse) >= 0.23.6
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "proc-macro-crate"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-proc-macro-utils-0.10/rust-proc-macro-utils.spec
+++ b/SPECS/rust-proc-macro-utils-0.10/rust-proc-macro-utils.spec
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name proc-macro-utils
+%global full_version 0.10.0
+%global pkgname proc-macro-utils-0.10
+
+Name:           rust-proc-macro-utils-0.10
+Version:        0.10.0
+Release:        %autorelease
+Summary:        Rust crate "proc-macro-utils"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/ModProg/proc-macro-utils
+#!RemoteAsset:  sha256:eeaf08a13de400bc215877b5bdc088f241b12eb42f0a548d3390dc1c56bb7071
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/proc-macro)
+
+%description
+Source code for takopackized Rust crate "proc-macro-utils"
+
+%package     -n %{name}+default
+Summary:        Low-level utilities on proc-macro and proc-macro2 types - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/parser)
+Requires:       crate(%{pkgname}/proc-macro)
+Requires:       crate(%{pkgname}/proc-macro2)
+Requires:       crate(%{pkgname}/quote)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust proc-macro-utils crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+parser
+Summary:        Low-level utilities on proc-macro and proc-macro2 types - feature "parser"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/proc-macro2)
+Requires:       crate(%{pkgname}/smallvec)
+Provides:       crate(%{pkgname}/parser)
+
+%description -n %{name}+parser
+This metapackage enables feature "parser" for the Rust proc-macro-utils crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+proc-macro2
+Summary:        Low-level utilities on proc-macro and proc-macro2 types - feature "proc-macro2"
+Requires:       crate(%{pkgname})
+Requires:       crate(proc-macro2-1.0/default) >= 1.0.106
+Provides:       crate(%{pkgname}/proc-macro2)
+
+%description -n %{name}+proc-macro2
+This metapackage enables feature "proc-macro2" for the Rust proc-macro-utils crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+quote
+Summary:        Low-level utilities on proc-macro and proc-macro2 types - feature "quote"
+Requires:       crate(%{pkgname})
+Requires:       crate(quote-1.0/default) >= 1.0.45
+Provides:       crate(%{pkgname}/quote)
+
+%description -n %{name}+quote
+This metapackage enables feature "quote" for the Rust proc-macro-utils crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+smallvec
+Summary:        Low-level utilities on proc-macro and proc-macro2 types - feature "smallvec"
+Requires:       crate(%{pkgname})
+Requires:       crate(smallvec-1.0/const-generics) >= 1.15.1
+Requires:       crate(smallvec-1.0/default) >= 1.15.1
+Provides:       crate(%{pkgname}/smallvec)
+
+%description -n %{name}+smallvec
+This metapackage enables feature "smallvec" for the Rust proc-macro-utils crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-pyproject-toml-0.13/rust-pyproject-toml.spec
+++ b/SPECS/rust-pyproject-toml-0.13/rust-pyproject-toml.spec
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name pyproject-toml
+%global full_version 0.13.7
+%global pkgname pyproject-toml-0.13
+
+Name:           rust-pyproject-toml-0.13
+Version:        0.13.7
+Release:        %autorelease
+Summary:        Rust crate "pyproject-toml"
+License:        MIT
+URL:            https://github.com/PyO3/pyproject-toml-rs.git
+#!RemoteAsset:  sha256:f6d755483ad14b49e76713b52285235461a5b4f73f17612353e11a5de36a5fd2
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(indexmap-2.0/default) >= 2.14.0
+Requires:       crate(indexmap-2.0/serde) >= 2.14.0
+Requires:       crate(pep440-rs-0.7/default) >= 0.7.3
+Requires:       crate(pep508-rs-0.9/default) >= 0.9.2
+Requires:       crate(serde-1.0/default) >= 1.0.228
+Requires:       crate(serde-1.0/derive) >= 1.0.228
+Requires:       crate(thiserror-2.0/default) >= 2.0.18
+Requires:       crate(toml-0.9/parse) >= 0.9.12
+Requires:       crate(toml-0.9/serde) >= 0.9.12
+Requires:       crate(toml-0.9/std) >= 0.9.12
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "pyproject-toml"
+
+%package     -n %{name}+glob
+Summary:        Pyproject.toml parser in Rust - feature "glob" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(glob-0.3/default) >= 0.3.1
+Provides:       crate(%{pkgname}/glob)
+Provides:       crate(%{pkgname}/pep639-glob)
+
+%description -n %{name}+glob
+This metapackage enables feature "glob" for the Rust pyproject-toml crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "pep639-glob" feature.
+
+%package     -n %{name}+tracing
+Summary:        Pyproject.toml parser in Rust - feature "tracing"
+Requires:       crate(%{pkgname})
+Requires:       crate(pep440-rs-0.7/tracing) >= 0.7.3
+Requires:       crate(pep508-rs-0.9/tracing) >= 0.9.2
+Provides:       crate(%{pkgname}/tracing)
+
+%description -n %{name}+tracing
+This metapackage enables feature "tracing" for the Rust pyproject-toml crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-quick-junit-0.6/rust-quick-junit.spec
+++ b/SPECS/rust-quick-junit-0.6/rust-quick-junit.spec
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name quick-junit
+%global full_version 0.6.0
+%global pkgname quick-junit-0.6
+
+Name:           rust-quick-junit-0.6
+Version:        0.6.0
+Release:        %autorelease
+Summary:        Rust crate "quick-junit"
+License:        Apache-2.0 OR MIT
+URL:            https://github.com/nextest-rs/quick-junit
+#!RemoteAsset:  sha256:e3e64c58c4c88fc1045e8fe98a1b7cec3643187e3dd678f9bbcdd8f12a6933d6
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(chrono-0.4/std) >= 0.4.44
+Requires:       crate(indexmap-2.0/default) >= 2.14.0
+Requires:       crate(newtype-uuid-1.0/default) >= 1.3.2
+Requires:       crate(quick-xml-0.38/default) >= 0.38.4
+Requires:       crate(strip-ansi-escapes-0.2/default) >= 0.2.1
+Requires:       crate(thiserror-2.0/default) >= 2.0.18
+Requires:       crate(uuid-1.0/default) >= 1.23.1
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "quick-junit"
+
+%package     -n %{name}+internal-testing
+Summary:        Data model, serializer, and deserializer for JUnit/XUnit XML - feature "internal-testing"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/proptest)
+Requires:       crate(xxhash-rust-0.8/default) >= 0.8.15
+Requires:       crate(xxhash-rust-0.8/xxh3) >= 0.8.15
+Provides:       crate(%{pkgname}/internal-testing)
+
+%description -n %{name}+internal-testing
+This metapackage enables feature "internal-testing" for the Rust quick-junit crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+proptest
+Summary:        Data model, serializer, and deserializer for JUnit/XUnit XML - feature "proptest"
+Requires:       crate(%{pkgname})
+Requires:       crate(newtype-uuid-1.0/proptest1) >= 1.3.2
+Requires:       crate(proptest-1.0/default) >= 1.7.0
+Requires:       crate(test-strategy-0.4/default) >= 0.4.3
+Provides:       crate(%{pkgname}/proptest)
+
+%description -n %{name}+proptest
+This metapackage enables feature "proptest" for the Rust quick-junit crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-quick-xml-0.38/rust-quick-xml.spec
+++ b/SPECS/rust-quick-xml-0.38/rust-quick-xml.spec
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name quick-xml
+%global full_version 0.38.4
+%global pkgname quick-xml-0.38
+
+Name:           rust-quick-xml-0.38
+Version:        0.38.4
+Release:        %autorelease
+Summary:        Rust crate "quick-xml"
+License:        MIT
+URL:            https://github.com/tafia/quick-xml
+#!RemoteAsset:  sha256:b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(memchr-2.0/default) >= 2.8.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/escape-html)
+Provides:       crate(%{pkgname}/overlapped-lists)
+
+%description
+Source code for takopackized Rust crate "quick-xml"
+
+%package     -n %{name}+arbitrary
+Summary:        High performance xml reader and writer - feature "arbitrary"
+Requires:       crate(%{pkgname})
+Requires:       crate(arbitrary-1.0/default) >= 1.0.0
+Requires:       crate(arbitrary-1.0/derive) >= 1.0.0
+Provides:       crate(%{pkgname}/arbitrary)
+
+%description -n %{name}+arbitrary
+This metapackage enables feature "arbitrary" for the Rust quick-xml crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+document-features
+Summary:        High performance xml reader and writer - feature "document-features"
+Requires:       crate(%{pkgname})
+Requires:       crate(document-features-0.2/default) >= 0.2.0
+Provides:       crate(%{pkgname}/document-features)
+
+%description -n %{name}+document-features
+This metapackage enables feature "document-features" for the Rust quick-xml crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+encoding-rs
+Summary:        High performance xml reader and writer - feature "encoding_rs" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(encoding-rs-0.8/default) >= 0.8.0
+Provides:       crate(%{pkgname}/encoding)
+Provides:       crate(%{pkgname}/encoding-rs)
+
+%description -n %{name}+encoding-rs
+This metapackage enables feature "encoding_rs" for the Rust quick-xml crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "encoding" feature.
+
+%package     -n %{name}+serde
+Summary:        High performance xml reader and writer - feature "serde" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/default) >= 1.0.139
+Provides:       crate(%{pkgname}/serde)
+Provides:       crate(%{pkgname}/serialize)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust quick-xml crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "serialize" feature.
+
+%package     -n %{name}+serde-types
+Summary:        High performance xml reader and writer - feature "serde-types"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/derive) >= 1.0.139
+Provides:       crate(%{pkgname}/serde-types)
+
+%description -n %{name}+serde-types
+This metapackage enables feature "serde-types" for the Rust quick-xml crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+tokio
+Summary:        High performance xml reader and writer - feature "tokio" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(tokio-1.0/io-util) >= 1.10
+Provides:       crate(%{pkgname}/async-tokio)
+Provides:       crate(%{pkgname}/tokio)
+
+%description -n %{name}+tokio
+This metapackage enables feature "tokio" for the Rust quick-xml crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "async-tokio" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-quickcheck-1.0/rust-quickcheck.spec
+++ b/SPECS/rust-quickcheck-1.0/rust-quickcheck.spec
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name quickcheck
+%global full_version 1.1.0
+%global pkgname quickcheck-1.0
+
+Name:           rust-quickcheck-1.0
+Version:        1.1.0
+Release:        %autorelease
+Summary:        Rust crate "quickcheck"
+License:        Unlicense OR MIT
+URL:            https://github.com/BurntSushi/quickcheck
+#!RemoteAsset:  sha256:95c589f335db0f6aaa168a7cd27b1fc6920f5e1470c804f814d9cd6e62a0f70b
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(rand-0.10/sys-rng) >= 0.10.1
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "quickcheck"
+
+%package     -n %{name}+default
+Summary:        Automatic property based testing with shrinking - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/regex)
+Requires:       crate(%{pkgname}/use-logging)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust quickcheck crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+env-logger
+Summary:        Automatic property based testing with shrinking - feature "env_logger"
+Requires:       crate(%{pkgname})
+Requires:       crate(env-logger-0.11) >= 0.11.0
+Provides:       crate(%{pkgname}/env-logger)
+
+%description -n %{name}+env-logger
+This metapackage enables feature "env_logger" for the Rust quickcheck crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+log
+Summary:        Automatic property based testing with shrinking - feature "log"
+Requires:       crate(%{pkgname})
+Requires:       crate(log-0.4/default) >= 0.4.0
+Provides:       crate(%{pkgname}/log)
+
+%description -n %{name}+log
+This metapackage enables feature "log" for the Rust quickcheck crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+regex
+Summary:        Automatic property based testing with shrinking - feature "regex"
+Requires:       crate(%{pkgname})
+Requires:       crate(env-logger-0.11/regex) >= 0.11.0
+Provides:       crate(%{pkgname}/regex)
+
+%description -n %{name}+regex
+This metapackage enables feature "regex" for the Rust quickcheck crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+use-logging
+Summary:        Automatic property based testing with shrinking - feature "use_logging"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/env-logger)
+Requires:       crate(%{pkgname}/log)
+Provides:       crate(%{pkgname}/use-logging)
+
+%description -n %{name}+use-logging
+This metapackage enables feature "use_logging" for the Rust quickcheck crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-quickcheck-macros-1.0/rust-quickcheck-macros.spec
+++ b/SPECS/rust-quickcheck-macros-1.0/rust-quickcheck-macros.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name quickcheck_macros
+%global full_version 1.2.0
+%global pkgname quickcheck-macros-1.0
+
+Name:           rust-quickcheck-macros-1.0
+Version:        1.2.0
+Release:        %autorelease
+Summary:        Rust crate "quickcheck_macros"
+License:        Unlicense OR MIT
+URL:            https://github.com/BurntSushi/quickcheck
+#!RemoteAsset:  sha256:a9a28b8493dd664c8b171dd944da82d933f7d456b829bfb236738e1fe06c5ba4
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(proc-macro2-1.0/default) >= 1.0.106
+Requires:       crate(quote-1.0/default) >= 1.0.45
+Requires:       crate(syn-2.0/default) >= 2.0.117
+Requires:       crate(syn-2.0/full) >= 2.0.117
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "quickcheck_macros"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-quote-use-0.8/rust-quote-use.spec
+++ b/SPECS/rust-quote-use-0.8/rust-quote-use.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name quote-use
+%global full_version 0.8.4
+%global pkgname quote-use-0.8
+
+Name:           rust-quote-use-0.8
+Version:        0.8.4
+Release:        %autorelease
+Summary:        Rust crate "quote-use"
+License:        MIT
+URL:            https://github.com/ModProg/quote-use
+#!RemoteAsset:  sha256:9619db1197b497a36178cfc736dc96b271fe918875fbf1344c436a7e93d0321e
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(quote-1.0/default) >= 1.0.45
+Requires:       crate(quote-use-macros-0.8/default) >= 0.8.4
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "quote-use"
+
+%package     -n %{name}+syn
+Summary:        Support `use` in procmacros hygienically - feature "syn"
+Requires:       crate(%{pkgname})
+Requires:       crate(syn-2.0/parsing) >= 2.0.0
+Requires:       crate(syn-2.0/printing) >= 2.0.0
+Provides:       crate(%{pkgname}/syn)
+
+%description -n %{name}+syn
+This metapackage enables feature "syn" for the Rust quote-use crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-quote-use-macros-0.8/rust-quote-use-macros.spec
+++ b/SPECS/rust-quote-use-macros-0.8/rust-quote-use-macros.spec
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name quote-use-macros
+%global full_version 0.8.4
+%global pkgname quote-use-macros-0.8
+
+Name:           rust-quote-use-macros-0.8
+Version:        0.8.4
+Release:        %autorelease
+Summary:        Rust crate "quote-use-macros"
+License:        MIT
+URL:            https://github.com/ModProg/quote-use
+#!RemoteAsset:  sha256:82ebfb7faafadc06a7ab141a6f67bcfb24cb8beb158c6fe933f2f035afa99f35
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(proc-macro-utils-0.10/default) >= 0.10.0
+Requires:       crate(proc-macro2-1.0/default) >= 1.0.106
+Requires:       crate(quote-1.0/default) >= 1.0.45
+Requires:       crate(syn-2.0/clone-impls) >= 2.0.117
+Requires:       crate(syn-2.0/extra-traits) >= 2.0.117
+Requires:       crate(syn-2.0/parsing) >= 2.0.117
+Requires:       crate(syn-2.0/printing) >= 2.0.117
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "quote-use-macros"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-rand-0.10/rust-rand.spec
+++ b/SPECS/rust-rand-0.10/rust-rand.spec
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name rand
+%global full_version 0.10.1
+%global pkgname rand-0.10
+
+Name:           rust-rand-0.10
+Version:        0.10.1
+Release:        %autorelease
+Summary:        Rust crate "rand"
+License:        MIT OR Apache-2.0
+URL:            https://rust-random.github.io/book
+#!RemoteAsset:  sha256:d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(rand-core-0.10) >= 0.10.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/alloc)
+Provides:       crate(%{pkgname}/log)
+Provides:       crate(%{pkgname}/simd-support)
+Provides:       crate(%{pkgname}/unbiased)
+
+%description
+Source code for takopackized Rust crate "rand"
+
+%package     -n %{name}+chacha
+Summary:        Random number generators and other randomness functionality - feature "chacha" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(chacha20-0.10/rng) >= 0.10.0
+Provides:       crate(%{pkgname}/chacha)
+Provides:       crate(%{pkgname}/std-rng)
+
+%description -n %{name}+chacha
+This metapackage enables feature "chacha" for the Rust rand crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "std_rng" feature.
+
+%package     -n %{name}+default
+Summary:        Random number generators and other randomness functionality - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/std)
+Requires:       crate(%{pkgname}/std-rng)
+Requires:       crate(%{pkgname}/sys-rng)
+Requires:       crate(%{pkgname}/thread-rng)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust rand crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+serde
+Summary:        Random number generators and other randomness functionality - feature "serde"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/default) >= 1.0.103
+Requires:       crate(serde-1.0/derive) >= 1.0.103
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust rand crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+std
+Summary:        Random number generators and other randomness functionality - feature "std"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/alloc)
+Requires:       crate(getrandom-0.4/std) >= 0.4.2
+Provides:       crate(%{pkgname}/std)
+
+%description -n %{name}+std
+This metapackage enables feature "std" for the Rust rand crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+sys-rng
+Summary:        Random number generators and other randomness functionality - feature "sys_rng"
+Requires:       crate(%{pkgname})
+Requires:       crate(getrandom-0.4/default) >= 0.4.2
+Requires:       crate(getrandom-0.4/sys-rng) >= 0.4.2
+Provides:       crate(%{pkgname}/sys-rng)
+
+%description -n %{name}+sys-rng
+This metapackage enables feature "sys_rng" for the Rust rand crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+thread-rng
+Summary:        Random number generators and other randomness functionality - feature "thread_rng"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/std)
+Requires:       crate(%{pkgname}/std-rng)
+Requires:       crate(%{pkgname}/sys-rng)
+Provides:       crate(%{pkgname}/thread-rng)
+
+%description -n %{name}+thread-rng
+This metapackage enables feature "thread_rng" for the Rust rand crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-rand-0.8/rust-rand.spec
+++ b/SPECS/rust-rand-0.8/rust-rand.spec
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name rand
+%global full_version 0.8.5
+%global pkgname rand-0.8
+
+Name:           rust-rand-0.8
+Version:        0.8.5
+Release:        %autorelease
+Summary:        Rust crate "rand"
+License:        MIT OR Apache-2.0
+URL:            https://rust-random.github.io/book
+#!RemoteAsset:  sha256:34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(rand-core-0.6/default) >= 0.6.4
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/min-const-gen)
+Provides:       crate(%{pkgname}/nightly)
+Provides:       crate(%{pkgname}/small-rng)
+
+%description
+Source code for takopackized Rust crate "rand"
+
+%package     -n %{name}+alloc
+Summary:        Random number generators and other randomness functionality - feature "alloc"
+Requires:       crate(%{pkgname})
+Requires:       crate(rand-core-0.6/alloc) >= 0.6.4
+Provides:       crate(%{pkgname}/alloc)
+
+%description -n %{name}+alloc
+This metapackage enables feature "alloc" for the Rust rand crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+default
+Summary:        Random number generators and other randomness functionality - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/std)
+Requires:       crate(%{pkgname}/std-rng)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust rand crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+getrandom
+Summary:        Random number generators and other randomness functionality - feature "getrandom"
+Requires:       crate(%{pkgname})
+Requires:       crate(rand-core-0.6/getrandom) >= 0.6.4
+Provides:       crate(%{pkgname}/getrandom)
+
+%description -n %{name}+getrandom
+This metapackage enables feature "getrandom" for the Rust rand crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+libc
+Summary:        Random number generators and other randomness functionality - feature "libc"
+Requires:       crate(%{pkgname})
+Requires:       crate(libc-0.2) >= 0.2.186
+Provides:       crate(%{pkgname}/libc)
+
+%description -n %{name}+libc
+This metapackage enables feature "libc" for the Rust rand crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+log
+Summary:        Random number generators and other randomness functionality - feature "log"
+Requires:       crate(%{pkgname})
+Requires:       crate(log-0.4/default) >= 0.4.4
+Provides:       crate(%{pkgname}/log)
+
+%description -n %{name}+log
+This metapackage enables feature "log" for the Rust rand crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+packed-simd
+Summary:        Random number generators and other randomness functionality - feature "packed_simd" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(packed-simd-2-0.3/default) >= 0.3.7
+Requires:       crate(packed-simd-2-0.3/into-bits) >= 0.3.7
+Provides:       crate(%{pkgname}/packed-simd)
+Provides:       crate(%{pkgname}/simd-support)
+
+%description -n %{name}+packed-simd
+This metapackage enables feature "packed_simd" for the Rust rand crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "simd_support" feature.
+
+%package     -n %{name}+rand-chacha
+Summary:        Random number generators and other randomness functionality - feature "rand_chacha" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(rand-chacha-0.3) >= 0.3.1
+Provides:       crate(%{pkgname}/rand-chacha)
+Provides:       crate(%{pkgname}/std-rng)
+
+%description -n %{name}+rand-chacha
+This metapackage enables feature "rand_chacha" for the Rust rand crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "std_rng" feature.
+
+%package     -n %{name}+serde
+Summary:        Random number generators and other randomness functionality - feature "serde"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/default) >= 1.0.103
+Requires:       crate(serde-1.0/derive) >= 1.0.103
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust rand crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+serde1
+Summary:        Random number generators and other randomness functionality - feature "serde1"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/serde)
+Requires:       crate(rand-core-0.6/serde1) >= 0.6.4
+Provides:       crate(%{pkgname}/serde1)
+
+%description -n %{name}+serde1
+This metapackage enables feature "serde1" for the Rust rand crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+std
+Summary:        Random number generators and other randomness functionality - feature "std"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/alloc)
+Requires:       crate(%{pkgname}/getrandom)
+Requires:       crate(%{pkgname}/libc)
+Requires:       crate(rand-chacha-0.3/std) >= 0.3.1
+Requires:       crate(rand-core-0.6/std) >= 0.6.4
+Provides:       crate(%{pkgname}/std)
+
+%description -n %{name}+std
+This metapackage enables feature "std" for the Rust rand crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-rand-chacha-0.3/rust-rand-chacha.spec
+++ b/SPECS/rust-rand-chacha-0.3/rust-rand-chacha.spec
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name rand_chacha
+%global full_version 0.3.1
+%global pkgname rand-chacha-0.3
+
+Name:           rust-rand-chacha-0.3
+Version:        0.3.1
+Release:        %autorelease
+Summary:        Rust crate "rand_chacha"
+License:        MIT OR Apache-2.0
+URL:            https://rust-random.github.io/book
+#!RemoteAsset:  sha256:e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(ppv-lite86-0.2/simd) >= 0.2.21
+Requires:       crate(rand-core-0.6/default) >= 0.6.4
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/simd)
+
+%description
+Source code for takopackized Rust crate "rand_chacha"
+
+%package     -n %{name}+serde
+Summary:        ChaCha random number generator - feature "serde" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/default) >= 1.0.0
+Requires:       crate(serde-1.0/derive) >= 1.0.0
+Provides:       crate(%{pkgname}/serde)
+Provides:       crate(%{pkgname}/serde1)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust rand_chacha crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "serde1" feature.
+
+%package     -n %{name}+std
+Summary:        ChaCha random number generator - feature "std" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(ppv-lite86-0.2/simd) >= 0.2.21
+Requires:       crate(ppv-lite86-0.2/std) >= 0.2.21
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description -n %{name}+std
+This metapackage enables feature "std" for the Rust rand_chacha crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "default" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-rand-core-0.10/rust-rand-core.spec
+++ b/SPECS/rust-rand-core-0.10/rust-rand-core.spec
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name rand_core
+%global full_version 0.10.0
+%global pkgname rand-core-0.10
+
+Name:           rust-rand-core-0.10
+Version:        0.10.0
+Release:        %autorelease
+Summary:        Rust crate "rand_core"
+License:        MIT OR Apache-2.0
+URL:            https://rust-random.github.io/book
+#!RemoteAsset:  sha256:0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "rand_core"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-redox-users-0.5/rust-redox-users.spec
+++ b/SPECS/rust-redox-users-0.5/rust-redox-users.spec
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name redox_users
+%global full_version 0.5.2
+%global pkgname redox-users-0.5
+
+Name:           rust-redox-users-0.5
+Version:        0.5.2
+Release:        %autorelease
+Summary:        Rust crate "redox_users"
+License:        MIT
+URL:            https://gitlab.redox-os.org/redox-os/users
+#!RemoteAsset:  sha256:a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(getrandom-0.2/default) >= 0.2.16
+Requires:       crate(getrandom-0.2/std) >= 0.2.16
+Requires:       crate(libredox-0.1/call) >= 0.1.10
+Requires:       crate(libredox-0.1/std) >= 0.1.10
+Requires:       crate(thiserror-2.0/default) >= 2.0.18
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "redox_users"
+
+%package     -n %{name}+auth
+Summary:        Access Redox users and groups functionality - feature "auth" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/rust-argon2)
+Requires:       crate(%{pkgname}/zeroize)
+Provides:       crate(%{pkgname}/auth)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+auth
+This metapackage enables feature "auth" for the Rust redox_users crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "default" feature.
+
+%package     -n %{name}+rust-argon2
+Summary:        Access Redox users and groups functionality - feature "rust-argon2"
+Requires:       crate(%{pkgname})
+Requires:       crate(rust-argon2-0.8/default) >= 0.8.0
+Provides:       crate(%{pkgname}/rust-argon2)
+
+%description -n %{name}+rust-argon2
+This metapackage enables feature "rust-argon2" for the Rust redox_users crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+zeroize
+Summary:        Access Redox users and groups functionality - feature "zeroize"
+Requires:       crate(%{pkgname})
+Requires:       crate(zeroize-1.0/default) >= 1.4
+Requires:       crate(zeroize-1.0/zeroize-derive) >= 1.4
+Provides:       crate(%{pkgname}/zeroize)
+
+%description -n %{name}+zeroize
+This metapackage enables feature "zeroize" for the Rust redox_users crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-ref-cast-1.0/rust-ref-cast.spec
+++ b/SPECS/rust-ref-cast-1.0/rust-ref-cast.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name ref-cast
+%global full_version 1.0.25
+%global pkgname ref-cast-1.0
+
+Name:           rust-ref-cast-1.0
+Version:        1.0.25
+Release:        %autorelease
+Summary:        Rust crate "ref-cast"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/dtolnay/ref-cast
+#!RemoteAsset:  sha256:f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(ref-cast-impl-1.0/default) >= 1.0.25
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "ref-cast"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-ref-cast-impl-1.0/rust-ref-cast-impl.spec
+++ b/SPECS/rust-ref-cast-impl-1.0/rust-ref-cast-impl.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name ref-cast-impl
+%global full_version 1.0.25
+%global pkgname ref-cast-impl-1.0
+
+Name:           rust-ref-cast-impl-1.0
+Version:        1.0.25
+Release:        %autorelease
+Summary:        Rust crate "ref-cast-impl"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/dtolnay/ref-cast
+#!RemoteAsset:  sha256:b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da
+Source:         https://crates.io/api/v1/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(proc-macro2-1.0/default) >= 1.0.106
+Requires:       crate(quote-1.0/default) >= 1.0.45
+Requires:       crate(syn-2.0/default) >= 2.0.117
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "ref-cast-impl"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog


### PR DESCRIPTION
necessity: a bunch of rustcrates used by python-ruff, which are packages useful for AI stack.

Generated by TakoPack.

AI declaration: organized by GPT-5.5, reviewed by human