### PR TITLE
SPECS: Add python-milvus-models & deps (part 3)

### DIFF
--- a/SPECS/python-beautifulsoup4/python-beautifulsoup4.spec
+++ b/SPECS/python-beautifulsoup4/python-beautifulsoup4.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Xuhai Chang <xuhai.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname beautifulsoup4
+
+Name:           python-%{srcname}
+Version:        4.14.3
+Release:        %autorelease
+Summary:        Screen-scraping library
+License:        MIT
+URL:            https://www.crummy.com/software/BeautifulSoup/bs4/
+#!RemoteAsset:  sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86
+Source0:        https://files.pythonhosted.org/packages/source/b/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l bs4 -L
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(soupsieve)
+BuildRequires:  python3dist(typing-extensions)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Beautiful Soup is a library for pulling data out of HTML and XML files.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-cbor/python-cbor.spec
+++ b/SPECS/python-cbor/python-cbor.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Xuhai Chang <xuhai.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname cbor
+
+Name:           python-%{srcname}
+Version:        1.0.0
+Release:        %autorelease
+Summary:        CBOR encoder and decoder for Python
+License:        Apache-2.0
+URL:            https://github.com/brianolson/cbor_py
+#!RemoteAsset:  sha256:13225a262ddf5615cbd9fd55a76a0d53069d18b07d2e9f19c39e6acb8609bbb6
+Source0:        https://files.pythonhosted.org/packages/source/c/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname} -L
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+CBOR encoder and decoder for Python.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+
+%changelog
+%autochangelog

--- a/SPECS/python-dunamai/python-dunamai.spec
+++ b/SPECS/python-dunamai/python-dunamai.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Xuhai Chang <xuhai.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname dunamai
+
+Name:           python-%{srcname}
+Version:        1.26.1
+Release:        %autorelease
+Summary:        Dynamic versioning library and CLI
+License:        MIT
+URL:            https://github.com/mtkennerly/dunamai
+#!RemoteAsset:  sha256:3b46007bd65b00b4824ead0a1aee365fd22d0ec2b9c219497d4fd48f52860c8b
+Source0:        https://files.pythonhosted.org/packages/source/d/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  %{srcname}
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(poetry-core)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Dunamai is a library and command line tool for producing dynamic, standards-
+compliant version strings, derived from tags in version control.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+%{_bindir}/dunamai
+
+%changelog
+%autochangelog

--- a/SPECS/python-flagembedding/python-flagembedding.spec
+++ b/SPECS/python-flagembedding/python-flagembedding.spec
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Xuhai Chang <xuhai.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname flagembedding
+%global pypi_name flagembedding
+
+Name:           python-%{srcname}
+Version:        1.4.0
+Release:        %autorelease
+Summary:        BGE one-stop retrieval toolkit for search and RAG
+License:        MIT
+URL:            https://github.com/FlagOpen/FlagEmbedding
+#!RemoteAsset:  sha256:2079c14ecf0341d64519785e53c0401122a752e5b6a0ac497f23c02f0d21b3b9
+Source0:        https://files.pythonhosted.org/packages/source/f/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  FlagEmbedding
+# evaluation.* needs faiss (no sdist on PyPI) and pytrec_eval (needs
+# trec_eval C library) which are difficult to package.
+# gemma_model fails: transformers 5.2.0 dropped GEMMA2_START_DOCSTRING.
+BuildOption(check):  -e 'FlagEmbedding.evaluation' -e 'FlagEmbedding.evaluation.*' -e 'FlagEmbedding.abc.evaluation' -e 'FlagEmbedding.abc.evaluation.*' -e 'FlagEmbedding.inference.reranker.decoder_only.models.gemma_model'
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+BuildRequires:  python3dist(torch)
+BuildRequires:  python3dist(transformers)
+BuildRequires:  python3dist(datasets)
+BuildRequires:  python3dist(accelerate)
+BuildRequires:  python3dist(sentence-transformers)
+BuildRequires:  python3dist(peft)
+BuildRequires:  python3dist(ir-datasets)
+BuildRequires:  python3dist(sentencepiece)
+BuildRequires:  python3dist(protobuf)
+# Needed by top-level imports from FlagEmbedding.__init__
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(tqdm)
+BuildRequires:  python3dist(packaging)
+
+Provides:       python3-%{srcname}= %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+FlagEmbedding provides BGE embedding and reranking utilities for search and
+retrieval-augmented generation workflows.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-griffe/python-griffe.spec
+++ b/SPECS/python-griffe/python-griffe.spec
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Xuhai Chang <xuhai.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname griffe
+
+Name:           python-%{srcname}
+Version:        2.0.2
+Release:        %autorelease
+Summary:        Signatures for entire Python programs
+License:        ISC
+URL:            https://github.com/mkdocstrings/griffe
+BuildArch:      noarch
+
+Requires:       python3dist(griffecli) = %{version}
+Requires:       python3dist(griffelib) = %{version}
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+# This is a meta package, so %python_provide is not applicable here.
+Provides:       python3dist(%{srcname}) = %{version}
+
+%description
+Signatures for entire Python programs. Extract the structure, the frame, the
+skeleton of your project, to generate API documentation or find breaking
+changes in your API. This is a meta-package that pulls in griffelib (core
+library) and griffecli (command-line interface).
+
+%files
+
+%changelog
+%autochangelog

