### PR TITLE
SPECS: squashfuse: Build against fuse3

### DIFF
--- a/SPECS/squashfuse/squashfuse.spec
+++ b/SPECS/squashfuse/squashfuse.spec
@@ -12,7 +12,7 @@ Release:        %autorelease
 Summary:        FUSE filesystem to mount squashfs archives
 License:        BSD-2-Clause
 URL:            https://github.com/vasi/squashfuse
-#!RemoteAsset
+#!RemoteAsset:  sha256:7730066d1e9baf0084c71674d168331296921e0d7ae0f34de7307744be4ed568
 Source:         https://github.com/vasi/squashfuse/archive/refs/tags/%{version}.tar.gz
 BuildSystem:    autotools
 
@@ -66,4 +66,4 @@ developing applications that use squashfuse.
 %{_libdir}/libsquashfuse_ll.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/squashfuse/squashfuse.spec
+++ b/SPECS/squashfuse/squashfuse.spec
@@ -24,7 +24,7 @@ BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  libtool
 BuildRequires:  gcc
-BuildRequires:  fuse-devel
+BuildRequires:  pkgconfig(fuse3)
 BuildRequires:  pkgconfig(libattr)
 BuildRequires:  pkgconfig(liblz4)
 BuildRequires:  pkgconfig(libzstd)


### PR DESCRIPTION
### Changes

- Normalize source metadata for the squashfuse 0.6.1 archive and use `%autochangelog`.

- Build against FUSE 3 through `pkgconfig(fuse3)` instead of the fuse2 devel package.
  Source: [`m4/squashfuse_fuse.m4`](https://github.com/vasi/squashfuse/blob/0.6.1/m4/squashfuse_fuse.m4)

  Upstream first probes `fuse3 >= 3.2` through pkg-config, then falls back to `fuse >= 2.6`.

  Source: [`configure.ac`](https://github.com/vasi/squashfuse/blob/0.6.1/configure.ac)

  `configure.ac` calls the FUSE detection macro and prefers `fusermount3` for test setup.

  Source: [`README`](https://github.com/vasi/squashfuse/blob/0.6.1/README)

  The upstream Ubuntu 22.04 example installs `libfuse3-dev` and `fuse3`.

AIGC Declaration: CodeX with gpt5.5 was used as coding agent.

Signed-off-by: Jingwiw <wangjingwei@iscas.ac.cn>