### PR TITLE
SPECS: openssh: Align optional build dependencies

### DIFF
--- a/SPECS/openssh/openssh.spec
+++ b/SPECS/openssh/openssh.spec
@@ -313,4 +313,4 @@ popd
 %attr(0644,root,root) %{_sysusersdir}/openssh-server.conf
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/openssh/openssh.spec
+++ b/SPECS/openssh/openssh.spec
@@ -60,12 +60,16 @@ BuildOption(conf):  --with-kerberos5${krb5_prefix:+=${krb5_prefix}}
 %else
 BuildOption(conf):  --without-kerberos5
 %endif
+%if %{with fido2}
+BuildOption(conf):  --with-security-key-builtin
+%else
+BuildOption(conf):  --without-security-key-builtin
+%endif
 BuildOption(conf):  --with-libedit
 
 BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  pkgconfig(zlib)
-BuildRequires:  pkgconfig(audit)
 BuildRequires:  util-linux
 BuildRequires:  groff
 BuildRequires:  pkgconfig(pam)
@@ -78,12 +82,13 @@ BuildRequires:  make
 BuildRequires:  pkgconfig(libfido2)
 %endif
 BuildRequires:  pkgconfig(libxcrypt)
-%if %{with kerberos}
+%if %{with kerberos5}
 BuildRequires:  pkgconfig(krb5)
 %endif
 BuildRequires:  pkgconfig(libedit)
 BuildRequires:  pkgconfig(ncurses)
 %if %{with selinux}
+BuildRequires:  pkgconfig(audit)
 BuildRequires:  pkgconfig(libselinux)
 %endif
 %if %{with xorg}

--- a/SPECS/openssh/openssh.spec
+++ b/SPECS/openssh/openssh.spec
@@ -101,7 +101,6 @@ Recommends:     p11-kit
 Requires:       openssl
 %if %{with selinux}
 Requires:       libselinux
-Requires:       pkgconfig(audit)
 %endif
 
 %description

--- a/SPECS/openssh/openssh.spec
+++ b/SPECS/openssh/openssh.spec
@@ -35,7 +35,7 @@ Source12:       50-openruyi-sshd.conf
 BuildSystem:    autotools
 
 # Lets us ship distro config in /etc/ssh/{ssh,sshd}_config.d/*.conf
-Patch0:         2000-ssh-sshd-_config-Include-_config.d-.conf.patch
+Patch2000:      2000-ssh-sshd-_config-Include-_config.d-.conf.patch
 
 BuildOption(conf):  --sysconfdir=%{_sysconfdir}/ssh
 BuildOption(conf):  --libexecdir=%{_libexecdir}/openssh
@@ -48,7 +48,6 @@ BuildOption(conf):  --without-zlib-version-check
 BuildOption(conf):  --without-ipaddr-display
 BuildOption(conf):  --with-pie=no
 BuildOption(conf):  --without-hardening
-BuildOption(conf):  --with-systemd
 BuildOption(conf):  --with-pam
 %if %{with selinux}
 BuildOption(conf):  --with-selinux
@@ -74,7 +73,6 @@ BuildRequires:  util-linux
 BuildRequires:  groff
 BuildRequires:  pkgconfig(pam)
 BuildRequires:  pkgconfig(openssl)
-BuildRequires:  pkgconfig(systemd)
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  make
 #BuildRequires:  pkgconfig(p11-kit-1)


### PR DESCRIPTION
### Changes

- Drop the unused `--with-systemd` configure option and the unused `pkgconfig(systemd)` build dependency.

  OpenSSH 10.3p1 enables systemd notification on Linux directly and implements it without linking libsystemd.

  Source: [`configure.ac`](https://github.com/openssh/openssh-portable/blob/V_10_3_P1/configure.ac#L1010)

  ```m4
  AC_DEFINE([SYSTEMD_NOTIFY], [1], [Have sshd notify systemd on start/reload])
  ```

  Source: [`openbsd-compat/port-linux.c`](https://github.com/openssh/openssh-portable/blob/V_10_3_P1/openbsd-compat/port-linux.c#L335-L418)

  ```c
  #ifdef SYSTEMD_NOTIFY

  static void
  ssh_systemd_notify(const char *fmt, ...)
  {
      ...
      if ((path = getenv("NOTIFY_SOCKET")) == NULL || strlen(path) == 0)
          return;
      ...
      if ((fd = socket(PF_UNIX, SOCK_DGRAM, 0)) == -1) {
          ...
      }
      ...
  }
  ```

  The package still keeps `systemd-rpm-macros`, because the spec installs systemd units and uses systemd scriptlet macros.

- Make the FIDO2 builtin support follow the existing `%bcond fido2`.

  Upstream has a dedicated switch for builtin U2F/FIDO support, and the builtin path probes libfido2.

  Source: [`configure.ac`](https://github.com/openssh/openssh-portable/blob/V_10_3_P1/configure.ac#L2303-L2307)

  ```m4
  AC_ARG_WITH([security-key-builtin],
      [  --with-security-key-builtin include builtin U2F/FIDO support],
      [ enable_sk_internal=$withval ]
  )
  ```

  Source: [`configure.ac`](https://github.com/openssh/openssh-portable/blob/V_10_3_P1/configure.ac#L3478-L3514)

  ```m4
  if test "x$enable_sk" = "xyes" -a "x$enable_sk_internal" != "xno" ; then
      ...
      if "$PKGCONFIG" libfido2; then
          ...
      fi
      ...
      AC_CHECK_HEADER([fido.h], [],
          [ fido2_error="missing fido.h from libfido2" ])
  ```

- Fix the Kerberos BuildRequires guard to use the actual `%bcond kerberos5`.

- Keep Linux audit BuildRequires scoped to the SELinux build path that enables it.

  The spec only passes `--with-audit=linux` inside `%if %{with selinux}`, so the audit build dependency belongs under the same guard.

  Source: [`configure.ac`](https://github.com/openssh/openssh-portable/blob/V_10_3_P1/configure.ac#L1981-L2018)

  ```m4
  AC_ARG_WITH([audit],
      [  --with-audit=module     Enable audit support (modules=debug,bsm,linux)],
      ...
      linux)
          ...
          AC_CHECK_HEADERS([libaudit.h])
          SSHDLIBS="$SSHDLIBS -laudit"
          AC_DEFINE([USE_LINUX_AUDIT], [1], [Use Linux audit module])
  ```

- Drop `Requires: pkgconfig(audit)` because pkgconfig dependencies are development interfaces, not runtime package requirements.

- Use `%autochangelog` directly, matching the current spec style.

AIGC Declaration: CodeX with gpt5.5 was used as coding agent.

Signed-off-by: Jingwiw <wangjingwei@iscas.ac.cn>