--- a/SPECS/python-griffecli/python-griffecli.spec
+++ b/SPECS/python-griffecli/python-griffecli.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Xuhai Chang <xuhai.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname griffecli
+
+Name:           python-%{srcname}
+Version:        2.0.2
+Release:        %autorelease
+Summary:        Griffe command-line interface
+License:        ISC
+URL:            https://github.com/mkdocstrings/griffe
+#!RemoteAsset:  sha256:40a1ad4181fc39685d025e119ae2c5b669acdc1f19b705fb9bf971f4e6f6dffb
+Source0:        https://files.pythonhosted.org/packages/source/g/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  %{srcname}
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(colorama)
+BuildRequires:  python3dist(griffelib)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(pdm-backend)
+BuildRequires:  python3dist(uv-dynamic-versioning)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Command-line interface for Griffe, providing tools to dump API data as JSON
+and check for API breaking changes.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+%{_bindir}/griffecli
+
+%changelog
+%autochangelog

--- a/SPECS/python-griffelib/python-griffelib.spec
+++ b/SPECS/python-griffelib/python-griffelib.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Xuhai Chang <xuhai.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname griffelib
+
+Name:           python-%{srcname}
+Version:        2.0.2
+Release:        %autorelease
+Summary:        Griffe core library for Python API signatures
+License:        ISC
+URL:            https://github.com/mkdocstrings/griffe
+#!RemoteAsset:  sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e
+Source0:        https://files.pythonhosted.org/packages/source/g/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  griffe
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(pdm-backend)
+BuildRequires:  python3dist(uv-dynamic-versioning)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Core library of Griffe, providing the ability to extract the structure, the
+frame, the skeleton of Python projects, to generate API documentation or find
+breaking changes in APIs.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-inscriptis/python-inscriptis.spec
+++ b/SPECS/python-inscriptis/python-inscriptis.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Xuhai Chang <xuhai.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname inscriptis
+
+Name:           python-%{srcname}
+Version:        2.7.1
+Release:        %autorelease
+Summary:        Convert HTML to text
+License:        Apache-2.0
+URL:            https://github.com/weblyzard/inscriptis
+#!RemoteAsset:  sha256:16517bab88ac2c8f01d58748bf070256e8af7a3fac96d1e317b01371d04a3c6e
+Source0:        https://files.pythonhosted.org/packages/source/i/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname} -L
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(lxml)
+BuildRequires:  python3dist(requests)
+BuildRequires:  python3dist(fastapi)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Inscriptis converts HTML documents to plain text.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+%{_bindir}/inscript
+%{_bindir}/inscriptis-api
+
+%changelog
+%autochangelog

