### PR TITLE
SPECS: libxmlb: Align stemmer build condition

### DIFF
--- a/SPECS/libxmlb/libxmlb.spec
+++ b/SPECS/libxmlb/libxmlb.spec
@@ -37,7 +37,7 @@ BuildOption(conf):  -Dtests=false
 
 BuildRequires:  meson
 BuildRequires:  gcc
-BuildRequires:  glib-devel
+BuildRequires:  pkgconfig(gio-2.0)
 BuildRequires:  pkgconfig(gobject-introspection-1.0)
 BuildRequires:  pkgconfig(liblzma)
 BuildRequires:  pkgconfig(libzstd)

--- a/SPECS/libxmlb/libxmlb.spec
+++ b/SPECS/libxmlb/libxmlb.spec
@@ -19,6 +19,11 @@ URL:            https://github.com/hughsie/libxmlb
 Source:         https://github.com/hughsie/libxmlb/archive/refs/tags/%{version}.tar.gz
 BuildSystem:    meson
 
+%if %{with stemmer}
+BuildOption(conf):  -Dstemmer=true
+%else
+BuildOption(conf):  -Dstemmer=false
+%endif
 %if %{with doc}
 BuildOption(conf):  -Dgtkdoc=true
 %else

--- a/SPECS/libxmlb/libxmlb.spec
+++ b/SPECS/libxmlb/libxmlb.spec
@@ -15,7 +15,7 @@ Release:        %autorelease
 Summary:        Library for querying compressed XML metadata
 License:        LGPL-2.1-or-later
 URL:            https://github.com/hughsie/libxmlb
-#!RemoteAsset
+#!RemoteAsset:  sha256:45245a5ebe8a3598449f4d53a576801bdb6489aae03ff2206ad4fc7799611014
 Source:         https://github.com/hughsie/libxmlb/archive/refs/tags/%{version}.tar.gz
 BuildSystem:    meson
 
@@ -99,4 +99,4 @@ Executable and data files for installed tests.
 %endif
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
### Changes

- Add the missing remote asset checksum and use `%autochangelog` directly.

- Make the existing stemmer bcond drive the Meson option.

  Upstream defaults `stemmer` to `false`, so the default build remains unchanged. This makes `%{with stemmer}` actually enable the feature that already has a conditional BuildRequires.

  Source: [`meson_options.txt`](https://github.com/hughsie/libxmlb/blob/0.3.24/meson_options.txt)

  ```meson
  option('stemmer', type : 'boolean', value : false, description : 'enable stemmer support')
  ```

  Source: [`meson.build`](https://github.com/hughsie/libxmlb/blob/0.3.24/meson.build)

  ```meson
  if get_option('stemmer')
    cc = meson.get_compiler('c')
    stemmer = cc.find_library('stemmer')
    libxmlb_deps += stemmer
    conf.set('HAVE_LIBSTEMMER', 1)
  endif
  ```

- Use `pkgconfig(gio-2.0)` instead of the broader `glib-devel` package name.

  libxmlb asks Meson for `gio-2.0`, so the BuildRequires should name the provider interface it actually consumes.

  Source: [`meson.build`](https://github.com/hughsie/libxmlb/blob/0.3.24/meson.build)

  ```meson
  gio = dependency('gio-2.0', version : '>= 2.45.8')
  ```

AIGC Declaration: CodeX with gpt5.5 was used as coding agent.

Signed-off-by: Jingwiw <wangjingwei@iscas.ac.cn>
