### PR TITLE
SPECS: kf6-kfilemetadata: Align optional dependency handling

### DIFF
--- a/SPECS/kf6-kfilemetadata/kf6-kfilemetadata.spec
+++ b/SPECS/kf6-kfilemetadata/kf6-kfilemetadata.spec
@@ -29,10 +29,10 @@ BuildOption(conf):  -DCMAKE_DISABLE_FIND_PACKAGE_FFmpeg=ON
 %endif
 
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
-BuildRequires:  attr-devel
+BuildRequires:  pkgconfig(libattr)
 BuildRequires:  ebook-tools
 BuildRequires:  pkgconfig
-BuildRequires:  cmake(exiv2) >= 0.21
+BuildRequires:  pkgconfig(exiv2)
 BuildRequires:  cmake(KF6Archive) >= %{_kf6_version}
 BuildRequires:  cmake(KF6Codecs) >= %{_kf6_version}
 BuildRequires:  cmake(KF6Config) >= %{_kf6_version}

--- a/SPECS/kf6-kfilemetadata/kf6-kfilemetadata.spec
+++ b/SPECS/kf6-kfilemetadata/kf6-kfilemetadata.spec
@@ -30,7 +30,7 @@ BuildOption(conf):  -DCMAKE_DISABLE_FIND_PACKAGE_FFmpeg=ON
 
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  pkgconfig(libattr)
-BuildRequires:  ebook-tools
+BuildRequires:  ebook-tools-devel
 BuildRequires:  pkgconfig
 BuildRequires:  pkgconfig(exiv2)
 BuildRequires:  cmake(KF6Archive) >= %{_kf6_version}

--- a/SPECS/kf6-kfilemetadata/kf6-kfilemetadata.spec
+++ b/SPECS/kf6-kfilemetadata/kf6-kfilemetadata.spec
@@ -24,6 +24,9 @@ Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{versi
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF
+%if %{without ffmpeg}
+BuildOption(conf):  -DCMAKE_DISABLE_FIND_PACKAGE_FFmpeg=ON
+%endif
 
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  attr-devel


### PR DESCRIPTION
### Changes

- Make `--without ffmpeg` actually disable FFmpeg discovery in CMake.

  The spec already has `%bcond ffmpeg 1`. When the bcond is disabled, passing `CMAKE_DISABLE_FIND_PACKAGE_FFmpeg=ON` prevents CMake from picking FFmpeg up from the buildroot anyway.

  Source: [`CMakeLists.txt`](https://invent.kde.org/frameworks/kfilemetadata/-/blob/v6.22.0/CMakeLists.txt#L82-L91)

  ```cmake
  find_package(FFmpeg 57.48 COMPONENTS AVCODEC)
  if (AVCODEC_FOUND)
      find_package(FFmpeg 57.40 COMPONENTS AVFORMAT)
      if (AVFORMAT_FOUND)
          find_package(FFmpeg 55.27 COMPONENTS AVUTIL)
      endif()
  endif()
  set_package_properties(FFmpeg PROPERTIES DESCRIPTION "Video Tag reader"
                         URL "https://ffmpeg.org/" TYPE OPTIONAL
                         PURPOSE "Support for video metadata")
  ```

- Use `pkgconfig(libattr)` for xattr support.

  kfilemetadata requires xattr support on Linux and looks for the libattr header/library pair.

  Source: [`CMakeLists.txt`](https://invent.kde.org/frameworks/kfilemetadata/-/blob/v6.22.0/CMakeLists.txt#L103-L109)

  ```cmake
  if ( CMAKE_SYSTEM_NAME MATCHES "Linux" )
      find_package(Xattr)
      set_package_properties(Xattr PROPERTIES DESCRIPTION "library libattr "
          URL "https://savannah.nongnu.org/projects/attr"
          TYPE REQUIRED
          PURPOSE "Extended attribute shared library")
  endif()
  ```

  Source: [`FindXattr.cmake`](https://invent.kde.org/frameworks/kfilemetadata/-/blob/v6.22.0/cmake/FindXattr.cmake#L16-L27)

  ```cmake
  find_path(XATTR_INCLUDE sys/xattr.h
      /usr/include
      /usr/local/include
      ${CMAKE_INCLUDE_PATH}
      ${CMAKE_INSTALL_PREFIX}/usr/include
  )

  find_library(XATTR_LIB NAMES attr libattr
      PATHS
          ${CMAKE_LIBRARY_PATH}
          ${CMAKE_INSTALL_PREFIX}/lib
  )
  ```

- Use `ebook-tools-devel` for EPub support.

  The EPub finder checks for `libepub` and `epub.h`; those are development files, so the build dependency should be the devel package rather than the runtime tools package.

  Source: [`CMakeLists.txt`](https://invent.kde.org/frameworks/kfilemetadata/-/blob/v6.22.0/CMakeLists.txt#L93-L96)

  ```cmake
  find_package(EPub)
  set_package_properties(EPub PROPERTIES DESCRIPTION "Ebook epub reader"
                         URL "https://sourceforge.net/projects/ebook-tools/" TYPE OPTIONAL
                         PURPOSE "Support for epub metadata")
  ```

  Source: [`FindEPub.cmake`](https://invent.kde.org/frameworks/kfilemetadata/-/blob/v6.22.0/cmake/FindEPub.cmake#L19-L28)

  ```cmake
  find_library (EPUB_LIBRARIES
    NAMES epub libepub
  )

  find_path (EPUB_INCLUDE_DIR
    NAMES epub.h
  )

  include (FindPackageHandleStandardArgs)
  find_package_handle_standard_args (EPub DEFAULT_MSG EPUB_LIBRARIES EPUB_INCLUDE_DIR)
  ```

- Use `pkgconfig(exiv2)` for Exiv2.

  The local CMake finder consumes the Exiv2 pkg-config result as hints for header and library lookup, so the pkgconfig dependency is the direct provider interface.

  Source: `FindLibExiv2.cmake` from the kfilemetadata build dependency stack

  ```cmake
  find_path(LibExiv2_INCLUDE_DIRS NAMES exiv2/exif.hpp
      HINTS ${PC_EXIV2_INCLUDEDIR}
  )

  find_library(LibExiv2_LIBRARIES NAMES exiv2 libexiv2
      HINTS ${PC_EXIV2_LIBRARY_DIRS}
  )
  ```

AIGC Declaration: CodeX with gpt5.5 was used as coding agent.

Signed-off-by: Jingwiw <wangjingwei@iscas.ac.cn>
