### PR TITLE
SPECS: rpm-config-openruyi: add zsh and fish completions dir macros

### DIFF
--- a/SPECS/rpm-config-openruyi/macros.completions
+++ b/SPECS/rpm-config-openruyi/macros.completions
@@ -1,0 +1,2 @@
+%fish_completions_dir %{_datadir}/fish/vendor_completions.d
+%zsh_completions_dir %{_datadir}/zsh/site-functions

--- a/SPECS/rpm-config-openruyi/rpm-config-openruyi.spec
+++ b/SPECS/rpm-config-openruyi/rpm-config-openruyi.spec
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: (C) 2025 openRuyi Project Contributors
 # SPDX-FileContributor: Zheng Junjie <zhengjunjie@iscas.ac.cn>
 # SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
+# SPDX-FileContributor: panglars <panghao.riscv@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
@@ -35,6 +36,7 @@ kernel.attr
 kmp.attr
 macros
 macros.buildsystem
+macros.completions
 macros.ldconfig
 macros.sbat
 macros.vendor
@@ -77,4 +79,4 @@ install -p -m 644 -t %{buildroot}%{_rpmconfigdir}/macros.d macros.*
 %{_rpmconfigdir}/find-supplements.ksyms
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Currently only `%{bash_completions_dir}` is available; `%{zsh_completions_dir}` and `%{fish_completions_dir}` completion macros need to be added.