### PR TITLE
SPECS: ceph: Require fuse3 for ceph-fuse

### DIFF
--- a/SPECS/ceph/ceph.spec
+++ b/SPECS/ceph/ceph.spec
@@ -412,7 +412,7 @@ and Kubernetes events integration.
 
 %package        fuse
 Summary:        Ceph fuse-based client
-Requires:       fuse
+Requires:       fuse3
 Requires:       python3
 
 %description    fuse


### PR DESCRIPTION
### Changes

- Make the `ceph-fuse` runtime dependency match the existing FUSE 3 build dependency.
  Local packaging evidence: `ceph.spec` already builds with `BuildRequires: pkgconfig(fuse3)`.

  Source: [`CMakeLists.txt`](https://github.com/ceph/ceph/blob/v20.2.1/CMakeLists.txt)

  Upstream enables `WITH_FUSE` through `find_package(FUSE REQUIRED)`.

  Source: [`cmake/modules/FindFUSE.cmake`](https://github.com/ceph/ceph/blob/v20.2.1/cmake/modules/FindFUSE.cmake)

  The FUSE find module searches `fuse3` before `fuse` unless a version older than 3.0 is requested.

  Source: [`src/CMakeLists.txt`](https://github.com/ceph/ceph/blob/v20.2.1/src/CMakeLists.txt)

  `ceph-fuse` links the discovered `FUSE::FUSE` target.

AIGC Declaration: CodeX with gpt5.5 was used as coding agent.

Signed-off-by: Jingwiw <wangjingwei@iscas.ac.cn>