--- a/SPECS/python-ir-datasets/python-ir-datasets.spec
+++ b/SPECS/python-ir-datasets/python-ir-datasets.spec
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Xuhai Chang <xuhai.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname ir-datasets
+%global pypi_name ir_datasets
+
+Name:           python-%{srcname}
+Version:        0.5.11
+Release:        %autorelease
+Summary:        Common interface to IR ranking datasets
+License:        MIT
+URL:            https://github.com/allenai/ir_datasets
+#!RemoteAsset:  sha256:06c90af634ae5063c813286b35065debca1a974d26e136403d899f3ecd7ad463
+Source0:        https://files.pythonhosted.org/packages/source/i/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{pypi_name} examples test -L
+# examples.* need external data files not available at build time.
+BuildOption(check):  -e 'examples.*'
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(beautifulsoup4)
+BuildRequires:  python3dist(inscriptis)
+BuildRequires:  python3dist(lxml)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(pyyaml)
+BuildRequires:  python3dist(requests)
+BuildRequires:  python3dist(tqdm)
+BuildRequires:  python3dist(trec-car-tools)
+BuildRequires:  python3dist(lz4)
+BuildRequires:  python3dist(warc3-wet)
+BuildRequires:  python3dist(warc3-wet-clueweb09)
+BuildRequires:  python3dist(zlib-state)
+BuildRequires:  python3dist(ijson)
+BuildRequires:  python3dist(unlzw3)
+BuildRequires:  python3dist(pyarrow)
+BuildRequires:  python3dist(pytest)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+ir-datasets provides a common Python interface to many information retrieval
+ranking benchmarks and training datasets.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+%{_bindir}/ir_datasets
+
+%changelog
+%autochangelog

