### PR TITLE
SPECS: onnxruntime: Workaround -Werror with gcc16

### DIFF
--- a/SPECS/onnxruntime/onnxruntime.spec
+++ b/SPECS/onnxruntime/onnxruntime.spec
@@ -30,8 +30,8 @@ BuildOption(conf):  -DCMAKE_INSTALL_LIBDIR=%{_lib}
 BuildOption(conf):  -DCMAKE_INSTALL_INCLUDEDIR=include
 BuildOption(conf):  -Donnxruntime_ENABLE_CPUINFO=ON
 BuildOption(conf):  -Donnxruntime_INSTALL_UNIT_TESTS=OFF
-# disable Werror uninitialized to avoid build failures
-BuildOption(conf):  -DCMAKE_CXX_FLAGS="-Wno-error=uninitialized"
+# FIXME: Avoid build failures with gcc >= 15.
+BuildOption(conf):  -DCMAKE_CXX_FLAGS="-Wno-error=uninitialized -Wno-error=sfinae-incomplete -Wno-error=maybe-uninitialized"
 BuildOption(conf):  -DCMAKE_C_FLAGS="-Wno-error=uninitialized"
 
 BuildRequires:  cmake
@@ -163,4 +163,4 @@ ln -s "../../../../libonnxruntime_providers_shared.so.%{version}" "%{buildroot}/
 %{python3_sitearch}/onnxruntime/capi/libonnxruntime_providers_shared.so
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Failure on riscv64 and x86-64:
```
/home/abuild/rpmbuild/BUILD/onnxruntime-1.24.1-build/onnxruntime-1.24.1/include/onnxruntime/core/graph/graph.h:68:7: error: defining 鈥榦nnxruntime::Node鈥�, which previously failed to be complete in a SFINAE context [-Werror=sfinae-incomplete=]
   68 | class Node {
      |       ^~~~
```
Failure on riscv64 only:
```
/home/abuild/rpmbuild/BUILD/onnxruntime-1.24.1-build/onnxruntime-1.24.1/onnxruntime/core/optimizer/concat_slice_elimination.cc:223:17: error: 鈥�*(absl::lts_20260107::inlined_vector_internal::ValueType*)((char*)&axes + offsetof(absl::lts_20260107::InlinedVector<long int, 6, std::allocator<long int> >,absl::lts_20260107::InlinedVector<long int, 6, std::allocator<long int> >::storage_.absl::lts_20260107::inlined_vector_internal::Storage<long int, 6, std::allocator<long int> >::data_))鈥� may be used uninitialized [-Werror=maybe-uninitialized]
  223 |     if (axes[0] != 0) return false;
```

This is not a good but worked fix.