### PR TITLE
SPECS: libvorbis: Using single job to build.

### DIFF
--- a/SPECS/libvorbis/libvorbis.spec
+++ b/SPECS/libvorbis/libvorbis.spec
@@ -5,13 +5,16 @@
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
+# Parallel build might fail on our platform.
+%global _smp_ncpus_max 1
+
 Name:           libvorbis
 Version:        1.3.7
 Release:        %autorelease
 Summary:        The Vorbis General Audio Compression Codec
 License:        BSD-3-Clause
 URL:            https://github.com/xiph/vorbis
-#!RemoteAsset
+#!RemoteAsset:  sha256:270c76933d0934e42c5ee0a54a36280e2d87af1de3cc3e584806357e237afd13
 Source:         https://github.com/xiph/vorbis/archive/refs/tags/v%{version}.tar.gz
 BuildSystem:    autotools
 
@@ -62,4 +65,4 @@ rm -f %{buildroot}%{_docdir}/%{name}-%{version}/doxygen-build.stamp
 %{_datadir}/aclocal/vorbis.m4
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
On our sg2044 platform, parallel build might failed with:

lto1: internal compiler error: resolution sub id 0xf54b34c78e93b495 not in object file

It seems the compiler failed to find some object in the output file. Maybe it is due to our platform problem, or the libvorbis logic. Using single job to avoid the error.