--- a/SPECS/python-lightning-utilities/python-lightning-utilities.spec
+++ b/SPECS/python-lightning-utilities/python-lightning-utilities.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Xuhai Chang <xuhai.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname lightning-utilities
+%global pypi_name lightning_utilities
+
+Name:           python-%{srcname}
+Version:        0.15.3
+Release:        %autorelease
+Summary:        PyTorch Lightning utilities
+License:        Apache-2.0
+URL:            https://github.com/Lightning-AI/utilities
+#!RemoteAsset:  sha256:792ae0204c79f6859721ac7f386c237a33b0ed06ba775009cb894e010a842033
+Source0:        https://files.pythonhosted.org/packages/source/l/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{pypi_name} -L
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(typing-extensions)
+BuildRequires:  python3dist(requests)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Common utilities for the PyTorch Lightning ecosystem.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-lz4/python-lz4.spec
+++ b/SPECS/python-lz4/python-lz4.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Xuhai Chang <xuhai.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname lz4
+
+Name:           python-%{srcname}
+Version:        4.4.5
+Release:        %autorelease
+Summary:        Python bindings for the LZ4 compression library
+License:        BSD-3-Clause
+URL:            https://github.com/python-lz4/python-lz4
+#!RemoteAsset:  sha256:5f0b9e53c1e82e88c10d7c180069363980136b9d7a8306c4dca4f760d60c39f0
+Source0:        https://files.pythonhosted.org/packages/source/l/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname} -L
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pkgconfig)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Python bindings for the LZ4 compression library.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-milvus-model/python-milvus-model.spec
+++ b/SPECS/python-milvus-model/python-milvus-model.spec
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Xuhai Chang <xuhai.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname milvus-model
+
+Name:           python-%{srcname}
+Version:        0.3.2
+Release:        %autorelease
+Summary:        Model components for PyMilvus, the Python SDK for Milvus
+License:        Apache-2.0
+URL:            https://github.com/milvus-io/milvus-model
+# v0.3.2 is not published on PyPI, use GitHub tarball instead
+#!RemoteAsset:  sha256:cb77e377cd8daffb0dde0fde1a114ac8227e4f9a2229b43211f1c8d9f8922332
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+# Upstream uses setuptools_scm for versioning which requires a git repo.
+# Since we build from a tarball, patch pyproject.toml in %%prep to use a
+# static version string instead.
+BuildOption(install):  pymilvus
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+# build-system.requires (gitpython and setuptools_scm removed in %%prep)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+# core runtime dependencies from pyproject.toml [dependencies]
+BuildRequires:  python3dist(transformers)
+BuildRequires:  python3dist(onnxruntime)
+BuildRequires:  python3dist(scipy)
+BuildRequires:  python3dist(protobuf)
+BuildRequires:  python3dist(numpy)
+# optional dependencies for a fully functional milvus-model package
+BuildRequires:  python3dist(cohere)
+BuildRequires:  python3dist(datasets)
+BuildRequires:  python3dist(flagembedding)
+BuildRequires:  python3dist(mistralai)
+BuildRequires:  python3dist(nltk)
+BuildRequires:  python3dist(nomic)
+BuildRequires:  python3dist(openai)
+BuildRequires:  python3dist(pyyaml)
+BuildRequires:  python3dist(requests)
+BuildRequires:  python3dist(sentence-transformers)
+BuildRequires:  python3dist(torch)
+BuildRequires:  python3dist(voyageai)
+BuildRequires:  python3dist(peft)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+The milvus-model library provides model components for PyMilvus, the official
+Python SDK for Milvus, an open-source vector database built for AI applications.
+
+%prep -a
+# Replace setuptools_scm dynamic versioning with a static version string
+# so the package can be built from a tarball without a git repository.
+sed -i \
+  -e 's/dynamic = \["version"\]/version = "%{version}"/' \
+  -e '/^requires.*=/,/^\]/{ /gitpython/d; /setuptools_scm/d; }' \
+  -e '/\[tool\.setuptools\.dynamic\]/,/^$/{d}' \
+  -e '/\[tool\.setuptools_scm\]/,/^$/{d}' \
+  pyproject.toml
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-mistralai/2000-relax-opentelemetry-semantic-conventions-upper-bound.patch
+++ b/SPECS/python-mistralai/2000-relax-opentelemetry-semantic-conventions-upper-bound.patch
@@ -1,0 +1,11 @@
+--- a/pyproject.toml	2020-02-02 08:00:00
++++ b/pyproject.toml	2026-04-23 22:57:37
+@@ -12,7 +12,7 @@
+     "python-dateutil >=2.8.2",
+     "typing-inspection >=0.4.0",
+     "opentelemetry-api (>=1.33.1,<2.0.0)",
+-    "opentelemetry-semantic-conventions (>=0.60b1,<0.61)",
++    "opentelemetry-semantic-conventions (>=0.60b1,<1.0)",
+     "jsonpath-python >=1.0.6", # required for speakeasy generated path with pagination
+ ]
+ 

