### PR TITLE
SPECS: crun: Align CRIU build condition

### DIFF
--- a/SPECS/crun/crun.spec
+++ b/SPECS/crun/crun.spec
@@ -26,6 +26,11 @@ BuildOption(conf):  --with-libkrun
 %if %{with wasm}
 BuildOption(conf):  --with-wasmedge
 %endif
+%if %{with criu}
+BuildOption(conf):  --enable-criu
+%else
+BuildOption(conf):  --disable-criu
+%endif
 %if %{without system_yajl}
 BuildOption(conf):  --enable-embedded-yajl
 %endif


### PR DESCRIPTION
### Changes

- Make CRIU support follow the existing `%bcond criu`.

  The spec already has `%bcond criu 0` and conditional CRIU BuildRequires. Pass the matching configure option explicitly so the default build disables CRIU instead of relying on configure-time auto probing.

  Source: [`configure.ac`](https://github.com/containers/crun/blob/1.27.1/configure.ac#L258-L287)

  ```m4
  AC_ARG_ENABLE([criu], AS_HELP_STRING([--disable-criu], [Disable CRIU based checkpoint/restore support]))
  AS_IF([test "x$enable_criu" != "xno"], [
      PKG_CHECK_MODULES([CRIU], [criu >= 3.15], [have_criu="yes"], [have_criu="no"
          AC_MSG_NOTICE([CRIU headers not found, building without CRIU support])])
      ...
  ], [AC_MSG_NOTICE([CRIU support disabled per user request])])
  ```

AIGC Declaration: CodeX with gpt5.5 was used as coding agent.

Signed-off-by: Jingwiw <wangjingwei@iscas.ac.cn>
