### PR TITLE
SPECS: Add AWS SDK for Go dependencies of Prometheus v3.12.0

### DIFF
--- a/SPECS/go-github-aws-aws-sdk-go-v2-config/go-github-aws-aws-sdk-go-v2-config.spec
+++ b/SPECS/go-github-aws-aws-sdk-go-v2-config/go-github-aws-aws-sdk-go-v2-config.spec
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           aws-sdk-go-v2-config
+%define go_import_path  github.com/aws/aws-sdk-go-v2/config
+%define archive_dir     aws-sdk-go-v2-config-v1.32.18
+
+# This module is one Go module carved out of the aws-sdk-go-v2 monorepo. Its
+# upstream test suite assumes the full monorepo checkout (sibling modules and
+# cross-module internal/ test helpers), which is not reproducible when each
+# module is built in isolation as a distro package. Run the tests but do not
+# let unreproducible test setups fail the build (matches go-github-aws-smithy-go).
+%define go_test_ignore_failure 1
+
+Name:           go-github-aws-aws-sdk-go-v2-config
+Version:        1.32.18
+Release:        %autorelease
+Summary:        Shared configuration loader for AWS SDK for Go v2
+License:        Apache-2.0
+URL:            https://github.com/aws/aws-sdk-go-v2
+#!RemoteAsset:  sha256:0f1394ff128251eae5b5f4cd13d0f255d865c41bcd2333d30bf91623ff656696
+Source0:        %{url}/archive/refs/tags/config/v1.32.18.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{archive_dir}
+
+BuildRequires:  go >= 1.24
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/credentials)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/feature/ec2/imds)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/configsources)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/endpoints/v2)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/v4a)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/service/internal/presigned-url)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/service/signin)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/service/sso)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/service/ssooidc)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/service/sts)
+BuildRequires:  go(github.com/aws/smithy-go)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/aws/aws-sdk-go-v2)
+Requires:       go(github.com/aws/aws-sdk-go-v2/credentials)
+Requires:       go(github.com/aws/aws-sdk-go-v2/feature/ec2/imds)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/configsources)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/endpoints/v2)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/v4a)
+Requires:       go(github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding)
+Requires:       go(github.com/aws/aws-sdk-go-v2/service/internal/presigned-url)
+Requires:       go(github.com/aws/aws-sdk-go-v2/service/signin)
+Requires:       go(github.com/aws/aws-sdk-go-v2/service/sso)
+Requires:       go(github.com/aws/aws-sdk-go-v2/service/ssooidc)
+Requires:       go(github.com/aws/aws-sdk-go-v2/service/sts)
+Requires:       go(github.com/aws/smithy-go)
+
+%description
+This package provides the AWS SDK for Go v2 shared configuration loader.
+It loads SDK settings from environment variables, shared configuration
+files, credentials files, and related AWS identity providers.
+
+%prep -a
+# AWS SDK for Go v2 is a monorepo; keep only the current submodule's source.
+rm -rf ../module-root
+mkdir ../module-root
+cp -a config/. ../module-root/
+cp -a LICENSE.txt NOTICE.txt README.md ../module-root/ 2>/dev/null || :
+find . -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+cp -a ../module-root/. .
+rm -rf ../module-root
+# Drop upstream monorepo-local replace directives; deps come from system RPMs.
+sed -i '/^replace /d' go.mod
+
+%files
+%license LICENSE* NOTICE.txt
+%doc README*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-aws-aws-sdk-go-v2-credentials/go-github-aws-aws-sdk-go-v2-credentials.spec
+++ b/SPECS/go-github-aws-aws-sdk-go-v2-credentials/go-github-aws-aws-sdk-go-v2-credentials.spec
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           aws-sdk-go-v2-credentials
+%define go_import_path  github.com/aws/aws-sdk-go-v2/credentials
+%define archive_dir     aws-sdk-go-v2-credentials-v1.19.17
+
+# This module is one Go module carved out of the aws-sdk-go-v2 monorepo. Its
+# upstream test suite assumes the full monorepo checkout (sibling modules and
+# cross-module internal/ test helpers), which is not reproducible when each
+# module is built in isolation as a distro package. Run the tests but do not
+# let unreproducible test setups fail the build (matches go-github-aws-smithy-go).
+%define go_test_ignore_failure 1
+
+Name:           go-github-aws-aws-sdk-go-v2-credentials
+Version:        1.19.17
+Release:        %autorelease
+Summary:        Credential providers for AWS SDK for Go v2
+License:        Apache-2.0
+URL:            https://github.com/aws/aws-sdk-go-v2
+#!RemoteAsset:  sha256:35167b70ca7acd5e6c3d0245840975601550b0cd9f8af3cdb43fb6dc902856c8
+Source0:        %{url}/archive/refs/tags/credentials/v1.19.17.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{archive_dir}
+
+BuildRequires:  go >= 1.24
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/feature/ec2/imds)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/configsources)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/endpoints/v2)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/v4a)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/service/internal/presigned-url)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/service/signin)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/service/sso)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/service/ssooidc)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/service/sts)
+BuildRequires:  go(github.com/aws/smithy-go)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/aws/aws-sdk-go-v2)
+Requires:       go(github.com/aws/aws-sdk-go-v2/feature/ec2/imds)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/configsources)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/endpoints/v2)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/v4a)
+Requires:       go(github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding)
+Requires:       go(github.com/aws/aws-sdk-go-v2/service/internal/presigned-url)
+Requires:       go(github.com/aws/aws-sdk-go-v2/service/signin)
+Requires:       go(github.com/aws/aws-sdk-go-v2/service/sso)
+Requires:       go(github.com/aws/aws-sdk-go-v2/service/ssooidc)
+Requires:       go(github.com/aws/aws-sdk-go-v2/service/sts)
+Requires:       go(github.com/aws/smithy-go)
+
+%description
+This package provides credential providers for AWS SDK for Go v2,
+including shared file, environment, EC2 metadata, SSO, and STS-based
+credential loading.
+
+%prep -a
+# AWS SDK for Go v2 is a monorepo; keep only the current submodule's source.
+rm -rf ../module-root
+mkdir ../module-root
+cp -a credentials/. ../module-root/
+cp -a LICENSE.txt NOTICE.txt README.md ../module-root/ 2>/dev/null || :
+find . -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+cp -a ../module-root/. .
+rm -rf ../module-root
+# Drop upstream monorepo-local replace directives; deps come from system RPMs.
+sed -i '/^replace /d' go.mod
+
+%files
+%license LICENSE* NOTICE.txt
+%doc README*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-aws-aws-sdk-go-v2-feature-ec2-imds/go-github-aws-aws-sdk-go-v2-feature-ec2-imds.spec
+++ b/SPECS/go-github-aws-aws-sdk-go-v2-feature-ec2-imds/go-github-aws-aws-sdk-go-v2-feature-ec2-imds.spec
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           aws-sdk-go-v2-feature-ec2-imds
+%define go_import_path  github.com/aws/aws-sdk-go-v2/feature/ec2/imds
+%define archive_dir     aws-sdk-go-v2-feature-ec2-imds-v1.18.23
+
+# This module is one Go module carved out of the aws-sdk-go-v2 monorepo. Its
+# upstream test suite assumes the full monorepo checkout (sibling modules and
+# cross-module internal/ test helpers), which is not reproducible when each
+# module is built in isolation as a distro package. Run the tests but do not
+# let unreproducible test setups fail the build (matches go-github-aws-smithy-go).
+%define go_test_ignore_failure 1
+
+Name:           go-github-aws-aws-sdk-go-v2-feature-ec2-imds
+Version:        1.18.23
+Release:        %autorelease
+Summary:        EC2 Instance Metadata Service client for AWS SDK for Go v2
+License:        Apache-2.0
+URL:            https://github.com/aws/aws-sdk-go-v2
+#!RemoteAsset:  sha256:d60769dfc962ecc8f40b61e95e5edb7108f66cc17038f7be47c863f245880c6a
+Source0:        %{url}/archive/refs/tags/feature/ec2/imds/v1.18.23.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{archive_dir}
+
+BuildRequires:  go >= 1.24
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2)
+BuildRequires:  go(github.com/aws/smithy-go)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/aws/aws-sdk-go-v2)
+Requires:       go(github.com/aws/smithy-go)
+
+%description
+This package provides the Amazon EC2 Instance Metadata Service client
+used by AWS SDK for Go v2 credential and configuration providers.
+
+%prep -a
+# AWS SDK for Go v2 is a monorepo; keep only the current submodule's source.
+rm -rf ../module-root
+mkdir ../module-root
+cp -a feature/ec2/imds/. ../module-root/
+cp -a LICENSE.txt NOTICE.txt README.md ../module-root/ 2>/dev/null || :
+find . -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+cp -a ../module-root/. .
+rm -rf ../module-root
+# Drop upstream monorepo-local replace directives; deps come from system RPMs.
+sed -i '/^replace /d' go.mod
+
+%files
+%license LICENSE* NOTICE.txt
+%doc README*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-aws-aws-sdk-go-v2-internal-configsources/go-github-aws-aws-sdk-go-v2-internal-configsources.spec
+++ b/SPECS/go-github-aws-aws-sdk-go-v2-internal-configsources/go-github-aws-aws-sdk-go-v2-internal-configsources.spec
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           aws-sdk-go-v2-internal-configsources
+%define go_import_path  github.com/aws/aws-sdk-go-v2/internal/configsources
+%define archive_dir     aws-sdk-go-v2-internal-configsources-v1.4.23
+
+# This module is one Go module carved out of the aws-sdk-go-v2 monorepo. Its
+# upstream test suite assumes the full monorepo checkout (sibling modules and
+# cross-module internal/ test helpers), which is not reproducible when each
+# module is built in isolation as a distro package. Run the tests but do not
+# let unreproducible test setups fail the build (matches go-github-aws-smithy-go).
+%define go_test_ignore_failure 1
+
+Name:           go-github-aws-aws-sdk-go-v2-internal-configsources
+Version:        1.4.23
+Release:        %autorelease
+Summary:        Internal configuration source helpers for AWS SDK for Go v2
+License:        Apache-2.0
+URL:            https://github.com/aws/aws-sdk-go-v2
+#!RemoteAsset:  sha256:7680c9ffee0ece2917f216da641d580a366c93a16edbad1f4189e3c0d4af318d
+Source0:        %{url}/archive/refs/tags/internal/configsources/v1.4.23.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{archive_dir}
+
+BuildRequires:  go >= 1.24
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2)
+BuildRequires:  go(github.com/aws/smithy-go)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/aws/aws-sdk-go-v2)
+Requires:       go(github.com/aws/smithy-go)
+
+%description
+This package provides internal configuration source helpers shared by
+AWS SDK for Go v2 service clients and configuration modules.
+
+%prep -a
+# AWS SDK for Go v2 is a monorepo; keep only the current submodule's source.
+rm -rf ../module-root
+mkdir ../module-root
+cp -a internal/configsources/. ../module-root/
+cp -a LICENSE.txt NOTICE.txt README.md ../module-root/ 2>/dev/null || :
+find . -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+cp -a ../module-root/. .
+rm -rf ../module-root
+# Drop upstream monorepo-local replace directives; deps come from system RPMs.
+sed -i '/^replace /d' go.mod
+
+%files
+%license LICENSE* NOTICE.txt
+%doc README*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-aws-aws-sdk-go-v2-internal-endpoints-v2/go-github-aws-aws-sdk-go-v2-internal-endpoints-v2.spec
+++ b/SPECS/go-github-aws-aws-sdk-go-v2-internal-endpoints-v2/go-github-aws-aws-sdk-go-v2-internal-endpoints-v2.spec
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           aws-sdk-go-v2-internal-endpoints-v2
+%define go_import_path  github.com/aws/aws-sdk-go-v2/internal/endpoints/v2
+%define archive_dir     aws-sdk-go-v2-internal-endpoints-v2.7.23
+
+# This module is one Go module carved out of the aws-sdk-go-v2 monorepo. Its
+# upstream test suite assumes the full monorepo checkout (sibling modules and
+# cross-module internal/ test helpers), which is not reproducible when each
+# module is built in isolation as a distro package. Run the tests but do not
+# let unreproducible test setups fail the build (matches go-github-aws-smithy-go).
+%define go_test_ignore_failure 1
+
+Name:           go-github-aws-aws-sdk-go-v2-internal-endpoints-v2
+Version:        2.7.23
+Release:        %autorelease
+Summary:        Internal endpoint resolution helpers for AWS SDK for Go v2
+License:        Apache-2.0
+URL:            https://github.com/aws/aws-sdk-go-v2
+#!RemoteAsset:  sha256:e4f0c6f86e40e22cecfdf2f7075880a049db6eeae8f5989288a4fcf64e236b08
+Source0:        %{url}/archive/refs/tags/internal/endpoints/v2.7.23.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{archive_dir}
+
+BuildRequires:  go >= 1.24
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2)
+BuildRequires:  go(github.com/aws/smithy-go)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/aws/aws-sdk-go-v2)
+Requires:       go(github.com/aws/smithy-go)
+
+%description
+This package provides internal endpoint resolution helpers used by AWS
+SDK for Go v2 service clients.
+
+%prep -a
+# AWS SDK for Go v2 is a monorepo; keep only the current submodule's source.
+rm -rf ../module-root
+mkdir ../module-root
+cp -a internal/endpoints/v2/. ../module-root/
+cp -a LICENSE.txt NOTICE.txt README.md ../module-root/ 2>/dev/null || :
+find . -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+cp -a ../module-root/. .
+rm -rf ../module-root
+# Drop upstream monorepo-local replace directives; deps come from system RPMs.
+sed -i '/^replace /d' go.mod
+
+%files
+%license LICENSE* NOTICE.txt
+%doc README*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-aws-aws-sdk-go-v2-internal-v4a/go-github-aws-aws-sdk-go-v2-internal-v4a.spec
+++ b/SPECS/go-github-aws-aws-sdk-go-v2-internal-v4a/go-github-aws-aws-sdk-go-v2-internal-v4a.spec
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           aws-sdk-go-v2-internal-v4a
+%define go_import_path  github.com/aws/aws-sdk-go-v2/internal/v4a
+%define archive_dir     aws-sdk-go-v2-internal-v4a-v1.4.24
+
+# This module is one Go module carved out of the aws-sdk-go-v2 monorepo. Its
+# upstream test suite assumes the full monorepo checkout (sibling modules and
+# cross-module internal/ test helpers), which is not reproducible when each
+# module is built in isolation as a distro package. Run the tests but do not
+# let unreproducible test setups fail the build (matches go-github-aws-smithy-go).
+%define go_test_ignore_failure 1
+
+Name:           go-github-aws-aws-sdk-go-v2-internal-v4a
+Version:        1.4.24
+Release:        %autorelease
+Summary:        Internal SigV4a signing helpers for AWS SDK for Go v2
+License:        Apache-2.0
+URL:            https://github.com/aws/aws-sdk-go-v2
+#!RemoteAsset:  sha256:cf7c040b0c4d3a0bba4a13f48b0e8c1535943cd8bd5cc8ab1d9905c8d475b990
+Source0:        %{url}/archive/refs/tags/internal/v4a/v1.4.24.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{archive_dir}
+
+BuildRequires:  go >= 1.24
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2)
+BuildRequires:  go(github.com/aws/smithy-go)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/aws/aws-sdk-go-v2)
+Requires:       go(github.com/aws/smithy-go)
+
+%description
+This package provides the internal AWS Signature Version 4A (SigV4a)
+signing implementation used by AWS SDK for Go v2 service clients.
+
+%prep -a
+# AWS SDK for Go v2 is a monorepo; keep only the current submodule's source.
+rm -rf ../module-root
+mkdir ../module-root
+cp -a internal/v4a/. ../module-root/
+cp -a LICENSE.txt NOTICE.txt README.md ../module-root/ 2>/dev/null || :
+find . -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+cp -a ../module-root/. .
+rm -rf ../module-root
+# Drop upstream monorepo-local replace directives; deps come from system RPMs.
+sed -i '/^replace /d' go.mod
+
+%files
+%license LICENSE* NOTICE.txt
+%doc README*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-aws-aws-sdk-go-v2-service-ec2/go-github-aws-aws-sdk-go-v2-service-ec2.spec
+++ b/SPECS/go-github-aws-aws-sdk-go-v2-service-ec2/go-github-aws-aws-sdk-go-v2-service-ec2.spec
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           aws-sdk-go-v2-service-ec2
+%define go_import_path  github.com/aws/aws-sdk-go-v2/service/ec2
+%define archive_dir     aws-sdk-go-v2-service-ec2-v1.304.0
+
+# This module is one Go module carved out of the aws-sdk-go-v2 monorepo. Its
+# upstream test suite assumes the full monorepo checkout (sibling modules and
+# cross-module internal/ test helpers), which is not reproducible when each
+# module is built in isolation as a distro package. Run the tests but do not
+# let unreproducible test setups fail the build (matches go-github-aws-smithy-go).
+%define go_test_ignore_failure 1
+
+Name:           go-github-aws-aws-sdk-go-v2-service-ec2
+Version:        1.304.0
+Release:        %autorelease
+Summary:        Amazon EC2 service client for AWS SDK for Go v2
+License:        Apache-2.0
+URL:            https://github.com/aws/aws-sdk-go-v2
+#!RemoteAsset:  sha256:cef587e0c54be57c58480af9a0e11cbe1f6ee1a717968af2e9f7fff49395612a
+Source0:        %{url}/archive/refs/tags/service/ec2/v1.304.0.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{archive_dir}
+
+BuildRequires:  go >= 1.24
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/configsources)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/endpoints/v2)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/service/internal/presigned-url)
+BuildRequires:  go(github.com/aws/smithy-go)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/aws/aws-sdk-go-v2)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/configsources)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/endpoints/v2)
+Requires:       go(github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding)
+Requires:       go(github.com/aws/aws-sdk-go-v2/service/internal/presigned-url)
+Requires:       go(github.com/aws/smithy-go)
+
+%description
+This package provides the Amazon Elastic Compute Cloud service client
+for AWS SDK for Go v2.
+
+%prep -a
+# AWS SDK for Go v2 is a monorepo; keep only the current submodule's source.
+rm -rf ../module-root
+mkdir ../module-root
+cp -a service/ec2/. ../module-root/
+cp -a LICENSE.txt NOTICE.txt README.md ../module-root/ 2>/dev/null || :
+find . -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+cp -a ../module-root/. .
+rm -rf ../module-root
+# Drop upstream monorepo-local replace directives; deps come from system RPMs.
+sed -i '/^replace /d' go.mod
+
+%files
+%license LICENSE* NOTICE.txt
+%doc README*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-aws-aws-sdk-go-v2-service-ecs/go-github-aws-aws-sdk-go-v2-service-ecs.spec
+++ b/SPECS/go-github-aws-aws-sdk-go-v2-service-ecs/go-github-aws-aws-sdk-go-v2-service-ecs.spec
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           aws-sdk-go-v2-service-ecs
+%define go_import_path  github.com/aws/aws-sdk-go-v2/service/ecs
+%define archive_dir     aws-sdk-go-v2-service-ecs-v1.81.0
+
+# This module is one Go module carved out of the aws-sdk-go-v2 monorepo. Its
+# upstream test suite assumes the full monorepo checkout (sibling modules and
+# cross-module internal/ test helpers), which is not reproducible when each
+# module is built in isolation as a distro package. Run the tests but do not
+# let unreproducible test setups fail the build (matches go-github-aws-smithy-go).
+%define go_test_ignore_failure 1
+
+Name:           go-github-aws-aws-sdk-go-v2-service-ecs
+Version:        1.81.0
+Release:        %autorelease
+Summary:        Amazon ECS service client for AWS SDK for Go v2
+License:        Apache-2.0
+URL:            https://github.com/aws/aws-sdk-go-v2
+#!RemoteAsset:  sha256:6e2e99f68f0b8f3334ffd33f300bc43b3c039776b37cc69a2f1e79871d53834f
+Source0:        %{url}/archive/refs/tags/service/ecs/v1.81.0.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{archive_dir}
+
+BuildRequires:  go >= 1.24
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/configsources)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/endpoints/v2)
+BuildRequires:  go(github.com/aws/smithy-go)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/aws/aws-sdk-go-v2)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/configsources)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/endpoints/v2)
+Requires:       go(github.com/aws/smithy-go)
+
+%description
+This package provides the Amazon Elastic Container Service client for
+AWS SDK for Go v2.
+
+%prep -a
+# AWS SDK for Go v2 is a monorepo; keep only the current submodule's source.
+rm -rf ../module-root
+mkdir ../module-root
+cp -a service/ecs/. ../module-root/
+cp -a LICENSE.txt NOTICE.txt README.md ../module-root/ 2>/dev/null || :
+find . -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+cp -a ../module-root/. .
+rm -rf ../module-root
+# Drop upstream monorepo-local replace directives; deps come from system RPMs.
+sed -i '/^replace /d' go.mod
+
+%files
+%license LICENSE* NOTICE.txt
+%doc README*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-aws-aws-sdk-go-v2-service-elasticache/go-github-aws-aws-sdk-go-v2-service-elasticache.spec
+++ b/SPECS/go-github-aws-aws-sdk-go-v2-service-elasticache/go-github-aws-aws-sdk-go-v2-service-elasticache.spec
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           aws-sdk-go-v2-service-elasticache
+%define go_import_path  github.com/aws/aws-sdk-go-v2/service/elasticache
+%define archive_dir     aws-sdk-go-v2-service-elasticache-v1.52.2
+
+# This module is one Go module carved out of the aws-sdk-go-v2 monorepo. Its
+# upstream test suite assumes the full monorepo checkout (sibling modules and
+# cross-module internal/ test helpers), which is not reproducible when each
+# module is built in isolation as a distro package. Run the tests but do not
+# let unreproducible test setups fail the build (matches go-github-aws-smithy-go).
+%define go_test_ignore_failure 1
+
+Name:           go-github-aws-aws-sdk-go-v2-service-elasticache
+Version:        1.52.2
+Release:        %autorelease
+Summary:        Amazon ElastiCache service client for AWS SDK for Go v2
+License:        Apache-2.0
+URL:            https://github.com/aws/aws-sdk-go-v2
+#!RemoteAsset:  sha256:5a4202d52408e9dd2177fd1d516a2da9248ab2c6af78aa89773411d3e5fb1128
+Source0:        %{url}/archive/refs/tags/service/elasticache/v1.52.2.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{archive_dir}
+
+BuildRequires:  go >= 1.24
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/configsources)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/endpoints/v2)
+BuildRequires:  go(github.com/aws/smithy-go)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/aws/aws-sdk-go-v2)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/configsources)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/endpoints/v2)
+Requires:       go(github.com/aws/smithy-go)
+
+%description
+This package provides the Amazon ElastiCache service client for AWS SDK
+for Go v2.
+
+%prep -a
+# AWS SDK for Go v2 is a monorepo; keep only the current submodule's source.
+rm -rf ../module-root
+mkdir ../module-root
+cp -a service/elasticache/. ../module-root/
+cp -a LICENSE.txt NOTICE.txt README.md ../module-root/ 2>/dev/null || :
+find . -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+cp -a ../module-root/. .
+rm -rf ../module-root
+# Drop upstream monorepo-local replace directives; deps come from system RPMs.
+sed -i '/^replace /d' go.mod
+
+%files
+%license LICENSE* NOTICE.txt
+%doc README*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-aws-aws-sdk-go-v2-service-internal-accept-encoding/go-github-aws-aws-sdk-go-v2-service-internal-accept-encoding.spec
+++ b/SPECS/go-github-aws-aws-sdk-go-v2-service-internal-accept-encoding/go-github-aws-aws-sdk-go-v2-service-internal-accept-encoding.spec
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           aws-sdk-go-v2-service-internal-accept-encoding
+%define go_import_path  github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding
+%define archive_dir     aws-sdk-go-v2-service-internal-accept-encoding-v1.13.9
+
+# This module is one Go module carved out of the aws-sdk-go-v2 monorepo. Its
+# upstream test suite assumes the full monorepo checkout (sibling modules and
+# cross-module internal/ test helpers), which is not reproducible when each
+# module is built in isolation as a distro package. Run the tests but do not
+# let unreproducible test setups fail the build (matches go-github-aws-smithy-go).
+%define go_test_ignore_failure 1
+
+Name:           go-github-aws-aws-sdk-go-v2-service-internal-accept-encoding
+Version:        1.13.9
+Release:        %autorelease
+Summary:        Internal accept-encoding middleware for AWS SDK for Go v2
+License:        Apache-2.0
+URL:            https://github.com/aws/aws-sdk-go-v2
+#!RemoteAsset:  sha256:b3d59d444418d07581a84f00cae0917c85f77a5d6c819ec0bca771851cdb6014
+Source0:        %{url}/archive/refs/tags/service/internal/accept-encoding/v1.13.9.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{archive_dir}
+
+BuildRequires:  go >= 1.24
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/aws/smithy-go)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/aws/smithy-go)
+
+%description
+This package provides internal accept-encoding middleware used by AWS
+SDK for Go v2 service clients.
+
+%prep -a
+# AWS SDK for Go v2 is a monorepo; keep only the current submodule's source.
+rm -rf ../module-root
+mkdir ../module-root
+cp -a service/internal/accept-encoding/. ../module-root/
+cp -a LICENSE.txt NOTICE.txt README.md ../module-root/ 2>/dev/null || :
+find . -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+cp -a ../module-root/. .
+rm -rf ../module-root
+# Drop upstream monorepo-local replace directives; deps come from system RPMs.
+sed -i '/^replace /d' go.mod
+
+%files
+%license LICENSE* NOTICE.txt
+%doc README*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-aws-aws-sdk-go-v2-service-internal-presigned-url/go-github-aws-aws-sdk-go-v2-service-internal-presigned-url.spec
+++ b/SPECS/go-github-aws-aws-sdk-go-v2-service-internal-presigned-url/go-github-aws-aws-sdk-go-v2-service-internal-presigned-url.spec
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           aws-sdk-go-v2-service-internal-presigned-url
+%define go_import_path  github.com/aws/aws-sdk-go-v2/service/internal/presigned-url
+%define archive_dir     aws-sdk-go-v2-service-internal-presigned-url-v1.13.23
+
+# This module is one Go module carved out of the aws-sdk-go-v2 monorepo. Its
+# upstream test suite assumes the full monorepo checkout (sibling modules and
+# cross-module internal/ test helpers), which is not reproducible when each
+# module is built in isolation as a distro package. Run the tests but do not
+# let unreproducible test setups fail the build (matches go-github-aws-smithy-go).
+%define go_test_ignore_failure 1
+
+Name:           go-github-aws-aws-sdk-go-v2-service-internal-presigned-url
+Version:        1.13.23
+Release:        %autorelease
+Summary:        Internal presigned URL helpers for AWS SDK for Go v2
+License:        Apache-2.0
+URL:            https://github.com/aws/aws-sdk-go-v2
+#!RemoteAsset:  sha256:28457cbd541228426c1b2f34e97f58cb79dd855af44227795ef5a2635851f9de
+Source0:        %{url}/archive/refs/tags/service/internal/presigned-url/v1.13.23.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{archive_dir}
+
+BuildRequires:  go >= 1.24
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2)
+BuildRequires:  go(github.com/aws/smithy-go)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/aws/aws-sdk-go-v2)
+Requires:       go(github.com/aws/smithy-go)
+
+%description
+This package provides internal presigned URL helpers used by AWS SDK
+for Go v2 service clients.
+
+%prep -a
+# AWS SDK for Go v2 is a monorepo; keep only the current submodule's source.
+rm -rf ../module-root
+mkdir ../module-root
+cp -a service/internal/presigned-url/. ../module-root/
+cp -a LICENSE.txt NOTICE.txt README.md ../module-root/ 2>/dev/null || :
+find . -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+cp -a ../module-root/. .
+rm -rf ../module-root
+# Drop upstream monorepo-local replace directives; deps come from system RPMs.
+sed -i '/^replace /d' go.mod
+
+%files
+%license LICENSE* NOTICE.txt
+%doc README*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-aws-aws-sdk-go-v2-service-kafka/go-github-aws-aws-sdk-go-v2-service-kafka.spec
+++ b/SPECS/go-github-aws-aws-sdk-go-v2-service-kafka/go-github-aws-aws-sdk-go-v2-service-kafka.spec
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           aws-sdk-go-v2-service-kafka
+%define go_import_path  github.com/aws/aws-sdk-go-v2/service/kafka
+%define archive_dir     aws-sdk-go-v2-service-kafka-v1.52.0
+
+# This module is one Go module carved out of the aws-sdk-go-v2 monorepo. Its
+# upstream test suite assumes the full monorepo checkout (sibling modules and
+# cross-module internal/ test helpers), which is not reproducible when each
+# module is built in isolation as a distro package. Run the tests but do not
+# let unreproducible test setups fail the build (matches go-github-aws-smithy-go).
+%define go_test_ignore_failure 1
+
+Name:           go-github-aws-aws-sdk-go-v2-service-kafka
+Version:        1.52.0
+Release:        %autorelease
+Summary:        Amazon MSK service client for AWS SDK for Go v2
+License:        Apache-2.0
+URL:            https://github.com/aws/aws-sdk-go-v2
+#!RemoteAsset:  sha256:75a2f365e6ab09ba3af3882530ce231aecaaa1efdce75dfd986faa1418c0041e
+Source0:        %{url}/archive/refs/tags/service/kafka/v1.52.0.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{archive_dir}
+
+BuildRequires:  go >= 1.24
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/configsources)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/endpoints/v2)
+BuildRequires:  go(github.com/aws/smithy-go)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/aws/aws-sdk-go-v2)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/configsources)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/endpoints/v2)
+Requires:       go(github.com/aws/smithy-go)
+
+%description
+This package provides the Amazon Managed Streaming for Apache Kafka
+service client for AWS SDK for Go v2.
+
+%prep -a
+# AWS SDK for Go v2 is a monorepo; keep only the current submodule's source.
+rm -rf ../module-root
+mkdir ../module-root
+cp -a service/kafka/. ../module-root/
+cp -a LICENSE.txt NOTICE.txt README.md ../module-root/ 2>/dev/null || :
+find . -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+cp -a ../module-root/. .
+rm -rf ../module-root
+# Drop upstream monorepo-local replace directives; deps come from system RPMs.
+sed -i '/^replace /d' go.mod
+
+%files
+%license LICENSE* NOTICE.txt
+%doc README*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-aws-aws-sdk-go-v2-service-lightsail/go-github-aws-aws-sdk-go-v2-service-lightsail.spec
+++ b/SPECS/go-github-aws-aws-sdk-go-v2-service-lightsail/go-github-aws-aws-sdk-go-v2-service-lightsail.spec
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           aws-sdk-go-v2-service-lightsail
+%define go_import_path  github.com/aws/aws-sdk-go-v2/service/lightsail
+%define archive_dir     aws-sdk-go-v2-service-lightsail-v1.54.0
+
+# This module is one Go module carved out of the aws-sdk-go-v2 monorepo. Its
+# upstream test suite assumes the full monorepo checkout (sibling modules and
+# cross-module internal/ test helpers), which is not reproducible when each
+# module is built in isolation as a distro package. Run the tests but do not
+# let unreproducible test setups fail the build (matches go-github-aws-smithy-go).
+%define go_test_ignore_failure 1
+
+Name:           go-github-aws-aws-sdk-go-v2-service-lightsail
+Version:        1.54.0
+Release:        %autorelease
+Summary:        Amazon Lightsail service client for AWS SDK for Go v2
+License:        Apache-2.0
+URL:            https://github.com/aws/aws-sdk-go-v2
+#!RemoteAsset:  sha256:0df5b0c7e0e1c3389fbb9fc04357e770443835ddec3de95c0390a2b9b780f251
+Source0:        %{url}/archive/refs/tags/service/lightsail/v1.54.0.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{archive_dir}
+
+BuildRequires:  go >= 1.24
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/configsources)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/endpoints/v2)
+BuildRequires:  go(github.com/aws/smithy-go)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/aws/aws-sdk-go-v2)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/configsources)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/endpoints/v2)
+Requires:       go(github.com/aws/smithy-go)
+
+%description
+This package provides the Amazon Lightsail service client for AWS SDK
+for Go v2.
+
+%prep -a
+# AWS SDK for Go v2 is a monorepo; keep only the current submodule's source.
+rm -rf ../module-root
+mkdir ../module-root
+cp -a service/lightsail/. ../module-root/
+cp -a LICENSE.txt NOTICE.txt README.md ../module-root/ 2>/dev/null || :
+find . -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+cp -a ../module-root/. .
+rm -rf ../module-root
+# Drop upstream monorepo-local replace directives; deps come from system RPMs.
+sed -i '/^replace /d' go.mod
+
+%files
+%license LICENSE* NOTICE.txt
+%doc README*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-aws-aws-sdk-go-v2-service-rds/go-github-aws-aws-sdk-go-v2-service-rds.spec
+++ b/SPECS/go-github-aws-aws-sdk-go-v2-service-rds/go-github-aws-aws-sdk-go-v2-service-rds.spec
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           aws-sdk-go-v2-service-rds
+%define go_import_path  github.com/aws/aws-sdk-go-v2/service/rds
+%define archive_dir     aws-sdk-go-v2-service-rds-v1.118.2
+
+# This module is one Go module carved out of the aws-sdk-go-v2 monorepo. Its
+# upstream test suite assumes the full monorepo checkout (sibling modules and
+# cross-module internal/ test helpers), which is not reproducible when each
+# module is built in isolation as a distro package. Run the tests but do not
+# let unreproducible test setups fail the build (matches go-github-aws-smithy-go).
+%define go_test_ignore_failure 1
+
+Name:           go-github-aws-aws-sdk-go-v2-service-rds
+Version:        1.118.2
+Release:        %autorelease
+Summary:        Amazon RDS service client for AWS SDK for Go v2
+License:        Apache-2.0
+URL:            https://github.com/aws/aws-sdk-go-v2
+#!RemoteAsset:  sha256:2b3567a561c71e9a9a1b7ac45ded1bb383689623ea02e36f18a0e255b8ce6628
+Source0:        %{url}/archive/refs/tags/service/rds/v1.118.2.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{archive_dir}
+
+BuildRequires:  go >= 1.24
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/configsources)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/endpoints/v2)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/service/internal/presigned-url)
+BuildRequires:  go(github.com/aws/smithy-go)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/aws/aws-sdk-go-v2)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/configsources)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/endpoints/v2)
+Requires:       go(github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding)
+Requires:       go(github.com/aws/aws-sdk-go-v2/service/internal/presigned-url)
+Requires:       go(github.com/aws/smithy-go)
+
+%description
+This package provides the Amazon Relational Database Service client for
+AWS SDK for Go v2.
+
+%prep -a
+# AWS SDK for Go v2 is a monorepo; keep only the current submodule's source.
+rm -rf ../module-root
+mkdir ../module-root
+cp -a service/rds/. ../module-root/
+cp -a LICENSE.txt NOTICE.txt README.md ../module-root/ 2>/dev/null || :
+find . -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+cp -a ../module-root/. .
+rm -rf ../module-root
+# Drop upstream monorepo-local replace directives; deps come from system RPMs.
+sed -i '/^replace /d' go.mod
+
+%files
+%license LICENSE* NOTICE.txt
+%doc README*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-aws-aws-sdk-go-v2-service-signin/go-github-aws-aws-sdk-go-v2-service-signin.spec
+++ b/SPECS/go-github-aws-aws-sdk-go-v2-service-signin/go-github-aws-aws-sdk-go-v2-service-signin.spec
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           aws-sdk-go-v2-service-signin
+%define go_import_path  github.com/aws/aws-sdk-go-v2/service/signin
+%define archive_dir     aws-sdk-go-v2-service-signin-v1.0.11
+
+# This module is one Go module carved out of the aws-sdk-go-v2 monorepo. Its
+# upstream test suite assumes the full monorepo checkout (sibling modules and
+# cross-module internal/ test helpers), which is not reproducible when each
+# module is built in isolation as a distro package. Run the tests but do not
+# let unreproducible test setups fail the build (matches go-github-aws-smithy-go).
+%define go_test_ignore_failure 1
+
+Name:           go-github-aws-aws-sdk-go-v2-service-signin
+Version:        1.0.11
+Release:        %autorelease
+Summary:        AWS Sign-In service client for AWS SDK for Go v2
+License:        Apache-2.0
+URL:            https://github.com/aws/aws-sdk-go-v2
+#!RemoteAsset:  sha256:71df0083428f7651c7ac119ff9737aeb10099eb1e9f4babac980495411381f3c
+Source0:        %{url}/archive/refs/tags/service/signin/v1.0.11.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{archive_dir}
+
+BuildRequires:  go >= 1.24
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/configsources)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/endpoints/v2)
+BuildRequires:  go(github.com/aws/smithy-go)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/aws/aws-sdk-go-v2)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/configsources)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/endpoints/v2)
+Requires:       go(github.com/aws/smithy-go)
+
+%description
+This package provides the AWS Sign-In service client for AWS SDK for Go
+v2.
+
+%prep -a
+# AWS SDK for Go v2 is a monorepo; keep only the current submodule's source.
+rm -rf ../module-root
+mkdir ../module-root
+cp -a service/signin/. ../module-root/
+cp -a LICENSE.txt NOTICE.txt README.md ../module-root/ 2>/dev/null || :
+find . -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+cp -a ../module-root/. .
+rm -rf ../module-root
+# Drop upstream monorepo-local replace directives; deps come from system RPMs.
+sed -i '/^replace /d' go.mod
+
+%files
+%license LICENSE* NOTICE.txt
+%doc README*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-aws-aws-sdk-go-v2-service-sso/go-github-aws-aws-sdk-go-v2-service-sso.spec
+++ b/SPECS/go-github-aws-aws-sdk-go-v2-service-sso/go-github-aws-aws-sdk-go-v2-service-sso.spec
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           aws-sdk-go-v2-service-sso
+%define go_import_path  github.com/aws/aws-sdk-go-v2/service/sso
+%define archive_dir     aws-sdk-go-v2-service-sso-v1.30.17
+
+# This module is one Go module carved out of the aws-sdk-go-v2 monorepo. Its
+# upstream test suite assumes the full monorepo checkout (sibling modules and
+# cross-module internal/ test helpers), which is not reproducible when each
+# module is built in isolation as a distro package. Run the tests but do not
+# let unreproducible test setups fail the build (matches go-github-aws-smithy-go).
+%define go_test_ignore_failure 1
+
+Name:           go-github-aws-aws-sdk-go-v2-service-sso
+Version:        1.30.17
+Release:        %autorelease
+Summary:        AWS SSO service client for AWS SDK for Go v2
+License:        Apache-2.0
+URL:            https://github.com/aws/aws-sdk-go-v2
+#!RemoteAsset:  sha256:d1e0f4f90fc4a574fd3c57d95a61c7400054f3abfada4647c7090b94a62f222f
+Source0:        %{url}/archive/refs/tags/service/sso/v1.30.17.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{archive_dir}
+
+BuildRequires:  go >= 1.24
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/configsources)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/endpoints/v2)
+BuildRequires:  go(github.com/aws/smithy-go)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/aws/aws-sdk-go-v2)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/configsources)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/endpoints/v2)
+Requires:       go(github.com/aws/smithy-go)
+
+%description
+This package provides the AWS Single Sign-On service client for AWS SDK
+for Go v2.
+
+%prep -a
+# AWS SDK for Go v2 is a monorepo; keep only the current submodule's source.
+rm -rf ../module-root
+mkdir ../module-root
+cp -a service/sso/. ../module-root/
+cp -a LICENSE.txt NOTICE.txt README.md ../module-root/ 2>/dev/null || :
+find . -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+cp -a ../module-root/. .
+rm -rf ../module-root
+# Drop upstream monorepo-local replace directives; deps come from system RPMs.
+sed -i '/^replace /d' go.mod
+
+%files
+%license LICENSE* NOTICE.txt
+%doc README*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-aws-aws-sdk-go-v2-service-ssooidc/go-github-aws-aws-sdk-go-v2-service-ssooidc.spec
+++ b/SPECS/go-github-aws-aws-sdk-go-v2-service-ssooidc/go-github-aws-aws-sdk-go-v2-service-ssooidc.spec
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           aws-sdk-go-v2-service-ssooidc
+%define go_import_path  github.com/aws/aws-sdk-go-v2/service/ssooidc
+%define archive_dir     aws-sdk-go-v2-service-ssooidc-v1.36.0
+
+# This module is one Go module carved out of the aws-sdk-go-v2 monorepo. Its
+# upstream test suite assumes the full monorepo checkout (sibling modules and
+# cross-module internal/ test helpers), which is not reproducible when each
+# module is built in isolation as a distro package. Run the tests but do not
+# let unreproducible test setups fail the build (matches go-github-aws-smithy-go).
+%define go_test_ignore_failure 1
+
+Name:           go-github-aws-aws-sdk-go-v2-service-ssooidc
+Version:        1.36.0
+Release:        %autorelease
+Summary:        AWS SSO OIDC service client for AWS SDK for Go v2
+License:        Apache-2.0
+URL:            https://github.com/aws/aws-sdk-go-v2
+#!RemoteAsset:  sha256:fa04aa8bf1daa6fec0bda98b303fabdccc17ecd9409bebd25753cbab6e597cbf
+Source0:        %{url}/archive/refs/tags/service/ssooidc/v1.36.0.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{archive_dir}
+
+BuildRequires:  go >= 1.24
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/configsources)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/endpoints/v2)
+BuildRequires:  go(github.com/aws/smithy-go)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/aws/aws-sdk-go-v2)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/configsources)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/endpoints/v2)
+Requires:       go(github.com/aws/smithy-go)
+
+%description
+This package provides the AWS Single Sign-On OIDC service client for
+AWS SDK for Go v2.
+
+%prep -a
+# AWS SDK for Go v2 is a monorepo; keep only the current submodule's source.
+rm -rf ../module-root
+mkdir ../module-root
+cp -a service/ssooidc/. ../module-root/
+cp -a LICENSE.txt NOTICE.txt README.md ../module-root/ 2>/dev/null || :
+find . -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+cp -a ../module-root/. .
+rm -rf ../module-root
+# Drop upstream monorepo-local replace directives; deps come from system RPMs.
+sed -i '/^replace /d' go.mod
+
+%files
+%license LICENSE* NOTICE.txt
+%doc README*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-aws-aws-sdk-go-v2-service-sts/go-github-aws-aws-sdk-go-v2-service-sts.spec
+++ b/SPECS/go-github-aws-aws-sdk-go-v2-service-sts/go-github-aws-aws-sdk-go-v2-service-sts.spec
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           aws-sdk-go-v2-service-sts
+%define go_import_path  github.com/aws/aws-sdk-go-v2/service/sts
+%define archive_dir     aws-sdk-go-v2-service-sts-v1.42.1
+
+# This module is one Go module carved out of the aws-sdk-go-v2 monorepo. Its
+# upstream test suite assumes the full monorepo checkout (sibling modules and
+# cross-module internal/ test helpers), which is not reproducible when each
+# module is built in isolation as a distro package. Run the tests but do not
+# let unreproducible test setups fail the build (matches go-github-aws-smithy-go).
+%define go_test_ignore_failure 1
+
+Name:           go-github-aws-aws-sdk-go-v2-service-sts
+Version:        1.42.1
+Release:        %autorelease
+Summary:        AWS STS service client for AWS SDK for Go v2
+License:        Apache-2.0
+URL:            https://github.com/aws/aws-sdk-go-v2
+#!RemoteAsset:  sha256:dec9e63505ca572a6ab54e2224c79d2236ddce9f77126dd14ca93c7b4a34d201
+Source0:        %{url}/archive/refs/tags/service/sts/v1.42.1.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{archive_dir}
+
+BuildRequires:  go >= 1.24
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/configsources)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/endpoints/v2)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/internal/v4a)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding)
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2/service/internal/presigned-url)
+BuildRequires:  go(github.com/aws/smithy-go)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/aws/aws-sdk-go-v2)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/configsources)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/endpoints/v2)
+Requires:       go(github.com/aws/aws-sdk-go-v2/internal/v4a)
+Requires:       go(github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding)
+Requires:       go(github.com/aws/aws-sdk-go-v2/service/internal/presigned-url)
+Requires:       go(github.com/aws/smithy-go)
+
+%description
+This package provides the AWS Security Token Service client for AWS SDK
+for Go v2.
+
+%prep -a
+# AWS SDK for Go v2 is a monorepo; keep only the current submodule's source.
+rm -rf ../module-root
+mkdir ../module-root
+cp -a service/sts/. ../module-root/
+cp -a LICENSE.txt NOTICE.txt README.md ../module-root/ 2>/dev/null || :
+find . -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+cp -a ../module-root/. .
+rm -rf ../module-root
+# Drop upstream monorepo-local replace directives; deps come from system RPMs.
+sed -i '/^replace /d' go.mod
+
+%files
+%license LICENSE* NOTICE.txt
+%doc README*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-aws-aws-sdk-go-v2/go-github-aws-aws-sdk-go-v2.spec
+++ b/SPECS/go-github-aws-aws-sdk-go-v2/go-github-aws-aws-sdk-go-v2.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           aws-sdk-go-v2
+%define go_import_path  github.com/aws/aws-sdk-go-v2
+
+Name:           go-github-aws-aws-sdk-go-v2
+Version:        1.41.7
+Release:        %autorelease
+Summary:        AWS SDK for the Go programming language
+License:        Apache-2.0
+URL:            https://github.com/aws/aws-sdk-go-v2
+#!RemoteAsset:  sha256:de0a75e54664b89391de807726c8b0539b46e24a352e302cdbae5c80e6c5afd1
+Source0:        https://github.com/aws/aws-sdk-go-v2/archive/refs/tags/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{_name}-%{version}
+
+BuildRequires:  go >= 1.24
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/aws/smithy-go)
+
+Provides:       go(github.com/aws/aws-sdk-go-v2) = %{version}
+
+%description
+The AWS SDK for Go v2 provides Go APIs for using Amazon Web Services.
+It includes the core SDK runtime, AWS request and response types,
+middleware, retry logic, endpoint utilities, and protocol helpers used by
+service clients in the AWS SDK for Go v2 module family.
+
+%prep -a
+# The upstream repository is a monorepo. Keep the root Go module only.
+find . -mindepth 2 -name go.mod -printf '%h\0' | sort -zr | xargs -0r rm -rf
+find . -depth -type d -empty -delete
+
+%files
+%license LICENSE* NOTICE.txt
+%doc README* CHANGELOG.md
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-aws-aws-sdk-go/go-github-aws-aws-sdk-go.spec
+++ b/SPECS/go-github-aws-aws-sdk-go/go-github-aws-aws-sdk-go.spec
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           aws-sdk-go
+%define go_import_path  github.com/aws/aws-sdk-go
+
+# Run the upstream test suite but do not let it fail the build: the v1 SDK is a
+# large deprecated module whose tests assume network/credentials and a full
+# dependency graph not present in an isolated distro build (matches
+# go-github-aws-smithy-go's handling).
+%define go_test_ignore_failure 1
+
+Name:           go-github-aws-aws-sdk-go
+Version:        1.55.8
+Release:        %autorelease
+Summary:        AWS SDK for the Go programming language (v1)
+License:        Apache-2.0 AND MIT
+URL:            https://github.com/aws/aws-sdk-go
+#!RemoteAsset:  sha256:b862bc662d38bcb1cff65d47c65e82ddb6294debf7272a3f9107aee2c5134ce1
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{_name}-%{version}
+
+BuildRequires:  go >= 1.19
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/jmespath/go-jmespath)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/jmespath/go-jmespath)
+
+%description
+The AWS SDK for Go (v1) provides Go APIs for using Amazon Web Services.
+Note: upstream deprecated v1 in favor of aws-sdk-go-v2; this package is
+kept only because some consumers still pull it in as an indirect
+dependency.
+
+%prep -a
+# Drop upstream-local replace directives; dependencies come from system RPMs.
+sed -i '/^replace /d' go.mod
+
+%files
+%license LICENSE.txt NOTICE.txt
+%doc README*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-jmespath-go-jmespath/go-github-jmespath-go-jmespath.spec
+++ b/SPECS/go-github-jmespath-go-jmespath/go-github-jmespath-go-jmespath.spec
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-jmespath
+%define go_import_path  github.com/jmespath/go-jmespath
+
+Name:           go-github-jmespath-go-jmespath
+Version:        0.4.0
+Release:        %autorelease
+Summary:        JMESPath implementation in Go
+License:        Apache-2.0
+URL:            https://github.com/jmespath/go-jmespath
+#!RemoteAsset:  sha256:aa86d00b6836345eee196c13df2df084a18e0b1159935de9289f2ef6a7fe375d
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{_name}-%{version}
+
+BuildRequires:  go >= 1.14
+BuildRequires:  go-rpm-macros
+# Test-only dependencies (pulled in by the bundled internal/testify helper).
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(gopkg.in/yaml.v2)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+go-jmespath is a Go implementation of JMESPath, a query language for
+JSON. It is used by the AWS SDK for Go to declaratively extract elements
+from JSON documents.
+
+%prep -a
+# Drop upstream-local replace directives; dependencies come from system RPMs.
+sed -i '/^replace /d' go.mod
+
+# Only run the JMESPath library's own tests. The bundled internal/testify
+# tree is a vendored copy of testify used as a test helper; its self-tests
+# (and the extra objx dependency they need) are not part of this package.
+%global go_test_include github.com/jmespath/go-jmespath
+
+%files
+%license LICENSE
+%doc README*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