--- a/SPECS/python-mistralai/python-mistralai.spec
+++ b/SPECS/python-mistralai/python-mistralai.spec
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Xuhai Chang <xuhai.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname mistralai
+
+Name:           python-%{srcname}
+Version:        2.4.2
+Release:        %autorelease
+Summary:        Python Client SDK for the Mistral AI API
+License:        Apache-2.0
+URL:            https://github.com/mistralai/client-python
+#!RemoteAsset:  sha256:7896ffa763e0be1ec05e5b436d2c21ae089e4b5438cda9033dcd1b25bc3021a2
+Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+# Backport to relax opentelemetry semantic conventions upper bound
+Patch2000:      2000-relax-opentelemetry-semantic-conventions-upper-bound.patch
+
+BuildOption(install):  mistralai
+# Exclude _s3 storage backend: aioboto3 pins aiobotocore==2.25.1 which
+# requires botocore<1.40.62, incompatible with main (1.42.89)
+BuildOption(check):  -e 'mistralai.extra.workflows.encoding.storage._s3'
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(authlib)
+BuildRequires:  python3dist(azure-storage-blob)
+BuildRequires:  python3dist(cryptography)
+BuildRequires:  python3dist(eval-type-backport)
+BuildRequires:  python3dist(gcloud-aio-storage)
+BuildRequires:  python3dist(google-auth)
+BuildRequires:  python3dist(griffe)
+BuildRequires:  python3dist(httpx)
+BuildRequires:  python3dist(jsonpath-python)
+BuildRequires:  python3dist(mcp)
+BuildRequires:  python3dist(opentelemetry-api)
+BuildRequires:  python3dist(opentelemetry-sdk)
+BuildRequires:  python3dist(opentelemetry-semantic-conventions)
+BuildRequires:  python3dist(pydantic)
+BuildRequires:  python3dist(pydantic-core)
+BuildRequires:  python3dist(pydantic-settings)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(python-dateutil)
+BuildRequires:  python3dist(typing-inspection)
+BuildRequires:  python3dist(websockets)
+BuildRequires:  python3dist(hatchling)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+The official Python client SDK for the Mistral AI API, providing access to
+Mistral's language models for chat, embeddings, and other AI capabilities.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-nomic/python-nomic.spec
+++ b/SPECS/python-nomic/python-nomic.spec
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Xuhai Chang <xuhai.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname nomic
+
+Name:           python-%{srcname}
+Version:        3.9.0
+Release:        %autorelease
+Summary:        The official Nomic Python client
+License:        Apache-2.0
+URL:            https://github.com/nomic-ai/nomic
+#!RemoteAsset:  sha256:5be6b2e39ea07cf9db386b663dac792ff6a3d91beccef8eb18820b517cd6c0b6
+Source0:        https://files.pythonhosted.org/packages/source/n/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  nomic
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(click)
+BuildRequires:  python3dist(filetype)
+BuildRequires:  python3dist(jsonlines)
+BuildRequires:  python3dist(jsonschema)
+BuildRequires:  python3dist(loguru)
+BuildRequires:  python3dist(rich)
+BuildRequires:  python3dist(requests)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(pandas)
+BuildRequires:  python3dist(pydantic)
+BuildRequires:  python3dist(tqdm)
+BuildRequires:  python3dist(pyarrow)
+BuildRequires:  python3dist(pillow)
+BuildRequires:  python3dist(pyjwt)
+BuildRequires:  python3dist(pytorch-lightning)
+BuildRequires:  python3dist(boto3)
+BuildRequires:  python3dist(sagemaker)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+The official Python client for Nomic, providing access to Atlas for data
+visualization and exploration, as well as Nomic Embed for text and image
+embeddings.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%{_bindir}/nomic
+
+%changelog
+%autochangelog

--- a/SPECS/python-opentelemetry-api/python-opentelemetry-api.spec
+++ b/SPECS/python-opentelemetry-api/python-opentelemetry-api.spec
@@ -44,8 +44,8 @@ sed -i 's/importlib-metadata >= 6.0, < 8.8.0/importlib-metadata >= 6.0/' pyproje
 %pyproject_buildrequires
 
 %files -f %{pyproject_files}
-%license LICENSE
 %doc README.rst
+%license LICENSE
 
 %changelog
 %autochangelog

--- a/SPECS/python-opentelemetry-sdk/python-opentelemetry-sdk.spec
+++ b/SPECS/python-opentelemetry-sdk/python-opentelemetry-sdk.spec
@@ -35,6 +35,11 @@ traces and metrics from your application.
 %generate_buildrequires
 %pyproject_buildrequires
 
+%prep -a
+# Relax exact version pins on sibling packages
+sed -i 's/opentelemetry-api == /opentelemetry-api >= /' pyproject.toml
+sed -i 's/opentelemetry-semantic-conventions == /opentelemetry-semantic-conventions >= /' pyproject.toml
+
 %files -f %{pyproject_files}
 %doc README.rst
 %license LICENSE

--- a/SPECS/python-opentelemetry-semantic-conventions/python-opentelemetry-semantic-conventions.spec
+++ b/SPECS/python-opentelemetry-semantic-conventions/python-opentelemetry-semantic-conventions.spec
@@ -38,8 +38,8 @@ a set of well-defined attribute keys and values for common telemetry concepts.
 %pyproject_buildrequires
 
 %files -f %{pyproject_files}
-%license LICENSE
 %doc README.rst
+%license LICENSE
 
 %changelog
 %autochangelog

