### PR TITLE
SPECS: KDE Frameworks: Update to 6.26 & Change BuildSystem

### DIFF
--- a/SPECS/kf6-attica/kf6-attica.spec
+++ b/SPECS/kf6-attica/kf6-attica.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname attica
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-attica
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Open Collaboration Service client library
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/attica.git
-#!RemoteAsset:  sha256:2274aa28804ba895c422c3fc24cdcc88ff435a9b39a887ceed93a6083d89fe00
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:eb2d3d2d8b12c2ab4d192c4ae6f07b0188a40aa002b3056db6369b47b2f9df96
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-baloo/kf6-baloo.spec
+++ b/SPECS/kf6-baloo/kf6-baloo.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname baloo
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-baloo
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Framework for searching and managing metadata
 License:        GPL-2.0-or-later AND LGPL-2.1-or-later AND LGPL-3.0-only
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/baloo.git
-#!RemoteAsset:  sha256:57b2ac1ae953d499b7364125fe3e7aa5857fb532456ecf0bda2635e875a66d2a
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:702f5b868aaef48153c6c3828111b3b335403079491a8f37043ebd89c6995b30
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-breeze-icons/kf6-breeze-icons.spec
+++ b/SPECS/kf6-breeze-icons/kf6-breeze-icons.spec
@@ -7,22 +7,26 @@
 %define qt6_version 6.8.0
 
 %define rname breeze-icons
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 %define _lto_cflags %{nil}
 
 Name:           kf6-breeze-icons
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Breeze icon theme
 License:        LGPL-3.0-only
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/breeze-icons
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:4e123fac511dfab2b7c505857849a5cecfac2ce6194e3230c51ceec31676b06e
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+BuildOption(conf):  -DBINARY_ICONS_RESOURCE:BOOL=TRUE
+BuildOption(conf):  -DWITH_ICON_GENERATION:BOOL=FALSE
+
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  libxml2
 # Skip 24px icons generation (saves ~30MB and installs dangling symlinks)
@@ -48,25 +52,9 @@ Requires:       %{name}%{?_isa} = %{version}-%{release}
 This package provides CMake config files for projects that wish to ensure
 the Breeze icons are available at build time.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-
-# kexi needs the icons resource
-%cmake_kf6 \
-  -DBINARY_ICONS_RESOURCE:BOOL=TRUE \
-  -DWITH_ICON_GENERATION:BOOL=FALSE
-
-%kf6_build
-
-%install
-%kf6_install
-
+%install -a
 # yast2-theme uses these, but it got renamed in 5.55.0
 ln -s yast-software-group.svg %{buildroot}%{_kf6_iconsdir}/breeze/preferences/32/yast-software.svg
-
-%fdupes %{buildroot}%{_kf6_iconsdir}
 
 %files
 %license COPYING*
@@ -90,4 +78,4 @@ ln -s yast-software-group.svg %{buildroot}%{_kf6_iconsdir}/breeze/preferences/32
 %{_kf6_libdir}/libKF6BreezeIcons.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-extra-cmake-modules/kf6-extra-cmake-modules.spec
+++ b/SPECS/kf6-extra-cmake-modules/kf6-extra-cmake-modules.spec
@@ -7,13 +7,13 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 Name:           kf6-extra-cmake-modules
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        CMake modules
 License:        BSD-3-Clause
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/extra-cmake-modules
-#!RemoteAsset:  sha256:82181d3956e40fe3667a1f37f8c54ff792037069717405c6e5898d63c316bfa4
+#!RemoteAsset:  sha256:2374a29b68298a6e70299a1f7321eb67ce293d1bbe3bdd5a1b9154eb16c04abb
 Source0:        https://invent.kde.org/frameworks/extra-cmake-modules/-/archive/v%{version}/extra-cmake-modules-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    cmake
@@ -43,4 +43,4 @@ Extra modules and scripts for CMake.
 %{_datadir}/ECM/
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-frameworkintegration/kf6-frameworkintegration.spec
+++ b/SPECS/kf6-frameworkintegration/kf6-frameworkintegration.spec
@@ -7,23 +7,22 @@
 %define qt6_version 6.8.0
 
 %define rname frameworkintegration
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-frameworkintegration
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Plugins responsible for better integration of Qt applications in KDE Workspace
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/frameworkintegration.git
-#!RemoteAsset:  sha256:63e414df5ca2e7c10292eee89394eff2987a19e2291b1288851a961828477a5e
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:84ebbad39b559e271bcec4817eba9124903ca660ad4f5c3f73f21a5f4a32062d
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF
 
-BuildRequires:  fdupes
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  cmake(AppStreamQt) >= 1.0
 BuildRequires:  cmake(KF6ColorScheme) >= %{_kf6_version}

--- a/SPECS/kf6-karchive/kf6-karchive.spec
+++ b/SPECS/kf6-karchive/kf6-karchive.spec
@@ -7,20 +7,22 @@
 %define qt6_version 6.8.0
 
 %define rname karchive
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-karchive
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Qt 6 addon providing access to numerous types of archives
 License:        LGPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/karchive
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:a7fdf6d0b8db88d60aa52bcc87d8e00d95391a1ad39a4b2a8e9f3027b8ff4035
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  pkgconfig
 BuildRequires:  cmake(Qt6Core) >= %{qt6_version}
@@ -53,26 +55,14 @@ KArchive provides classes for easy reading, creation and manipulation of
 It also provides transparent compression and decompression of data, like the
 GZip format, via a subclass of QIODevice. Development files
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
+%install -a
 # todo: fix the name error.
 # Avoid illegal package names
 rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 # Use langpacks macro to auto-split translations
-%find_lang %{name}6 --with-qt --all-name --generate-subpackages
+%find_lang %{name} --with-qt --all-name --generate-subpackages
 
