### PR TITLE
SPECS: rust: Set to rva23 target for rva23 project.

### DIFF
--- a/SPECS/cloud-hypervisor/cloud-hypervisor.spec
+++ b/SPECS/cloud-hypervisor/cloud-hypervisor.spec
@@ -35,14 +35,11 @@ Requires: bash
 Requires: glibc
 Requires: libcap
 
-# TODO: Use rva23 rust toolchain to compile
 %ifarch x86_64
-%define rust_def_target x86_64-unknown-linux-gnu
 %define cargo_pkg_feature_opts --no-default-features --features "mshv,kvm" -p cloud-hypervisor
 %endif
 
 %ifarch riscv64
-%define rust_def_target riscv64gc-unknown-linux-gnu
 %define cargo_pkg_feature_opts --no-default-features --features "kvm" -p cloud-hypervisor
 %endif
 
@@ -72,19 +69,19 @@ if [[ $? -ne 0 ]]; then
 fi
 
 export OPENSSL_NO_VENDOR=1
-cargo build --release --target=%{rust_def_target} %{cargo_pkg_feature_opts} %{cargo_offline}
-cargo build --release --target=%{rust_def_target} --package vhost_user_net %{cargo_offline}
-cargo build --release --target=%{rust_def_target} --package vhost_user_block %{cargo_offline}
+cargo build --release %{cargo_pkg_feature_opts} %{cargo_offline}
+cargo build --release --package vhost_user_net %{cargo_offline}
+cargo build --release --package vhost_user_block %{cargo_offline}
 
 %install
 rm -rf %{buildroot}
 install -d %{buildroot}%{_bindir}
-install -D -m755  ./target/%{rust_def_target}/release/cloud-hypervisor %{buildroot}%{_bindir}
-install -D -m755  ./target/%{rust_def_target}/release/ch-remote %{buildroot}%{_bindir}
+install -D -m755  ./target/release/cloud-hypervisor %{buildroot}%{_bindir}
+install -D -m755  ./target/release/ch-remote %{buildroot}%{_bindir}
 install -d %{buildroot}%{_libdir}
 install -d %{buildroot}%{_libdir}/cloud-hypervisor
-install -D -m755 target/%{rust_def_target}/release/vhost_user_block %{buildroot}%{_libdir}/cloud-hypervisor
-install -D -m755 target/%{rust_def_target}/release/vhost_user_net %{buildroot}%{_libdir}/cloud-hypervisor
+install -D -m755 target/release/vhost_user_block %{buildroot}%{_libdir}/cloud-hypervisor
+install -D -m755 target/release/vhost_user_net %{buildroot}%{_libdir}/cloud-hypervisor
 
 %files
 %defattr(-,root,root,-)

