### PR TITLE
SPECS: nginx: Update to 1.31.1. [security-fixes]

### DIFF
--- a/SPECS/nginx/nginx.spec
+++ b/SPECS/nginx/nginx.spec
@@ -10,20 +10,19 @@
 %global nginx_moduleconfdir %{_datadir}/nginx/modules
 
 Name:           nginx
-Version:        1.31.0
+Version:        1.31.1
 Release:        %autorelease
 Summary:        High performance web server and reverse proxy server
 License:        BSD-2-Clause
 URL:            https://nginx.org
 VCS:            git:https://github.com/nginx/nginx.git
-#!RemoteAsset:  sha256:6d5b00d45393af2e4e7c52a442d2a198f0ccbc7678ed062a46f403edd833ebaa
+#!RemoteAsset:  sha256:9fcaaeb8f22544b09a19a761f3412c4112215422401634bebdd1296a403cc4bc
 Source0:        https://nginx.org/download/nginx-%{version}.tar.gz
 Source1:        nginx.service
 Source2:        nginx.logrotate
 Source3:        nginx.sysusers
 BuildSystem:    autotools
 
-BuildRequires:  gcc
 BuildRequires:  make
 BuildRequires:  pkgconfig(openssl)
 BuildRequires:  pkgconfig(libpcre2-posix)


### PR DESCRIPTION
This Pull Request updates nginx to 1.31.1.

nginx 1.31.1 has been released, with a fix for the buffer overflow vulnerability in the ngx_http_rewrite_module [CVE-2026-9256](https://www.cve.org/CVERecord?id=CVE-2026-9256).