### PR TITLE
SPECS: linux: Cleanup

### DIFF
--- a/SPECS/linux/linux.spec
+++ b/SPECS/linux/linux.spec
@@ -429,6 +429,7 @@ ln -sf %{_usrsrc}/kernels/%{kernel_full_version} source
 popd
 
 install -Dm644 $(make %{kernel_make_flags} -s image_name) %{buildroot}%{modpath}/vmlinuz
+zstd -f .config -o %{buildroot}%{modpath}/config.zst
 
 echo "Module signing would happen here for version %{kernel_full_version}."
 
@@ -446,10 +447,12 @@ fi
 
 %files core
 %{modpath}/vmlinuz
+%{modpath}/config.zst
 
 %files modules
 %{modpath}/*
 %exclude %{modpath}/vmlinuz
+%exclude %{modpath}/config.zst
 %exclude %{modpath}/build
 %exclude %{modpath}/source
 

--- a/SPECS/linux/linux.spec
+++ b/SPECS/linux/linux.spec
@@ -388,6 +388,7 @@ located at %{_usrsrc}/kernels/%{kernel_full_version}, with symlinks provided und
 %if %{need_dtbs}
 %package        dtbs
 Summary:        Devicetree blob files from Linux sources
+Requires:       %{name}-core = %{version}-%{release}
 
 %description    dtbs
 This package provides the DTB files built from Linux sources that may be used

--- a/SPECS/linux/linux.spec
+++ b/SPECS/linux/linux.spec
@@ -8,10 +8,6 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 %global modpath %{_prefix}/lib/modules/%{kver}
 
-%ifarch riscv64
-#!BuildConstraint: hardware:jobs 32
-%endif
-
 # Whether dtbs needed for arch
 %ifarch riscv64
 %global need_dtbs 1

--- a/SPECS/linux/linux.spec
+++ b/SPECS/linux/linux.spec
@@ -443,13 +443,24 @@ zstd -f .config -o %{buildroot}%{modpath}/config.zst
 
 echo "Module signing would happen here for version %{kernel_full_version}."
 
+%pretrans
+# Cleanup state file ahead to avoid leftovers from previous failure.
+rm -f "%{_localstatedir}/lib/rpm-state/%{name}-%{kernel_full_version}.just_installed"
+
 %post
+# Workaround reinstalling: let %%preun know that the same package is installed just before.
+touch "%{_localstatedir}/lib/rpm-state/%{name}-%{kernel_full_version}.just_installed"
+
 %{_bindir}/kernel-install add %{kernel_full_version} %{modpath}/vmlinuz
 
 %preun
-if [ $1 -eq 0 ] ; then
+# Why not "if [ $1 -eq 0 ]"? It breaks kernel removal when multi versions were installed.
+if [ ! -e "%{_localstatedir}/lib/rpm-state/%{name}-%{kernel_full_version}.just_installed" ]; then
     %{_bindir}/kernel-install remove %{kernel_full_version}
 fi
+
+%posttrans
+rm -f "%{_localstatedir}/lib/rpm-state/%{name}-%{kernel_full_version}.just_installed"
 
 %files
 %license COPYING

--- a/SPECS/linux/linux.spec
+++ b/SPECS/linux/linux.spec
@@ -87,8 +87,6 @@ Requires(preun): %{name}-modules%{?_isa} = %{version}-%{release}
 Requires(preun): %{name}-dtbs%{?_isa} = %{version}-%{release}
 %endif
 
-# TODO: kmod should be the dependencies of kernel-install
-Requires(post):   kmod
 Requires(post):   kernel-install
 Requires(preun):  kernel-install
 

--- a/SPECS/linux/linux.spec
+++ b/SPECS/linux/linux.spec
@@ -446,15 +446,15 @@ fi
 %doc README
 
 %files core
+%dir %{modpath}
 %{modpath}/vmlinuz
 %{modpath}/config.zst
 
 %files modules
-%{modpath}/*
-%exclude %{modpath}/vmlinuz
-%exclude %{modpath}/config.zst
-%exclude %{modpath}/build
-%exclude %{modpath}/source
+%{modpath}/kernel
+%{modpath}/modules.builtin
+%{modpath}/modules.builtin.modinfo
+%{modpath}/modules.order
 
 %files devel
 %{_usrsrc}/kernels/%{kernel_full_version}/

--- a/SPECS/linux/linux.spec
+++ b/SPECS/linux/linux.spec
@@ -4,6 +4,7 @@
 # SPDX-FileContributor: Jingwiw <wangjingwei@iscas.ac.cn>
 # SPDX-FileContributor: Zheng Junjie <zhengjunjie@iscas.ac.cn>
 # SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
+# SPDX-FileContributor: Hangfan Li <lihangfan@iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/linux/linux.spec
+++ b/SPECS/linux/linux.spec
@@ -368,7 +368,7 @@ providing the minimal set of files needed to boot the system.
 
 %package        modules
 Summary:        Kernel modules for the Linux kernel
-Requires:       %{name}-core = %{version}-%{release}
+Requires:       %{name}-core%{?_isa} = %{version}-%{release}
 
 %description    modules
 Contains all the kernel modules (.ko files) and associated metadata for
@@ -388,7 +388,7 @@ located at %{_usrsrc}/kernels/%{kernel_full_version}, with symlinks provided und
 %if %{need_dtbs}
 %package        dtbs
 Summary:        Devicetree blob files from Linux sources
-Requires:       %{name}-core = %{version}-%{release}
+Requires:       %{name}-core%{?_isa} = %{version}-%{release}
 
 %description    dtbs
 This package provides the DTB files built from Linux sources that may be used

--- a/SPECS/linux/linux.spec
+++ b/SPECS/linux/linux.spec
@@ -15,7 +15,6 @@
 %global need_dtbs 0
 %endif
 
-%global signmodules 1
 %global kver %{version}-%{release}
 %global kernel_make_flags LD=ld.bfd KBUILD_BUILD_VERSION=%{release}
 

--- a/SPECS/linux/linux.spec
+++ b/SPECS/linux/linux.spec
@@ -6,7 +6,6 @@
 # SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
-%global modpath %{_prefix}/lib/modules/%{kver}
 
 # Whether dtbs needed for arch
 %ifarch riscv64
@@ -15,8 +14,23 @@
 %global need_dtbs 0
 %endif
 
-%global kver %{version}-%{release}
-%global kernel_make_flags LD=ld.bfd KBUILD_BUILD_VERSION=%{release}
+#### About Versioning
+#
+# CONFIG_LOCALVERSION_AUTO must not be set.
+# This ensures kernel build system never injects hash value generated from commit id.
+# This also bypass the KBUILD_BUILD_VERSION logic.
+#
+
+# Making flavored kernels by setting this one.
+# This will be included into `uname -r` so that multiple kernels will co-exist
+# %%global variant_name
+
+# SHOULD NOT TOUCH
+%global kernel_local_version    %{?variant_name:%{variant_name}-}%{release}
+%global kernel_full_version     %{version}-%{kernel_local_version}
+
+%global kernel_make_flags LD=ld.bfd
+%global modpath %{_prefix}/lib/modules/%{kernel_full_version}
 
 Name:           linux
 Version:        7.0.10
@@ -366,8 +380,8 @@ Requires:       dwarves
 %description    devel
 This package provides the kernel headers and Makefiles necessary to build
 external kernel modules against the installed kernel. The development files are
-located at %{_usrsrc}/kernels/%{kver}, with symlinks provided under
-%{_prefix}/lib/modules/%{kver}/ for compatibility.
+located at %{_usrsrc}/kernels/%{kernel_full_version}, with symlinks provided under
+%{_prefix}/lib/modules/%{kernel_full_version}/ for compatibility.
 
 %if %{need_dtbs}
 %package        dtbs
@@ -381,7 +395,7 @@ for booting.
 %prep
 %autosetup -p1
 cp %{SOURCE1} .config
-echo "-%{release}" > localversion
+echo "-%{kernel_local_version}" > localversion
 
 %conf
 %make_build %{kernel_make_flags} olddefconfig
@@ -395,7 +409,7 @@ echo "-%{release}" > localversion
 %endif
 
 %install
-%define ksrcpath %{buildroot}%{_usrsrc}/kernels/%{kver}
+%define ksrcpath %{buildroot}%{_usrsrc}/kernels/%{kernel_full_version}
 install -d %{buildroot}%{modpath} %{ksrcpath}
 
 %make_build %{kernel_make_flags} INSTALL_MOD_PATH=%{buildroot}%{_prefix} INSTALL_MOD_STRIP=1 DEPMOD=true modules_install
@@ -408,20 +422,20 @@ install -d %{buildroot}%{modpath} %{ksrcpath}
 
 pushd %{buildroot}%{modpath}
 rm -f build source
-ln -sf %{_usrsrc}/kernels/%{kver} build
-ln -sf %{_usrsrc}/kernels/%{kver} source
+ln -sf %{_usrsrc}/kernels/%{kernel_full_version} build
+ln -sf %{_usrsrc}/kernels/%{kernel_full_version} source
 popd
 
 install -Dm644 $(make %{kernel_make_flags} -s image_name) %{buildroot}%{modpath}/vmlinuz
 
-echo "Module signing would happen here for version %{kver}."
+echo "Module signing would happen here for version %{kernel_full_version}."
 
 %post
-%{_bindir}/kernel-install add %{kver} %{modpath}/vmlinuz
+%{_bindir}/kernel-install add %{kernel_full_version} %{modpath}/vmlinuz
 
 %postun
 if [ $1 -eq 0 ] ; then
-    %{_bindir}/kernel-install remove %{kver}
+    %{_bindir}/kernel-install remove %{kernel_full_version}
 fi
 
 %files
@@ -438,7 +452,7 @@ fi
 %exclude %{modpath}/source
 
 %files devel
-%{_usrsrc}/kernels/%{kver}/
+%{_usrsrc}/kernels/%{kernel_full_version}/
 %{modpath}/build
 %{modpath}/source
 

--- a/SPECS/linux/linux.spec
+++ b/SPECS/linux/linux.spec
@@ -31,7 +31,7 @@
 %global kernel_full_version     %{version}-%{kernel_local_version}
 
 %global kernel_make_flags LD=ld.bfd
-%global modpath %{_prefix}/lib/modules/%{kernel_full_version}
+%global modpath /lib/modules/%{kernel_full_version}
 
 Name:           linux
 Version:        7.0.10
@@ -383,7 +383,7 @@ Requires:       dwarves
 This package provides the kernel headers and Makefiles necessary to build
 external kernel modules against the installed kernel. The development files are
 located at %{_usrsrc}/kernels/%{kernel_full_version}, with symlinks provided under
-%{_prefix}/lib/modules/%{kernel_full_version}/ for compatibility.
+/lib/modules/%{kernel_full_version}/ for compatibility.
 
 %if %{need_dtbs}
 %package        dtbs
@@ -415,7 +415,7 @@ echo "-%{kernel_local_version}" > localversion
 %define ksrcpath %{buildroot}%{_usrsrc}/kernels/%{kernel_full_version}
 install -d %{buildroot}%{modpath} %{ksrcpath}
 
-%make_build %{kernel_make_flags} INSTALL_MOD_PATH=%{buildroot}%{_prefix} INSTALL_MOD_STRIP=1 DEPMOD=true modules_install
+%make_build %{kernel_make_flags} INSTALL_MOD_PATH=%{buildroot} INSTALL_MOD_STRIP=1 DEPMOD=true modules_install
 
 %if %{need_dtbs}
 %make_build %{kernel_make_flags} INSTALL_DTBS_PATH=%{buildroot}%{modpath}/dtb dtbs_install

--- a/SPECS/linux/linux.spec
+++ b/SPECS/linux/linux.spec
@@ -77,9 +77,10 @@ Requires:       %{name}-modules%{?_isa} = %{version}-%{release}
 %if %{need_dtbs}
 Requires:       %{name}-dtbs%{?_isa} = %{version}-%{release}
 %endif
+# TODO: kmod should be the dependencies of kernel-install
 Requires(post):   kmod
 Requires(post):   kernel-install
-Requires(postun): kernel-install
+Requires(preun):  kernel-install
 
 %patchlist
 0001-UPSTREAM-rust-clk-implement-Send-and-Sync.patch
@@ -433,7 +434,7 @@ echo "Module signing would happen here for version %{kernel_full_version}."
 %post
 %{_bindir}/kernel-install add %{kernel_full_version} %{modpath}/vmlinuz
 
-%postun
+%preun
 if [ $1 -eq 0 ] ; then
     %{_bindir}/kernel-install remove %{kernel_full_version}
 fi

--- a/SPECS/linux/linux.spec
+++ b/SPECS/linux/linux.spec
@@ -73,11 +73,20 @@ BuildRequires:  pkgconfig(openssl)
 BuildRequires:  kmod
 BuildRequires:  rpm-config-openruyi
 
+# Meta-package: default installation
 Requires:       %{name}-core%{?_isa} = %{version}-%{release}
 Requires:       %{name}-modules%{?_isa} = %{version}-%{release}
 %if %{need_dtbs}
 Requires:       %{name}-dtbs%{?_isa} = %{version}-%{release}
 %endif
+
+# Meta-package: order of removal
+Requires(preun): %{name}-core%{?_isa} = %{version}-%{release}
+Requires(preun): %{name}-modules%{?_isa} = %{version}-%{release}
+%if %{need_dtbs}
+Requires(preun): %{name}-dtbs%{?_isa} = %{version}-%{release}
+%endif
+
 # TODO: kmod should be the dependencies of kernel-install
 Requires(post):   kmod
 Requires(post):   kernel-install
@@ -356,15 +365,15 @@ Requires(preun):  kernel-install
 0001-RUYI-mmc-sdhci-of-dwcmshc-Add-support-for-SG2042-FPG.patch
 
 %description
-This is a meta-package that installs the core kernel image and modules.
-For a minimal boot environment, install the 'linux-core' package instead.
+This is a meta-package that handles standard kernel installation.
+To avoid the execution of kernel service scriptlet, please install
+%{name}-core%{?_isa}, %{name}-modules%{?_isa} instead.
 
 %package        core
-Summary:        The core Linux kernel image and initrd
+Summary:        The core Linux kernel image
 
 %description    core
-Contains the bootable kernel image (vmlinuz) and a generic, pre-built initrd,
-providing the minimal set of files needed to boot the system.
+Contains the bootable kernel image (vmlinuz) and its Kconfig options.
 
 %package        modules
 Summary:        Kernel modules for the Linux kernel

--- a/SPECS/openruyi-config-linux-dnf/linux-policy.conf
+++ b/SPECS/openruyi-config-linux-dnf/linux-policy.conf
@@ -1,0 +1,3 @@
+[main]
+installonlypkgs=linux linux-core linux-modules linux-dtbs
+installonly_limit=3

--- a/SPECS/openruyi-config-linux-dnf/openruyi-config-linux-dnf.spec
+++ b/SPECS/openruyi-config-linux-dnf/openruyi-config-linux-dnf.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Hangfan Li <lihangfan@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           openruyi-config-linux-dnf
+Version:        20260602
+Release:        %autorelease
+Summary:        Specific DNF5 configuration files for Linux kernel
+License:        GPL-2.0-or-later
+URL:            https://github.com/openRuyi-Project/openRuyi
+BuildArch:      noarch
+
+# libdnf5 owns the directories we need
+Requires:       libdnf5
+Supplements:    libdnf5
+
+%sourcelist
+linux-policy.conf
+
+%description
+This package contains the DNF configuration for the openRuyi Linux
+kernel maintainence.
+
+%prep
+%setup -c -T
+cp -p %{sources} .
+
+%install
+install -p -Dm 644 -t %{buildroot}%{_datadir}/dnf5/libdnf.conf.d linux-policy.conf
+
+%files
+%{_datadir}/dnf5/libdnf.conf.d/linux-policy.conf
+
+%changelog
+%autochangelog

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -433,6 +433,7 @@ This package provide mount.ddi and systemd-dissect.
 
 %package     -n kernel-install
 Summary:        This package provides kernel-install tool
+Requires:       kmod
 
 %description -n kernel-install
 This package provides kernel-install tool


### PR DESCRIPTION
What's changed:

- Major changes to versioning, supporting flavored kernel
- Ships config.zst
- Accurate filelist for modules

`linux` meta-package now is designed to handle kernel service scripts, and is optional if only files are intended to be installed.

Issue tracking:

- [x] `protect_running_kernel` not working
  - Solved by removing `%{_prefix}` from filelist
- [x] `/lib/modules/xxx` left unremoved when uninstalling linux-*
  - Owns `/lib/modules/xxxx` now
- [x] kernel-install scripts not working properly when uninstalling.
  - postun -> preun
  - mark reinstallation through rpm-state instead of `$1` from scriptlet
- [ ] manually removing meta-package linux-x.x.x will not remove sub-packages after `dnf upgrade`
  - WONTFIX, as that is how dnf works (by changing install reason from dependency to user)
  - Normal update-and-replace process not affected
- [x] Make dnf5 preinstall configuration to `/usr/share/dnf5/libdnf.conf.d/50-kernel-policy.conf`
  - `installonlypkgs`, `installonly_limit`
  - Added `openruyi-config-linux-dnf` and supplements `libdnf5`
- [ ] Cleanup rpm macros
- [ ] Rework `linux-lts`