--- a/SPECS/firefox/2003-blindly-set-rust-rva23-target-when-needed.patch
+++ b/SPECS/firefox/2003-blindly-set-rust-rva23-target-when-needed.patch
@@ -1,0 +1,59 @@
+From 8e96237ef3d552c0a0aaa1d6528fa3f2cbcacce6 Mon Sep 17 00:00:00 2001
+From: Kai Zhang <zhangkai@iscas.ac.cn>
+Date: Thu, 4 Jun 2026 17:15:11 +0800
+Subject: [PATCH] riscv64: Blindly set rust rva23 target when needed
+
+Firefox doesn't support rust riscv64a23-unknown-linux-gnu now.
+When using rva23 rust to build, the failure may like:
+
+  0:37.22 checking for rust host triplet...
+  0:37.22 E ERROR: The rust compiler host (riscv64a23-unknown-linux-gnu) is not suitable for the configure host (riscv64-unknown-linux-gnu/riscv64gc-unknown-linux-gnu).
+  0:37.22 To resolve this, install and select a Rust toolchain for riscv64gc-unknown-linux-gnu:
+  0:37.22   rustup default stable-riscv64gc-unknown-linux-gnu
+  0:37.22 Then rerun configure.
+
+Workaround the problem if we really have a rva23 rustc.
+
+Signed-off-by: Kai Zhang <zhangkai@iscas.ac.cn>
+---
+ build/moz.configure/rust.configure | 13 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/build/moz.configure/rust.configure b/build/moz.configure/rust.configure
+index a89585f6f81d..82c5a97b7cae 100644
+--- a/build/moz.configure/rust.configure
++++ b/build/moz.configure/rust.configure
+@@ -488,6 +488,12 @@ def assert_rust_compile(host_or_target, rustc_target, rustc):
+ def rust_host_triple(
+     rustc, host, compiler_info, rustc_host, rust_supported_targets, arm_target
+ ):
++    # There's no easy way to match RUST riscv64a23-unknown-linux-gnu against AUTOCONF
++    # riscv64-unknown-linux-gnu target, because riscv64gc-unknown-linux-gnu always
++    # wins. So just return it.
++    if rustc_host == "riscv64a23-unknown-linux-gnu":
++        return rustc_host
++
+     rustc_target = detect_rustc_target(
+         host, compiler_info, arm_target, rust_supported_targets
+     )
+@@ -517,12 +523,15 @@ def rust_host_triple(
+ 
+ 
+ @depends(
+-    rustc, target, c_compiler, rust_supported_targets, arm_target, when=rust_compiler
++    rustc, target, c_compiler, rust_supported_targets, arm_target, rustc_info.host, when=rust_compiler
+ )
+ @checking("for rust target triplet")
+ def rust_target_triple(
+-    rustc, target, compiler_info, rust_supported_targets, arm_target
++    rustc, target, compiler_info, rust_supported_targets, arm_target, rustc_host
+ ):
++    if rustc_host == "riscv64a23-unknown-linux-gnu":
++        return rustc_host
++
+     rustc_target = detect_rustc_target(
+         target, compiler_info, arm_target, rust_supported_targets
+     )
+-- 
+2.43.0
+

--- a/SPECS/firefox/firefox.spec
+++ b/SPECS/firefox/firefox.spec
@@ -307,6 +307,7 @@ Requires:       ffmpeg
 2001-riscv64-enable-gles-rendering.patch
 # https://phabricator.services.mozilla.com/D301784
 2002-riscv64-libyuv-add-RVV-sources-to-build.patch
+2003-blindly-set-rust-rva23-target-when-needed.patch
 
 %description
 Mozilla Firefox is a free, open-source web browser developed by

--- a/SPECS/python-cryptography/0001-Fix-installing-stray-files-into-site-packages.patch
+++ b/SPECS/python-cryptography/0001-Fix-installing-stray-files-into-site-packages.patch
@@ -1,0 +1,48 @@
+From b89a7737e3f135333125b0984e75ea553a485203 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20G=C3=B3rny?= <mgorny@gentoo.org>
+Date: Sun, 15 Feb 2026 17:47:48 +0100
+Subject: [PATCH] Fix installing stray files into site-packages
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fix the `include` pattern in `pyproject.toml` not to install stray files
+such as `CHANGELOG.rst`, `CONTRIBUTING.rst`, `docs` and `tests` straight
+into site-packages.  Apparently Maturin did not install them before due
+to a bug, but it was fixed in maturin 1.12.0, leading to the files being
+suddenly installed.
+
+Originally reported as https://bugs.gentoo.org/970090.
+
+Signed-off-by: Michał Górny <mgorny@gentoo.org>
+---
+ pyproject.toml | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index e26b386280a5..8640cb6e5951 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -106,10 +106,10 @@ module-name = "cryptography.hazmat.bindings._rust"
+ locked = true
+ sdist-generator = "git"
+ include = [
+-    "CHANGELOG.rst",
+-    "CONTRIBUTING.rst",
++    { path = "CHANGELOG.rst", format = "sdist" },
++    { path = "CONTRIBUTING.rst", format = "sdist" },
+ 
+-    "docs/**/*",
++    { path = "docs/**/*", format = "sdist" },
+ 
+     { path = "src/_cffi_src/**/*.py", format = "sdist" },
+     { path = "src/_cffi_src/**/*.c", format = "sdist" },
+@@ -121,7 +121,7 @@ include = [
+     { path = "src/rust/**/Cargo.lock", format = "sdist" },
+     { path = "src/rust/**/*.rs", format = "sdist" },
+ 
+-    "tests/**/*.py",
++    { path = "tests/**/*.py", format = "sdist" },
+ ]
+ exclude = [
+     "vectors/**/*",

--- a/SPECS/python-cryptography/python-cryptography.spec
+++ b/SPECS/python-cryptography/python-cryptography.spec
@@ -20,6 +20,8 @@ Source0:        https://files.pythonhosted.org/packages/source/c/%{srcname}/%{sr
 Source1:        https://github.com/TakoPack/%{name}-vendor/releases/download/vendor-%{version}/%{srcname}-%{version}-vendor.tar.bz2
 BuildSystem:    pyproject
 
+Patch0:         0001-Fix-installing-stray-files-into-site-packages.patch
+
 BuildOption(prep):  -a1
 BuildOption(install):  %{srcname}
 

--- a/SPECS/python-maturin/python-maturin.spec
+++ b/SPECS/python-maturin/python-maturin.spec
@@ -7,14 +7,14 @@
 %global srcname maturin
 
 Name:           python-%{srcname}
-Version:        1.9.6
+Version:        1.13.3
 Release:        %autorelease
 Summary:        Build and publish Rust crates as Python packages
 License:        Apache-2.0 OR MIT
 URL:            https://github.com/PyO3/maturin
-#!RemoteAsset:  sha256:2c2ae37144811d365509889ed7220b0598487f1278c2441829c3abf56cc6324a
+#!RemoteAsset:  sha256:771e1e9e71a278e56db01552e0d1acfd1464259f9575b6e72842f893cd299079
 Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
-#!RemoteAsset:  sha256:1f1d31f07dc2715e7d3eef9f2c4875690f5e40d7b8e7de4aff778a759d0b9414
+#!RemoteAsset:  sha256:54efe94ac7fb7b28fb7c8c97ff6d77f854295d782c43e3f033e61617df1e1b5d
 Source1:        https://github.com/TakoPack/python-%{srcname}-vendor/releases/download/vendor-%{version}/%{srcname}-%{version}-vendor.tar.bz2
 BuildSystem:    pyproject
 

--- a/SPECS/python-pydantic-core/python-pydantic-core.spec
+++ b/SPECS/python-pydantic-core/python-pydantic-core.spec
@@ -32,6 +32,7 @@ BuildRequires:  python3dist(wheel)
 BuildRequires:  python3dist(typing-extensions)
 BuildRequires:  python3dist(puccinialin)
 BuildRequires:  python3dist(maturin)
+BuildRequires:  crate(target-lexicon-0.13/default) >= 0.13.3
 
 Provides:       python3-%{srcname} = %{version}-%{release}
 Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
@@ -50,6 +51,11 @@ replace-with = "vendored-sources"
 [source.vendored-sources]
 directory = "vendor"
 EOF
+
+# Substitute target-lexicon with our version to support rust rva23 target.
+rm -rf vendor/target-lexicon/{*,.*}
+cp -rf /usr/share/cargo/registry/target-lexicon-0.13*/{*,.*} vendor/target-lexicon/
+rm -f Cargo.lock
 
 %generate_buildrequires
 %pyproject_buildrequires

--- a/SPECS/python-sudachipy/python-sudachipy.spec
+++ b/SPECS/python-sudachipy/python-sudachipy.spec
@@ -7,12 +7,12 @@
 %global srcname sudachipy
 
 Name:           python-sudachipy
-Version:        0.6.10
+Version:        0.6.11
 Release:        %autorelease
 Summary:        A Japanese morphological analyzer
 License:        Apache-2.0
 URL:            https://github.com/WorksApplications/sudachi.rs/
-#!RemoteAsset:  sha256:b8910a4610de98b2c3cb6dc3362fea93e3ba5059f1eb445a68baa9585278f31b
+#!RemoteAsset:  sha256:4f03310fd3fc779b3000f49395c939d18a30081632d3cb14488426f7c07cc526
 Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
 #!RemoteAsset:  sha256:c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
 Source1:        https://raw.githubusercontent.com/WorksApplications/sudachi.rs/v%{version}/LICENSE
@@ -28,8 +28,8 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(setuptools-rust)
 BuildRequires:  python3dist(wheel)
-BuildRequires:  crate(pyo3-0.23/extension-module) >= 0.23.5
-BuildRequires:  crate(pyo3-macros-0.23) >= 0.23.5
+BuildRequires:  crate(pyo3-0.27/extension-module) >= 0.27.2
+BuildRequires:  crate(pyo3-macros-0.27) >= 0.27.2
 BuildRequires:  crate(scopeguard-1.0) >= 1.2.0
 BuildRequires:  crate(thread-local-1.0) >= 1.1.9
 BuildRequires:  crate(indoc-2.0) >= 2.0.7
@@ -74,6 +74,9 @@ replace-with = "system-registry"
 [source.system-registry]
 directory = "/usr/share/cargo/registry"
 EOF
+
+# Remove stale Cargo.lock
+rm -f Cargo.lock
 
 %files -f %{pyproject_files}
 %doc README.md

--- a/SPECS/rust/rust.spec
+++ b/SPECS/rust/rust.spec
@@ -14,7 +14,11 @@
 %global rust_arch x86_64-unknown-linux-gnu
 %endif
 %ifarch riscv64
+%if "%{openruyi_riscv_arch}" == "-march=rva23u64"
+%global rust_arch riscv64a23-unknown-linux-gnu
+%else
 %global rust_arch riscv64gc-unknown-linux-gnu
+%endif
 %endif
 
 # We might use rust-rv64gc to bootstrap rust-rva23u64.
@@ -104,7 +108,7 @@ export %{rust_env}
 # Skip these 2 tests due to no network access.
 ./x.py test --no-fail-fast --target %{rust_arch} --host %{rust_arch} cargo \
             --test-args '--skip net_err_suggests_fetch_with_cli --skip publish_to_crates_io_warns' || :
-./x.py test --no-fail-fast --target %{rust_arch} --host %{rust_arch} clippy || :
+./x.py test --no-fail-fast --target %{rust_arch} --host %{rust_arch} clippy
 ./x.py test --target %{rust_arch} --host %{rust_arch} rust-analyzer
 ./x.py test --target %{rust_arch} --host %{rust_arch} rustfmt
 


### PR DESCRIPTION
## Summary

See discussion: https://github.com/openRuyi-Project/openRuyi/discussions/133

There altogether 25 packags depend on rust in our project now, including itself. Except newly added python-outlines-core, all verified success build with rva23 rust.
```
./SPECS/aardvark-dns/aardvark-dns.spec:BuildRequires:  rust
./SPECS/cargo-c/cargo-c.spec:BuildRequires:  rust
./SPECS/cbindgen/cbindgen.spec:BuildRequires:  rust
./SPECS/ceph/ceph.spec:BuildRequires:  rust
./SPECS/cloud-hypervisor/cloud-hypervisor.spec:BuildRequires:  rust >= 1.88.0
./SPECS/firefox/firefox.spec:BuildRequires:  rust
./SPECS/gstreamer/gstreamer.spec:BuildRequires:  rust
./SPECS/netavark/netavark.spec:BuildRequires:  rust
./SPECS/niri/niri.spec:BuildRequires:  rust
./SPECS/python-cryptography/python-cryptography.spec:BuildRequires:  rust
./SPECS/python-hf-xet/python-hf-xet.spec:BuildRequires:  rust
./SPECS/python-jiter/python-jiter.spec:BuildRequires:  rust
./SPECS/python-libcst/python-libcst.spec:BuildRequires:  rust
./SPECS/python-maturin/python-maturin.spec:BuildRequires:  rust
./SPECS/python-orjson/python-orjson.spec:BuildRequires:  rust
./SPECS/python-ormsgpack/python-ormsgpack.spec:BuildRequires:  rust
./SPECS/python-outlines-core/python-outlines-core.spec:BuildRequires:  rust
./SPECS/python-pydantic-core/python-pydantic-core.spec:BuildRequires:  rust
./SPECS/python-rpds-py/python-rpds-py.spec:BuildRequires:  rust
./SPECS/python-safetensors/python-safetensors.spec:BuildRequires:  rust
./SPECS/python-sudachipy/python-sudachipy.spec:BuildRequires:  rust
./SPECS/python-tiktoken/python-tiktoken.spec:BuildRequires:  rust
./SPECS/python-tokenizers/python-tokenizers.spec:BuildRequires:  rust
./SPECS/python-uuid-utils/python-uuid-utils.spec:BuildRequires:  rust
./SPECS/rust/rust.spec:BuildRequires:  rust >= 1.94.0
```
## Related Issue

- cloud-hypervisor: Remove hardcoded --target arguments so can leverage this rva23 target.

- python-maturin: Upgrade, especially the vendor tarball, so can adapt to rust rva23 target. Notably, we need [target-lexicon >= 0.13.3](https://github.com/bytecodealliance/target-lexicon/commit/8c68f3e43bc2caf29c97442687673186e26e0f37)I tried verifying that all packages depended on it are still built fine.

- python-cryptography: There is no vendor tarball for its newer version. I just backported the upstream patch to adapt to rva23 target.

- python-pydantic-core: Upstream newest version still locked to target-lexicon 0.13.2. So I used our version(0.13.5) to substitue it.

- python-sudachipy: Minor upgrade to support rva23 target. But its Cargo.lock is too strict for our crates version.

- firefox: Force rva23 target when using rva23 rustc.

## Checklist