--- a/SPECS/python-pytorch-lightning/python-pytorch-lightning.spec
+++ b/SPECS/python-pytorch-lightning/python-pytorch-lightning.spec
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Xuhai Chang <xuhai.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pytorch-lightning
+%global pypi_name pytorch_lightning
+
+Name:           python-%{srcname}
+Version:        2.6.4
+Release:        %autorelease
+Summary:        The lightweight PyTorch wrapper for ML researchers
+License:        Apache-2.0
+URL:            https://github.com/Lightning-AI/lightning
+#!RemoteAsset:  sha256:fdd2a7052b9afb92394968205b9b55baab426aa57dec11b95bf1b84a67c2bc25
+Source0:        https://files.pythonhosted.org/packages/source/p/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{pypi_name} lightning_fabric -L
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(torch)
+BuildRequires:  python3dist(tqdm)
+BuildRequires:  python3dist(pyyaml)
+BuildRequires:  python3dist(fsspec)
+BuildRequires:  python3dist(torchmetrics)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(typing-extensions)
+BuildRequires:  python3dist(lightning-utilities)
+BuildRequires:  python3dist(requests)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+PyTorch Lightning is the lightweight PyTorch wrapper for high-performance
+AI research. Scale your models, not the boilerplate.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-soupsieve/python-soupsieve.spec
+++ b/SPECS/python-soupsieve/python-soupsieve.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Xuhai Chang <xuhai.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname soupsieve
+
+Name:           python-%{srcname}
+Version:        2.8.4
+Release:        %autorelease
+Summary:        CSS selector library for Beautiful Soup
+License:        MIT
+URL:            https://github.com/facelessuser/soupsieve
+#!RemoteAsset:  sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e
+Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname} -L
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(hatchling)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Soup Sieve is a CSS selector library designed to be used with Beautiful Soup.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+# soupsieve and beautifulsoup4 have a circular build dependency.
+# Skip %%check to break the cycle.
+%check
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE.md
+
+%changelog
+%autochangelog

--- a/SPECS/python-torchmetrics/python-torchmetrics.spec
+++ b/SPECS/python-torchmetrics/python-torchmetrics.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Xuhai Chang <xuhai.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname torchmetrics
+
+Name:           python-%{srcname}
+Version:        1.9.0
+Release:        %autorelease
+Summary:        Collection of PyTorch metric implementations
+License:        Apache-2.0
+URL:            https://github.com/Lightning-AI/torchmetrics
+#!RemoteAsset:  sha256:a488609948600df52d3db4fcdab02e62aab2a85ef34da67037dc3e65b8512faa
+Source0:        https://files.pythonhosted.org/packages/source/t/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname} -L
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(torch)
+BuildRequires:  python3dist(lightning-utilities)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+TorchMetrics is a collection of machine learning metrics for PyTorch.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-trec-car-tools/python-trec-car-tools.spec
+++ b/SPECS/python-trec-car-tools/python-trec-car-tools.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Xuhai Chang <xuhai.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname trec-car-tools
+
+Name:           python-%{srcname}
+Version:        2.6
+Release:        %autorelease
+Summary:        Tools for the TREC CAR dataset
+License:        MIT
+URL:            https://github.com/TREMA-UNH/trec-car-tools
+#!RemoteAsset:  sha256:2fce2de120224fd569b151d5bed358a4ed334e643889b9e3dfe3e5a3d15d21c8
+Source0:        https://files.pythonhosted.org/packages/source/t/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l trec_car -L
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(cbor)
+BuildRequires:  python3dist(numpy)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Python tools for reading and processing TREC CAR datasets.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+
+%changelog
+%autochangelog

--- a/SPECS/python-unlzw3/python-unlzw3.spec
+++ b/SPECS/python-unlzw3/python-unlzw3.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Xuhai Chang <xuhai.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname unlzw3
+
+Name:           python-%{srcname}
+Version:        0.2.3
+Release:        %autorelease
+Summary:        Pure Python LZW decompressor
+License:        MIT
+URL:            https://github.com/umeat/unlzw3
+#!RemoteAsset:  sha256:ede5d928c792fff9da406f20334f9739693327f448f383ae1df1774627197bbb
+Source0:        https://files.pythonhosted.org/packages/source/u/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname} -L
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+unlzw3 is a pure Python implementation of LZW decompression.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+
+%changelog
+%autochangelog

