### PR TITLE
SPECS: kata-containers: add 3.29.0 for Cloud Hypervisor

### DIFF
--- a/SPECS/kata-containers/0001-agent-poll-sysfs-while-waiting-for-PCI-net-devices.patch
+++ b/SPECS/kata-containers/0001-agent-poll-sysfs-while-waiting-for-PCI-net-devices.patch
@@ -1,0 +1,103 @@
+From 23aadc5366840c3003cf53b737b64afbab8216d4 Mon Sep 17 00:00:00 2001
+From: wangyf0611 <wangyufeng@iscas.ac.cn>
+Date: Wed, 3 Jun 2026 14:16:49 +0800
+Subject: [PATCH] agent: poll sysfs while waiting for PCI net devices
+
+Signed-off-by: wangyf0611 <wangyufeng@iscas.ac.cn>
+---
+ .../src/device/network_device_handler.rs      | 51 ++++++++++++++++---
+ 1 file changed, 45 insertions(+), 6 deletions(-)
+
+diff --git a/src/agent/src/device/network_device_handler.rs b/src/agent/src/device/network_device_handler.rs
+index 54504d487..b5814f292 100644
+--- a/src/agent/src/device/network_device_handler.rs
++++ b/src/agent/src/device/network_device_handler.rs
+@@ -5,18 +5,26 @@
+ //
+ #[cfg(target_arch = "s390x")]
+ use crate::ccw;
++#[cfg(target_arch = "riscv64")]
++use crate::AGENT_CONFIG;
+ use crate::linux_abi::*;
+ use crate::sandbox::Sandbox;
+-use crate::uevent::{wait_for_uevent, Uevent, UeventMatcher};
++#[cfg(not(target_arch = "riscv64"))]
++use crate::uevent::wait_for_uevent;
++use crate::uevent::{Uevent, UeventMatcher};
+ #[cfg(not(target_arch = "s390x"))]
+ use crate::{device::pcipath_to_sysfs, pci};
+ use anyhow::{anyhow, Result};
+ use regex::Regex;
+ use std::fs;
+ use std::sync::Arc;
++#[cfg(target_arch = "riscv64")]
++use std::time::Duration;
+ use tokio::sync::Mutex;
++#[cfg(target_arch = "riscv64")]
++use tokio::time::{sleep, Instant};
+ 
+-fn check_existing(re: Regex) -> Result<bool> {
++fn check_existing(re: &Regex) -> Result<bool> {
+     // Check if the interface is already added in case network is cold-plugged
+     // or the uevent loop is started before network is added.
+     // We check for the device in the sysfs directory for network devices.
+@@ -49,13 +57,44 @@ pub async fn wait_for_pci_net_interface(
+         matcher.devpath.as_str()
+     );
+     let re = Regex::new(&pattern).expect("BUG: Failed to compile regex for NetPciMatcher");
+-    if check_existing(re)? {
++    if check_existing(&re)? {
+         return Ok(());
+     }
+ 
+-    let _uev = wait_for_uevent(sandbox, matcher).await?;
++    #[cfg(target_arch = "riscv64")]
++    {
++        let _ = sandbox;
++        // Some virtual PCI network devices can be visible in sysfs without a net
++        // uevent reaching the agent watcher. Poll the same sysfs symlink pattern
++        // used for cold-plug detection so UpdateInterface can still proceed.
++        let timeout = AGENT_CONFIG.hotplug_timeout;
++        let deadline = Instant::now() + timeout;
++        let interval = Duration::from_millis(100);
++
++        loop {
++            if check_existing(&re)? {
++                return Ok(());
++            }
++
++            if Instant::now() >= deadline {
++                break;
++            }
++
++            sleep(interval).await;
++        }
+ 
+-    Ok(())
++        Err(anyhow!(
++            "Timeout after {:?} waiting for net interface {:?}",
++            timeout,
++            matcher
++        ))
++    }
++
++    #[cfg(not(target_arch = "riscv64"))]
++    {
++        let _uev = wait_for_uevent(sandbox, matcher).await?;
++        Ok(())
++    }
+ }
+ 
+ #[cfg(not(target_arch = "s390x"))]
+@@ -91,7 +130,7 @@ pub async fn wait_for_ccw_net_interface(
+     device: &ccw::Device,
+ ) -> Result<()> {
+     let matcher = NetCcwMatcher::new(CCW_ROOT_BUS_PATH, device);
+-    if check_existing(matcher.re.clone())? {
++    if check_existing(&matcher.re)? {
+         return Ok(());
+     }
+     let _uev = wait_for_uevent(sandbox, matcher).await?;
+-- 
+2.50.1 (Apple Git-155)
+

--- a/SPECS/kata-containers/0002-agent-resolve-RISC-V-platform-PCI-root-bus-path.patch
+++ b/SPECS/kata-containers/0002-agent-resolve-RISC-V-platform-PCI-root-bus-path.patch
@@ -1,0 +1,69 @@
+From 3e8fe90bd2e95b57436d468492e262a669247a01 Mon Sep 17 00:00:00 2001
+From: wangyf0611 <wangyufeng@iscas.ac.cn>
+Date: Wed, 13 May 2026 03:15:55 +0000
+Subject: [PATCH 2/6] agent: resolve RISC-V platform PCI root bus path
+
+Signed-off-by: wangyf0611 <wangyufeng@iscas.ac.cn>
+---
+ src/agent/src/linux_abi.rs | 33 +++++++++++++++++++++++++++++++--
+ 1 file changed, 31 insertions(+), 2 deletions(-)
+
+diff --git a/src/agent/src/linux_abi.rs b/src/agent/src/linux_abi.rs
+index cb5c6bc3f..4991259ed 100644
+--- a/src/agent/src/linux_abi.rs
++++ b/src/agent/src/linux_abi.rs
+@@ -9,13 +9,12 @@ use cfg_if::cfg_if;
+ use std::str::FromStr;
+ // Linux ABI related constants.
+ 
+-#[cfg(target_arch = "aarch64")]
++#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
+ use std::fs;
+ 
+ pub const SYSFS_DIR: &str = "/sys";
+ #[cfg(any(
+     all(target_arch = "powerpc64", target_endian = "little"),
+-    target_arch = "riscv64",
+     target_arch = "s390x",
+     target_arch = "x86_64",
+     target_arch = "x86"
+@@ -26,6 +25,36 @@ pub fn create_pci_root_bus_path(root_complex: &str) -> String {
+     format!("/devices/pci0000:{root_complex}")
+ }
+ 
++#[cfg(target_arch = "riscv64")]
++pub fn create_pci_root_bus_path(root_complex: &str) -> String {
++    let acpi_root_bus_path = format!("/devices/pci0000:{root_complex}");
++    let acpi_sysfs_dir = format!("{SYSFS_DIR}{acpi_root_bus_path}");
++    if fs::metadata(acpi_sysfs_dir).is_ok() {
++        return acpi_root_bus_path;
++    }
++
++    let fallback = format!("/devices/platform/30000000.pci/pci0000:{root_complex}");
++    let platform_sysfs_dir = format!("{SYSFS_DIR}/devices/platform");
++    let entries = match fs::read_dir(platform_sysfs_dir) {
++        Ok(entries) => entries,
++        Err(_) => return fallback,
++    };
++
++    for entry in entries.flatten() {
++        let dir_name = entry.file_name();
++        let root_bus_path = format!(
++            "/devices/platform/{}/pci0000:{root_complex}",
++            dir_name.to_string_lossy()
++        );
++        let sysfs_dir = format!("{SYSFS_DIR}{root_bus_path}");
++        if fs::metadata(sysfs_dir).is_ok() {
++            return root_bus_path;
++        }
++    }
++
++    fallback
++}
++
+ // This is used in several modules, let's create a helper function to parse the
+ // qom path and switch easily once the shim sends us the full NUMA path
+ pub fn pcipath_from_dev_tree_path(dev_tree_path: &str) -> Result<(&str, pci::Path)> {
+-- 
+2.50.1 (Apple Git-155)
+

--- a/SPECS/kata-containers/0003-virtcontainers-extend-Cloud-Hypervisor-boot-timeout-.patch
+++ b/SPECS/kata-containers/0003-virtcontainers-extend-Cloud-Hypervisor-boot-timeout-.patch
@@ -1,0 +1,64 @@
+From 8c32a6a33446233db7d5251f8c8b3347594441e2 Mon Sep 17 00:00:00 2001
+From: wangyf0611 <wangyufeng@iscas.ac.cn>
+Date: Wed, 13 May 2026 03:15:56 +0000
+Subject: [PATCH 3/6] virtcontainers: extend Cloud Hypervisor boot timeout on
+ RISC-V
+
+Signed-off-by: wangyf0611 <wangyufeng@iscas.ac.cn>
+---
+ src/runtime/virtcontainers/clh.go | 24 ++++++++++++++++++------
+ 1 file changed, 18 insertions(+), 6 deletions(-)
+
+diff --git a/src/runtime/virtcontainers/clh.go b/src/runtime/virtcontainers/clh.go
+index 51e3577ab..c9a4020e2 100644
+--- a/src/runtime/virtcontainers/clh.go
++++ b/src/runtime/virtcontainers/clh.go
+@@ -76,9 +76,10 @@ const (
+ 	clhTimeout                     = 10
+ 	clhAPITimeout                  = 1
+ 	clhAPITimeoutConfidentialGuest = 20
+-	// Minimum timout for calling CreateVM followed by BootVM. Executing these two APIs
++	// Minimum timeout for calling CreateVM followed by BootVM. Executing these two APIs
+ 	// might take longer than the value returned by getClhAPITimeout().
+-	clhCreateAndBootVMMinimumTimeout = 10
++	clhCreateAndBootVMMinimumTimeout        = 10
++	clhRiscv64CreateAndBootVMMinimumTimeout = 60
+ 	// Timeout for hot-plug - hotplug devices can take more time, than usual API calls
+ 	// Use longer time timeout for it.
+ 	clhHotPlugAPITimeout                   = 5
+@@ -318,6 +319,20 @@ func (clh *cloudHypervisor) getClhAPITimeout() time.Duration {
+ 	return clhAPITimeout
+ }
+ 
++func (clh *cloudHypervisor) getClhCreateAndBootVMTimeout() time.Duration {
++	minimumTimeout := time.Duration(clhCreateAndBootVMMinimumTimeout)
++	if runtime.GOARCH == "riscv64" {
++		minimumTimeout = time.Duration(clhRiscv64CreateAndBootVMMinimumTimeout)
++	}
++
++	apiTimeout := clh.getClhAPITimeout()
++	if apiTimeout < minimumTimeout {
++		return minimumTimeout
++	}
++
++	return apiTimeout
++}
++
+ func (clh *cloudHypervisor) getClhStopSandboxTimeout() time.Duration {
+ 	// Increase the StopSandboxTimeout when dealing with a Confidential Guest.
+ 	// The value has been chosen based on tests using `ctr`, and hopefully
+@@ -764,10 +779,7 @@ func (clh *cloudHypervisor) StartVM(ctx context.Context, timeout int) error {
+ 		return fmt.Errorf("failed to launch cloud-hypervisor: %q", err)
+ 	}
+ 
+-	bootTimeout := clh.getClhAPITimeout()
+-	if bootTimeout < clhCreateAndBootVMMinimumTimeout {
+-		bootTimeout = clhCreateAndBootVMMinimumTimeout
+-	}
++	bootTimeout := clh.getClhCreateAndBootVMTimeout()
+ 	ctx, cancel := context.WithTimeout(ctx, bootTimeout*time.Second)
+ 	defer cancel()
+ 
+-- 
+2.50.1 (Apple Git-155)
+

--- a/SPECS/kata-containers/0004-runtime-enable-Cloud-Hypervisor-config-on-RISC-V.patch
+++ b/SPECS/kata-containers/0004-runtime-enable-Cloud-Hypervisor-config-on-RISC-V.patch
@@ -1,0 +1,22 @@
+From ba05fe8cd6f7f7c8512a58f07c9a2318e4662a6b Mon Sep 17 00:00:00 2001
+From: wangyf0611 <wangyufeng@iscas.ac.cn>
+Date: Thu, 14 May 2026 19:37:00 +0800
+Subject: [PATCH 4/6] runtime: enable Cloud Hypervisor config on RISC-V
+
+Signed-off-by: wangyf0611 <wangyufeng@iscas.ac.cn>
+---
+ src/runtime/arch/riscv64-options.mk | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/runtime/arch/riscv64-options.mk b/src/runtime/arch/riscv64-options.mk
+index 55ba9da80..347642f3c 100644
+--- a/src/runtime/arch/riscv64-options.mk
++++ b/src/runtime/arch/riscv64-options.mk
+@@ -11,3 +11,4 @@ MACHINEACCELERATORS :=
+ CPUFEATURES :=
+ 
+ QEMUCMD := qemu-system-riscv64
++CLHCMD := cloud-hypervisor
+-- 
+2.50.1 (Apple Git-155)
+

--- a/SPECS/kata-containers/0005-kata-sys-util-fix-warnings-with-newer-Rust.patch
+++ b/SPECS/kata-containers/0005-kata-sys-util-fix-warnings-with-newer-Rust.patch
@@ -1,0 +1,86 @@
+From 9356e0b1aca8638cba51554e98db1a0c96a13396 Mon Sep 17 00:00:00 2001
+From: wangyf0611 <wangyufeng@iscas.ac.cn>
+Date: Mon, 18 May 2026 17:41:57 +0800
+Subject: [PATCH 5/6] kata-sys-util: fix warnings with newer Rust
+
+Signed-off-by: wangyf0611 <wangyufeng@iscas.ac.cn>
+---
+ src/libs/kata-sys-util/src/mount.rs      | 13 +++++++------
+ src/libs/kata-sys-util/src/protection.rs |  4 ++--
+ 2 files changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/src/libs/kata-sys-util/src/mount.rs b/src/libs/kata-sys-util/src/mount.rs
+index 892e95639..0533e51a2 100644
+--- a/src/libs/kata-sys-util/src/mount.rs
++++ b/src/libs/kata-sys-util/src/mount.rs
+@@ -225,7 +225,7 @@ pub fn create_mount_destination<S: AsRef<Path>, D: AsRef<Path>, R: AsRef<Path>>(
+ /// Caller needs to ensure safety of the `dst` to avoid possible file path based attacks.
+ pub fn bind_remount<P: AsRef<Path>>(dst: P, readonly: bool) -> Result<()> {
+     let dst = dst.as_ref();
+-    if dst.is_empty() {
++    if NixPath::is_empty(dst) {
+         return Err(Error::NullMountPointPath);
+     }
+     let dst = dst
+@@ -262,10 +262,10 @@ pub fn bind_mount_unchecked<S: AsRef<Path>, D: AsRef<Path>>(
+ 
+     let src = src.as_ref();
+     let dst = dst.as_ref();
+-    if src.is_empty() {
++    if NixPath::is_empty(src) {
+         return Err(Error::NullMountPointPath);
+     }
+-    if dst.is_empty() {
++    if NixPath::is_empty(dst) {
+         return Err(Error::NullMountPointPath);
+     }
+     let abs_src = src
+@@ -760,19 +760,20 @@ pub fn umount_timeout<P: AsRef<Path>>(path: P, timeout: u64) -> Result<()> {
+ /// # Safety
+ /// Caller needs to ensure safety of the `path` to avoid possible file path based attacks.
+ pub fn umount_all<P: AsRef<Path>>(mountpoint: P, lazy_umount: bool) -> Result<()> {
+-    if mountpoint.as_ref().is_empty() || !mountpoint.as_ref().exists() {
++    let mountpoint = mountpoint.as_ref();
++    if NixPath::is_empty(mountpoint) || !mountpoint.exists() {
+         return Ok(());
+     }
+ 
+     loop {
+-        if let Err(e) = umount2(mountpoint.as_ref(), lazy_umount) {
++        if let Err(e) = umount2(mountpoint, lazy_umount) {
+             // EINVAL is returned if the target is not a mount point, indicating that we are
+             // done. It can also indicate a few other things (such as invalid flags) which we
+             // unfortunately end up squelching here too.
+             if e.kind() == io::ErrorKind::InvalidInput {
+                 break;
+             } else {
+-                return Err(Error::Umount(mountpoint.as_ref().to_path_buf(), e));
++                return Err(Error::Umount(mountpoint.to_path_buf(), e));
+             }
+         }
+     }
+diff --git a/src/libs/kata-sys-util/src/protection.rs b/src/libs/kata-sys-util/src/protection.rs
+index 77d2698d0..38a38009a 100644
+--- a/src/libs/kata-sys-util/src/protection.rs
++++ b/src/libs/kata-sys-util/src/protection.rs
+@@ -126,7 +126,7 @@ pub fn arch_guest_protection(
+         // shouldn't hurt to double-check and have better logging if anything
+         // goes wrong.
+ 
+-        let fn0 = unsafe { x86_64::__cpuid(0) };
++        let fn0 = x86_64::__cpuid(0);
+         // The values in [ ebx, edx, ecx ] spell out "AuthenticAMD" when
+         // interpreted byte-wise as ASCII.  No need to bother here with an
+         // actual conversion to string though.
+@@ -139,7 +139,7 @@ pub fn arch_guest_protection(
+         }
+ 
+         // AMD64 Architecture Prgrammer's Manual Fn8000_001f docs on pg. 640
+-        let fn8000_001f = unsafe { x86_64::__cpuid(0x8000_001f) };
++        let fn8000_001f = x86_64::__cpuid(0x8000_001f);
+         if fn8000_001f.eax & 0x10 == 0 {
+             return Err(ProtectionError::CheckFailed("SEV not supported".to_owned()));
+         }
+-- 
+2.50.1 (Apple Git-155)
+

--- a/SPECS/kata-containers/0006-agent-generate-version-file-for-optimized-builds.patch
+++ b/SPECS/kata-containers/0006-agent-generate-version-file-for-optimized-builds.patch
@@ -1,0 +1,26 @@
+From 7823606289e25473b605b4e2e7603477118b54f1 Mon Sep 17 00:00:00 2001
+From: wangyf0611 <wangyufeng@iscas.ac.cn>
+Date: Mon, 18 May 2026 17:45:44 +0800
+Subject: [PATCH 6/6] agent: generate version file for optimized builds
+
+Signed-off-by: wangyf0611 <wangyufeng@iscas.ac.cn>
+---
+ src/agent/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/agent/Makefile b/src/agent/Makefile
+index 4305c41d4..5ce024c2d 100644
+--- a/src/agent/Makefile
++++ b/src/agent/Makefile
+@@ -134,7 +134,7 @@ $(GENERATED_FILES): %: %.in $(VERSION_FILE)
+ 	@sed $(foreach r,$(GENERATED_REPLACEMENTS),-e 's|@$r@|$($r)|g') "$<" > "$@"
+ 
+ ##TARGET optimize: optimized  build
+-optimize: show-summary show-header
++optimize: $(GENERATED_CODE) show-summary show-header
+ 	@RUSTFLAGS="-C link-arg=-s $(EXTRA_RUSTFLAGS) --deny warnings" cargo build --target $(TRIPLE) $(if $(findstring release,$(BUILD_TYPE)),--release) $(EXTRA_RUSTFEATURES)
+ 
+ ##TARGET install: install agent
+-- 
+2.50.1 (Apple Git-155)
+

--- a/SPECS/kata-containers/kata-containers.spec
+++ b/SPECS/kata-containers/kata-containers.spec
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: wangyf0611 <wangyufeng@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           kata-containers
+Version:        3.29.0
+Release:        %autorelease
+Summary:        Secure container runtime with lightweight virtual machines
+License:        Apache-2.0
+URL:            https://github.com/kata-containers/kata-containers
+#!RemoteAsset:  sha256:8dab047ee17d2cd2fc8cdb01d2530c65cd2235e48e964c95a9a3a9275f721078
+Source0:        %{url}/archive/refs/tags/%{version}.tar.gz#/%{name}-%{version}.tar.gz
+#!RemoteAsset:  sha256:ae81cfe188b12fb0c01c2186c20d63cd99fdbb85b6c0d7542a830c9c3dae2deb
+Source1:        %{url}/releases/download/%{version}/%{name}-%{version}-vendor.tar.gz
+# Kata's runtime is built through upstream Go Makefiles; the Rust agent is built
+# in the same package because Kata ships both components together.
+BuildSystem:    golang
+
+BuildRequires:  cargo >= 1.92.0
+BuildRequires:  git
+BuildRequires:  go >= 1.25.9
+BuildRequires:  go-rpm-macros
+BuildRequires:  libseccomp-devel
+BuildRequires:  make
+BuildRequires:  protobuf-devel
+BuildRequires:  rust >= 1.92.0
+BuildRequires:  rust-rpm-macros
+
+Requires:       cloud-hypervisor
+
+Recommends:     virtiofsd
+
+%patchlist
+# Poll sysfs while waiting for PCI network devices so Cloud Hypervisor hotplug
+# does not stall when the uevent watcher misses an already-created netdev.
+0001-agent-poll-sysfs-while-waiting-for-PCI-net-devices.patch
+# Resolve the platform PCI root bus path used by RISC-V virt machines without
+# ACPI, falling back to /devices/platform/.../pci0000:* when needed.
+0002-agent-resolve-RISC-V-platform-PCI-root-bus-path.patch
+# Increase the Cloud Hypervisor CreateVM and BootVM timeout on riscv64, where
+# nested virtualization under QEMU/TCG boots more slowly during validation.
+0003-virtcontainers-extend-Cloud-Hypervisor-boot-timeout-.patch
+# Register Cloud Hypervisor as an available riscv64 hypervisor in Kata's
+# architecture options so DEFAULT_HYPERVISOR=cloud-hypervisor is accepted.
+0004-runtime-enable-Cloud-Hypervisor-config-on-RISC-V.patch
+# Build with newer Rust by removing ambiguous NixPath method calls and
+# unnecessary x86_64 CPUID unsafe blocks that are denied as warnings.
+0005-kata-sys-util-fix-warnings-with-newer-Rust.patch
+# Ensure the optimized kata-agent build generates src/version.rs before Cargo
+# compiles the binary.
+0006-agent-generate-version-file-for-optimized-builds.patch
+
+%description
+Kata Containers provides a secure container runtime using lightweight virtual
+machines. It integrates with OCI and CRI runtimes while improving workload
+isolation with a dedicated guest kernel and agent.
+
+%prep
+%autosetup -p1
+tar -xf %{SOURCE1}
+cat >> .cargo/config <<EOF
+[net]
+offline = true
+EOF
+
+%build
+export GOFLAGS="-mod=vendor"
+rust_host_triple="$(rustc -vV | sed -n 's/^host: //p')"
+make -C src/runtime \
+    PREFIX=%{_prefix} \
+    LIBEXECDIR=%{_libexecdir} \
+    DEFAULT_HYPERVISOR=cloud-hypervisor
+
+make -C src/agent \
+    BUILD_TYPE=release \
+    TRIPLE="${rust_host_triple}" \
+    optimize
+
+%install
+export GOFLAGS="-mod=vendor"
+rust_host_triple="$(rustc -vV | sed -n 's/^host: //p')"
+make -C src/runtime \
+    DESTDIR=%{buildroot} \
+    PREFIX=%{_prefix} \
+    LIBEXECDIR=%{_libexecdir} \
+    DEFAULT_HYPERVISOR=cloud-hypervisor \
+    install
+
+install -Dpm0755 target/${rust_host_triple}/release/kata-agent \
+    %{buildroot}%{_datadir}/kata-containers/kata-agent
+
+%check
+# Upstream tests require nested virtualization, container runtime state, or
+# privileged kernel features that are unavailable in a normal package chroot.
+
+%files
+%doc README.md VERSION
+%license LICENSE
+%{_bindir}/kata-runtime
+%{_bindir}/containerd-shim-kata-v2
+%{_bindir}/kata-monitor
+%{_bindir}/kata-collect-data.sh
+%{_datadir}/bash-completion/completions/kata-runtime
+%{_datadir}/defaults/kata-containers/
+%{_datadir}/kata-containers/kata-agent
+
+%changelog
+%autochangelog


### PR DESCRIPTION
Add kata-containers 3.29.0 packaging for openRuyi with Cloud Hypervisor enabled on riscv64.

- Uses upstream 3.29.0 source plus patches aligned with kata-containers/kata-containers#13079 for RISC-V Cloud Hypervisor runtime support.
- Keeps a pinned Cargo vendor tarball for this submission, following the temporary vendor approach used by the current cloud-hypervisor package.
- Addresses the previous #410 review issues: no ExclusiveArch, no empty BuildSystem, no unnecessary gcc BuildRequires, uses %autosetup, keeps patch comments specific, and omits VCS.
- Validation: OBS home:yufeng:kata-containers rev6 succeeded on x86_64 and riscv64; the rev6 riscv64 RPM was installed on openRuyi and ran a Kata + Cloud Hypervisor busybox container with working networking in 34 seconds.
- AI assistance was used for review triage, SPEC iteration, and validation log consolidation; build and runtime validation were executed in the recorded OBS/openRuyi environments.
