### PR TITLE
SPECS: pinentry: Align GNOME build condition

### DIFF
--- a/SPECS/pinentry/pinentry.spec
+++ b/SPECS/pinentry/pinentry.spec
@@ -29,7 +29,11 @@ BuildSystem:    autotools
 
 BuildOption(conf):  --disable-rpath
 BuildOption(conf):  --disable-dependency-tracking
+%if %{with gnome}
 BuildOption(conf):  --enable-pinentry-gnome3
+%else
+BuildOption(conf):  --disable-pinentry-gnome3
+%endif
 %if %{with gtk2}
 BuildOption(conf):  --enable-pinentry-gtk2
 %else

--- a/SPECS/pinentry/pinentry.spec
+++ b/SPECS/pinentry/pinentry.spec
@@ -21,12 +21,10 @@ Summary:        Collection of simple PIN or passphrase entry dialogs
 License:        GPL-2.0-or-later
 URL:            https://gnupg.org/
 VCS:            git:https://git.gnupg.org/pinentry.git
-#!RemoteAsset
+#!RemoteAsset:  sha256:8e986ed88561b4da6e9efe0c54fa4ca8923035c99264df0b0464497c5fb94e9e
 Source0:        %{url}/ftp/gcrypt/%{name}/%{name}-%{version}.tar.bz2
-#!RemoteAsset
-Source1:        %{url}/ftp/gcrypt/%{name}/%{name}-%{version}.tar.bz2.sig
 # We need this wrapper
-Source2:        pinentry
+Source1:        pinentry
 BuildSystem:    autotools
 
 BuildOption(conf):  --disable-rpath
@@ -165,7 +163,7 @@ ln -s pinentry-gtk-2 $RPM_BUILD_ROOT%{_bindir}/pinentry-gtk
 ln -s pinentry-qt $RPM_BUILD_ROOT%{_bindir}/pinentry-qt4
 ln -s pinentry-qt $RPM_BUILD_ROOT%{_bindir}/pinentry-qt5
 %endif
-install -p -m755 -D %{SOURCE2} $RPM_BUILD_ROOT%{_bindir}/pinentry
+install -p -m755 -D %{SOURCE1} $RPM_BUILD_ROOT%{_bindir}/pinentry
 # unpackaged files
 rm -fv $RPM_BUILD_ROOT%{_infodir}/dir
 %if %{with qt6}
@@ -209,4 +207,4 @@ install -d %{buildroot}%{_datadir}/pixmaps
 %{_bindir}/pinentry-tty
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
### Changes

- Add the missing remote asset checksum, drop the unused signature source, and keep the local wrapper as `Source1`.

- Make the GNOME3 pinentry configure option follow `%bcond gnome`.

  The spec defaults `%bcond gnome 0`, and the `pkgconfig(gcr-4)` BuildRequires, subpackage, and files are already guarded by `%{with gnome}`. The old configure flags still always requested `--enable-pinentry-gnome3`, so a build environment with gcr available could enable GNOME3 support despite the bcond default.

  Source: `pinentry-1.3.2/configure.ac:435-480`

  ```m4
  AC_ARG_ENABLE(pinentry-gnome3,
              AS_HELP_STRING([--enable-pinentry-gnome3],[build GNOME 3 pinentry]),
              pinentry_gnome_3=$enableval, pinentry_gnome_3=maybe)

  if test "$pinentry_gnome_3" != "no"; then
          PKG_CHECK_MODULES(
                  GNOME3,
                  [gcr-4],
                  [
                          pinentry_gnome_3=yes
                  ],
                  [PKG_CHECK_MODULES(
                          GNOME3,
                          [gcr-base-3],
                          [
                                  pinentry_gnome_3=yes
                          ],
                          [
                                  AC_MSG_WARN([pkg-config could not find the module gcr-4 or gcr-base-3])
                                  pinentry_gnome_3=no
                          ]
                  )]
          )
  fi

  AM_CONDITIONAL(BUILD_PINENTRY_GNOME_3, test "$pinentry_gnome_3" = "yes")
  ```

AIGC Declaration: CodeX with gpt5.5 was used as coding agent.

Signed-off-by: Jingwiw <wangjingwei@iscas.ac.cn>