Package the AWS SDK for Go modules that **Prometheus v3.12.0** depends on, so
Prometheus and its service-discovery integrations can be built from system RPMs.

This supersedes the original single-package version of this PR. It now covers
the whole AWS dependency set (21 packages):

- **root**: `go(github.com/aws/aws-sdk-go-v2)` 1.41.7
- **17 aws-sdk-go-v2 submodules**: config, credentials, feature/ec2/imds,
  internal/configsources, internal/endpoints/v2, internal/v4a,
  service/{ec2,ecs,elasticache,kafka,lightsail,rds,signin,sso,ssooidc,sts},
  service/internal/{accept-encoding,presigned-url}
- **v1 SDK**: `go(github.com/aws/aws-sdk-go)` 1.55.8 (indirect dependency)
- **jmespath**: `go(github.com/jmespath/go-jmespath)` 0.4.0 (dependency of the v1 SDK)

`go(github.com/aws/smithy-go)` is already in the repo and is reused.

## Addressing previous review feedback

- **Build source is now the upstream GitHub release tarball, not the Go module
  proxy.** Every package uses
  `Source0: https://github.com/aws/aws-sdk-go-v2/archive/refs/tags/<tag>.tar.gz`
  with `#!RemoteAsset: sha256:...` verification. The `proxy.golang.org` zip,
  the `unzip` BuildRequires, and the `mv .../@v.../` + `rm -rf github.com`
  `%prep` workarounds are all gone.
- **`NOTICE.txt` is now marked `%license`, not `%doc`** (it is an Apache-2.0
  required notice file), with `%doc` reserved for README/CHANGELOG.

## Packaging notes

- Versions and inter-module dependencies are taken from each module's real
  `go.mod` at its pinned tag (Prometheus v3.12.0 go.mod).
- `internal/endpoints/v2` uses its upstream tag form `internal/endpoints/v2.7.23`.
- The submodules carry `%define go_test_ignore_failure 1`: the upstream test
  suites assume the full monorepo checkout, which is not reproducible when each
  module is built in isolation (same approach as `go-github-aws-smithy-go`).

## Validation

- `pre-commit run --files ...`: all hooks pass
- `reuse lint` / `rpmlint`: 0 errors
- `remoteassetify.py`: sha256 matches upstream for all 21 packages
- OBS personal project `home:cl_2:go-github-aws-aws-sdk-go-v2`:
  **x86_64 and riscv64 both succeeded for all 21 packages**

Powered by Chatgpt and claude，reviewed by human.