-%files -f %{name}6.lang
+%files -f %{name}.lang
 %license LICENSES/*
 %doc README.md
 %{_kf6_debugdir}/karchive.categories
@@ -83,6 +73,7 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_kf6_includedir}/KArchive/
 %{_kf6_cmakedir}/KF6Archive/
 %{_kf6_libdir}/libKF6Archive.so
+%{_kf6_pkgconfigdir}/KF6Archive.pc
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kauth/kf6-kauth.spec
+++ b/SPECS/kf6-kauth/kf6-kauth.spec
@@ -7,20 +7,22 @@
 %define qt6_version 6.8.0
 
 %define rname   kauth
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kauth
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Framework which lets applications perform actions as a privileged user
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kauth
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:e6b6562114c2cb71db6ca48fdf0ebed2df70e164c48295b35433a80b03385847
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  kf6-kcoreaddons-devel >= %{_kf6_version}
 BuildRequires:  qt6-qttools
@@ -47,26 +49,14 @@ Requires:       cmake(KF6CoreAddons) >= %{_kf6_version}
 KAuth is a framework to let applications perform actions as a privileged user.
 Development files.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
+%install -a
 # todo: fix the name error.
 # Avoid illegal package names
 rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 # Use langpacks macro to auto-split translations
-%find_lang %{name}6 --with-qt --all-name --generate-subpackages
+%find_lang %{name} --with-qt --all-name --generate-subpackages
 
-%files -f %{name}6.lang
+%files -f %{name}.lang
 %license LICENSES/*
 %doc README.md
 %dir %{_kf6_plugindir}/kf6/kauth
@@ -88,4 +78,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_kf6_libdir}/libKF6AuthCore.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kbookmarks/kf6-kbookmarks.spec
+++ b/SPECS/kf6-kbookmarks/kf6-kbookmarks.spec
@@ -7,20 +7,22 @@
 %define qt6_version 6.8.0
 
 %define rname kbookmarks
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kbookmarks
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Framework for manipulating bookmarks in XBEL format
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kbookmarks
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:82e8794281870686da9e7e7b5ddc0839f50b15d919357490d508faccb2635030
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  cmake(KF6Config) >= %{_kf6_version}
 BuildRequires:  cmake(KF6ConfigWidgets) >= %{_kf6_version}
@@ -49,26 +51,14 @@ Requires:       cmake(Qt6Xml) >= %{qt6_version}
 Development files for kbookmarks, a framework for accessing and
 manipulating bookmarks using the XBEL format
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
+%install -a
 # todo: fix the name error.
 # Avoid illegal package names
 rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 # Use langpacks macro to auto-split translations
-%find_lang %{name}6 --with-qt --all-name --generate-subpackages
+%find_lang %{name} --with-qt --all-name --generate-subpackages
 
-%files -f %{name}6.lang
+%files -f %{name}.lang
 %license LICENSES/*
 %doc README.md
 %{_kf6_debugdir}/kbookmarks.categories
@@ -85,4 +75,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_kf6_includedir}/KBookmarksWidgets/
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kcmutils/kf6-kcmutils.spec
+++ b/SPECS/kf6-kcmutils/kf6-kcmutils.spec
@@ -10,23 +10,24 @@
 # Internal QML import
 %global __requires_exclude qt6qmlimport\\(org\\.kde\\.kcmutils\\.private.*\\)
 
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kcmutils
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Classes to work with KCModules
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kcmutils
-#!RemoteAsset:  sha256:c6ed2d3be1f0e4efc91abca48afd64ff0c8917fbb6bc3c0b9725c66b3b9e3993
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:6d0810649b71528124cdf9dbdeb8b3c6c6d31d787325ca3e4a20c536ecbdf2d9
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF
 
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
+BuildRequires:  kf6-kirigami >= %{_kf6_version}
 BuildRequires:  cmake(KF6ConfigWidgets) >= %{_kf6_version}
 BuildRequires:  cmake(KF6CoreAddons) >= %{_kf6_version}
 BuildRequires:  cmake(KF6GuiAddons) >= %{_kf6_version}

--- a/SPECS/kf6-kcodecs/kf6-kcodecs.spec
+++ b/SPECS/kf6-kcodecs/kf6-kcodecs.spec
@@ -7,20 +7,22 @@
 %define qt6_version 6.8.0
 
 %define rname   kcodecs
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kcodecs
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Method collection to manipulate strings using various encodings
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kcodecs
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:ee1fe3bd8bcd93a84d44186a5fc50395b6bf43dd2bf8972338a7aad72aa0bcb4
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+
 BuildRequires:  gperf
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  cmake(Qt6Core) >= %{qt6_version}
@@ -43,26 +45,14 @@ Requires:       cmake(Qt6Core) >= %{qt6_version}
 Development files for KCodecs, a method collection to manipulate
 strings using various encodings.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
+%install -a
 # todo: fix the name error.
 # Avoid illegal package names
 rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 # Use langpacks macro to auto-split translations
-%find_lang %{name}6 --with-qt --all-name --generate-subpackages
+%find_lang %{name} --with-qt --all-name --generate-subpackages
 
-%files -f %{name}6.lang
+%files -f %{name}.lang
 %license LICENSES/*
 %doc README.md
 %{_kf6_debugdir}/*.categories
@@ -75,4 +65,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_kf6_libdir}/libKF6Codecs.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kcolorscheme/kf6-kcolorscheme.spec
+++ b/SPECS/kf6-kcolorscheme/kf6-kcolorscheme.spec
@@ -7,20 +7,22 @@
 %define qt6_version 6.8.0
 
 %define rname kcolorscheme
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kcolorscheme
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Classes to read and interact with KColorScheme
 License:        LGPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kcolorscheme
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:74149a0379bd8bf6590d3c1f7f8c503665e0f3adafc2adbd44fc6bb764c969f1
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  qt6-qtbase-private-devel >= %{qt6_version}
 BuildRequires:  cmake(KF6Codecs) >= %{_kf6_version}
@@ -46,26 +48,14 @@ Requires:       cmake(Qt6Gui) >= %{qt6_version}
 %description    devel
 Classes to read and interact with KColorScheme. Development files.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
+%install -a
 # todo: fix the name error.
 # Avoid illegal package names
 rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 # Use langpacks macro to auto-split translations
-%find_lang %{name}6 --with-qt --all-name --generate-subpackages
+%find_lang %{name} --with-qt --all-name --generate-subpackages
 
-%files -f %{name}6.lang
+%files -f %{name}.lang
 %license LICENSES/*
 %doc README.md
 %{_kf6_debugdir}/kcolorscheme.categories
@@ -77,4 +67,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_kf6_libdir}/libKF6ColorScheme.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kcompletion/kf6-kcompletion.spec
+++ b/SPECS/kf6-kcompletion/kf6-kcompletion.spec
@@ -7,20 +7,22 @@
 %define qt6_version 6.8.0
 
 %define rname kcompletion
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kcompletion
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Widgets with advanced completion support
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kcompletion
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:95f71eb807e4de40ecdfe7234c9c3d844423171ac52588aecca642f78d904e48
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  cmake(KF6Codecs) >= %{_kf6_version}
 BuildRequires:  cmake(KF6Config) >= %{_kf6_version}
@@ -47,26 +49,14 @@ Development files for KCompletion, a widget collection with advanced
 completion support as well as a lower-level completion class which
 can be used with own widgets.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
+%install -a
 # todo: fix the name error.
 # Avoid illegal package names
 rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 # Use langpacks macro to auto-split translations
-%find_lang %{name}6 --with-qt --all-name --generate-subpackages
+%find_lang %{name} --with-qt --all-name --generate-subpackages
 
-%files -f %{name}6.lang
+%files -f %{name}.lang
 %license LICENSES/*
 %doc README.md
 %{_kf6_debugdir}/kcompletion.categories
@@ -79,4 +69,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_kf6_plugindir}/designer/kcompletion6widgets.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kconfig/kf6-kconfig.spec
+++ b/SPECS/kf6-kconfig/kf6-kconfig.spec
@@ -7,20 +7,22 @@
 %define qt6_version 6.8.0
 
 %define rname kconfig
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kconfig
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Advanced configuration system
 License:        LGPL-2.1-or-later AND GPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            https://invent.kde.org/frameworks/kconfig
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:8bb5aa918d8e60ec140a33db3c329414d2319dc97a1644b368da5576125c92b5
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  cmake(Qt6Core) >= %{qt6_version}
 BuildRequires:  cmake(Qt6DBus) >= %{qt6_version}
@@ -51,13 +53,6 @@ their changes to their respective configuration files.
 
 KConfigQml provides QtQuick bindings to KConfig, allowing it to be used with QML.
 
-%package        imports
-Summary:        QML imports for kconfig
-Requires:       %{name}%{?_isa} = %{version}-%{release}
-
-%description    imports
-QML imports for kconfig.
-
 %package        devel
 Summary:        KConfig Development files
 Requires:       %{name}%{?_isa} = %{version}-%{release}
@@ -80,19 +75,6 @@ KConfigGui provides a way to hook widgets to the configuration so that they are
 automatically initialized from the configuration and automatically propagate
 their changes to their respective configuration files. Development files.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
 %files
 %license LICENSES/*
 %doc README.md
@@ -105,8 +87,6 @@ their changes to their respective configuration files. Development files.
 %{_kf6_libdir}/libKF6ConfigQml.so.*
 %{_datadir}/locale/*/LC_MESSAGES/kconfig6_qt.qm
 %{_kf6_libexecdir}/kconf_update
-
-%files imports
 %{_kf6_qmldir}/org/kde/config/
 
 %files devel
@@ -121,4 +101,4 @@ their changes to their respective configuration files. Development files.
 %{_kf6_libexecdir}/kconfig_compiler_kf6
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kconfigwidgets/kf6-kconfigwidgets.spec
+++ b/SPECS/kf6-kconfigwidgets/kf6-kconfigwidgets.spec
@@ -7,20 +7,22 @@
 %define qt6_version 6.8.0
 
 %define rname kconfigwidgets
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kconfigwidgets
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Widgets for configuration dialogs
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kconfigwidgets
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:3babcef22aea293fad0db65fcdbf76eb4ac9077bc758ee8daec108090242ea3c
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  qt6-qtbase-private-devel >= %{qt6_version}
 BuildRequires:  cmake(KF6Codecs) >= %{_kf6_version}
@@ -55,26 +57,14 @@ Requires:       cmake(KF6WidgetsAddons) >= %{_kf6_version}
 KConfigWidgets provides easy-to-use classes to create configuration dialogs, as
 well as a set of widgets which uses KConfig to store their settings. Development files.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
+%install -a
 # todo: fix the name error.
 # Avoid illegal package names
 rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 # Use langpacks macro to auto-split translations
-%find_lang %{name}6 --with-qt --all-name --generate-subpackages
+%find_lang %{name} --with-qt --all-name --generate-subpackages
 
