### PR TITLE
SPECS: openjdk-25, 26: Add zifencei to -march for rva23 target.

### DIFF
--- a/SPECS/openjdk-25/openjdk-25.spec
+++ b/SPECS/openjdk-25/openjdk-25.spec
@@ -95,6 +95,11 @@ bash ../configure \
     --with-vendor-url="%{_vendor_url}" \
     --with-vendor-bug-url="%{_vendor_bug_url}" \
     --enable-unlimited-crypto \
+%ifarch riscv64
+  %if "%{openruyi_riscv_arch}" == "-march=rva23u64"
+    --with-extra-cxxflags="-march=rva23u64_zifencei" \
+  %endif
+%endif
     --disable-warnings-as-errors
 make images
 popd

--- a/SPECS/openjdk-latest/openjdk-latest.spec
+++ b/SPECS/openjdk-latest/openjdk-latest.spec
@@ -97,6 +97,11 @@ bash ../configure \
     --with-vendor-url="%{_vendor_url}" \
     --with-vendor-bug-url="%{_vendor_bug_url}" \
     --enable-unlimited-crypto \
+%ifarch riscv64
+  %if "%{openruyi_riscv_arch}" == "-march=rva23u64"
+    --with-extra-cxxflags="-march=rva23u64_zifencei" \
+  %endif
+%endif
     --disable-warnings-as-errors
 make images
 popd


### PR DESCRIPTION
Rva23u64 mandatory extensions don't contain zifencei. Without it, the build would fail at src/hotspot/os_cpu/linux_riscv/orderAccess_linux_riscv.hpp with:
  Error: unrecognized opcode `fence.i', extension `zifencei' required