### PR TITLE
SPECS: discover: Fix Requires typo.

### DIFF
--- a/SPECS/discover/discover.spec
+++ b/SPECS/discover/discover.spec
@@ -68,7 +68,7 @@ Requires:       kf6-kdeclarative >= %{kf6_version}
 Requires:       kf6-kirigami >= %{kf6_version}
 Requires:       kf6-kuserfeedback >= %{kf6_version}
 Requires:       kirigami-addons
-Requires:       qt6-declarative >= %{qt6_version}
+Requires:       qt6-qtdeclarative >= %{qt6_version}
 
 Recommends:     discover-backend-flatpak
 Recommends:     discover-backend-fwupd


### PR DESCRIPTION
This Pull Request fixes a typo in the `discover` package spec by correcting the Qt6 declarative dependency name.