### PR TITLE
SPECS: bindfs: Build against fuse3

### DIFF
--- a/SPECS/bindfs/bindfs.spec
+++ b/SPECS/bindfs/bindfs.spec
@@ -17,12 +17,14 @@ VCS:            git:https://github.com/mpartel/bindfs
 Source:         https://bindfs.org/downloads/bindfs-%{version}.tar.gz
 BuildSystem:    autotools
 
-BuildRequires:  pkgconfig(fuse)
+BuildOption(conf):  --with-fuse3
+
+BuildRequires:  pkgconfig(fuse3)
 BuildRequires:  make
 BuildRequires:  autoconf
 BuildRequires:  automake
 
-Requires:       fuse
+Requires:       fuse3
 
 %description
 bindfs is a FUSE filesystem for mirroring a directory to another directory


### PR DESCRIPTION
### Changes

- Build bindfs explicitly with FUSE 3 and require `fuse3` at runtime.
  Source: [`configure.ac`](https://github.com/mpartel/bindfs/blob/1.18.4/configure.ac)

  Upstream 1.18.4 exposes `--with-fuse3`, checks `pkgconfig(fuse3)`, and prefers FUSE 3 when autodetecting.

  Source: [`README.md`](https://github.com/mpartel/bindfs/blob/1.18.4/README.md)

  The upstream README says Linux development/testing primarily targets FUSE 3.

AIGC Declaration: CodeX with gpt5.5 was used as coding agent.

Signed-off-by: Jingwiw <wangjingwei@iscas.ac.cn>