### PR TITLE
SPECS: enchant: Align provider build conditions

### DIFF
--- a/SPECS/enchant/enchant.spec
+++ b/SPECS/enchant/enchant.spec
@@ -21,6 +21,13 @@ BuildSystem:    autotools
 
 %if %{with aspell}
 BuildOption(conf):  --with-aspell
+%else
+BuildOption(conf):  --without-aspell
+%endif
+%if %{with nuspell}
+BuildOption(conf):  --with-nuspell
+%else
+BuildOption(conf):  --without-nuspell
 %endif
 BuildOption(conf):  --disable-static
 


### PR DESCRIPTION
### Changes

- Make the disabled aspell and nuspell bconds explicit in configure arguments.

  The current default build only enables the hunspell and voikko providers. The spec already keeps aspell and nuspell BuildRequires and packaged backend files behind disabled bconds, while upstream provider detection defaults to `check`. Passing `--without-aspell` and `--without-nuspell` keeps the declared bconds aligned with the current default build fact.

  Source: [`configure.ac`](https://github.com/rrthomas/enchant/blob/v2.8.16/configure.ac)

  ```m4
  AC_ARG_WITH([$1],
     AS_HELP_STRING([--with-[]$1],
        [enable the $1 provider @<:@default=provider_check@:>@]),
        [with_[]$1=$withval],
        [with_[]$1=provider_check])
  ```

  Source: [`configure.ac`](https://github.com/rrthomas/enchant/blob/v2.8.16/configure.ac)

  ```m4
  ENCHANT_CHECK_PKG_CONFIG_PROVIDER([nuspell], [NUSPELL], [nuspell >= 5.1.0])
  ENCHANT_CHECK_LIB_PROVIDER([aspell], [ASPELL], [get_aspell_dict_info_list],,, [ASPELL_H])
  ```

AIGC Declaration: CodeX with gpt5.5 was used as coding agent.

Signed-off-by: Jingwiw <wangjingwei@iscas.ac.cn>
