### PR TITLE
SPECS: gd: Align optional codec options

### DIFF
--- a/SPECS/gd/gd.spec
+++ b/SPECS/gd/gd.spec
@@ -16,7 +16,7 @@ Summary:        A Drawing Library for Programs That Use PNG and JPEG Output
 License:        MIT
 URL:            http://libgd.github.io/
 VCS:            git:https://github.com/libgd/libgd
-#!RemoteAsset
+#!RemoteAsset:  sha256:3fe822ece20796060af63b7c60acb151e5844204d289da0ce08f8fdf131e5a61
 Source0:        https://github.com/libgd/libgd/releases/download/%{name}-%{version}/libgd-%{version}.tar.xz
 BuildSystem:    autotools
 
@@ -111,4 +111,4 @@ export TMPDIR=/tmp
 %{_libdir}/pkgconfig/gdlib.pc
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/gd/gd.spec
+++ b/SPECS/gd/gd.spec
@@ -22,7 +22,6 @@ BuildSystem:    autotools
 
 BuildOption(conf):  --disable-static
 BuildOption(conf):  --disable-werror
-BuildOption(conf):  --disable-slient-rules
 BuildOption(conf):  --without-liq
 BuildOption(conf):  --without-x
 BuildOption(conf):  --with-fontconfig

--- a/SPECS/gd/gd.spec
+++ b/SPECS/gd/gd.spec
@@ -31,12 +31,18 @@ BuildOption(conf):  --with-jpeg
 BuildOption(conf):  --with-png
 %if %{with avif}
 BuildOption(conf):  --with-avif
+%else
+BuildOption(conf):  --without-avif
 %endif
 %if %{with webp}
 BuildOption(conf):  --with-webp
+%else
+BuildOption(conf):  --without-webp
 %endif
 %if %{with xpm}
 BuildOption(conf):  --with-xpm
+%else
+BuildOption(conf):  --without-xpm
 %endif
 
 BuildRequires:  automake


### PR DESCRIPTION
### Changes

- Add the missing remote asset checksum for the gd source archive.

- Make the optional AVIF, WebP, and XPM codec choices explicit when their bconds are disabled.

  These bconds default to disabled in the spec, but upstream defaults feature checks to `auto` when no `--with/--without` value is passed.

  Source: [`configure.ac`](https://github.com/libgd/libgd/blob/gd-2.3.3/configure.ac#L126-L137)

  ```m4
  m4_define([GD_LIB_CHECK], [dnl
    ...
    AC_ARG_WITH([$3],
      [AS_HELP_STRING([--with-$3@<:@=DIR@:>@], [Support $3 (optionally in DIR)])],
      [gd_with_lib=$withval],
      [gd_with_lib=auto])
    AC_MSG_RESULT([$gd_with_lib])

    gd_found_lib=no
    gd_require_pkg_name=""
    if test "$gd_with_lib" != "no"; then
  ```

  Source: [`configure.ac`](https://github.com/libgd/libgd/blob/gd-2.3.3/configure.ac#L265-L302)

  ```m4
  dnl Check for xpm support.
  GD_LIB_PKG_CHECK([LIBXPM], [XPM], [xpm], [xpm], [
    ...
  ])

  dnl Check for webp support.
  GD_LIB_PKG_CHECK([LIBWEBP], [WEBP], [webp], [libwebp >= 0.2.0], [
    ...
  ])

  dnl Check for avif support.
  GD_LIB_PKG_CHECK([LIBAVIF], [AVIF], [avif], [libavif >= 0.8.2], [
    ...
  ])
  ```

- Drop the misspelled `--disable-slient-rules` configure option.

  The package build log reported it as an unrecognized option, and the autotools build path already passes the correctly spelled `--disable-silent-rules`.

- Use `%autochangelog` directly, matching the current spec style.

AIGC Declaration: CodeX with gpt5.5 was used as coding agent.

Signed-off-by: Jingwiw <wangjingwei@iscas.ac.cn>
