### PR TITLE
SPECS: ffmpeg: Align librtmp build condition

### DIFF
--- a/SPECS/ffmpeg/ffmpeg.spec
+++ b/SPECS/ffmpeg/ffmpeg.spec
@@ -110,7 +110,7 @@ BuildRequires:  pkgconfig(zlib)
 BuildRequires:  pkgconfig(libopenjp2)
 BuildRequires:  texinfo
 %if %{with librtmp}
-BuildRequires:  librtmp-devel
+BuildRequires:  pkgconfig(librtmp)
 %endif
 BuildRequires:  pkgconfig(xevdb)
 BuildRequires:  pkgconfig(xeveb)

--- a/SPECS/ffmpeg/ffmpeg.spec
+++ b/SPECS/ffmpeg/ffmpeg.spec
@@ -15,12 +15,12 @@
 %bcond lv2 0
 
 %if %{with all_codecs}
-%bcond rtmp 1
+%bcond librtmp 1
 %bcond vvc 1
 %bcond x264 1
 %bcond x265 1
 %else
-%bcond rtmp 0
+%bcond librtmp 0
 %bcond vvc 0
 %bcond x264 0
 %bcond x265 0
@@ -109,7 +109,7 @@ BuildRequires:  pkgconfig(zlib)
 # BuildRequires:  pkgconfig(openh264)
 BuildRequires:  pkgconfig(libopenjp2)
 BuildRequires:  texinfo
-%if %{with rtmp}
+%if %{with librtmp}
 BuildRequires:  librtmp-devel
 %endif
 BuildRequires:  pkgconfig(xevdb)


### PR DESCRIPTION
### Changes

- Align the librtmp bcond, BuildRequires, and configure option.

  The spec already passes `--enable-librtmp` under `%{with librtmp}`, but the bcond and BuildRequires were guarded by `%{with rtmp}`. Use one `librtmp` condition so `all_codecs` controls both dependency selection and the configure option.

  Source: [`configure`](https://github.com/FFmpeg/FFmpeg/blob/n8.1.1/configure#L275)

  ```sh
  --enable-librtmp         enable RTMP[E] support via librtmp [no]
  ```

- Use `pkgconfig(librtmp)` for the librtmp build dependency.

  FFmpeg checks librtmp through pkg-config, so the BuildRequires should name that provider interface instead of the downstream devel package name.

  Source: [`configure`](https://github.com/FFmpeg/FFmpeg/blob/n8.1.1/configure#L7366)

  ```sh
  enabled librtmp           && require_pkg_config librtmp librtmp librtmp/rtmp.h RTMP_Socket
  ```

AIGC Declaration: CodeX with gpt5.5 was used as coding agent.

Signed-off-by: Jingwiw <wangjingwei@iscas.ac.cn>
