### PR TITLE
SPECS: tinysparql: Align libstemmer and completion dependencies

### DIFF
--- a/SPECS/tinysparql/tinysparql.spec
+++ b/SPECS/tinysparql/tinysparql.spec
@@ -14,7 +14,7 @@ Release:        %autorelease
 Summary:        Desktop-neutral metadata database and search tool
 License:        GPL-2.0-or-later
 URL:            https://gitlab.gnome.org/GNOME/tinysparql
-#!RemoteAsset
+#!RemoteAsset:  sha256:5a7f3e789db6671a550ed6280ed4f60a60bea77368da92be68dc7d8d7e230265
 Source0:        https://download.gnome.org/sources/tinysparql/3.10/tinysparql-%{version}.tar.xz
 BuildSystem:    meson
 
@@ -138,4 +138,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %endif
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/tinysparql/tinysparql.spec
+++ b/SPECS/tinysparql/tinysparql.spec
@@ -7,6 +7,7 @@
 
 %bcond doc 0
 %bcond tests 0
+%bcond libstemmer 0
 
 Name:           tinysparql
 Version:        3.10.1

--- a/SPECS/tinysparql/tinysparql.spec
+++ b/SPECS/tinysparql/tinysparql.spec
@@ -43,6 +43,7 @@ BuildRequires:  gcc
 BuildRequires:  gettext
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  vala
+BuildRequires:  pkgconfig(bash-completion)
 BuildRequires:  pkgconfig(dbus-1)
 BuildRequires:  pkgconfig(gobject-introspection-1.0)
 BuildRequires:  pkgconfig(icu-i18n)


### PR DESCRIPTION
### Changes

- Add the missing remote asset checksum for the tinysparql source archive.

- Give the existing libstemmer build condition an explicit default.

  Upstream defaults stemmer support to `auto`, and the spec already has conditional logic around stemmer. Setting the bcond default keeps the package's default build state explicit instead of letting the buildroot decide it.

  Source: [`meson_options.txt`](https://gitlab.gnome.org/GNOME/tinysparql/-/blob/3.10.1/meson_options.txt#L8-L9)

  ```meson
  option('stemmer', type: 'feature', value: 'auto',
         description: 'Stemming words while indexing')
  ```

  Source: [`meson.build`](https://gitlab.gnome.org/GNOME/tinysparql/-/blob/3.10.1/meson.build#L151-L155)

  ```meson
  libstemmer = cc.find_library('stemmer', required: get_option('stemmer'))
  if not libstemmer.found()
    subproject('libstemmer')
    libstemmer = dependency('libstemmer', required: true)
  endif
  ```

- Add `pkgconfig(bash-completion)` for the enabled bash completion install path.

  Bash completion installation is enabled by default, and Meson uses the `bash-completion` pkg-config file to get the packaged `completionsdir`.

  Source: [`meson_options.txt`](https://gitlab.gnome.org/GNOME/tinysparql/-/blob/3.10.1/meson_options.txt#L15-L18)

  ```meson
  option('bash_completion', type: 'boolean', value: true,
         description: 'Whether to install Bash completion files')
  option('bash_completion_dir', type: 'string',
         description: 'Directory to install Bash completion files')
  ```

  Source: [`meson.build`](https://gitlab.gnome.org/GNOME/tinysparql/-/blob/3.10.1/meson.build#L311-L320)

  ```meson
  if get_option('bash_completion')
    bash_completion_dir = get_option('bash_completion_dir')

    if bash_completion_dir == ''
      bash_completion_package = dependency('bash-completion', required: false)
      if bash_completion_package.found()
        bash_completion_dir = bash_completion_package.get_variable(pkgconfig: 'completionsdir',
                                                                   pkgconfig_define: [ 'prefix', get_option('prefix') ])
      else
        bash_completion_dir = join_paths(datadir, 'bash-completion', 'completions')
      endif
  ```

  Source: [`src/cli/meson.build`](https://gitlab.gnome.org/GNOME/tinysparql/-/blob/3.10.1/src/cli/meson.build#L49-L53)

  ```meson
  if get_option('bash_completion')
      install_data(
          sources: 'bash-completion/tinysparql',
          install_dir: bash_completion_dir,
          rename: main_command_name)
  endif
  ```

- Use `%autochangelog` directly, matching the current spec style.

AIGC Declaration: CodeX with gpt5.5 was used as coding agent.

Signed-off-by: Jingwiw <wangjingwei@iscas.ac.cn>