-%files -f %{name}6.lang
+%files -f %{name}.lang
 %license LICENSES/*
 %doc README.md
 %{_kf6_debugdir}/kconfigwidgets.categories
@@ -89,4 +79,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_kf6_plugindir}/designer/kconfigwidgets6widgets.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kcoreaddons/kf6-kcoreaddons.spec
+++ b/SPECS/kf6-kcoreaddons/kf6-kcoreaddons.spec
@@ -12,14 +12,14 @@
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kcoreaddons
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Utilities for core application functionality and accessing the OS
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            https://invent.kde.org/frameworks/kcoreaddons
-#!RemoteAsset:  sha256:843d27cd76ca890c4f352d6f29d2e2b8747883602b63119106b1eb229b95e649
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:92fdbfab68e52d9eacf44a992f01cb364d6395c24441e2fd47dd48a23b3281f6
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF
@@ -37,6 +37,8 @@ BuildRequires:  cmake(Qt6LinguistTools) >= %{qt6_version}
 BuildRequires:  cmake(Qt6Qml) >= %{qt6_version}
 BuildRequires:  cmake(Qt6QuickTest) >= %{qt6_version}
 BuildRequires:  cmake(Qt6ToolsTools) >= %{qt6_version}
+BuildRequires:  pkgconfig(mount)
+BuildRequires:  pkgconfig(libudev)
 BuildRequires:  qt6-qttools
 BuildRequires:  qt6-doctools
 BuildRequires:  qt6-linguist

--- a/SPECS/kf6-kcrash/kf6-kcrash.spec
+++ b/SPECS/kf6-kcrash/kf6-kcrash.spec
@@ -11,16 +11,18 @@
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kcrash
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        An application crash handler
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kcrash
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:d05d93863a745ce0d4ab8ccff684a84a813ee4cbcc68c9c7a5175107b107e931
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  pkgconfig
 BuildRequires:  cmake(KF6CoreAddons) >= %{_kf6_version}
@@ -46,19 +48,6 @@ Requires:       cmake(Qt6Core) >= %{qt6_version}
 KCrash provides support for intercepting and handling application crashes.
 Development files.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
 %files
 %license LICENSES/*
 %doc README*
@@ -72,4 +61,4 @@ Development files.
 %{_kf6_libdir}/libKF6Crash.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kdbusaddons/kf6-kdbusaddons.spec
+++ b/SPECS/kf6-kdbusaddons/kf6-kdbusaddons.spec
@@ -11,16 +11,18 @@
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kdbusaddons
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Convenience classes for QtDBus
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            https://invent.kde.org/frameworks/kdbusaddons
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:894bb2e032c6f6d9b4a58b8b24678692a9f4e70e953ff4dabda2ed4e9b5431e2
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  qt6-qttools
 BuildRequires:  qt6-doctools
@@ -54,19 +56,6 @@ Requires:       cmake(Qt6DBus) >= %{qt6_version}
 KDBusAddons provides convenience classes on top of QtDBus, as well as an API to
 create KDED modules. Development files.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
 %files
 %license LICENSES/*
 %doc README.md
@@ -84,4 +73,4 @@ create KDED modules. Development files.
 %{_kf6_libdir}/libKF6DBusAddons.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kdeclarative/kf6-kdeclarative.spec
+++ b/SPECS/kf6-kdeclarative/kf6-kdeclarative.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kdeclarative
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kdeclarative
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Integration of QML and KDE workspaces
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kdeclarative.git
-#!RemoteAsset:  sha256:055a97da106cdc1f8796cb90cdd262c8f88c41522ef5e86068c3ce7dc28c4be7
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:9a464e560e436cd3a626ca6aab894f414c6212d2de8b9c5a8eda33be213e00d8
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kded/kf6-kded.spec
+++ b/SPECS/kf6-kded/kf6-kded.spec
@@ -7,20 +7,22 @@
 %define qt6_version 6.8.0
 
 %define rname kded
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kded
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Central daemon of KDE workspaces
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kded
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:4265d1162cbd7febf16d103bf1bd9fab858fa3f54f52797ed0938436bee347af
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  cmake(KF6Config) >= %{_kf6_version}
@@ -51,19 +53,6 @@ KDED runs in the background and performs a number of small tasks.
 Some of these tasks are built in, others are started on demand.
 Development files.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
 %preun
 %systemd_user_preun plasma-kded6.service
 
@@ -91,4 +80,4 @@ Development files.
 %{_kf6_dbusinterfacesdir}/org.kde.kded6.xml
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kdesu/kf6-kdesu.spec
+++ b/SPECS/kf6-kdesu/kf6-kdesu.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kdesu
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kdesu
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        User interface for running shell commands with root privileges
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kdesu.git
-#!RemoteAsset:  sha256:5b5947a2153d9fa0a5009c4a2af5c55dda4c10e970de603356327f2c5962864f
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:37df33a1236850b6bebd773a1aeab56ca597e347432924ca5855369337d4be24
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kdnssd/kf6-kdnssd.spec
+++ b/SPECS/kf6-kdnssd/kf6-kdnssd.spec
@@ -11,14 +11,14 @@
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kdnssd
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Network service discovery using Zeroconf
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kdnssd.git
-#!RemoteAsset:  sha256:5bedf0c89cd9d4152580af76dd7db27df8563fef217e8b66c7a1947c1d6295a9
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:8439daed9c4b942a74393daf23c8d97fdaabd81b93dc347f91bbb45a2bf85248
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kdoctools/kf6-kdoctools.spec
+++ b/SPECS/kf6-kdoctools/kf6-kdoctools.spec
@@ -7,22 +7,24 @@
 %define qt6_version 6.8.0
 
 %define rname kdoctools
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kdoctools
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Tools to create documentation from DocBook
 License:        LGPL-2.1-or-later AND MIT
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kdoctools
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:3fbea5de215076130007f3c18e16b870774ffa4fc85ddace201ac020d0245fb6
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
+
+BuildOption(conf):  -DBUILD_TESTING=OFF
 
 BuildRequires:  docbook-xsl
 BuildRequires:  docbook-dtds
-BuildRequires:  fdupes
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  perl-URI
 BuildRequires:  perl-Exporter
@@ -53,26 +55,14 @@ Requires:       cmake(Qt6Core) >= %{qt6_version}
 Provides tools to generate documentation in various format from DocBook files.
 Development files.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
+%install -a
 # todo: fix the name error.
 # Avoid illegal package names
 rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 # Use langpacks macro to auto-split translations
-%find_lang %{name}6 --with-qt --all-name --generate-subpackages
+%find_lang %{name} --with-qt --all-name --generate-subpackages
 
-%files -f %{name}6.lang
+%files -f %{name}.lang
 %license LICENSES/*.txt
 %doc README.md
 %{_kf6_libdir}/libKF6DocTools.so.*
@@ -92,4 +82,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_libdir}/libKF6DocTools.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kfilemetadata/kf6-kfilemetadata.spec
+++ b/SPECS/kf6-kfilemetadata/kf6-kfilemetadata.spec
@@ -7,20 +7,20 @@
 %define qt6_version 6.8.0
 
 %define rname kfilemetadata
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 %bcond ffmpeg 1
 
 Name:           kf6-kfilemetadata
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Library for extracting Metadata
 License:        GPL-2.0-or-later AND LGPL-2.1-or-later AND LGPL-3.0-only
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kfilemetadata.git
-#!RemoteAsset:  sha256:58e594fdb77883d684bd699731ed57ff24e8970c13c2a1bdb470f5dca84fb2bd
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:f75942b9a3d1be0b0910cd50a22c3c432ededdc506858c8d5511ddf5498051f2
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kglobalaccel/kf6-kglobalaccel.spec
+++ b/SPECS/kf6-kglobalaccel/kf6-kglobalaccel.spec
@@ -7,20 +7,22 @@
 %define qt6_version 6.8.0
 
 %define rname kglobalaccel
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kglobalaccel
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Global desktop keyboard shortcuts
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kglobalaccel
-#!RemoteAsset:  sha256:332e3be3d0ac2aec8e786419c1e875a1b33ae84b8aada3283639deccc6ffd4d8
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:3f19d22d143577e5ddcc883170fe19a56f8f65766e41c4f9c011c4dfbde17a61
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  pkgconfig
 BuildRequires:  qt6-qtbase-private-devel >= %{qt6_version}
@@ -58,26 +60,14 @@ KGlobalAccel allows you to have global accelerators that are independent of
 the focused window.  Unlike regular shortcuts, the application's window does not
 need focus for them to be activated. Development files.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
+%install -a
 # todo: fix the name error.
 # Avoid illegal package names
 rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 # Use langpacks macro to auto-split translations
-%find_lang %{name}6 --with-qt --all-name --generate-subpackages
+%find_lang %{name} --with-qt --all-name --generate-subpackages
 
-%files -f %{name}6.lang
+%files -f %{name}.lang
 %license LICENSES/*
 %doc README.md
 %{_kf6_debugdir}/kglobalaccel.categories
@@ -92,4 +82,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_kf6_dbusinterfacesdir}/kf6_org.kde.kglobalaccel.Component.xml
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kguiaddons/kf6-kguiaddons.spec
+++ b/SPECS/kf6-kguiaddons/kf6-kguiaddons.spec
@@ -8,21 +8,24 @@
 
 %define rname kguiaddons
 
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 # %%{!?_kf6_version: %%global _kf6_version %%{version}}
-%global _kf6_version 6.22.0
+%global _kf6_version 6.26.0
 
 Name:           kf6-kguiaddons
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Utilities for graphical user interfaces
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kguiaddons
-#!RemoteAsset:  sha256:b7652bcebebfc8c1fda2893c1aeff4136c586ee77ffc6e589e3634f0e5539eef
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:8375342f852104f36fd72a6870eb9795183af4516592cd6fa73445ea6b813172
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+BuildOption(conf):  -DBUILD_PYTHON_BINDINGS=OFF
+
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  pkgconfig
 BuildRequires:  qt6-qtbase-private-devel >= %{qt6_version}
@@ -55,15 +58,6 @@ Obsoletes:      kguiaddons < %{version}-%{release}
 The KDE GUI addons provide utilities for graphical user interfaces in the areas
 of colors, fonts, text, images, keyboard input.
 
-%package        imports
-Summary:        QtQuick bindings for utilities for graphical user interfaces
-Requires:       %{name}%{?_isa} = %{version}-%{release}
-
-%description    imports
-The KDE GUI addons provide utilities for graphical user interfaces in the areas
-of colors, fonts, text, images, keyboard input. This package provides QtQuick
-bindings to use these GUI addons with QML and QtQuick applications.
-
 %package        devel
 Summary:        Utilities for graphical user interfaces: Build Environment
 Requires:       %{name}%{?_isa} = %{version}-%{release}
@@ -72,31 +66,15 @@ Requires:       %{name}%{?_isa} = %{version}-%{release}
 The KDE GUI addons provide utilities for graphical user interfaces in the areas
 of colors, fonts, text, images, keyboard input. Development files.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6 \
-  -DBUILD_PYTHON_BINDINGS=OFF
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
 %files
-%license LICENSES/*
 %doc README.md
+%license LICENSES/*
 %{_kf6_applicationsdir}/google-maps-geo-handler.desktop
 %{_kf6_applicationsdir}/openstreetmap-geo-handler.desktop
 %{_kf6_applicationsdir}/wheelmap-geo-handler.desktop
 %{_kf6_bindir}/kde-geo-uri-handler
 %{_kf6_debugdir}/kguiaddons.categories
 %{_kf6_libdir}/libKF6GuiAddons.so.*
-
-%files imports
 %{_kf6_qmldir}/org/kde/guiaddons/
 
 %files devel

--- a/SPECS/kf6-kholidays/kf6-kholidays.spec
+++ b/SPECS/kf6-kholidays/kf6-kholidays.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kholidays
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kholidays
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Holiday calculation library
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kholidays.git
-#!RemoteAsset:  sha256:39b7f1c713d6c5ae225bfa18a6dece20ff7a7f4c325a0c6fc4a48cf3e4e0a690
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:fc4f46cb5bb8e4766f550fe1a8b401731d797fcf6afa7cb53679048c215a60be
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF
@@ -28,6 +28,8 @@ BuildRequires:  cmake(Qt6Core) >= %{qt6_version}
 BuildRequires:  cmake(Qt6LinguistTools) >= %{qt6_version}
 BuildRequires:  cmake(Qt6Qml) >= %{qt6_version}
 BuildRequires:  cmake(Qt6ToolsTools) >= %{qt6_version}
+BuildRequires:  flex
+BuildRequires:  bison
 BuildRequires:  qt6-qttools
 BuildRequires:  qt6-doctools
 BuildRequires:  qt6-linguist

--- a/SPECS/kf6-ki18n/kf6-ki18n.spec
+++ b/SPECS/kf6-ki18n/kf6-ki18n.spec
@@ -11,16 +11,18 @@
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-ki18n
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        KDE Gettext-based UI text internationalization
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            https://invent.kde.org/frameworks/ki18n
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:484aad486bfafef6c86d8d5b26529258e67c74c96250c1ac212ddf568448c7c0
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+
 BuildRequires:  gettext-runtime
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  python3
@@ -38,20 +40,13 @@ in applications, based on the GNU Gettext translation system.
 It wraps the standard Gettext functionality, so that the programmers
 and translators can use the familiar Gettext tools and workflows.
 
-%package        imports
-Summary:        QML components for ki18n Framework
-Requires:       %{name}%{?_isa} = %{version}-%{release}
-
-%description    imports
-This package contains QML imports for the ki18n framework.
-
 %package        devel
 Summary:        KDE Gettext-based UI text internationalization
 Requires:       gettext-runtime
 Requires:       gettext-tools
 Requires:       kf6-extra-cmake-modules
 Requires:       %{name}%{?_isa} = %{version}-%{release}
-Requires:       python3
+Requires:       python
 Requires:       cmake(Qt6Widgets) >= %{qt6_version}
 
 %description    devel
@@ -60,19 +55,6 @@ in applications, based on the GNU Gettext translation system.
 It wraps the standard Gettext functionality, so that the programmers
 and translators can use the familiar Gettext tools and workflows.
 Development files.
-
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
 
 %files
 %license LICENSES/*
@@ -85,8 +67,6 @@ Development files.
 %{_kf6_libdir}/libKF6I18nQml.so.*
 %{_kf6_sharedir}/locale/*/LC_SCRIPTS/ki18n6/
 %{_kf6_sharedir}/locale/*/LC_MESSAGES/ki18n6.mo
-
-%files imports
 %{_kf6_qmldir}/org/kde/i18n/
 %{_kf6_qmldir}/org/kde/ki18n/
 
@@ -99,4 +79,4 @@ Development files.
 %{_kf6_libdir}/libKF6I18nQml.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kiconthemes/kf6-kiconthemes.spec
+++ b/SPECS/kf6-kiconthemes/kf6-kiconthemes.spec
@@ -7,20 +7,22 @@
 %define qt6_version 6.8.0
 
 %define rname kiconthemes
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kiconthemes
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Icon GUI utilities
 License:        LGPL-2.1-or-later AND GPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kiconthemes
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:ed6c0c0bfed517dd5b6462d9b1c84ebe7bc99c7a75214921b5978f086df8653d
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  qt6-qtbase-private-devel >= %{qt6_version}
 BuildRequires:  cmake(KF6Archive) >= %{_kf6_version}
@@ -56,26 +58,14 @@ Requires:       cmake(Qt6Widgets) >= %{qt6_version}
 This library contains classes to improve the handling of icons
 in applications using the KDE Frameworks. Development files.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
+%install -a
 # todo: fix the name error.
 # Avoid illegal package names
 rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 # Use langpacks macro to auto-split translations
-%find_lang %{name}6 --with-qt --all-name --generate-subpackages
+%find_lang %{name} --with-qt --all-name --generate-subpackages
 
-%files -f %{name}6.lang
+%files -f %{name}.lang
 %license LICENSES/*
 %doc README.md
 %{_kf6_debugdir}/kiconthemes.categories
@@ -100,4 +90,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_kf6_plugindir}/designer/kiconthemes6widgets.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kidletime/kf6-kidletime.spec
+++ b/SPECS/kf6-kidletime/kf6-kidletime.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kidletime
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kidletime
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        User and system idle time reporting singleton
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kidletime.git
-#!RemoteAsset:  sha256:0701ba4c321785ba670f4a9dba54c551ffd476451caba2c77b9f079e8db42a2e
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:f0efd67ee0e5b5eb9200e924e9478c1ecb179b4a38e0cf125b377e7fa373ef07
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kimageformats/kf6-kimageformats.spec
+++ b/SPECS/kf6-kimageformats/kf6-kimageformats.spec
@@ -14,18 +14,18 @@
 %bcond jxl 1
 %bcond jp2 1
 
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kimageformats
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Image format plugins for Qt
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kimageformats.git
-#!RemoteAsset:  sha256:d6eede9a75aa4b33c3e8afdebdcc9664cf423effeabe684b21dc1cc9728a2073
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:c192552ee1831fd5e09af4e3633bb24726dfb4031170c4285024683bedaf9972
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF
@@ -124,6 +124,7 @@ to provide additional image format plugins for QtGui.
 %{_kf6_plugindir}/imageformats/kimg_raw.so
 %{_kf6_plugindir}/imageformats/kimg_rgb.so
 %{_kf6_plugindir}/imageformats/kimg_sct.so
+%{_kf6_plugindir}/imageformats/kimg_tim.so
 %{_kf6_plugindir}/imageformats/kimg_tga.so
 %{_kf6_plugindir}/imageformats/kimg_xcf.so
 

--- a/SPECS/kf6-kio/kf6-kio.spec
+++ b/SPECS/kf6-kio/kf6-kio.spec
@@ -11,16 +11,18 @@
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kio
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Network transparent access to files and data
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kio
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:567f64db9766986b5535d884a5db30203685c33e67f56892bceff30e1bd5cc8a
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  attr-devel
 BuildRequires:  pkgconfig
@@ -106,25 +108,14 @@ will ever need. In fact, the KDE file manager (Dolphin) and the KDE
 file dialog also uses this to provide its network-enabled file management.
 Development files.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%cmake_kf6
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
+%install -a
 # todo: fix the name error.
 # Avoid illegal package names
 rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 # Use langpacks macro to auto-split translations
-%find_lang %{name}6 --with-qt --all-name --generate-subpackages
+%find_lang %{name} --with-qt --all-name --generate-subpackages
 
-%files -f %{name}6.lang
+%files -f %{name}.lang
 %license LICENSES/*
 %doc README.md
 %{_kf6_applicationsdir}/ktelnetservice6.desktop
@@ -180,4 +171,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_kf6_sharedir}/kdevappwizard/templates/kioworker6.tar.bz2
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kirigami/kf6-kirigami.spec
+++ b/SPECS/kf6-kirigami/kf6-kirigami.spec
@@ -7,18 +7,22 @@
 %define qt6_version 6.8.0
 
 %define rname kirigami
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kirigami
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Set of QtQuick components
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kirigami
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:b268785b271198acec7fe4b6177eafdee890e180245c7168916da3ccff1425ff
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
+
+BuildOption(conf):  -DBUILD_TESTING=OFF
+BuildOption(conf):  -DQT_QML_NO_CACHEGEN:BOOL=TRUE
 
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  qt6-qtbase-private-devel >= %{qt6_version}
@@ -53,26 +57,14 @@ Requires:       cmake(Qt6Quick) >= %{qt6_version}
 QtQuick plugins to build user interfaces based on the KDE UX guidelines.
 Development files.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-
-%cmake_kf6 \
-  -DQT_QML_NO_CACHEGEN:BOOL=TRUE
-
-%kf6_build
-
-%install
-%kf6_install
-
+%install -a
 # todo: fix the name error.
 # Avoid illegal package names
 rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 # Use langpacks macro to auto-split translations
-%find_lang %{name}6 --with-qt --all-name --generate-subpackages
+%find_lang %{name} --with-qt --all-name --generate-subpackages
 
-%files -f %{name}6.lang
+%files -f %{name}.lang
 %license LICENSES/*
 %doc README.md
 %{_kf6_debugdir}/kirigami.categories
@@ -80,8 +72,13 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 # This is actually a plugin
 %{_kf6_libdir}/libKirigamiPrivate.so.*
 %{_kf6_libdir}/libKirigami.so.*
+%{_kf6_libdir}/libKirigamiControls.so.*
 %{_kf6_libdir}/libKirigamiDelegates.so.*
 %{_kf6_libdir}/libKirigamiDialogs.so.*
+%{_kf6_libdir}/libKirigamiForms.so.*
+%{_kf6_libdir}/libKirigamiFormsPrivateCards.so.*
+%{_kf6_libdir}/libKirigamiFormsPrivateFlat.so.*
+%{_kf6_libdir}/libKirigamiFormsPrivateTemplates.so.*
 %{_kf6_libdir}/libKirigamiLayouts.so.*
 %{_kf6_libdir}/libKirigamiLayoutsPrivate.so.*
 %{_kf6_libdir}/libKirigamiPlatform.so.*
@@ -96,8 +93,13 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %dir %{_kf6_includedir}/Kirigami/
 %{_kf6_includedir}/Kirigami/Platform/
 %{_kf6_libdir}/libKirigami.so
+%{_kf6_libdir}/libKirigamiControls.so
 %{_kf6_libdir}/libKirigamiDelegates.so
 %{_kf6_libdir}/libKirigamiDialogs.so
+%{_kf6_libdir}/libKirigamiForms.so
+%{_kf6_libdir}/libKirigamiFormsPrivateCards.so
+%{_kf6_libdir}/libKirigamiFormsPrivateFlat.so
+%{_kf6_libdir}/libKirigamiFormsPrivateTemplates.so
 %{_kf6_libdir}/libKirigamiLayouts.so
 %{_kf6_libdir}/libKirigamiLayoutsPrivate.so
 %{_kf6_libdir}/libKirigamiPlatform.so
@@ -108,4 +110,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_kf6_sharedir}/kdevappwizard/templates/kirigami6.tar.bz2
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kitemmodels/kf6-kitemmodels.spec
+++ b/SPECS/kf6-kitemmodels/kf6-kitemmodels.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kitemmodels
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kitemmodels
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Set of item models extending the Qt model-view framework
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kitemmodels.git
-#!RemoteAsset:  sha256:beed81bfe0d42f5f3de2487cb19875dd148547a861601ad56801c258cc68ccd4
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:a996201062ff7d21f9db972debc2d9615762ddb0fd9da069a42b7fd7bba1e61d
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kitemviews/kf6-kitemviews.spec
+++ b/SPECS/kf6-kitemviews/kf6-kitemviews.spec
@@ -7,20 +7,22 @@
 %define qt6_version 6.8.0
 
 %define rname kitemviews
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kitemviews
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Set of item views extending the Qt model-view framework
 License:        LGPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kitemviews
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:e76cc9d7561d0aae22b07a77552fbcddf61c8066bac5cfac9958ac065b617e74
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  cmake(Qt6LinguistTools) >= %{qt6_version}
 BuildRequires:  cmake(Qt6ToolsTools) >= %{qt6_version}
@@ -44,26 +46,14 @@ KItemViews includes a set of views, which can be used with item models. It
 includes views for categorizing lists and to add search filters to flat and
 hierarchical lists. Development files.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
+%install -a
 # todo: fix the name error.
 # Avoid illegal package names
 rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 # Use langpacks macro to auto-split translations
-%find_lang %{name}6 --with-qt --all-name --generate-subpackages
+%find_lang %{name} --with-qt --all-name --generate-subpackages
 
-%files -f %{name}6.lang
+%files -f %{name}.lang
 %license LICENSES/*
 %doc README.md
 %{_kf6_debugdir}/kitemviews.categories
@@ -76,4 +66,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_kf6_plugindir}/designer/kitemviews6widgets.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kjobwidgets/kf6-kjobwidgets.spec
+++ b/SPECS/kf6-kjobwidgets/kf6-kjobwidgets.spec
@@ -8,20 +8,23 @@
 
 %define rname kjobwidgets
 
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kjobwidgets
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Widgets for showing progress of asynchronous jobs
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kjobwidgets
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:8057b7bd132cc2b469ac406f95ba22bc3cfc240c1031485f19fa072ab942f71e
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+BuildOption(conf):  -DBUILD_PYTHON_BINDINGS=OFF
+
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  pkgconfig
 BuildRequires:  qt6-qtbase-private-devel >= %{qt6_version}
@@ -50,19 +53,6 @@ Requires:       cmake(Qt6Widgets) >= %{qt6_version}
 KJobWIdgets provides widgets for showing progress of asynchronous jobs.
 Development files.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6 -DBUILD_PYTHON_BINDINGS=OFF
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
 %files
 %license LICENSES/*
 %doc README.md
@@ -80,4 +70,4 @@ Development files.
 %{_kf6_libdir}/libKF6JobWidgets.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-knewstuff/kf6-knewstuff.spec
+++ b/SPECS/kf6-knewstuff/kf6-knewstuff.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname knewstuff
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-knewstuff
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Framework for downloading and sharing additional application data
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://github.com/KDE/knewstuff.git
-#!RemoteAsset:  sha256:1f6d4e72d8b66ee93eec8268fadb0d1731716f6a82cb2e46f1ef955c4ef6b1b5
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:94ef39077ba53a72f4e555b6f94a2762cba79730619cb80a31c5435642ebe1aa
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-knotifications/kf6-knotifications.spec
+++ b/SPECS/kf6-knotifications/kf6-knotifications.spec
@@ -12,16 +12,19 @@
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-knotifications
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        KDE Desktop notifications
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/knotifications
-#!RemoteAsset:  sha256:c49aaef3ccf3dfac73ac07159b3ee0ddbf6e39696e44165d3b0a1ea02a77408c
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:2033a798856a9d2776e6e4cef6f3eb3bc24b938c0d00b06b2f6e71be44e1446a
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+BuildOption(conf):  -DBUILD_PYTHON_BINDINGS=OFF
+
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  pkgconfig
 BuildRequires:  cmake(KF6Config) >= %{_kf6_version}
@@ -47,16 +50,6 @@ BuildRequires:  cmake(PySide6)
 KNotification is used to notify the user of an event. It covers feedback and
 persistent events.
 
-%package        imports
-Summary:        KDE Desktop notifications - QML files
-Requires:       %{name}%{?_isa} = %{version}-%{release}
-
-%description    imports
-KNotification is used to notify the user of an event. It covers feedback and
-persistent events.
-This package contains files that allow using knotification in QtQuick based
-applications.
-
 %package        devel
 Summary:        KDE Desktop notifications: Build Environment
 Requires:       %{name}%{?_isa} = %{version}-%{release}
@@ -77,20 +70,6 @@ Requires:       %{name}%{?_isa} = %{version}-%{release}
 %description -n python-%{name}
 The package contains the PySide6 bindings library for %{name}.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6 \
-  -DBUILD_PYTHON_BINDINGS=OFF
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
 %files
 %license LICENSES/*
 %doc README.md
@@ -98,8 +77,6 @@ The package contains the PySide6 bindings library for %{name}.
 %{_kf6_debugdir}/knotifications.renamecategories
 %{_kf6_libdir}/libKF6Notifications.so.*
 %{_datadir}/locale/*/LC_MESSAGES/knotifications6_qt.qm
