### PR TITLE
SPECS: glusterfs: Drop unused fuse BuildRequires

### DIFF
--- a/SPECS/glusterfs/glusterfs.spec
+++ b/SPECS/glusterfs/glusterfs.spec
@@ -38,7 +38,6 @@ BuildRequires:  python3
 BuildRequires:  pkgconfig(readline)
 BuildRequires:  rpcgen
 BuildRequires:  systemd-rpm-macros
-BuildRequires:  pkgconfig(fuse)
 BuildRequires:  pkgconfig(libcrypto)
 BuildRequires:  pkgconfig(libtirpc)
 BuildRequires:  pkgconfig(liburcu)

--- a/SPECS/glusterfs/glusterfs.spec
+++ b/SPECS/glusterfs/glusterfs.spec
@@ -90,6 +90,18 @@ chmod -v u-s "%{buildroot}/%{_bindir}/fusermount-glusterfs"
 rm -fv "%{buildroot}/%{_bindir}/conf.py"
 rm -f "%{buildroot}/etc/bash_completion.d/gluster.bash"
 %fdupes %{buildroot}/%{_prefix}
+ln -sfn --relative "%{buildroot}%{_libexecdir}/glusterfs/gfind_missing_files/gfind_missing_files.sh" \
+    "%{buildroot}%{_bindir}/gfind_missing_files"
+ln -sfn --relative "%{buildroot}%{_libexecdir}/glusterfs/peer_eventsapi.py" \
+    "%{buildroot}%{_bindir}/gluster-eventsapi"
+ln -sfn --relative "%{buildroot}%{_libexecdir}/glusterfs/peer_georep-sshkey.py" \
+    "%{buildroot}%{_bindir}/gluster-georep-sshkey"
+ln -sfn --relative "%{buildroot}%{_libexecdir}/glusterfs/peer_mountbroker.py" \
+    "%{buildroot}%{_bindir}/gluster-mountbroker"
+ln -sfn --relative "%{buildroot}%{_libexecdir}/glusterfs/gfevents/glustereventsd.py" \
+    "%{buildroot}%{_bindir}/glustereventsd"
+ln -sfn --relative "%{buildroot}%{_libexecdir}/glusterfs/glusterfind/S57glusterfind-delete-post.py" \
+    "%{buildroot}%{_localstatedir}/lib/glusterd/hooks/1/delete/post/S57glusterfind-delete-post"
 %py3_shebang_fix .
 
 %post

--- a/SPECS/glusterfs/glusterfs.spec
+++ b/SPECS/glusterfs/glusterfs.spec
@@ -12,7 +12,7 @@ Summary:        Aggregating distributed file system
 License:        GPL-2.0-only OR LGPL-3.0-or-later
 URL:            https://www.gluster.org/
 VCS:            git:https://github.com/gluster/glusterfs
-#!RemoteAsset
+#!RemoteAsset:  sha256:6a31b8450d02cd12f47f4571c031e9d6b8705279a0e8970ae9a05e1c87dffb76
 Source:         https://download.gluster.org/pub/gluster/glusterfs/11/%{version}/glusterfs-%{version}.tar.gz
 BuildSystem:    autotools
 
@@ -161,4 +161,4 @@ rm -f "%{buildroot}/etc/bash_completion.d/gluster.bash"
 %{_libdir}/pkgconfig/libgfchangelog.pc
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
### Changes

- Normalize source metadata for the glusterfs 11.1 archive and use `%autochangelog`.

- Drop the unused external fuse2 build dependency.
  Source: [`configure.ac`](https://github.com/gluster/glusterfs/blob/v11.1/configure.ac)

  Upstream configures Gluster's FUSE mount components from its own tree and sets Linux FUSE helper flags without requiring an external `pkgconfig(fuse)` dependency for this build.

  Source: [`contrib/fuse-util/Makefile.am`](https://github.com/gluster/glusterfs/blob/v11.1/contrib/fuse-util/Makefile.am)

  `fusermount-glusterfs` is built from Gluster's own `contrib/fuse-lib` and `contrib/fuse-include` sources.

  Source: [`contrib/fuse-lib/mount-common.c`](https://github.com/gluster/glusterfs/blob/v11.1/contrib/fuse-lib/mount-common.c)
  Source: [`contrib/fuse-include/mount_util.h`](https://github.com/gluster/glusterfs/blob/v11.1/contrib/fuse-include/mount_util.h)

  The source tree carries the mount helper implementation and header used by the FUSE utility.

- Rewrite generated absolute symlinks to relative links in `%install`.
  OBS evidence: after this change, x86_64 and rva20 validation no longer report absolute symlink warnings for the glusterfs helper links.

AIGC Declaration: CodeX with gpt5.5 was used as coding agent.

Signed-off-by: Jingwiw <wangjingwei@iscas.ac.cn>