--- a/SPECS/python-uv-dynamic-versioning/python-uv-dynamic-versioning.spec
+++ b/SPECS/python-uv-dynamic-versioning/python-uv-dynamic-versioning.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Xuhai Chang <xuhai.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname uv-dynamic-versioning
+%global pypi_name uv_dynamic_versioning
+
+Name:           python-%{srcname}
+Version:        0.14.0
+Release:        %autorelease
+Summary:        Dynamic versioning plugin for hatchling using uv
+License:        MIT
+URL:            https://github.com/ninoseki/uv-dynamic-versioning
+#!RemoteAsset:  sha256:574fbc07e87ace45c01d55967ad3b864871257b98ff5b8ac87c261227ac8db5b
+Source0:        https://files.pythonhosted.org/packages/source/u/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  %{pypi_name}
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(dunamai)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(jinja2)
+BuildRequires:  python3dist(tomlkit)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+A hatchling plugin for dynamic versioning powered by dunamai, designed to
+work with uv-based Python projects.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+%{_bindir}/uv-dynamic-versioning
+
+%changelog
+%autochangelog

--- a/SPECS/python-warc3-wet-clueweb09/python-warc3-wet-clueweb09.spec
+++ b/SPECS/python-warc3-wet-clueweb09/python-warc3-wet-clueweb09.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Xuhai Chang <xuhai.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname warc3-wet-clueweb09
+
+Name:           python-%{srcname}
+Version:        0.2.5
+Release:        %autorelease
+Summary:        ClueWeb09 WARC WET parser
+License:        MIT
+URL:            https://github.com/seanmacavaney/warc3-wet-clueweb09
+#!RemoteAsset:  sha256:3054bfc07da525d5967df8ca3175f78fa3f78514c82643f8c81fbca96300b836
+Source0:        https://files.pythonhosted.org/packages/source/w/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l warc3_wet_clueweb09 -L
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Parser for ClueWeb09 WARC WET files used by ir-datasets.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+
+%changelog
+%autochangelog

--- a/SPECS/python-warc3-wet/python-warc3-wet.spec
+++ b/SPECS/python-warc3-wet/python-warc3-wet.spec
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Xuhai Chang <xuhai.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname warc3-wet
+%global pypi_name warc3_wet
+
+Name:           python-%{srcname}
+Version:        0.2.5
+Release:        %autorelease
+Summary:        WARC WET file parser
+License:        MIT
+URL:            https://github.com/seanmacavaney/warc3-wet
+#!RemoteAsset:  sha256:15e50402dabaa1e95307f1e2a6169cfd5f137b70761d9f0b16a10aa6de227970
+Source0:        https://files.pythonhosted.org/packages/source/w/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l warc -L
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Parser for WARC WET files used by ir-datasets.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+
+%changelog
+%autochangelog

--- a/SPECS/python-zlib-state/python-zlib-state.spec
+++ b/SPECS/python-zlib-state/python-zlib-state.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Xuhai Chang <xuhai.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname zlib-state
+%global pypi_name zlib_state
+
+Name:           python-%{srcname}
+Version:        0.1.12
+Release:        %autorelease
+Summary:        Save and restore zlib state
+License:        MIT
+URL:            https://github.com/seanmacavaney/zlib-state
+#!RemoteAsset:  sha256:ccbb06321daf165b022aa4d22d62effb7df76f55035d50bbe8b93696db416cf0
+Source0:        https://files.pythonhosted.org/packages/source/z/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l zlib_state -L
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+BuildRequires:  pkgconfig(zlib)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+zlib-state provides helpers for saving and restoring zlib decompression state.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%{python3_sitearch}/_zlib_state*.so
+
+%changelog
+%autochangelog


### PR DESCRIPTION
necessity: a bunch of python dependencies for python-milvus-model
python-milvus-model itself is included, finally