-
-%files imports
 %{_kf6_qmldir}/org/kde/notification/
 
 %files devel

--- a/SPECS/kf6-knotifyconfig/kf6-knotifyconfig.spec
+++ b/SPECS/kf6-knotifyconfig/kf6-knotifyconfig.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname knotifyconfig
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-knotifyconfig
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Configuration dialog for desktop notifications
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/knotifyconfig.git
-#!RemoteAsset:  sha256:14c6864a1e18d06f778d432fb7a186b036e593f372184b97208c7ddddfa39db4
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:062e22f48a1da485d42ef56b37db1fc502f5f9305871483627d218f357560a28
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kpackage/kf6-kpackage.spec
+++ b/SPECS/kf6-kpackage/kf6-kpackage.spec
@@ -7,20 +7,22 @@
 %define qt6_version 6.8.0
 
 %define rname kpackage
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kpackage
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Non-binary asset user-installable package managing framework
 License:        GPL-2.0-or-later AND LGPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kpackage
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:313cda4a335ecdb67bb8e2fcc15bdeb5970db17d5597282ca655bf97a98abab5
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  cmake(KF6Archive) >= %{_kf6_version}
 BuildRequires:  cmake(KF6CoreAddons) >= %{_kf6_version}
@@ -50,24 +52,14 @@ non-binary assets.
 
 Development files.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6
