### PR TITLE
SPECS: python-numpy: Upgrade to 2.4.6.

### DIFF
--- a/SPECS/python-numpy/python-numpy.spec
+++ b/SPECS/python-numpy/python-numpy.spec
@@ -7,12 +7,12 @@
 %global srcname numpy
 
 Name:           python-%{srcname}
-Version:        2.4.0
+Version:        2.4.6
 Release:        %autorelease
 Summary:        NumPy: array processing for numbers, strings, records, and objects
 License:        BSD-3-Clause
 URL:            https://github.com/numpy/numpy
-#!RemoteAsset:  sha256:6e504f7b16118198f138ef31ba24d985b124c2c469fe8467007cf30fd992f934
+#!RemoteAsset:  sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda
 Source:         https://files.pythonhosted.org/packages/source/n/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildSystem:    pyproject
 


### PR DESCRIPTION
This is a bugfix version. It also fixes x86-64 build error under gcc16 due to old x86-simd-sort code, like:
```
[  241s]   ../numpy/_core/src/npysort/x86-simd-sort/src/xss-common-comparators.hpp:43:32: error: inlining failed in call to ‘always_inline’ ‘STDSortComparator’: target specific option mismatch
[  241s]      43 |     X86_SIMD_SORT_FINLINE bool STDSortComparator(const type_t &a,
[  241s]         |                                ^
[  241s]   /usr/include/c++/16/bits/stl_algo.h:1757:20: note: called from here
[  241s]    1757 |       while (__comp(__val, *__next))
[  241s]         |                    ^
```