### PR TITLE
SPECS: Add OpenAI SDK packaging support

### DIFF
--- a/SPECS/portaudio/0001-backport-cmake-install-libdir-and-soname.patch
+++ b/SPECS/portaudio/0001-backport-cmake-install-libdir-and-soname.patch
@@ -1,0 +1,50 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -375,6 +375,10 @@ IF(PA_BUILD_SHARED)
+   TARGET_INCLUDE_DIRECTORIES(portaudio PRIVATE ${PA_PRIVATE_INCLUDE_PATHS})
+   TARGET_INCLUDE_DIRECTORIES(portaudio PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>" "$<INSTALL_INTERFACE:include>")
+   TARGET_LINK_LIBRARIES(portaudio ${PA_LIBRARY_DEPENDENCIES})
++  IF(NOT WIN32)
++    SET_TARGET_PROPERTIES(portaudio PROPERTIES VERSION ${PA_SOVERSION}
++      SOVERSION 2)
++  ENDIF()
+ ENDIF()
+ 
+ IF(PA_BUILD_STATIC)
+@@ -443,7 +447,7 @@ IF(NOT PA_OUTPUT_OSX_FRAMEWORK AND NOT PA_DISABLE_INSTALL)
+   INCLUDE(CMakePackageConfigHelpers)
+ 
+   CONFIGURE_PACKAGE_CONFIG_FILE(cmake_support/portaudioConfig.cmake.in ${CMAKE_BINARY_DIR}/cmake/portaudio/portaudioConfig.cmake
+-    INSTALL_DESTINATION "lib/cmake/portaudio"
++    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/portaudio"
+     NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+   WRITE_BASIC_PACKAGE_VERSION_FILE(${CMAKE_BINARY_DIR}/cmake/portaudio/portaudioConfigVersion.cmake
+     VERSION ${PA_VERSION}
+@@ -451,14 +455,14 @@ IF(NOT PA_OUTPUT_OSX_FRAMEWORK AND NOT PA_DISABLE_INSTALL)
+   CONFIGURE_FILE(cmake_support/portaudio-2.0.pc.in ${CMAKE_CURRENT_BINARY_DIR}/portaudio-2.0.pc @ONLY)
+   INSTALL(FILES README.md DESTINATION share/doc/portaudio)
+   INSTALL(FILES LICENSE.txt DESTINATION share/doc/portaudio)
+-  INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/portaudio-2.0.pc DESTINATION lib/pkgconfig)
++  INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/portaudio-2.0.pc DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+   INSTALL(FILES ${PA_PUBLIC_INCLUDES} DESTINATION include)
+   INSTALL(TARGETS ${PA_TARGETS}
+     EXPORT portaudio-targets
+     RUNTIME DESTINATION bin
+-    LIBRARY DESTINATION lib
+-    ARCHIVE DESTINATION lib)
+-  INSTALL(EXPORT portaudio-targets FILE "portaudioTargets.cmake" DESTINATION "lib/cmake/portaudio")
++    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
++  INSTALL(EXPORT portaudio-targets FILE "portaudioTargets.cmake" DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/portaudio")
+   EXPORT(TARGETS ${PA_TARGETS} FILE "${PROJECT_BINARY_DIR}/cmake/portaudio/portaudioTargets.cmake")
+   INSTALL(FILES "${CMAKE_BINARY_DIR}/cmake/portaudio/portaudioConfig.cmake"
+                 "${CMAKE_BINARY_DIR}/cmake/portaudio/portaudioConfigVersion.cmake"
+@@ -462,7 +466,7 @@ IF(NOT PA_OUTPUT_OSX_FRAMEWORK AND NOT PA_DISABLE_INSTALL)
+   EXPORT(TARGETS ${PA_TARGETS} FILE "${PROJECT_BINARY_DIR}/cmake/portaudio/portaudioTargets.cmake")
+   INSTALL(FILES "${CMAKE_BINARY_DIR}/cmake/portaudio/portaudioConfig.cmake"
+                 "${CMAKE_BINARY_DIR}/cmake/portaudio/portaudioConfigVersion.cmake"
+-    DESTINATION "lib/cmake/portaudio")
++    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/portaudio")
+ 
+   IF (NOT TARGET uninstall)
+     CONFIGURE_FILE(

--- a/SPECS/portaudio/portaudio.spec
+++ b/SPECS/portaudio/portaudio.spec
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           portaudio
+Version:        19.7.0
+Release:        %autorelease
+Summary:        Portable cross-platform Audio I/O library
+License:        MIT
+URL:            https://www.portaudio.com
+VCS:            git:https://github.com/PortAudio/portaudio.git
+#!RemoteAsset:  sha256:5af29ba58bbdbb7bbcefaaecc77ec8fc413f0db6f4c4e286c40c3e1b83174fa0
+Source0:        https://github.com/PortAudio/portaudio/archive/v%{version}.tar.gz#/portaudio-%{version}.tar.gz
+BuildSystem:    cmake
+
+# Backport upstream CMake install-dir and shared-library versioning fixes from
+# master, including PortAudio/portaudio@99b4ee829ce171bc52a4eb9f026ea6168147af43.
+Patch0:         0001-backport-cmake-install-libdir-and-soname.patch
+
+BuildOption(conf):  -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+BuildOption(conf):  -DCMAKE_BUILD_TYPE=Release
+BuildOption(conf):  -DBUILD_SHARED_LIBS=ON
+BuildOption(conf):  -DPA_BUILD_STATIC=OFF
+BuildOption(conf):  -DPA_BUILD_TESTS=OFF
+BuildOption(conf):  -DPA_BUILD_EXAMPLES=OFF
+
+BuildRequires:  cmake
+
+%description
+PortAudio is a free, cross-platform, open-source audio I/O library.
+It provides a single API for recording and playing sound across
+Linux (ALSA, JACK, OSS), macOS (CoreAudio), and Windows (WASAPI, ASIO, WDM-KS).
+
+%package        devel
+Summary:        Development files for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+Header files and development libraries for building applications
+that use PortAudio.
+
+%files
+%doc %{_docdir}/portaudio/README.md
+%license LICENSE.txt
+%license %{_docdir}/portaudio/LICENSE.txt
+%{_libdir}/libportaudio.so.*
+
+%files devel
+%{_includedir}/portaudio.h
+%{_libdir}/libportaudio.so
+%{_libdir}/pkgconfig/portaudio-2.0.pc
+%{_libdir}/cmake/portaudio/
+
+%changelog
+%autochangelog

--- a/SPECS/python-anthropic/python-anthropic.spec
+++ b/SPECS/python-anthropic/python-anthropic.spec
@@ -7,12 +7,12 @@
 %global srcname anthropic
 
 Name:           python-%{srcname}
-Version:        0.102.0
+Version:        0.105.2
 Release:        %autorelease
 Summary:        Official Python library for the Anthropic API
 License:        MIT
 URL:            https://github.com/anthropics/anthropic-sdk-python
-#!RemoteAsset:  sha256:96f747cad11886c4ae12d4080131b94eebd68b202bd2190fe27959031bb1fa9c
+#!RemoteAsset:  sha256:0e26b90841c2dced7cc6e98d21d5517d0be33f1876b8e779f478202e28bcaa07
 Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject

--- a/SPECS/python-openai/python-openai.spec
+++ b/SPECS/python-openai/python-openai.spec
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname openai
+
+Name:           python-%{srcname}
+Version:        2.40.0
+Release:        %autorelease
+Summary:        The official Python library for the OpenAI API
+License:        Apache-2.0
+URL:            https://github.com/openai/openai-python
+#!RemoteAsset:  sha256:9a756f91f274a24ad6026cbcb2042fd356c8d4a10e8f347b08d34465e585f7a2
+Source0:        https://files.pythonhosted.org/packages/source/o/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname} -L
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(anyio)
+BuildRequires:  python3dist(distro)
+BuildRequires:  python3dist(hatch-fancy-pypi-readme)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(httpx)
+BuildRequires:  python3dist(jiter)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pydantic)
+BuildRequires:  python3dist(sniffio)
+BuildRequires:  python3dist(sounddevice)
+BuildRequires:  python3dist(tqdm)
+BuildRequires:  python3dist(typing-extensions)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+openai is the official Python SDK for accessing OpenAI APIs, with both
+synchronous and asynchronous clients.
+
+%prep -a
+# Upstream pins the build backend to hatchling==1.26.3. The distro build uses
+# the packaged hatchling, so relax this before dependencies are calculated.
+sed -i 's/hatchling==1.26.3/hatchling>=1.26.3/' pyproject.toml
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-opentelemetry-api/python-opentelemetry-api.spec
+++ b/SPECS/python-opentelemetry-api/python-opentelemetry-api.spec
@@ -8,13 +8,13 @@
 %global pypi_name opentelemetry_api
 
 Name:           python-%{srcname}
-Version:        1.42.0
+Version:        1.42.1
 Release:        %autorelease
 Summary:        OpenTelemetry Python API
 License:        Apache-2.0
 URL:            https://github.com/open-telemetry/opentelemetry-python
 VCS:            git:https://github.com/open-telemetry/opentelemetry-python.git
-#!RemoteAsset:  sha256:ea84c893ad177791d138e0349d6ceebd8d3bf006440900400ce220008dafc372
+#!RemoteAsset:  sha256:56c63bea9f77b62856be8c47600474acad853b2924b99b1687c4cb6297166716
 Source:         https://files.pythonhosted.org/packages/source/o/%{srcname}/%{pypi_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject

--- a/SPECS/python-opentelemetry-sdk/python-opentelemetry-sdk.spec
+++ b/SPECS/python-opentelemetry-sdk/python-opentelemetry-sdk.spec
@@ -8,12 +8,12 @@
 %global pypi_name opentelemetry_sdk
 
 Name:           python-%{srcname}
-Version:        1.42.0
+Version:        1.42.1
 Release:        %autorelease
 Summary:        OpenTelemetry Python SDK
 License:        Apache-2.0
 URL:            https://github.com/open-telemetry/opentelemetry-python
-#!RemoteAsset:  sha256:2479e462cc69357825c2c847ce4a601bc1b17e1279aa7f80d3490f0ae614d0e5
+#!RemoteAsset:  sha256:8c834e8f8c9ba4171d4ec843d0cb8a67e4c7394d3f9e9297e582cbd9456ddbf7
 Source0:        https://files.pythonhosted.org/packages/source/o/%{srcname}/%{pypi_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject

--- a/SPECS/python-opentelemetry-semantic-conventions-ai/python-opentelemetry-semantic-conventions-ai.spec
+++ b/SPECS/python-opentelemetry-semantic-conventions-ai/python-opentelemetry-semantic-conventions-ai.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname opentelemetry-semantic-conventions-ai
+%global pypi_name opentelemetry_semantic_conventions_ai
+
+Name:           python-%{srcname}
+Version:        0.5.1
+Release:        %autorelease
+Summary:        OpenTelemetry Semantic Conventions Extension for Large Language Models
+License:        Apache-2.0
+URL:            https://github.com/traceloop/openllmetry-python
+#!RemoteAsset:  sha256:153906200d8c1d2f8e09bd78dbef526916023de85ac3dab35912bfafb69ff04c
+Source0:        https://files.pythonhosted.org/packages/source/o/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l opentelemetry -L
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(opentelemetry-sdk)
+BuildRequires:  python3dist(opentelemetry-semantic-conventions)
+BuildRequires:  python3dist(pip)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+This package provides OpenTelemetry Semantic Conventions extensions for
+Large Language Models (LLMs), defining well-known attribute keys and values
+for tracing LLM interactions.
+
+%files -f %{pyproject_files}
+%doc README.md
+
+%changelog
+%autochangelog

--- a/SPECS/python-opentelemetry-semantic-conventions/python-opentelemetry-semantic-conventions.spec
+++ b/SPECS/python-opentelemetry-semantic-conventions/python-opentelemetry-semantic-conventions.spec
@@ -8,13 +8,13 @@
 %global pypi_name opentelemetry_semantic_conventions
 
 Name:           python-%{srcname}
-Version:        0.63b0
+Version:        0.63b1
 Release:        %autorelease
 Summary:        OpenTelemetry Semantic Conventions
 License:        Apache-2.0
 URL:            https://github.com/open-telemetry/opentelemetry-python
 VCS:            git:https://github.com/open-telemetry/opentelemetry-python.git
-#!RemoteAsset:  sha256:cfea295264654fa324fcef24aa56fb1836fdc0da27db128645dc6aa76115cc6c
+#!RemoteAsset:  sha256:3daf963611334b365e98a57438183eb012d3bfb40b2d931a9af613476b8701a9
 Source:         https://files.pythonhosted.org/packages/source/o/%{srcname}/%{pypi_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject

--- a/SPECS/python-sounddevice/python-sounddevice.spec
+++ b/SPECS/python-sounddevice/python-sounddevice.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname sounddevice
+
+Name:           python-%{srcname}
+Version:        0.5.5
+Release:        %autorelease
+Summary:        Play and Record Sound with Python
+License:        MIT
+URL:            https://github.com/spatialaudio/python-sounddevice
+#!RemoteAsset:  sha256:22487b65198cb5bf2208755105b524f78ad173e5ab6b445bdab1c989f6698df3
+Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname} _%{srcname} -L
+
+BuildRequires:  pkgconfig(portaudio-2.0)
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(cffi)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm)
+
+Requires:       portaudio%{?_isa}
+Requires:       python3dist(cffi)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+sounddevice provides Python bindings for the PortAudio library, allowing
+playback and recording of audio via NumPy arrays. It uses CFFI for the
+foreign function interface to PortAudio.
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

`python-openai` is a core dependency for modern LLM application stacks and is
commonly required by AI frameworks, inference clients, agent frameworks, and
OpenAI-compatible API integrations. Packaging it in openRuyi allows downstream
LLM-related packages to depend on a distro-provided SDK instead of vendoring or
installing it from PyPI.

## Related Issue

NO

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.
- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: ChatGPT:GPT-5.5 Thinking
Use GPT-5.5 to write the patch files.

```mermaid
flowchart LR
    %% Newly added packages
    portaudio["portaudio\n19.7.0"]
    sounddevice["python-sounddevice\n0.5.5"]
    openai["python-openai\n2.40.0"]
    otel_ai["python-opentelemetry-semantic-conventions-ai\n0.5.1"]

    %% Updated packages
    anthropic["python-anthropic\n0.105.2"]
    otel_api["python-opentelemetry-api\n1.42.1"]
    otel_semconv["python-opentelemetry-semantic-conventions\n0.63b1"]
    otel_sdk["python-opentelemetry-sdk\n1.42.1"]

    %% Existing common Python deps
    anyio["python-anyio"]
    distro["python-distro"]
    docstring_parser["python-docstring-parser"]
    hatch_fancy["python-hatch-fancy-pypi-readme"]
    hatchling["python-hatchling"]
    httpx["python-httpx"]
    importlib_metadata["python-importlib-metadata"]
    jiter["python-jiter"]
    numpy["python-numpy"]
    pydantic["python-pydantic"]
    sniffio["python-sniffio"]
    tqdm["python-tqdm"]
    typing_extensions["python-typing-extensions"]
    cffi["python-cffi"]

    %% Core dependency edges inside this batch
    sounddevice -->|runtime| portaudio
    sounddevice -.->|build/check| portaudio
    openai -.->|check optional voice helper| sounddevice

    otel_semconv -->|runtime| otel_api
    otel_sdk -->|runtime| otel_api
    otel_sdk -->|runtime| otel_semconv
    otel_ai -.->|build/import check| otel_sdk
    otel_ai -.->|build/import check| otel_semconv

    %% openai deps
    openai -.->|build/check| anyio
    openai -.->|build/check| distro
    openai -.->|build| hatch_fancy
    openai -.->|build| hatchling
    openai -.->|build/check| httpx
    openai -.->|build/check| jiter
    openai -.->|check optional voice helper| numpy
    openai -.->|build/check| pydantic
    openai -.->|build/check| sniffio
    openai -.->|build/check| tqdm
    openai -.->|build/check| typing_extensions

    %% anthropic deps
    anthropic -.->|build/check| anyio
    anthropic -.->|build/check| distro
    anthropic -.->|build/check| docstring_parser
    anthropic -.->|build| hatch_fancy
    anthropic -.->|build| hatchling
    anthropic -.->|build/check| httpx
    anthropic -.->|build/check| jiter
    anthropic -.->|build/check| pydantic
    anthropic -.->|build/check| sniffio
    anthropic -.->|build/check| typing_extensions

    %% sounddevice deps
    sounddevice -->|runtime| cffi
    sounddevice -.->|build/check| cffi

    %% opentelemetry deps
    otel_api -->|runtime| importlib_metadata
    otel_api -->|runtime| typing_extensions
    otel_semconv -->|runtime| typing_extensions
    otel_ai -.->|build| hatchling

    classDef newPkg fill:#dcfce7,stroke:#16a34a,color:#14532d;
    classDef updatedPkg fill:#dbeafe,stroke:#2563eb,color:#1e3a8a;
    classDef existingPkg fill:#f3f4f6,stroke:#6b7280,color:#111827;

    class portaudio,sounddevice,openai,otel_ai newPkg;
    class anthropic,otel_api,otel_semconv,otel_sdk updatedPkg;
    class anyio,distro,docstring_parser,hatch_fancy,hatchling,httpx,importlib_metadata,jiter,numpy,pydantic,sniffio,tqdm,typing_extensions,cffi existingPkg;
```