-
-%kf6_build
-
-%install
-%kf6_install
-
+%install -a
 # todo: fix the name error.
 # Avoid illegal package names
 rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 # Use langpacks macro to auto-split translations
-%find_lang %{name}6 --with-qt --all-name --generate-subpackages
+%find_lang %{name} --with-qt --all-name --generate-subpackages
 
-%files -f %{name}6.lang
+%files -f %{name}.lang
 %license LICENSES/*.txt
 %doc README.md
 %{_kf6_libdir}/libKF6Package.so.*
@@ -83,4 +75,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_kf6_libdir}/libKF6Package.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kparts/kf6-kparts.spec
+++ b/SPECS/kf6-kparts/kf6-kparts.spec
@@ -7,20 +7,22 @@
 %define qt6_version 6.8.0
 
 %define rname kparts
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kparts
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Plugin framework for user interface components
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kparts
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:049c2cf048b4cbbffe0bea9357bd9ab53b8be672ba509b2bb058f764d21b3f5b
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  cmake(KF6Config) >= %{_kf6_version}
 BuildRequires:  cmake(KF6CoreAddons) >= %{_kf6_version}
@@ -58,26 +60,14 @@ This library implements the framework for KDE parts, which are
 elaborate widgets with a user-interface defined in terms of actions
 (menu items, toolbar icons). Development files.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
+%install -a
 # todo: fix the name error.
 # Avoid illegal package names
 rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 # Use langpacks macro to auto-split translations
-%find_lang %{name}6 --with-qt --all-name --generate-subpackages
+%find_lang %{name} --with-qt --all-name --generate-subpackages
 
-%files -f %{name}6.lang
+%files -f %{name}.lang
 %license LICENSES/*
 %doc README.md
 %{_kf6_debugdir}/kparts.categories
@@ -90,4 +80,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_kf6_sharedir}/kdevappwizard/templates/
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kpty/kf6-kpty.spec
+++ b/SPECS/kf6-kpty/kf6-kpty.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kpty
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kpty
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Primitives to interface with pseudo terminal devices
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kpty.git
-#!RemoteAsset:  sha256:e974ae36e609d1fb485782139f8c6aa260fcee8f651da3dd0d175dad1c0b9663
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:7613c26cfaa7465a2fe28a22762ceb38266414e7f4a94a127c09dc0628625553
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kquickcharts/kf6-kquickcharts.spec
+++ b/SPECS/kf6-kquickcharts/kf6-kquickcharts.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kquickcharts
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kquickcharts
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Set of charts for QtQuick applications
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kquickcharts.git
-#!RemoteAsset:  sha256:10e82ca86ae8e22910a1e58db9fc647335e9335bd9fad3c713c39f79479f14a4
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:ae3e0784a2a2d1396cb751cc61f43a567e066d6434971246b1a18365481a1b52
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-krunner/kf6-krunner.spec
+++ b/SPECS/kf6-krunner/kf6-krunner.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname krunner
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-krunner
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        KDE Framework for providing different actions given a string query
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/krunner.git
-#!RemoteAsset:  sha256:094c6630958f82a44d668b04056f630fbe486f8328149a235ee88073d43b120a
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:3519c7fe170be1359a4c38dd5269de64c0208ccfeb950661002ddfa4e92f2bf0
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kservice/kf6-kservice.spec
+++ b/SPECS/kf6-kservice/kf6-kservice.spec
@@ -7,21 +7,23 @@
 %define qt6_version 6.8.0
 
 %define rname kservice
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kservice
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Plugin framework for desktop services
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kservice
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:f8528524ccafb6a495962dd3260c442377920169f1c444f11657ea42558a53b6
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
+
+BuildOption(conf):  -DBUILD_TESTING=OFF
 
 BuildRequires:  bison
-BuildRequires:  fdupes
 BuildRequires:  flex
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  cmake(KF6Config) >= %{_kf6_version}
@@ -35,7 +37,7 @@ BuildRequires:  qt6-doctools
 BuildRequires:  qt6-linguist
 BuildRequires:  docbook-dtds
 
-Recommends:     kded6 >= %{_kf6_version}
+Recommends:     kded >= %{_kf6_version}
 
 %description
 Provides a plugin framework for handling desktop services. Services can
@@ -61,18 +63,14 @@ application specific code. Development files
 
 %kf6_build
 
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
+%install -a
 # todo: fix the name error.
 # Avoid illegal package names
 rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 # Use langpacks macro to auto-split translations
-%find_lang %{name}6 --with-qt --all-name --generate-subpackages
+%find_lang %{name} --with-qt --all-name --generate-subpackages
 
-%files -f %{name}6.lang
+%files -f %{name}.lang
 %license LICENSES/*
 %doc README.md
 %doc %lang(en) %{_kf6_mandir}/*/kbuildsycoca6.*
