### PR TITLE
SPECS: memcached: Align optional build dependencies

### DIFF
--- a/SPECS/memcached/memcached.spec
+++ b/SPECS/memcached/memcached.spec
@@ -47,7 +47,7 @@ BuildRequires:  automake
 BuildRequires:  pkgconfig(libseccomp)
 %endif
 %if %{with sasl} || %{with sasl_pwdb}
-BuildRequires:  cyrus-sasl-devel
+BuildRequires:  pkgconfig(libsasl2)
 %endif
 
 %description

--- a/SPECS/memcached/memcached.spec
+++ b/SPECS/memcached/memcached.spec
@@ -32,7 +32,7 @@ BuildOption(conf):  --enable-seccomp
 BuildOption(conf):  --enable-sasl
 %endif
 %if %{with sasl_pwdb}
-BuildOption(conf):  --enable-pwdb
+BuildOption(conf):  --enable-sasl-pwdb
 %endif
 %if %{with dtrace}
 BuildOption(conf):  --enable-dtrace
@@ -43,7 +43,10 @@ BuildRequires:  pkgconfig(libevent)
 BuildRequires:  pkgconfig(openssl)
 BuildRequires:  autoconf
 BuildRequires:  automake
-%if %{with sasl}
+%if %{with seccomp}
+BuildRequires:  pkgconfig(libseccomp)
+%endif
+%if %{with sasl} || %{with sasl_pwdb}
 BuildRequires:  cyrus-sasl-devel
 %endif
 

--- a/SPECS/memcached/memcached.spec
+++ b/SPECS/memcached/memcached.spec
@@ -18,7 +18,7 @@ Summary:        In-memory caching service
 License:        BSD-3-Clause
 URL:            https://memcached.org/
 VCS:            git:https://github.com/memcached/memcached.git
-#!RemoteAsset
+#!RemoteAsset:  sha256:b1d02d7e9887d80f4885a024931c8bbe9c16d333200d2dcadde8597892c54855
 Source:         https://memcached.org/files/memcached-%{version}.tar.gz
 BuildSystem:    autotools
 
@@ -68,4 +68,4 @@ mkdir -p %{buildroot}/%{_localstatedir}/run/%{name}
 %dir %attr(750,nobody,nobody) %{_localstatedir}/run/%{name}
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
### Changes

- Add the missing remote asset checksum and use `%autochangelog` directly.

- Add the seccomp build dependency under the existing `%bcond seccomp`.

  The spec defaults seccomp on and passes `--enable-seccomp`, while upstream checks for `seccomp_rule_add` from libseccomp. The BuildRequires should describe that default build fact directly.

  Source: [`configure.ac`](https://github.com/memcached/memcached/blob/1.6.28/configure.ac)

  ```m4
  AC_ARG_ENABLE(seccomp,
    [AS_HELP_STRING([--enable-seccomp],[Enable seccomp restrictions EXPERIMENTAL])])

  AS_IF([test "x$enable_seccomp" = "xyes" ], [
     AC_CHECK_LIB(seccomp, seccomp_rule_add, [
  ```

- Use the upstream SASL password database option name and align the SASL dependency guard.

  `--enable-sasl-pwdb` is the configure option upstream exposes. Enabling it also enables SASL, so the SASL BuildRequires must cover either `%{with sasl}` or `%{with sasl_pwdb}`.

  Source: [`configure.ac`](https://github.com/memcached/memcached/blob/1.6.28/configure.ac)

  ```m4
  AC_ARG_ENABLE(sasl,
    [AS_HELP_STRING([--enable-sasl],[Enable SASL authentication])])

  AC_ARG_ENABLE(sasl_pwdb,
    [AS_HELP_STRING([--enable-sasl-pwdb],[Enable plaintext password db])])

  AS_IF([test "x$enable_sasl_pwdb" = "xyes"],
        [enable_sasl=yes ])
  ```

- Use `pkgconfig(libsasl2)` for the SASL build dependency.

  Upstream checks the SASL header and library symbols directly; in openRuyi, the cyrus-sasl devel package exposes `libsasl2.pc`, so the pkgconfig dependency names the same development interface more precisely.

  Source: [`configure.ac`](https://github.com/memcached/memcached/blob/1.6.28/configure.ac)

  ```m4
  AC_CHECK_HEADERS([sasl/sasl.h])
  if test "x$enable_sasl" = "xyes"; then
    AC_SEARCH_LIBS([sasl_server_init], [sasl2 sasl], [],
  ```

  Source: [`SPECS/cyrus-sasl/cyrus-sasl.spec`](https://github.com/openRuyi-Project/openRuyi/blob/main/SPECS/cyrus-sasl/cyrus-sasl.spec)

  ```spec
  %files devel
  %{_libdir}/pkgconfig/libsasl2.pc
  ```

AIGC Declaration: CodeX with gpt5.5 was used as coding agent.

Signed-off-by: Jingwiw <wangjingwei@iscas.ac.cn>
