### PR TITLE
SPECS: systemtap: Align optional build options and dependencies

### DIFF
--- a/SPECS/systemtap/systemtap.spec
+++ b/SPECS/systemtap/systemtap.spec
@@ -48,7 +48,7 @@ BuildRequires:  pkgconfig(json-c)
 BuildRequires:  dyninst-devel
 BuildRequires:  pkgconfig(libselinux)
 %endif
-BuildRequires:  sqlite-devel
+BuildRequires:  pkgconfig(sqlite3)
 BuildRequires:  pkgconfig(systemd)
 BuildRequires:  python3
 BuildRequires:  python3-devel
@@ -97,9 +97,6 @@ subpackage instead.
 
 %package        server
 Summary:        Instrumentation System Server
-%if %{with avahi}
-BuildRequires:  avahi-devel
-%endif
 Requires:       %{name}-devel = %{version}-%{release}
 Requires:       openssl
 Requires:       systemd

--- a/SPECS/systemtap/systemtap.spec
+++ b/SPECS/systemtap/systemtap.spec
@@ -22,6 +22,16 @@ BuildSystem:    autotools
 
 BuildOption(conf):  --disable-docs
 BuildOption(conf):  --with-python3
+%if %{with avahi}
+BuildOption(conf):  --with-avahi
+%else
+BuildOption(conf):  --without-avahi
+%endif
+%if %{with dyninst}
+BuildOption(conf):  --with-dyninst
+%else
+BuildOption(conf):  --without-dyninst
+%endif
 
 BuildRequires:  config
 BuildRequires:  make


### PR DESCRIPTION
### Changes

- Make the `avahi` and `dyninst` configure options follow their bconds.

  Both bconds default to off in this spec. Upstream otherwise probes optional support when the option is not explicitly disabled, so pass the matching `--without-*` flags for the default build.

  Source: `systemtap-5.5/configure.ac:477-492`

  ```m4
  AC_ARG_WITH([avahi],
    AS_HELP_STRING([--without-avahi],
      [Do not use Avahi even if present]))

  AS_IF([test "x$with_avahi" != "xno"], [
    PKG_CHECK_MODULES([avahi], [avahi-client],
      [have_avahi=yes
       AC_DEFINE([HAVE_AVAHI], [1], [Define to 1 if you have the avahi libraries.])
      ], [have_avahi=no])
  ], [have_avahi=no])
  ```

  Source: `systemtap-5.5/configure.ac:651-717`

  ```m4
  AC_ARG_WITH([dyninst],
    AS_HELP_STRING([--with-dyninst=DIRECTORY],
      [find dyninst headers/libraries in DIRECTORY]))

  case "$with_dyninst" in
  no) ;;
  ''|yes) # Try a simple-minded distro search
       DYNINST_CXXFLAGS="-I/usr/include/dyninst"
       ...
  esac

  if test "$with_dyninst" != "no"; then
    AC_CHECK_HEADERS([dyninst/BPatch_object.h], [
        AC_DEFINE([HAVE_DYNINST],[1],[Define to 1 if Dyninst is enabled])
        have_dyninst=yes
        AC_MSG_NOTICE([dyninst support available])])
  fi
  ```

- Use `pkgconfig(sqlite3)` for the SQLite build dependency.

  Upstream checks SQLite through pkg-config, and the local sqlite devel package provides `sqlite3.pc`.

  Source: `systemtap-5.5/configure.ac:249-262`

  ```m4
  AC_ARG_ENABLE([sqlite],
    AS_HELP_STRING([--enable-sqlite], [build with sqlite support]),
    [],
    [enable_sqlite=check])

  AS_IF([test "x$enable_sqlite" != xno],
    [PKG_CHECK_MODULES([sqlite3], [sqlite3 > 3.7],
      [AC_DEFINE([HAVE_LIBSQLITE3], [1], [Define to 1 if you have the 'sqlite3' library (-lsqlite3).])],
      [if test "x$enable_sqlite" != xcheck; then
        AC_MSG_FAILURE([--enable-sqlite was given, but test for sqlite > 3.7 failed])
       fi])])
  ```

- Drop the duplicate `avahi-devel` BuildRequires from the server subpackage block.

  The avahi dependency is already expressed once as `pkgconfig(avahi-client)` under the same `%{with avahi}` condition, matching the upstream pkg-config check.

  Source: `systemtap-5.5/configure.ac:477-487`

  ```m4
  AC_ARG_WITH([avahi],
    AS_HELP_STRING([--without-avahi],
      [Do not use Avahi even if present]))

  AS_IF([test "x$with_avahi" != "xno"], [
    PKG_CHECK_MODULES([avahi], [avahi-client],
      [have_avahi=yes
       AC_DEFINE([HAVE_AVAHI], [1], [Define to 1 if you have the avahi libraries.])
      ], [have_avahi=no])
  ], [have_avahi=no])
  ```

AIGC Declaration: CodeX with gpt5.5 was used as coding agent.

Signed-off-by: Jingwiw <wangjingwei@iscas.ac.cn>