@@ -88,4 +86,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_kf6_libdir}/libKF6Service.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kstatusnotifieritem/kf6-kstatusnotifieritem.spec
+++ b/SPECS/kf6-kstatusnotifieritem/kf6-kstatusnotifieritem.spec
@@ -8,18 +8,18 @@
 
 %define rname kstatusnotifieritem
 
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kstatusnotifieritem
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Implementation of Status Notifier Items
 License:        LGPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kstatusnotifieritem.git
-#!RemoteAsset:  sha256:53ceda99fec1ddef9865ffb820ce824ce0c83f05ada5b750223abc68a9a5f2a2
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:898914c94820f99889d879f33cabbb5fbe7b9f4e24a6a1d9a9b4439489bc3266
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-ksvg/kf6-ksvg.spec
+++ b/SPECS/kf6-ksvg/kf6-ksvg.spec
@@ -7,20 +7,23 @@
 %define qt6_version 6.8.0
 
 %define rname ksvg
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-ksvg
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Components for handling SVGs
 License:        GPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/ksvg
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:f3a7412e227d13b1cafec91c1b58dd3f86980abefc08b2535b46bef362b4c07e
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
 Patch0:         0001-Revert-Support-for-fractional-scaling.patch
+
+BuildOption(conf):  -DBUILD_TESTING=OFF
 
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  cmake(KF6Archive) >= %{_kf6_version}
@@ -51,17 +54,6 @@ Requires:       %{name}%{?_isa} = %{version}-%{release}
 %description    devel
 Development Files for the ksvg framework.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6
