### PR TITLE
SPECS: mergerfs: Drop unused fuse BuildRequires

### DIFF
--- a/SPECS/mergerfs/mergerfs.spec
+++ b/SPECS/mergerfs/mergerfs.spec
@@ -40,7 +40,9 @@ behavior.
 %files
 %doc README.md
 %{_bindir}/*
+%if "%{_sbindir}" != "%{_bindir}"
 %{_sbindir}/*
+%endif
 %{_mandir}/man1/*.1*
 %{_libdir}/mergerfs
 

--- a/SPECS/mergerfs/mergerfs.spec
+++ b/SPECS/mergerfs/mergerfs.spec
@@ -11,7 +11,7 @@ Release:        %{autorelease}
 Summary:        A FUSE union filesystem
 License:        MIT
 URL:            https://github.com/trapexit/mergerfs
-#!RemoteAsset
+#!RemoteAsset:  sha256:d3ac8c07af0d0667f825bc50796896696d92734dafea962884eecd983f255dca
 Source0:        https://github.com/trapexit/mergerfs/releases/download/%{version}/%{name}-%{version}.tar.gz
 BuildSystem:    autotools
 
@@ -46,4 +46,4 @@ behavior.
 %{_libdir}/mergerfs
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/mergerfs/mergerfs.spec
+++ b/SPECS/mergerfs/mergerfs.spec
@@ -24,7 +24,6 @@ BuildOption(install):  LIBDIR=%{_libdir}
 
 BuildRequires:  gcc-c++
 BuildRequires:  pkgconfig(libattr)
-BuildRequires:  pkgconfig(fuse)
 BuildRequires:  libtool
 
 %description


### PR DESCRIPTION
### Changes

- Normalize source metadata for the mergerfs 2.41.1 archive and use `%autochangelog`.

- Drop the unused external fuse2 build dependency.
  Source: [`Makefile`](https://github.com/trapexit/mergerfs/blob/2.41.1/Makefile)

  Upstream builds with headers under `libfuse/include` and links its local `libfuse.a`.

  Source: [`libfuse/Makefile`](https://github.com/trapexit/mergerfs/blob/2.41.1/libfuse/Makefile)

  The bundled `libfuse` directory builds `libfuse.a` itself.

  Source: [`libfuse/include/fuse.h`](https://github.com/trapexit/mergerfs/blob/2.41.1/libfuse/include/fuse.h)

  The source tree carries its own FUSE API header.

- Avoid duplicate `%files` entries when `%{_sbindir}` and `%{_bindir}` are identical.
  OBS evidence: after this change, x86_64 and rva20 validation no longer report `File listed twice` for the mergerfs binaries.

AIGC Declaration: CodeX with gpt5.5 was used as coding agent.

Signed-off-by: Jingwiw <wangjingwei@iscas.ac.cn>