### PR TITLE
SPECS: ntfs-3g: Use internal fuse-lite

### DIFF
--- a/SPECS/ntfs-3g/ntfs-3g.spec
+++ b/SPECS/ntfs-3g/ntfs-3g.spec
@@ -24,14 +24,13 @@ BuildOption(conf):  --enable-extras
 BuildOption(conf):  --enable-crypto
 BuildOption(conf):  --enable-quarantined
 BuildOption(conf):  --exec-prefix=/
-BuildOption(conf):  --with-fuse=external
+BuildOption(conf):  --with-fuse=internal
 
 BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  libtool
 BuildRequires:  make
 BuildRequires:  pkgconfig
-BuildRequires:  pkgconfig(fuse)
 BuildRequires:  pkgconfig(gnutls)
 BuildRequires:  pkgconfig(hwinfo)
 BuildRequires:  pkgconfig(libgcrypt)

--- a/SPECS/ntfs-3g/ntfs-3g.spec
+++ b/SPECS/ntfs-3g/ntfs-3g.spec
@@ -10,7 +10,7 @@ Release:        %autorelease
 Summary:        NTFS userspace driver for Linux
 License:        GPL-2.0-or-later
 URL:            https://github.com/tuxera/ntfs-3g
-#!RemoteAsset
+#!RemoteAsset:  sha256:8bd7749ea9d8534c9f0664d48b576e90b96d45ec8803c9427f6ffaa2f0dde299
 Source0:        %{url}/archive/refs/tags/%{version}.tar.gz#%{name}-%{version}.tar.gz
 BuildSystem:    autotools
 
@@ -107,4 +107,4 @@ ln -s -f %{_sbindir}/mount.ntfs-3g %{buildroot}%{_sbindir}/mount.ntfs
 %{_libdir}/pkgconfig/libntfs-3g.pc
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/ntfs-3g/ntfs-3g.spec
+++ b/SPECS/ntfs-3g/ntfs-3g.spec
@@ -46,7 +46,7 @@ Windows 10, and Windows 11.
 
 %package        devel
 Summary:        Development files and libraries for ntfs-3g
-Requires:       %{name}{?_isa} = %{version}-%{release}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
 
 %description    devel
 Headers and libraries for developing applications that use ntfs-3g

--- a/SPECS/ntfs-3g/ntfs-3g.spec
+++ b/SPECS/ntfs-3g/ntfs-3g.spec
@@ -55,7 +55,10 @@ functionality.
 autoreconf -fiv
 
 %install -a
-ln -s -f %{_sbindir}/mount.ntfs-3g %{buildroot}%{_sbindir}/mount.ntfs
+ln -sfn --relative "%{buildroot}%{_bindir}/ntfs-3g" "%{buildroot}%{_sbindir}/mount.ntfs-3g"
+ln -sfn --relative "%{buildroot}%{_bindir}/lowntfs-3g" "%{buildroot}%{_sbindir}/mount.lowntfs-3g"
+ln -sfn --relative "%{buildroot}%{_sbindir}/mkntfs" "%{buildroot}%{_sbindir}/mkfs.ntfs"
+ln -sfn mount.ntfs-3g "%{buildroot}%{_sbindir}/mount.ntfs"
 
 %files
 %doc AUTHORS ChangeLog CREDITS NEWS README
@@ -98,7 +101,7 @@ ln -s -f %{_sbindir}/mount.ntfs-3g %{buildroot}%{_sbindir}/mount.ntfs
 %{_mandir}/man8/ntfs-3g*
 %{_mandir}/man8/mkntfs.8*
 %{_mandir}/man8/mkfs.ntfs.8*
-%{_mandir}/man8/ntfs[^m][^o]*.8*
+%{_mandir}/man8/ntfs[^-m][^o]*.8*
 
 %files devel
 %{_includedir}/ntfs-3g/


### PR DESCRIPTION
### Changes

- Normalize source metadata for the ntfs-3g 2022.10.3 archive and use `%autochangelog`.

- Fix the devel subpackage dependency to use `%{?_isa}` syntax.

- Build with ntfs-3g's internal fuse-lite implementation and drop the external fuse2 build dependency.
  Source: [`configure.ac`](https://github.com/tuxera/ntfs-3g/blob/2022.10.3/configure.ac#L229-L240)

  On Linux, upstream defaults `--with-fuse` to `internal`.

  Source: [`configure.ac`](https://github.com/tuxera/ntfs-3g/blob/2022.10.3/configure.ac#L275-L329)

  The external path is the one that requires `pkg-config` and `fuse >= 2.6.0`; the internal path defines `FUSE_INTERNAL`.

  Source: [`src/Makefile.am`](https://github.com/tuxera/ntfs-3g/blob/2022.10.3/src/Makefile.am#L6-L12)
  Source: [`libfuse-lite/Makefile.am`](https://github.com/tuxera/ntfs-3g/blob/2022.10.3/libfuse-lite/Makefile.am#L5-L31)

  With internal FUSE selected, `ntfs-3g` and `lowntfs-3g` link against the bundled `libfuse-lite.la`.

- Recreate generated mount helper symlinks as relative symlinks and narrow the manpage glob so `ntfs-3g` manpages are not listed twice.

AIGC Declaration: CodeX with gpt5.5 was used as coding agent.

Signed-off-by: Jingwiw <wangjingwei@iscas.ac.cn>