-
-%kf6_build
-
-%install
-%kf6_install
-
 %files
 %license LICENSES/*
 %doc README.md
@@ -75,4 +67,4 @@ Development Files for the ksvg framework.
 %{_kf6_libdir}/libKF6Svg.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-ktexteditor/kf6-ktexteditor.spec
+++ b/SPECS/kf6-ktexteditor/kf6-ktexteditor.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname ktexteditor
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-ktexteditor
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Embeddable text editor component
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/ktexteditor.git
-#!RemoteAsset:  sha256:1d9b336a2b26ecc6a1c5b8133eacea69ed786b3eb6f1ec2ad6705c2bea62e1c5
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:ec7bc094f93d514b5f675ae95c274dd24acc47769d971606d8708cc88f811341
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DENABLE_KAUTH:BOOL=FALSE

--- a/SPECS/kf6-ktextwidgets/kf6-ktextwidgets.spec
+++ b/SPECS/kf6-ktextwidgets/kf6-ktextwidgets.spec
@@ -7,20 +7,22 @@
 %define qt6_version 6.8.0
 
 %define rname ktextwidgets
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-ktextwidgets
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        KDE Text editing widgets
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/ktextwidgets
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:6511f9909f90fac951e2873a44dd451b8ac71d38085a62c65a6fb5028e62d84d
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  cmake(KF6Completion) >= %{_kf6_version}
 BuildRequires:  cmake(KF6Config) >= %{_kf6_version}
@@ -53,26 +55,14 @@ Requires:       cmake(Qt6Widgets) >= %{qt6_version}
 KTextWidgets provides widgets for displaying and editing text. It supports
 rich text as well as plain text. Development files.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
+%install -a
 # todo: fix the name error.
 # Avoid illegal package names
 rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 # Use langpacks macro to auto-split translations
-%find_lang %{name}6 --with-qt --all-name --generate-subpackages
+%find_lang %{name} --with-qt --all-name --generate-subpackages
 
-%files -f %{name}6.lang
+%files -f %{name}.lang
 %license LICENSES/*
 %doc README.md
 %{_kf6_libdir}/libKF6TextWidgets.so.*
@@ -84,4 +74,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_kf6_plugindir}/designer/ktextwidgets6widgets.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kunitconversion/kf6-kunitconversion.spec
+++ b/SPECS/kf6-kunitconversion/kf6-kunitconversion.spec
@@ -8,18 +8,18 @@
 
 %define rname kunitconversion
 
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kunitconversion
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Tool for converting physical units
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kunitconversion.git
-#!RemoteAsset:  sha256:580357277fad7659d33555f25783a6cd27286b73cdd74c781b4989e4f6247b91
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:94404453011eec373f858ef4a58091d24fbadbb90f96bbbf470c098646d9675e
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kuserfeedback/kf6-kuserfeedback.spec
+++ b/SPECS/kf6-kuserfeedback/kf6-kuserfeedback.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kuserfeedback
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kuserfeedback
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Framework for collecting feedback from application users
 License:        MIT
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kuserfeedback.git
-#!RemoteAsset:  sha256:10e2db5703649bfd377121ea2daf629dae8cc082d0457488a04238d55d9e8b87
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:6cc18dca65a24af2ac262cb9c8761991701c8081a7133487b4ec936003f3f864
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DQT_MAJOR_VERSION:STRING=6

--- a/SPECS/kf6-kwallet/kf6-kwallet.spec
+++ b/SPECS/kf6-kwallet/kf6-kwallet.spec
@@ -7,20 +7,22 @@
 %define qt6_version 6.8.0
 
 %define rname kwallet
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kwallet
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Safe desktop-wide storage for passwords
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kwallet
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:2321f8591f1f225d3d7253fae9ee61d0789db231b3eeae6a5f8a14c013531389
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  libgcrypt-devel >= 1.5.0
 BuildRequires:  gpgmepp-devel
@@ -59,11 +61,7 @@ This framework contains two main components:
 Summary:        Safe desktop-wide storage for passwords
 Requires:       kf6-kwallet >= %{version}
 Recommends:     kf6-kwallet-tools
-# kwalletd6 ships a compat org.kde.kwalletd5.service file. It needs to replace
-# kwalletd5 to keep using plasma5 with KF6-based apps
-Provides:       kwalletd5 = %{version}-%{release}
-Obsoletes:      kwalletd5 < %{version}
-Obsoletes:      kwalletd5-lang < %{version}
+Provides:       kwalletd = %{version}-%{release}
 
 %description -n kwalletd6
 This framework contains two main components:
@@ -81,26 +79,14 @@ This framework contains two main components:
 * The kwalletd used to safely store the passwords on KDE work spaces.
 Development files.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
+%install -a
 # todo: fix the name error.
 # Avoid illegal package names
 rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 # Use langpacks macro to auto-split translations
-%find_lang %{name}6 --with-qt --all-name --generate-subpackages
+%find_lang %{name} --with-qt --all-name --generate-subpackages
 
-%files -f %{name}6.lang
+%files -f %{name}.lang
 %license LICENSES/*
 %doc README.md
 %{_kf6_debugdir}/kwallet.categories
@@ -130,4 +116,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_kf6_dbusinterfacesdir}/kf6_org.kde.KWallet.xml
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-kwidgetsaddons/kf6-kwidgetsaddons.spec
+++ b/SPECS/kf6-kwidgetsaddons/kf6-kwidgetsaddons.spec
@@ -8,20 +8,23 @@
 
 %define rname kwidgetsaddons
 
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kwidgetsaddons
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Large set of desktop widgets
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kwidgetsaddons
-#!RemoteAsset:  sha256:e8832ac697054ed3241e8299ba71b8d766579b7e6cb0fd8dd176cad10aec754b
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:65044882e30b305fe9fb20331a354cd811ca9d80b5c7f9fa722639f3334fe630
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+BuildOption(conf):  -DBUILD_PYTHON_BINDINGS=OFF
+
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  cmake(Qt6LinguistTools) >= %{qt6_version}
 BuildRequires:  cmake(Qt6ToolsTools) >= %{qt6_version}
@@ -51,27 +54,14 @@ Requires:       cmake(Qt6Widgets) >= %{qt6_version}
 This repository contains add-on widgets and classes for applications
 that use the Qt Widgets module.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6 \
-  -DBUILD_PYTHON_BINDINGS=OFF
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
+%install -a
 # todo: fix the name error.
 # Avoid illegal package names
 rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 # Use langpacks macro to auto-split translations
-%find_lang %{name}6 --with-qt --all-name --generate-subpackages
+%find_lang %{name} --with-qt --all-name --generate-subpackages
 
-%files -f %{name}6.lang
+%files -f %{name}.lang
 %license LICENSES/*
 %doc README.md
 %{_kf6_debugdir}/kwidgetsaddons.categories

--- a/SPECS/kf6-kwindowsystem/kf6-kwindowsystem.spec
+++ b/SPECS/kf6-kwindowsystem/kf6-kwindowsystem.spec
@@ -8,14 +8,14 @@
 %define qt6_version 6.8.0
 
 Name:           kf6-kwindowsystem
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        KDE Access to window manager
 License:        LGPL-2.1-or-later
 URL:            https://kde.org
 VCS:            git:https://invent.kde.org/frameworks/kwindowsystem
-#!RemoteAsset:  sha256:2821da92854e77d4d2accb5b6f26d189a3e62246fc0dcafbd04f1a78090e5195
-Source0:        https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:5f7962b7c986e77c5d25fa4f7d09cd89144b8781e57ebc37fd45eaec1961bb02
+Source0:        https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF
@@ -28,7 +28,7 @@ BuildRequires:  doxygen
 BuildRequires:  graphviz
 BuildRequires:  xmlto
 BuildRequires:  pkgconfig
-BuildRequires:  kf6-extra-cmake-modules >= 6.22.0
+BuildRequires:  kf6-extra-cmake-modules >= 6.26.0
 BuildRequires:  qt6-qtbase-private-devel >= 6.8.0
 BuildRequires:  cmake(Qt6GuiPrivate)
 BuildRequires:  cmake(Qt6LinguistTools)

--- a/SPECS/kf6-kxmlgui/kf6-kxmlgui.spec
+++ b/SPECS/kf6-kxmlgui/kf6-kxmlgui.spec
@@ -8,20 +8,23 @@
 
 %define rname kxmlgui
 
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kxmlgui
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Framework for managing menu and toolbar actions
 License:        LGPL-2.1-or-later AND GPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kxmlgui
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:4383855cea5a7f9a269c72dda15490b8d70c1d23d17950963937332fc5d6b7a0
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+BuildOption(conf):  -DBUILD_PYTHON_BINDINGS=OFF
+
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  pkgconfig
 BuildRequires:  qt6-qtbase-private-devel >= %{qt6_version}
@@ -68,26 +71,14 @@ abstract way. The actions are configured through a XML description and hooks
 in the application code. The framework supports merging of multiple
 description for example for integrating actions from plugins. Development files.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6 -DBUILD_PYTHON_BINDINGS=OFF
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
+%install -a
 # todo: fix the name error.
 # Avoid illegal package names
 rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 # Use langpacks macro to auto-split translations
-%find_lang %{name}6 --with-qt --all-name --generate-subpackages
+%find_lang %{name} --with-qt --all-name --generate-subpackages
 
-%files -f %{name}6.lang
+%files -f %{name}.lang
 %license LICENSES/*
 %doc README.md
 %{_kf6_debugdir}/kxmlgui.categories
@@ -101,4 +92,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_kf6_plugindir}/designer/kxmlgui6widgets.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-modemmanager-qt/kf6-modemmanager-qt.spec
+++ b/SPECS/kf6-modemmanager-qt/kf6-modemmanager-qt.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname modemmanager-qt
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-modemmanager-qt
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Qt wrapper for ModemManager DBus API
 License:        LGPL-2.1-only OR LGPL-3.0-only
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/modemmanager-qtt.git
-#!RemoteAsset:  sha256:04263688fdb9f92eb13c3a07d1a0a2f62d0579b23fdd380582f4fd28e3738772
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:bef456ac0a5983bcc14a1580cb0d32a001241f380d901cb503613855380af3a5
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-networkmanager-qt/kf6-networkmanager-qt.spec
+++ b/SPECS/kf6-networkmanager-qt/kf6-networkmanager-qt.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname networkmanager-qt
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-networkmanager-qt
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        A Qt wrapper for NetworkManager DBus API
 License:        LGPL-2.1-only OR LGPL-3.0-only
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/networkmanager-qt.git
-#!RemoteAsset:  sha256:707ac2d5dc96496dcc9966ef2100c336e07a9b6cf3ad07d83e03c6d76c380e6e
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:a5cfed06af6156161f7fee56efe1521a6e9e26119327069f1799986f90b432e5
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-prison/kf6-prison.spec
+++ b/SPECS/kf6-prison/kf6-prison.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname prison
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-prison
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Barcode abstraction layer library
 License:        MIT
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/prison.git
-#!RemoteAsset:  sha256:c40d692607bdadf8dbd5a56761289b1ee96973f048ca3671e760519e2ae4339a
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:0414ddc310bca5eecfc1a6f9d4463b8a6d81894db4128ac43b4f8c1e14b73b5b
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF
@@ -57,12 +57,16 @@ uniform access to generation of barcodes with data.
 %{_kf6_debugdir}/prison.renamecategories
 %{_kf6_libdir}/libKF6Prison.so.6
 %{_kf6_libdir}/libKF6Prison.so.%{version}
+%{_kf6_libdir}/libKF6PrisonScanner.so.6
+%{_kf6_libdir}/libKF6PrisonScanner.so.%{version}
 %{_kf6_qmldir}/org/kde/prison/
 
 %files devel
 %{_kf6_cmakedir}/KF6Prison/
 %{_kf6_includedir}/Prison/
+%{_kf6_includedir}/PrisonScanner/
 %{_kf6_libdir}/libKF6Prison.so
+%{_kf6_libdir}/libKF6PrisonScanner.so
 
 %changelog
 %autochangelog

--- a/SPECS/kf6-purpose/kf6-purpose.spec
+++ b/SPECS/kf6-purpose/kf6-purpose.spec
@@ -10,18 +10,18 @@
 %define qt6_version 6.8.0
 
 %define rname purpose
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-purpose
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Framework to integrate services and actions in applications
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/purpose.git
-#!RemoteAsset:  sha256:a2912583948f423e4d666f9cbf1cf1ac463a246e10e717078b4831f60cc2198c
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:cc7b7599d1ac7ce7ed07351a35d742fac1b7e554b208a7b1c92e859b3b4add30
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF
@@ -46,6 +46,9 @@ BuildRequires:  cmake(Qt6Widgets) >= %{qt6_version}
 BuildRequires:  qt6-qttools
 BuildRequires:  qt6-doctools
 BuildRequires:  qt6-linguist
+BuildRequires:  cmake(KF6Declarative) >= %{_kf6_version}
+BuildRequires:  cmake(KF6Prison) >= %{_kf6_version}
+BuildRequires:  kf6-kitemmodels
 
 Requires:       accounts-qml-module
 Requires:       kf6-kdeclarative >= %{_kf6_version}

--- a/SPECS/kf6-qqc2-desktop-style/kf6-qqc2-desktop-style.spec
+++ b/SPECS/kf6-qqc2-desktop-style/kf6-qqc2-desktop-style.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname qqc2-desktop-style
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-qqc2-desktop-style
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        A Qt Quick Controls 2 Style for Desktop UIs
 License:        GPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/qqc2-desktop-style.git
-#!RemoteAsset:  sha256:b0786080873728d4c24eced8f4d62f67263718fb5dc699d47696362328b81fae
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:1805fa31355ff86c02158fd2b8d396fd88835d01db97d8700314c48ee3360986
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-rpm-macros/kf6-rpm-macros.spec
+++ b/SPECS/kf6-rpm-macros/kf6-rpm-macros.spec
@@ -108,4 +108,4 @@ mkdir -p %{buildroot}%{_kf6_sharedir}/plasma/plasmoids
 %dir %{_kf6_sharedir}/krunner/dbusplugins
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-solid/kf6-solid.spec
+++ b/SPECS/kf6-solid/kf6-solid.spec
@@ -9,17 +9,19 @@
 %define rname solid
 
 Name:           kf6-solid
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        KDE Desktop hardware abstraction
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/solid
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:85cfab9b0787f59478661140997c485fadab62cec535ffcef2953d312f736c4a
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
+
+BuildOption(conf):  -DBUILD_TESTING=OFF
 
 BuildRequires:  bison
-BuildRequires:  fdupes
 BuildRequires:  flex
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  pkgconfig
@@ -51,26 +53,14 @@ Solid is a device integration framework. It provides a way of querying and
 interacting with hardware independently of the underlying operating system.
 Development files.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
+%install -a
 # todo: fix the name error.
 # Avoid illegal package names
 rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 # Use langpacks macro to auto-split translations
-%find_lang %{name}6 --with-qt --all-name --generate-subpackages
+%find_lang %{name} --with-qt --all-name --generate-subpackages
 
-%files -f %{name}6.lang
+%files -f %{name}.lang
 %license LICENSES/*
 %doc README.md
 %{_kf6_debugdir}/solid.categories
@@ -84,4 +74,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_kf6_libdir}/libKF6Solid.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-sonnet/kf6-sonnet.spec
+++ b/SPECS/kf6-sonnet/kf6-sonnet.spec
@@ -7,20 +7,22 @@
 %define qt6_version 6.8.0
 
 %define rname sonnet
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-sonnet
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        KDE spell checking library
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/sonnet
-#!RemoteAsset
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:3ac4e165c0b3c79eda416b754bb837292f354188a1220f2065f57f686489af25
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+
 BuildRequires:  kf6-extra-cmake-modules >= %{_kf6_version}
 BuildRequires:  pkgconfig
 BuildRequires:  cmake(Qt6Core) >= %{qt6_version}
@@ -59,26 +61,14 @@ Requires:       %{name}%{?_isa} = %{version}-%{release}
 The %{name}-voikko package contains the Finnish voikko spellchecking
 plugin for %{name}.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6
-
-%kf6_build
-
-%install
-%kf6_install
-
-%fdupes %{buildroot}
-
+%install -a
 # todo: fix the name error.
 # Avoid illegal package names
 rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 # Use langpacks macro to auto-split translations
-%find_lang %{name}6 --with-qt --all-name --generate-subpackages
+%find_lang %{name} --with-qt --all-name --generate-subpackages
 
-%files -f %{name}6.lang
+%files -f %{name}.lang
 %license LICENSES/*
 %doc README.md
 %dir %{_kf6_plugindir}/kf6/sonnet
@@ -103,4 +93,4 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_kf6_plugindir}/kf6/sonnet/sonnet_voikko.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-syndication/kf6-syndication.spec
+++ b/SPECS/kf6-syndication/kf6-syndication.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname syndication
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-syndication
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        RSS/Atom parsing library
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/syndication.git
-#!RemoteAsset:  sha256:faf3a88e6711b06a35edf28c415fd665b5699a7cafee6fed2cb4997f318d8de0
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:6130b8bc976cb078eda34b833ecd558a156b4e6bc4cb55e57ac362cb2998ba47
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-syntax-highlighting/kf6-syntax-highlighting.spec
+++ b/SPECS/kf6-syntax-highlighting/kf6-syntax-highlighting.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname syntax-highlighting
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-syntax-highlighting
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        Syntax highlighting engine and library
 License:        LGPL-2.1-or-later AND GPL-2.0-only AND GPL-2.0-or-later AND GPL-3.0-only AND MIT AND BSD-3-Clause AND Artistic-1.0
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/syntax-highlighting.git
-#!RemoteAsset:  sha256:50b73ea99413dd988fa34fd169129bcdbfe1dc3b43c48d5f92bbadb2511a728a
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:a4e86d167cd5f3c4318584119451f891551c24cd4a0ff1f7ef95e2476a39c5ac
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-threadweaver/kf6-threadweaver.spec
+++ b/SPECS/kf6-threadweaver/kf6-threadweaver.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname threadweaver
-# Full KF6 version (e.g. 6.22.0)
+# Full KF6 version (e.g. 6.26.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-threadweaver
-Version:        6.22.0
+Version:        6.26.0
 Release:        %autorelease
 Summary:        KDE Helper for multithreaded programming
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/threadweaver.git
-#!RemoteAsset:  sha256:2f51e312779dc5f592e8def4db225c3c40531d871e8a4d31a8f2a22de2a6582b
-Source:         https://download.kde.org/stable/frameworks/6.22/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:ad32daeafac62077590885f3abc4bcac1abbc6faeb34c20b32f6040648f7de1b
+Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF


### PR DESCRIPTION
The commit includes the following:

1. Update KDE Frameworks to 6.26.0.

2. Migrate some historically missing packages to the CMake BuildSystem.

3. Remove unnecessary fdupes (the build system can now do this automatically, without needing to add them to the spec file).

https://kde.org/announcements/frameworks/6/6.26.0/