### PR TITLE
SPECS: add Rust crate dependencies for Python extensions

### DIFF
--- a/SPECS/rust-addr2line-0.24/rust-addr2line.spec
+++ b/SPECS/rust-addr2line-0.24/rust-addr2line.spec
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name addr2line
+%global full_version 0.24.2
+%global pkgname addr2line-0.24
+
+Name:           rust-addr2line-0.24
+Version:        0.24.2
+Release:        %autorelease
+Summary:        Rust crate "addr2line"
+License:        Apache-2.0 OR MIT
+URL:            https://github.com/gimli-rs/addr2line
+#!RemoteAsset:  sha256:dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(gimli-0.31/read) >= 0.31.1
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/cargo-all)
+
+%description
+Source code for takopackized Rust crate "addr2line"
+
+%package     -n %{name}+fallible-iterator
+Summary:        Cross-platform symbolication library written in Rust, using `gimli` - feature "fallible-iterator"
+Requires:       crate(%{pkgname})
+Requires:       crate(fallible-iterator-0.3) >= 0.3.0
+Provides:       crate(%{pkgname}/fallible-iterator)
+
+%description -n %{name}+fallible-iterator
+This metapackage enables feature "fallible-iterator" for the Rust addr2line crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+rustc-demangle
+Summary:        Cross-platform symbolication library written in Rust, using `gimli` - feature "rustc-demangle"
+Requires:       crate(%{pkgname})
+Requires:       crate(rustc-demangle-0.1/default) >= 0.1.0
+Provides:       crate(%{pkgname}/rustc-demangle)
+
+%description -n %{name}+rustc-demangle
+This metapackage enables feature "rustc-demangle" for the Rust addr2line crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+smallvec
+Summary:        Cross-platform symbolication library written in Rust, using `gimli` - feature "smallvec"
+Requires:       crate(%{pkgname})
+Requires:       crate(smallvec-1.0) >= 1.0.0
+Provides:       crate(%{pkgname}/smallvec)
+
+%description -n %{name}+smallvec
+This metapackage enables feature "smallvec" for the Rust addr2line crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+std
+Summary:        Cross-platform symbolication library written in Rust, using `gimli` - feature "std"
+Requires:       crate(%{pkgname})
+Requires:       crate(gimli-0.31/read) >= 0.31.1
+Requires:       crate(gimli-0.31/std) >= 0.31.1
+Provides:       crate(%{pkgname}/std)
+
+%description -n %{name}+std
+This metapackage enables feature "std" for the Rust addr2line crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-aws-lc-rs-1.0/rust-aws-lc-rs.spec
+++ b/SPECS/rust-aws-lc-rs-1.0/rust-aws-lc-rs.spec
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name aws-lc-rs
+%global full_version 1.15.2
+%global pkgname aws-lc-rs-1.0
+
+Name:           rust-aws-lc-rs-1.0
+Version:        1.15.2
+Release:        %autorelease
+Summary:        Rust crate "aws-lc-rs"
+License:        ISC AND (Apache-2.0 OR ISC)
+URL:            https://github.com/aws/aws-lc-rs
+#!RemoteAsset:  sha256:6a88aab2464f1f25453baa7a07c84c5b7684e274054ba06817f382357f77a288
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(zeroize-1.0/default) >= 1.8.2
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/alloc)
+Provides:       crate(%{pkgname}/test-logging)
+Provides:       crate(%{pkgname}/unstable)
+
+%description
+This library strives to be API-compatible with the popular Rust library named ring.
+Source code for takopackized Rust crate "aws-lc-rs"
+
+%package     -n %{name}+aws-lc-sys
+Summary:        Cryptographic library using AWS-LC for its cryptographic operations - feature "aws-lc-sys" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(aws-lc-sys-0.35) >= 0.35.0
+Provides:       crate(%{pkgname}/aws-lc-sys)
+Provides:       crate(%{pkgname}/non-fips)
+
+%description -n %{name}+aws-lc-sys
+This library strives to be API-compatible with the popular Rust library named ring.
+This metapackage enables feature "aws-lc-sys" for the Rust aws-lc-rs crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "non-fips" feature.
+
+%package     -n %{name}+prebuilt-nasm
+Summary:        Cryptographic library using AWS-LC for its cryptographic operations - feature "prebuilt-nasm"
+Requires:       crate(%{pkgname})
+Requires:       crate(aws-lc-sys-0.35/prebuilt-nasm) >= 0.35.0
+Provides:       crate(%{pkgname}/prebuilt-nasm)
+
+%description -n %{name}+prebuilt-nasm
+This library strives to be API-compatible with the popular Rust library named ring.
+This metapackage enables feature "prebuilt-nasm" for the Rust aws-lc-rs crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-aws-lc-sys-0.35/rust-aws-lc-sys.spec
+++ b/SPECS/rust-aws-lc-sys-0.35/rust-aws-lc-sys.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name aws-lc-sys
+%global full_version 0.35.0
+%global pkgname aws-lc-sys-0.35
+
+Name:           rust-aws-lc-sys-0.35
+Version:        0.35.0
+Release:        %autorelease
+Summary:        Rust crate "aws-lc-sys"
+License:        ISC AND (Apache-2.0 OR ISC) AND OpenSSL
+URL:            https://github.com/aws/aws-lc-rs
+#!RemoteAsset:  sha256:b45afffdee1e7c9126814751f88dddc747f41d91da16c9551a0f1e8a11e788a1
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(cc-1.0/default) >= 1.2.52
+Requires:       crate(cc-1.0/parallel) >= 1.2.52
+Requires:       crate(cmake-0.1/default) >= 0.1.57
+Requires:       crate(dunce-1.0/default) >= 1.0.5
+Requires:       crate(fs-extra-1.0/default) >= 1.3.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/all-bindings)
+Provides:       crate(%{pkgname}/asan)
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/prebuilt-nasm)
+
+%description
+It іs based on code from the Google BoringSSL project and the OpenSSL project.
+Source code for takopackized Rust crate "aws-lc-sys"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-base64-0.13/rust-base64.spec
+++ b/SPECS/rust-base64-0.13/rust-base64.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name base64
+%global full_version 0.13.1
+%global pkgname base64-0.13
+
+Name:           rust-base64-0.13
+Version:        0.13.1
+Release:        %autorelease
+Summary:        Rust crate "base64"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/marshallpierce/rust-base64
+#!RemoteAsset:  sha256:9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/alloc)
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description
+Source code for takopackized Rust crate "base64"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-bigdecimal-0.4/rust-bigdecimal.spec
+++ b/SPECS/rust-bigdecimal-0.4/rust-bigdecimal.spec
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name bigdecimal
+%global full_version 0.4.10
+%global pkgname bigdecimal-0.4
+
+Name:           rust-bigdecimal-0.4
+Version:        0.4.10
+Release:        %autorelease
+Summary:        Rust crate "bigdecimal"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/akubera/bigdecimal-rs
+#!RemoteAsset:  sha256:4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(autocfg-1.0/default) >= 1.5.0
+Requires:       crate(libm-0.2/default) >= 0.2.16
+Requires:       crate(num-bigint-0.4) >= 0.4.6
+Requires:       crate(num-integer-0.1) >= 0.1.46
+Requires:       crate(num-traits-0.2) >= 0.2.19
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/string-only)
+
+%description
+Source code for takopackized Rust crate "bigdecimal"
+
+%package     -n %{name}+serde
+Summary:        Arbitrary precision decimal numbers - feature "serde"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0) >= 1.0.0
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust bigdecimal crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+serde-json
+Summary:        Arbitrary precision decimal numbers - feature "serde_json"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/derive) >= 1.0.0
+Requires:       crate(serde-json-1.0/alloc) >= 1.0.0
+Requires:       crate(serde-json-1.0/arbitrary-precision) >= 1.0.0
+Provides:       crate(%{pkgname}/serde-json)
+
+%description -n %{name}+serde-json
+This metapackage enables feature "serde_json" for the Rust bigdecimal crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+std
+Summary:        Arbitrary precision decimal numbers - feature "std" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(num-bigint-0.4/std) >= 0.4.6
+Requires:       crate(num-integer-0.1/std) >= 0.1.46
+Requires:       crate(num-traits-0.2/std) >= 0.2.19
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description -n %{name}+std
+This metapackage enables feature "std" for the Rust bigdecimal crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "default" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-borrow-or-share-0.2/rust-borrow-or-share.spec
+++ b/SPECS/rust-borrow-or-share-0.2/rust-borrow-or-share.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name borrow-or-share
+%global full_version 0.2.2
+%global pkgname borrow-or-share-0.2
+
+Name:           rust-borrow-or-share-0.2
+Version:        0.2.2
+Release:        %autorelease
+Summary:        Rust crate "borrow-or-share"
+License:        MIT-0
+URL:            https://github.com/yescallop/borrow-or-share
+#!RemoteAsset:  sha256:3eeab4423108c5d7c744f4d234de88d18d636100093ae04caf4825134b9c3a32
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description
+Source code for takopackized Rust crate "borrow-or-share"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-bytecount-0.6/rust-bytecount.spec
+++ b/SPECS/rust-bytecount-0.6/rust-bytecount.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name bytecount
+%global full_version 0.6.9
+%global pkgname bytecount-0.6
+
+Name:           rust-bytecount-0.6
+Version:        0.6.9
+Release:        %autorelease
+Summary:        Rust crate "bytecount"
+License:        Apache-2.0 OR MIT
+URL:            https://github.com/llogiq/bytecount
+#!RemoteAsset:  sha256:175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/generic-simd)
+Provides:       crate(%{pkgname}/html-report)
+Provides:       crate(%{pkgname}/runtime-dispatch-simd)
+
+%description
+Source code for takopackized Rust crate "bytecount"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-clap-lex-0.7/rust-clap-lex.spec
+++ b/SPECS/rust-clap-lex-0.7/rust-clap-lex.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name clap_lex
+%global full_version 0.7.5
+%global pkgname clap-lex-0.7
+
+Name:           rust-clap-lex-0.7
+Version:        0.7.5
+Release:        %autorelease
+Summary:        Rust crate "clap_lex"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/clap-rs/clap
+#!RemoteAsset:  sha256:b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "clap_lex"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-cmake-0.1/rust-cmake.spec
+++ b/SPECS/rust-cmake-0.1/rust-cmake.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name cmake
+%global full_version 0.1.57
+%global pkgname cmake-0.1
+
+Name:           rust-cmake-0.1
+Version:        0.1.57
+Release:        %autorelease
+Summary:        Rust crate "cmake"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/rust-lang/cmake-rs
+#!RemoteAsset:  sha256:75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(cc-1.0/default) >= 1.2.52
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "cmake"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-dary-heap-0.3/rust-dary-heap.spec
+++ b/SPECS/rust-dary-heap-0.3/rust-dary-heap.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name dary_heap
+%global full_version 0.3.8
+%global pkgname dary-heap-0.3
+
+Name:           rust-dary-heap-0.3
+Version:        0.3.8
+Release:        %autorelease
+Summary:        Rust crate "dary_heap"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/hanmertens/dary_heap
+#!RemoteAsset:  sha256:06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/extra)
+Provides:       crate(%{pkgname}/unstable)
+Provides:       crate(%{pkgname}/unstable-nightly)
+
+%description
+Source code for takopackized Rust crate "dary_heap"
+
+%package     -n %{name}+serde
+Summary:        D-ary heap - feature "serde"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/alloc) >= 1.0.228
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust dary_heap crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-derivre-0.3/rust-derivre.spec
+++ b/SPECS/rust-derivre-0.3/rust-derivre.spec
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name derivre
+%global full_version 0.3.11
+%global pkgname derivre-0.3
+
+Name:           rust-derivre-0.3
+Version:        0.3.11
+Release:        %autorelease
+Summary:        Rust crate "derivre"
+License:        MIT
+URL:            https://github.com/microsoft/derivre
+#!RemoteAsset:  sha256:dd3bf7087923a80510e6ea986960cb4011bcf54259ecb19a80bf40a645a1526c
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(anyhow-1.0/default) >= 1.0.98
+Requires:       crate(bytemuck-1.0/default) >= 1.23.1
+Requires:       crate(bytemuck-derive-1.0/default) >= 1.9.3
+Requires:       crate(hashbrown-0.15) >= 0.15.4
+Requires:       crate(regex-syntax-0.8/default) >= 0.8.5
+Requires:       crate(strum-0.27/default) >= 0.27.1
+Requires:       crate(strum-0.27/derive) >= 0.27.1
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/compress)
+
+%description
+Source code for takopackized Rust crate "derivre"
+
+%package     -n %{name}+ahash
+Summary:        Derivative-based regular expression engine - feature "ahash"
+Requires:       crate(%{pkgname})
+Requires:       crate(ahash-0.8/default) >= 0.8.12
+Provides:       crate(%{pkgname}/ahash)
+
+%description -n %{name}+ahash
+This metapackage enables feature "ahash" for the Rust derivre crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+default
+Summary:        Derivative-based regular expression engine - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/ahash)
+Requires:       crate(%{pkgname}/compress)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust derivre crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-dirs-5.0/rust-dirs.spec
+++ b/SPECS/rust-dirs-5.0/rust-dirs.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name dirs
+%global full_version 5.0.1
+%global pkgname dirs-5.0
+
+Name:           rust-dirs-5.0
+Version:        5.0.1
+Release:        %autorelease
+Summary:        Rust crate "dirs"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/soc/dirs-rs
+#!RemoteAsset:  sha256:44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(dirs-sys-0.4/default) >= 0.4.1
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "dirs"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-dirs-sys-0.4/2000-remove-windows-target-dependencies.patch
+++ b/SPECS/rust-dirs-sys-0.4/2000-remove-windows-target-dependencies.patch
@@ -1,0 +1,15 @@
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -22,12 +22,3 @@ default-features = false
+ 
+ [target."cfg(unix)".dependencies.libc]
+ version = "0.2"
+-
+-[target."cfg(windows)".dependencies.windows-sys]
+-version = "0.48.0"
+-features = [
+-    "Win32_UI_Shell",
+-    "Win32_Foundation",
+-    "Win32_Globalization",
+-    "Win32_System_Com",
+-]

--- a/SPECS/rust-dirs-sys-0.4/rust-dirs-sys.spec
+++ b/SPECS/rust-dirs-sys-0.4/rust-dirs-sys.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name dirs-sys
+%global full_version 0.4.1
+%global pkgname dirs-sys-0.4
+
+Name:           rust-dirs-sys-0.4
+Version:        0.4.1
+Release:        %autorelease
+Summary:        Rust crate "dirs-sys"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/dirs-dev/dirs-sys-rs
+#!RemoteAsset:  sha256:520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+# Remove Windows-only target dependencies from Linux/RISC-V packaging; cargo
+# metadata still checks target dependency sources when using a replacement registry.
+Patch2000:      2000-remove-windows-target-dependencies.patch
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(libc-0.2/default) >= 0.2.180
+Requires:       crate(option-ext-0.2/default) >= 0.2.0
+Requires:       crate(redox-users-0.4) >= 0.4.6
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "dirs-sys"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-email-address-0.2/rust-email-address.spec
+++ b/SPECS/rust-email-address-0.2/rust-email-address.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name email_address
+%global full_version 0.2.9
+%global pkgname email-address-0.2
+
+Name:           rust-email-address-0.2
+Version:        0.2.9
+Release:        %autorelease
+Summary:        Rust crate "email_address"
+License:        MIT
+URL:            https://github.com/johnstonskj/rust-email_address.git
+#!RemoteAsset:  sha256:e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "email_address"
+
+%package     -n %{name}+serde
+Summary:        Rust crate providing an implementation of an RFC-compliant `EmailAddress` newtype - feature "serde" and 2 more
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/default) >= 1.0.219
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/serde)
+Provides:       crate(%{pkgname}/serde-support)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust email_address crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "default", and "serde_support" features.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-esaxx-rs-0.1/rust-esaxx-rs.spec
+++ b/SPECS/rust-esaxx-rs-0.1/rust-esaxx-rs.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name esaxx-rs
+%global full_version 0.1.10
+%global pkgname esaxx-rs-0.1
+
+Name:           rust-esaxx-rs-0.1
+Version:        0.1.10
+Release:        %autorelease
+Summary:        Rust crate "esaxx-rs"
+License:        Apache-2.0
+URL:            https://github.com/Narsil/esaxx-rs
+#!RemoteAsset:  sha256:d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "esaxx-rs"
+
+%package     -n %{name}+cc
+Summary:        Wrapping around sentencepiece's esaxxx library - feature "cc" and 2 more
+Requires:       crate(%{pkgname})
+Requires:       crate(cc-1.0/default) >= 1.0.0
+Provides:       crate(%{pkgname}/cc)
+Provides:       crate(%{pkgname}/cpp)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+cc
+This metapackage enables feature "cc" for the Rust esaxx-rs crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "cpp", and "default" features.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-fluent-uri-0.3/rust-fluent-uri.spec
+++ b/SPECS/rust-fluent-uri-0.3/rust-fluent-uri.spec
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name fluent-uri
+%global full_version 0.3.2
+%global pkgname fluent-uri-0.3
+
+Name:           rust-fluent-uri-0.3
+Version:        0.3.2
+Release:        %autorelease
+Summary:        Rust crate "fluent-uri"
+License:        MIT
+URL:            https://github.com/yescallop/fluent-uri-rs
+#!RemoteAsset:  sha256:1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(borrow-or-share-0.2/default) >= 0.2.2
+Requires:       crate(ref-cast-1.0/default) >= 1.0.24
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/net)
+Provides:       crate(%{pkgname}/std)
+
+%description
+Source code for takopackized Rust crate "fluent-uri"
+
+%package     -n %{name}+serde
+Summary:        Generic URI/IRI handling library compliant with RFC 3986/3987 - feature "serde"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/default) >= 1.0.219
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust fluent-uri crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-fraction-0.15/rust-fraction.spec
+++ b/SPECS/rust-fraction-0.15/rust-fraction.spec
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name fraction
+%global full_version 0.15.3
+%global pkgname fraction-0.15
+
+Name:           rust-fraction-0.15
+Version:        0.15.3
+Release:        %autorelease
+Summary:        Rust crate "fraction"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/dnsl48/fraction.git
+#!RemoteAsset:  sha256:0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(num-0.4) >= 0.4.3
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/with-decimal)
+Provides:       crate(%{pkgname}/with-dynaint)
+Provides:       crate(%{pkgname}/with-unicode)
+
+%description
+Source code for takopackized Rust crate "fraction"
+
+%package     -n %{name}+byteorder
+Summary:        Lossless fractions and decimals; drop-in float replacement - feature "byteorder"
+Requires:       crate(%{pkgname})
+Requires:       crate(byteorder-1.0/default) >= 1.0.0
+Provides:       crate(%{pkgname}/byteorder)
+
+%description -n %{name}+byteorder
+This metapackage enables feature "byteorder" for the Rust fraction crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+bytes
+Summary:        Lossless fractions and decimals; drop-in float replacement - feature "bytes"
+Requires:       crate(%{pkgname})
+Requires:       crate(bytes-1.0/default) >= 1.0.0
+Provides:       crate(%{pkgname}/bytes)
+
+%description -n %{name}+bytes
+This metapackage enables feature "bytes" for the Rust fraction crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+default
+Summary:        Lossless fractions and decimals; drop-in float replacement - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/with-bigint)
+Requires:       crate(%{pkgname}/with-decimal)
+Requires:       crate(%{pkgname}/with-dynaint)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust fraction crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+lazy-static
+Summary:        Lossless fractions and decimals; drop-in float replacement - feature "lazy_static"
+Requires:       crate(%{pkgname})
+Requires:       crate(lazy-static-1.0/default) >= 1.5.0
+Provides:       crate(%{pkgname}/lazy-static)
+
+%description -n %{name}+lazy-static
+This metapackage enables feature "lazy_static" for the Rust fraction crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+serde
+Summary:        Lossless fractions and decimals; drop-in float replacement - feature "serde"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/default) >= 1.0.0
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust fraction crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+serde-derive
+Summary:        Lossless fractions and decimals; drop-in float replacement - feature "serde_derive"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-derive-1.0/default) >= 1.0.0
+Provides:       crate(%{pkgname}/serde-derive)
+
+%description -n %{name}+serde-derive
+This metapackage enables feature "serde_derive" for the Rust fraction crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+with-bigint
+Summary:        Lossless fractions and decimals; drop-in float replacement - feature "with-bigint" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/lazy-static)
+Requires:       crate(num-0.4/num-bigint) >= 0.4.3
+Requires:       crate(num-0.4/std) >= 0.4.3
+Provides:       crate(%{pkgname}/with-approx)
+Provides:       crate(%{pkgname}/with-bigint)
+
+%description -n %{name}+with-bigint
+This metapackage enables feature "with-bigint" for the Rust fraction crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "with-approx" feature.
+
+%package     -n %{name}+with-serde-support
+Summary:        Lossless fractions and decimals; drop-in float replacement - feature "with-serde-support"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/serde)
+Requires:       crate(%{pkgname}/serde-derive)
+Requires:       crate(num-0.4/serde) >= 0.4.3
+Provides:       crate(%{pkgname}/with-serde-support)
+
+%description -n %{name}+with-serde-support
+This metapackage enables feature "with-serde-support" for the Rust fraction crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-fs-extra-1.0/rust-fs-extra.spec
+++ b/SPECS/rust-fs-extra-1.0/rust-fs-extra.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name fs_extra
+%global full_version 1.3.0
+%global pkgname fs-extra-1.0
+
+Name:           rust-fs-extra-1.0
+Version:        1.3.0
+Release:        %autorelease
+Summary:        Rust crate "fs_extra"
+License:        MIT
+URL:            https://github.com/webdesus/fs_extra
+#!RemoteAsset:  sha256:42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Recursively copy folders with information about process and much more.
+Source code for takopackized Rust crate "fs_extra"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-futures-timer-3.0/rust-futures-timer.spec
+++ b/SPECS/rust-futures-timer-3.0/rust-futures-timer.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name futures-timer
+%global full_version 3.0.3
+%global pkgname futures-timer-3.0
+
+Name:           rust-futures-timer-3.0
+Version:        3.0.3
+Release:        %autorelease
+Summary:        Rust crate "futures-timer"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/async-rs/futures-timer
+#!RemoteAsset:  sha256:f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "futures-timer"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-gimli-0.31/rust-gimli.spec
+++ b/SPECS/rust-gimli-0.31/rust-gimli.spec
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name gimli
+%global full_version 0.31.1
+%global pkgname gimli-0.31
+
+Name:           rust-gimli-0.31
+Version:        0.31.1
+Release:        %autorelease
+Summary:        Rust crate "gimli"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/gimli-rs/gimli
+#!RemoteAsset:  sha256:07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/read)
+Provides:       crate(%{pkgname}/read-core)
+
+%description
+Source code for takopackized Rust crate "gimli"
+
+%package     -n %{name}+default
+Summary:        Reading and writing the DWARF debugging format - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/read-all)
+Requires:       crate(%{pkgname}/write)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust gimli crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+endian-reader
+Summary:        Reading and writing the DWARF debugging format - feature "endian-reader"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/read)
+Requires:       crate(stable-deref-trait-1.0) >= 1.1.0
+Provides:       crate(%{pkgname}/endian-reader)
+
+%description -n %{name}+endian-reader
+This metapackage enables feature "endian-reader" for the Rust gimli crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+fallible-iterator
+Summary:        Reading and writing the DWARF debugging format - feature "fallible-iterator"
+Requires:       crate(%{pkgname})
+Requires:       crate(fallible-iterator-0.3) >= 0.3.0
+Provides:       crate(%{pkgname}/fallible-iterator)
+
+%description -n %{name}+fallible-iterator
+This metapackage enables feature "fallible-iterator" for the Rust gimli crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+read-all
+Summary:        Reading and writing the DWARF debugging format - feature "read-all"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/endian-reader)
+Requires:       crate(%{pkgname}/fallible-iterator)
+Requires:       crate(%{pkgname}/read)
+Requires:       crate(%{pkgname}/std)
+Provides:       crate(%{pkgname}/read-all)
+
+%description -n %{name}+read-all
+This metapackage enables feature "read-all" for the Rust gimli crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+std
+Summary:        Reading and writing the DWARF debugging format - feature "std"
+Requires:       crate(%{pkgname})
+Requires:       crate(fallible-iterator-0.3/std) >= 0.3.0
+Requires:       crate(stable-deref-trait-1.0/std) >= 1.1.0
+Provides:       crate(%{pkgname}/std)
+
+%description -n %{name}+std
+This metapackage enables feature "std" for the Rust gimli crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+write
+Summary:        Reading and writing the DWARF debugging format - feature "write"
+Requires:       crate(%{pkgname})
+Requires:       crate(indexmap-2.0/default) >= 2.0.0
+Provides:       crate(%{pkgname}/write)
+
+%description -n %{name}+write
+This metapackage enables feature "write" for the Rust gimli crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-hf-hub-0.4/rust-hf-hub.spec
+++ b/SPECS/rust-hf-hub-0.4/rust-hf-hub.spec
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name hf-hub
+%global full_version 0.4.1
+%global pkgname hf-hub-0.4
+
+Name:           rust-hf-hub-0.4
+Version:        0.4.1
+Release:        %autorelease
+Summary:        Rust crate "hf-hub"
+License:        Apache-2.0
+URL:            https://github.com/huggingface/hf-hub
+#!RemoteAsset:  sha256:112fa2f6ad4ab815b9e1b938b4b1e437032d055e2f92ed10fd6ab2e62d02c6b6
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(dirs-5.0/default) >= 5.0.1
+Requires:       crate(log-0.4/default) >= 0.4.29
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "hf-hub"
+
+%package     -n %{name}+default
+Summary:        This crates aims ease the interaction with [huggingface](https://huggingface.co/)  It aims to be compatible with [huggingface_hub](https://github.com/huggingface/huggingface_hub/) python package, but only implements a smaller subset of functions - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/default-tls)
+Requires:       crate(%{pkgname}/tokio)
+Requires:       crate(%{pkgname}/ureq)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust hf-hub crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+native-tls
+Summary:        This crates aims ease the interaction with [huggingface](https://huggingface.co/)  It aims to be compatible with [huggingface_hub](https://github.com/huggingface/huggingface_hub/) python package, but only implements a smaller subset of functions - feature "native-tls" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(native-tls-0.2/default) >= 0.2.12
+Requires:       crate(reqwest-0.12/default) >= 0.12.28
+Requires:       crate(reqwest-0.12/json) >= 0.12.28
+Requires:       crate(reqwest-0.12/stream) >= 0.12.28
+Requires:       crate(ureq-2.0/json) >= 2.12.1
+Requires:       crate(ureq-2.0/native-tls) >= 2.12.1
+Requires:       crate(ureq-2.0/socks-proxy) >= 2.12.1
+Provides:       crate(%{pkgname}/default-tls)
+Provides:       crate(%{pkgname}/native-tls)
+
+%description -n %{name}+native-tls
+This metapackage enables feature "native-tls" for the Rust hf-hub crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "default-tls" feature.
+
+%package     -n %{name}+rustls-tls
+Summary:        This crates aims ease the interaction with [huggingface](https://huggingface.co/)  It aims to be compatible with [huggingface_hub](https://github.com/huggingface/huggingface_hub/) python package, but only implements a smaller subset of functions - feature "rustls-tls"
+Requires:       crate(%{pkgname})
+Requires:       crate(reqwest-0.12/json) >= 0.12.28
+Requires:       crate(reqwest-0.12/rustls-tls) >= 0.12.28
+Requires:       crate(reqwest-0.12/stream) >= 0.12.28
+Requires:       crate(rustls-0.23/default) >= 0.23.36
+Provides:       crate(%{pkgname}/rustls-tls)
+
+%description -n %{name}+rustls-tls
+This metapackage enables feature "rustls-tls" for the Rust hf-hub crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+tokio
+Summary:        This crates aims ease the interaction with [huggingface](https://huggingface.co/)  It aims to be compatible with [huggingface_hub](https://github.com/huggingface/huggingface_hub/) python package, but only implements a smaller subset of functions - feature "tokio"
+Requires:       crate(%{pkgname})
+Requires:       crate(futures-0.3/default) >= 0.3.28
+Requires:       crate(indicatif-0.17/default) >= 0.17.11
+Requires:       crate(num-cpus-1.0/default) >= 1.15.0
+Requires:       crate(rand-0.8/default) >= 0.8.5
+Requires:       crate(reqwest-0.12/charset) >= 0.12.28
+Requires:       crate(reqwest-0.12/http2) >= 0.12.28
+Requires:       crate(reqwest-0.12/json) >= 0.12.28
+Requires:       crate(reqwest-0.12/macos-system-configuration) >= 0.12.28
+Requires:       crate(reqwest-0.12/stream) >= 0.12.28
+Requires:       crate(serde-1.0/default) >= 1.0.228
+Requires:       crate(serde-1.0/derive) >= 1.0.228
+Requires:       crate(serde-json-1.0/default) >= 1.0.149
+Requires:       crate(thiserror-2.0/default) >= 2.0.17
+Requires:       crate(tokio-1.0/default) >= 1.29.1
+Requires:       crate(tokio-1.0/fs) >= 1.29.1
+Requires:       crate(tokio-1.0/macros) >= 1.29.1
+Requires:       crate(tokio-1.0/rt-multi-thread) >= 1.29.1
+Provides:       crate(%{pkgname}/tokio)
+
+%description -n %{name}+tokio
+This metapackage enables feature "tokio" for the Rust hf-hub crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+ureq
+Summary:        This crates aims ease the interaction with [huggingface](https://huggingface.co/)  It aims to be compatible with [huggingface_hub](https://github.com/huggingface/huggingface_hub/) python package, but only implements a smaller subset of functions - feature "ureq"
+Requires:       crate(%{pkgname})
+Requires:       crate(http-1.0/default) >= 1.4.0
+Requires:       crate(indicatif-0.17/default) >= 0.17.11
+Requires:       crate(rand-0.8/default) >= 0.8.5
+Requires:       crate(serde-1.0/default) >= 1.0.228
+Requires:       crate(serde-1.0/derive) >= 1.0.228
+Requires:       crate(serde-json-1.0/default) >= 1.0.149
+Requires:       crate(thiserror-2.0/default) >= 2.0.17
+Requires:       crate(ureq-2.0/default) >= 2.12.1
+Requires:       crate(ureq-2.0/json) >= 2.12.1
+Requires:       crate(ureq-2.0/socks-proxy) >= 2.12.1
+Provides:       crate(%{pkgname}/ureq)
+
+%description -n %{name}+ureq
+This metapackage enables feature "ureq" for the Rust hf-hub crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-hyper-tls-0.6/rust-hyper-tls.spec
+++ b/SPECS/rust-hyper-tls-0.6/rust-hyper-tls.spec
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name hyper-tls
+%global full_version 0.6.0
+%global pkgname hyper-tls-0.6
+
+Name:           rust-hyper-tls-0.6
+Version:        0.6.0
+Release:        %autorelease
+Summary:        Rust crate "hyper-tls"
+License:        MIT OR Apache-2.0
+URL:            https://hyper.rs
+#!RemoteAsset:  sha256:70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(bytes-1.0/default) >= 1.11.1
+Requires:       crate(http-body-util-0.1/default) >= 0.1.3
+Requires:       crate(hyper-1.0/default) >= 1.6.0
+Requires:       crate(hyper-util-0.1/client-legacy) >= 0.1.14
+Requires:       crate(hyper-util-0.1/default) >= 0.1.14
+Requires:       crate(hyper-util-0.1/tokio) >= 0.1.14
+Requires:       crate(native-tls-0.2/default) >= 0.2.14
+Requires:       crate(tokio-1.0/default) >= 1.46.0
+Requires:       crate(tokio-native-tls-0.3/default) >= 0.3.1
+Requires:       crate(tower-service-0.3/default) >= 0.3.3
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "hyper-tls"
+
+%package     -n %{name}+alpn
+Summary:        Default TLS implementation for use with hyper - feature "alpn"
+Requires:       crate(%{pkgname})
+Requires:       crate(native-tls-0.2/alpn) >= 0.2.14
+Provides:       crate(%{pkgname}/alpn)
+
+%description -n %{name}+alpn
+This metapackage enables feature "alpn" for the Rust hyper-tls crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+vendored
+Summary:        Default TLS implementation for use with hyper - feature "vendored"
+Requires:       crate(%{pkgname})
+Requires:       crate(native-tls-0.2/vendored) >= 0.2.14
+Provides:       crate(%{pkgname}/vendored)
+
+%description -n %{name}+vendored
+This metapackage enables feature "vendored" for the Rust hyper-tls crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-indicatif-0.17/rust-indicatif.spec
+++ b/SPECS/rust-indicatif-0.17/rust-indicatif.spec
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name indicatif
+%global full_version 0.17.11
+%global pkgname indicatif-0.17
+
+Name:           rust-indicatif-0.17
+Version:        0.17.11
+Release:        %autorelease
+Summary:        Rust crate "indicatif"
+License:        MIT
+URL:            https://github.com/console-rs/indicatif
+#!RemoteAsset:  sha256:183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(console-0.15/ansi-parsing) >= 0.15.11
+Requires:       crate(number-prefix-0.4/default) >= 0.4.0
+Requires:       crate(portable-atomic-1.0/default) >= 1.13.0
+Requires:       crate(web-time-1.0/default) >= 1.1.0
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "indicatif"
+
+%package     -n %{name}+default
+Summary:        Progress bar and cli reporting library for Rust - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/unicode-width)
+Requires:       crate(console-0.15/ansi-parsing) >= 0.15.11
+Requires:       crate(console-0.15/unicode-width) >= 0.15.11
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust indicatif crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+futures
+Summary:        Progress bar and cli reporting library for Rust - feature "futures"
+Requires:       crate(%{pkgname})
+Requires:       crate(futures-core-0.3) >= 0.3.0
+Provides:       crate(%{pkgname}/futures)
+
+%description -n %{name}+futures
+This metapackage enables feature "futures" for the Rust indicatif crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+improved-unicode
+Summary:        Progress bar and cli reporting library for Rust - feature "improved_unicode"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/unicode-segmentation)
+Requires:       crate(%{pkgname}/unicode-width)
+Requires:       crate(console-0.15/ansi-parsing) >= 0.15.11
+Requires:       crate(console-0.15/unicode-width) >= 0.15.11
+Provides:       crate(%{pkgname}/improved-unicode)
+
+%description -n %{name}+improved-unicode
+This metapackage enables feature "improved_unicode" for the Rust indicatif crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+rayon
+Summary:        Progress bar and cli reporting library for Rust - feature "rayon"
+Requires:       crate(%{pkgname})
+Requires:       crate(rayon-1.0/default) >= 1.1
+Provides:       crate(%{pkgname}/rayon)
+
+%description -n %{name}+rayon
+This metapackage enables feature "rayon" for the Rust indicatif crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+tokio
+Summary:        Progress bar and cli reporting library for Rust - feature "tokio"
+Requires:       crate(%{pkgname})
+Requires:       crate(tokio-1.0/default) >= 1.0.0
+Requires:       crate(tokio-1.0/io-util) >= 1.0.0
+Provides:       crate(%{pkgname}/tokio)
+
+%description -n %{name}+tokio
+This metapackage enables feature "tokio" for the Rust indicatif crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+unicode-segmentation
+Summary:        Progress bar and cli reporting library for Rust - feature "unicode-segmentation"
+Requires:       crate(%{pkgname})
+Requires:       crate(unicode-segmentation-1.0/default) >= 1.0.0
+Provides:       crate(%{pkgname}/unicode-segmentation)
+
+%description -n %{name}+unicode-segmentation
+This metapackage enables feature "unicode-segmentation" for the Rust indicatif crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+unicode-width
+Summary:        Progress bar and cli reporting library for Rust - feature "unicode-width"
+Requires:       crate(%{pkgname})
+Requires:       crate(unicode-width-0.2/default) >= 0.2.2
+Provides:       crate(%{pkgname}/unicode-width)
+
+%description -n %{name}+unicode-width
+This metapackage enables feature "unicode-width" for the Rust indicatif crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-instant-0.1/rust-instant.spec
+++ b/SPECS/rust-instant-0.1/rust-instant.spec
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name instant
+%global full_version 0.1.13
+%global pkgname instant-0.1
+
+Name:           rust-instant-0.1
+Version:        0.1.13
+Release:        %autorelease
+Summary:        Rust crate "instant"
+License:        BSD-3-Clause
+URL:            https://github.com/sebcrozet/instant
+#!RemoteAsset:  sha256:e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(cfg-if-1.0/default) >= 1.0.1
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/inaccurate)
+Provides:       crate(%{pkgname}/now)
+
+%description
+Source code for takopackized Rust crate "instant"
+
+%package     -n %{name}+js-sys
+Summary:        Unmaintained, consider using web-time instead - A partial replacement for std::time::Instant that works on WASM to - feature "js-sys"
+Requires:       crate(%{pkgname})
+Requires:       crate(js-sys-0.3/default) >= 0.3.0
+Provides:       crate(%{pkgname}/js-sys)
+
+%description -n %{name}+js-sys
+This metapackage enables feature "js-sys" for the Rust instant crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+wasm-bindgen
+Summary:        Unmaintained, consider using web-time instead - A partial replacement for std::time::Instant that works on WASM to - feature "wasm-bindgen"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/js-sys)
+Requires:       crate(%{pkgname}/wasm-bindgen-rs)
+Requires:       crate(%{pkgname}/web-sys)
+Provides:       crate(%{pkgname}/wasm-bindgen)
+
+%description -n %{name}+wasm-bindgen
+This metapackage enables feature "wasm-bindgen" for the Rust instant crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+wasm-bindgen-rs
+Summary:        Unmaintained, consider using web-time instead - A partial replacement for std::time::Instant that works on WASM to - feature "wasm-bindgen_rs"
+Requires:       crate(%{pkgname})
+Requires:       crate(wasm-bindgen-0.2/default) >= 0.2.0
+Provides:       crate(%{pkgname}/wasm-bindgen-rs)
+
+%description -n %{name}+wasm-bindgen-rs
+This metapackage enables feature "wasm-bindgen_rs" for the Rust instant crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+web-sys
+Summary:        Unmaintained, consider using web-time instead - A partial replacement for std::time::Instant that works on WASM to - feature "web-sys"
+Requires:       crate(%{pkgname})
+Requires:       crate(web-sys-0.3/default) >= 0.3.0
+Requires:       crate(web-sys-0.3/performance) >= 0.3.0
+Requires:       crate(web-sys-0.3/performancetiming) >= 0.3.0
+Requires:       crate(web-sys-0.3/window) >= 0.3.0
+Provides:       crate(%{pkgname}/web-sys)
+
+%description -n %{name}+web-sys
+This metapackage enables feature "web-sys" for the Rust instant crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-io-uring-0.7/rust-io-uring.spec
+++ b/SPECS/rust-io-uring-0.7/rust-io-uring.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name io-uring
+%global full_version 0.7.8
+%global pkgname io-uring-0.7
+
+Name:           rust-io-uring-0.7
+Version:        0.7.8
+Release:        %autorelease
+Summary:        Rust crate "io-uring"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/tokio-rs/io-uring
+#!RemoteAsset:  sha256:b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(bitflags-2.0/default) >= 2.9.1
+Requires:       crate(cfg-if-1.0/default) >= 1.0.1
+Requires:       crate(libc-0.2) >= 0.2.174
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/io-safety)
+
+%description
+Source code for takopackized Rust crate "io-uring"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-jsonschema-0.29/rust-jsonschema.spec
+++ b/SPECS/rust-jsonschema-0.29/rust-jsonschema.spec
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name jsonschema
+%global full_version 0.29.1
+%global pkgname jsonschema-0.29
+
+Name:           rust-jsonschema-0.29
+Version:        0.29.1
+Release:        %autorelease
+Summary:        Rust crate "jsonschema"
+License:        MIT
+URL:            https://github.com/Stranger6667/jsonschema
+#!RemoteAsset:  sha256:161c33c3ec738cfea3288c5c53dfcdb32fd4fc2954de86ea06f71b5a1a40bfcd
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(ahash-0.8/default) >= 0.8.12
+Requires:       crate(ahash-0.8/serde) >= 0.8.12
+Requires:       crate(base64-0.22/default) >= 0.22.1
+Requires:       crate(bytecount-0.6/default) >= 0.6.9
+Requires:       crate(bytecount-0.6/runtime-dispatch-simd) >= 0.6.9
+Requires:       crate(email-address-0.2/default) >= 0.2.9
+Requires:       crate(fancy-regex-0.14/default) >= 0.14.0
+Requires:       crate(fraction-0.15/with-bigint) >= 0.15.3
+Requires:       crate(idna-1.0/default) >= 1.0.3
+Requires:       crate(itoa-1.0/default) >= 1.0.15
+Requires:       crate(num-cmp-0.1/default) >= 0.1.0
+Requires:       crate(once-cell-1.0/default) >= 1.21.3
+Requires:       crate(percent-encoding-2.0/default) >= 2.3.1
+Requires:       crate(referencing-0.29/default) >= 0.29.1
+Requires:       crate(regex-syntax-0.8/default) >= 0.8.5
+Requires:       crate(serde-1.0/default) >= 1.0.219
+Requires:       crate(serde-1.0/derive) >= 1.0.219
+Requires:       crate(serde-json-1.0/default) >= 1.0.140
+Requires:       crate(uuid-simd-0.8/default) >= 0.8.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/resolve-file)
+
+%description
+Source code for takopackized Rust crate "jsonschema"
+
+%package     -n %{name}+default
+Summary:        JSON schema validaton library - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/resolve-file)
+Requires:       crate(%{pkgname}/resolve-http)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust jsonschema crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+reqwest
+Summary:        JSON schema validaton library - feature "reqwest" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(reqwest-0.12/blocking) >= 0.12.22
+Requires:       crate(reqwest-0.12/json) >= 0.12.22
+Provides:       crate(%{pkgname}/reqwest)
+Provides:       crate(%{pkgname}/resolve-http)
+
+%description -n %{name}+reqwest
+This metapackage enables feature "reqwest" for the Rust jsonschema crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "resolve-http" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-linux-raw-sys-0.9/rust-linux-raw-sys.spec
+++ b/SPECS/rust-linux-raw-sys-0.9/rust-linux-raw-sys.spec
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name linux-raw-sys
+%global full_version 0.9.4
+%global pkgname linux-raw-sys-0.9
+
+Name:           rust-linux-raw-sys-0.9
+Version:        0.9.4
+Release:        %autorelease
+Summary:        Rust crate "linux-raw-sys"
+License:        Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT
+URL:            https://github.com/sunfishcode/linux-raw-sys
+#!RemoteAsset:  sha256:cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/bootparam)
+Provides:       crate(%{pkgname}/btrfs)
+Provides:       crate(%{pkgname}/elf)
+Provides:       crate(%{pkgname}/elf-uapi)
+Provides:       crate(%{pkgname}/errno)
+Provides:       crate(%{pkgname}/general)
+Provides:       crate(%{pkgname}/if-arp)
+Provides:       crate(%{pkgname}/if-ether)
+Provides:       crate(%{pkgname}/if-packet)
+Provides:       crate(%{pkgname}/image)
+Provides:       crate(%{pkgname}/io-uring)
+Provides:       crate(%{pkgname}/ioctl)
+Provides:       crate(%{pkgname}/landlock)
+Provides:       crate(%{pkgname}/loop-device)
+Provides:       crate(%{pkgname}/mempolicy)
+Provides:       crate(%{pkgname}/net)
+Provides:       crate(%{pkgname}/netlink)
+Provides:       crate(%{pkgname}/no-std)
+Provides:       crate(%{pkgname}/prctl)
+Provides:       crate(%{pkgname}/ptrace)
+Provides:       crate(%{pkgname}/std)
+Provides:       crate(%{pkgname}/system)
+Provides:       crate(%{pkgname}/xdp)
+
+%description
+Source code for takopackized Rust crate "linux-raw-sys"
+
+%package     -n %{name}+default
+Summary:        Generated bindings for Linux's userspace API - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/errno)
+Requires:       crate(%{pkgname}/general)
+Requires:       crate(%{pkgname}/std)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust linux-raw-sys crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-lru-slab-0.1/rust-lru-slab.spec
+++ b/SPECS/rust-lru-slab-0.1/rust-lru-slab.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name lru-slab
+%global full_version 0.1.2
+%global pkgname lru-slab-0.1
+
+Name:           rust-lru-slab-0.1
+Version:        0.1.2
+Release:        %autorelease
+Summary:        Rust crate "lru-slab"
+License:        MIT OR Apache-2.0 OR Zlib
+URL:            https://github.com/Ralith/lru-slab
+#!RemoteAsset:  sha256:112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "lru-slab"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-macro-rules-attribute-0.2/rust-macro-rules-attribute.spec
+++ b/SPECS/rust-macro-rules-attribute-0.2/rust-macro-rules-attribute.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name macro_rules_attribute
+%global full_version 0.2.2
+%global pkgname macro-rules-attribute-0.2
+
+Name:           rust-macro-rules-attribute-0.2
+Version:        0.2.2
+Release:        %autorelease
+Summary:        Rust crate "macro_rules_attribute"
+License:        Apache-2.0 OR MIT OR Zlib
+URL:            https://crates.io/crates/macro_rules_attribute
+#!RemoteAsset:  sha256:65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(macro-rules-attribute-proc-macro-0.2/default) >= 0.2.2
+Requires:       crate(paste-1.0/default) >= 1.0.15
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/better-docs)
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "macro_rules_attribute"
+
+%package     -n %{name}+verbose-expansions
+Summary:        Use declarative macros in attribute or derive position - feature "verbose-expansions"
+Requires:       crate(%{pkgname})
+Requires:       crate(macro-rules-attribute-proc-macro-0.2/verbose-expansions) >= 0.2.2
+Provides:       crate(%{pkgname}/verbose-expansions)
+
+%description -n %{name}+verbose-expansions
+This metapackage enables feature "verbose-expansions" for the Rust macro_rules_attribute crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-macro-rules-attribute-proc-macro-0.2/rust-macro-rules-attribute-proc-macro.spec
+++ b/SPECS/rust-macro-rules-attribute-proc-macro-0.2/rust-macro-rules-attribute-proc-macro.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name macro_rules_attribute-proc_macro
+%global full_version 0.2.2
+%global pkgname macro-rules-attribute-proc-macro-0.2
+
+Name:           rust-macro-rules-attribute-proc-macro-0.2
+Version:        0.2.2
+Release:        %autorelease
+Summary:        Rust crate "macro_rules_attribute-proc_macro"
+License:        Apache-2.0 OR MIT OR Zlib
+URL:            https://github.com/danielhenrymantilla/macro_rules_attribute-rs
+#!RemoteAsset:  sha256:670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/verbose-expansions)
+
+%description
+Source code for takopackized Rust crate "macro_rules_attribute-proc_macro"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-monostate-0.1/rust-monostate.spec
+++ b/SPECS/rust-monostate-0.1/rust-monostate.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name monostate
+%global full_version 0.1.18
+%global pkgname monostate-0.1
+
+Name:           rust-monostate-0.1
+Version:        0.1.18
+Release:        %autorelease
+Summary:        Rust crate "monostate"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/dtolnay/monostate
+#!RemoteAsset:  sha256:3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(monostate-impl-0.1/default) >= 0.1.18
+Requires:       crate(serde-1.0) >= 1.0.228
+Requires:       crate(serde-core-1.0) >= 1.0.228
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "monostate"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-monostate-impl-0.1/rust-monostate-impl.spec
+++ b/SPECS/rust-monostate-impl-0.1/rust-monostate-impl.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name monostate-impl
+%global full_version 0.1.18
+%global pkgname monostate-impl-0.1
+
+Name:           rust-monostate-impl-0.1
+Version:        0.1.18
+Release:        %autorelease
+Summary:        Rust crate "monostate-impl"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/dtolnay/monostate
+#!RemoteAsset:  sha256:e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(proc-macro2-1.0/default) >= 1.0.105
+Requires:       crate(quote-1.0/default) >= 1.0.43
+Requires:       crate(syn-2.0/parsing) >= 2.0.114
+Requires:       crate(syn-2.0/proc-macro) >= 2.0.114
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "monostate-impl"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-native-tls-0.2/rust-native-tls.spec
+++ b/SPECS/rust-native-tls-0.2/rust-native-tls.spec
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name native-tls
+%global full_version 0.2.14
+%global pkgname native-tls-0.2
+
+Name:           rust-native-tls-0.2
+Version:        0.2.14
+Release:        %autorelease
+Summary:        Rust crate "native-tls"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/sfackler/rust-native-tls
+#!RemoteAsset:  sha256:87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(libc-0.2/default) >= 0.2.174
+Requires:       crate(log-0.4/default) >= 0.4.27
+Requires:       crate(openssl-0.10/default) >= 0.10.78
+Requires:       crate(openssl-probe-0.1/default) >= 0.1.6
+Requires:       crate(openssl-sys-0.9/default) >= 0.9.114
+Requires:       crate(schannel-0.1/default) >= 0.1.27
+Requires:       crate(security-framework-2.0/default) >= 2.11.1
+Requires:       crate(security-framework-sys-2.0/default) >= 2.14.0
+Requires:       crate(tempfile-3.0/default) >= 3.20.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "native-tls"
+
+%package     -n %{name}+alpn
+Summary:        Wrapper over a platform's native TLS implementation - feature "alpn"
+Requires:       crate(%{pkgname})
+Requires:       crate(security-framework-2.0/alpn) >= 2.11.1
+Provides:       crate(%{pkgname}/alpn)
+
+%description -n %{name}+alpn
+This metapackage enables feature "alpn" for the Rust native-tls crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+vendored
+Summary:        Wrapper over a platform's native TLS implementation - feature "vendored"
+Requires:       crate(%{pkgname})
+Requires:       crate(openssl-0.10/vendored) >= 0.10.78
+Provides:       crate(%{pkgname}/vendored)
+
+%description -n %{name}+vendored
+This metapackage enables feature "vendored" for the Rust native-tls crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-num-0.4/rust-num.spec
+++ b/SPECS/rust-num-0.4/rust-num.spec
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name num
+%global full_version 0.4.3
+%global pkgname num-0.4
+
+Name:           rust-num-0.4
+Version:        0.4.3
+Release:        %autorelease
+Summary:        Rust crate "num"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/rust-num/num
+#!RemoteAsset:  sha256:35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(num-complex-0.4) >= 0.4.6
+Requires:       crate(num-integer-0.1/i128) >= 0.1.46
+Requires:       crate(num-iter-0.1/i128) >= 0.1.45
+Requires:       crate(num-rational-0.4) >= 0.4.2
+Requires:       crate(num-traits-0.2/i128) >= 0.2.19
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "num"
+
+%package     -n %{name}+alloc
+Summary:        Collection of numeric types and traits for Rust, including bigint, complex, rational, range iterators, generic integers, and more! - feature "alloc"
+Requires:       crate(%{pkgname})
+Requires:       crate(num-bigint-0.4) >= 0.4.6
+Requires:       crate(num-rational-0.4/num-bigint) >= 0.4.2
+Provides:       crate(%{pkgname}/alloc)
+
+%description -n %{name}+alloc
+This metapackage enables feature "alloc" for the Rust num crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+libm
+Summary:        Collection of numeric types and traits for Rust, including bigint, complex, rational, range iterators, generic integers, and more! - feature "libm"
+Requires:       crate(%{pkgname})
+Requires:       crate(num-complex-0.4/libm) >= 0.4.6
+Requires:       crate(num-traits-0.2/i128) >= 0.2.19
+Requires:       crate(num-traits-0.2/libm) >= 0.2.19
+Provides:       crate(%{pkgname}/libm)
+
+%description -n %{name}+libm
+This metapackage enables feature "libm" for the Rust num crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+num-bigint
+Summary:        Collection of numeric types and traits for Rust, including bigint, complex, rational, range iterators, generic integers, and more! - feature "num-bigint"
+Requires:       crate(%{pkgname})
+Requires:       crate(num-bigint-0.4) >= 0.4.6
+Provides:       crate(%{pkgname}/num-bigint)
+
+%description -n %{name}+num-bigint
+This metapackage enables feature "num-bigint" for the Rust num crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+rand
+Summary:        Collection of numeric types and traits for Rust, including bigint, complex, rational, range iterators, generic integers, and more! - feature "rand"
+Requires:       crate(%{pkgname})
+Requires:       crate(num-bigint-0.4/rand) >= 0.4.6
+Requires:       crate(num-complex-0.4/rand) >= 0.4.6
+Provides:       crate(%{pkgname}/rand)
+
+%description -n %{name}+rand
+This metapackage enables feature "rand" for the Rust num crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+serde
+Summary:        Collection of numeric types and traits for Rust, including bigint, complex, rational, range iterators, generic integers, and more! - feature "serde"
+Requires:       crate(%{pkgname})
+Requires:       crate(num-bigint-0.4/serde) >= 0.4.6
+Requires:       crate(num-complex-0.4/serde) >= 0.4.6
+Requires:       crate(num-rational-0.4/serde) >= 0.4.2
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust num crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+std
+Summary:        Collection of numeric types and traits for Rust, including bigint, complex, rational, range iterators, generic integers, and more! - feature "std" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(num-bigint-0.4) >= 0.4.6
+Requires:       crate(num-bigint-0.4/std) >= 0.4.6
+Requires:       crate(num-complex-0.4/std) >= 0.4.6
+Requires:       crate(num-integer-0.1/i128) >= 0.1.46
+Requires:       crate(num-integer-0.1/std) >= 0.1.46
+Requires:       crate(num-iter-0.1/i128) >= 0.1.45
+Requires:       crate(num-iter-0.1/std) >= 0.1.45
+Requires:       crate(num-rational-0.4/num-bigint-std) >= 0.4.2
+Requires:       crate(num-rational-0.4/std) >= 0.4.2
+Requires:       crate(num-traits-0.2/i128) >= 0.2.19
+Requires:       crate(num-traits-0.2/std) >= 0.2.19
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description -n %{name}+std
+This metapackage enables feature "std" for the Rust num crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "default" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-num-cmp-0.1/rust-num-cmp.spec
+++ b/SPECS/rust-num-cmp-0.1/rust-num-cmp.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name num-cmp
+%global full_version 0.1.0
+%global pkgname num-cmp-0.1
+
+Name:           rust-num-cmp-0.1
+Version:        0.1.0
+Release:        %autorelease
+Summary:        Rust crate "num-cmp"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/lifthrasiir/num-cmp
+#!RemoteAsset:  sha256:63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/i128)
+
+%description
+Source code for takopackized Rust crate "num-cmp"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-num-complex-0.4/rust-num-complex.spec
+++ b/SPECS/rust-num-complex-0.4/rust-num-complex.spec
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name num-complex
+%global full_version 0.4.6
+%global pkgname num-complex-0.4
+
+Name:           rust-num-complex-0.4
+Version:        0.4.6
+Release:        %autorelease
+Summary:        Rust crate "num-complex"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/rust-num/num-complex
+#!RemoteAsset:  sha256:73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(num-traits-0.2/i128) >= 0.2.19
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "num-complex"
+
+%package     -n %{name}+bytemuck
+Summary:        Complex numbers implementation for Rust - feature "bytemuck"
+Requires:       crate(%{pkgname})
+Requires:       crate(bytemuck-1.0/default) >= 1.0.0
+Provides:       crate(%{pkgname}/bytemuck)
+
+%description -n %{name}+bytemuck
+This metapackage enables feature "bytemuck" for the Rust num-complex crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+libm
+Summary:        Complex numbers implementation for Rust - feature "libm"
+Requires:       crate(%{pkgname})
+Requires:       crate(num-traits-0.2/i128) >= 0.2.19
+Requires:       crate(num-traits-0.2/libm) >= 0.2.19
+Provides:       crate(%{pkgname}/libm)
+
+%description -n %{name}+libm
+This metapackage enables feature "libm" for the Rust num-complex crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+rand
+Summary:        Complex numbers implementation for Rust - feature "rand"
+Requires:       crate(%{pkgname})
+Requires:       crate(rand-0.8) >= 0.8.0
+Provides:       crate(%{pkgname}/rand)
+
+%description -n %{name}+rand
+This metapackage enables feature "rand" for the Rust num-complex crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+serde
+Summary:        Complex numbers implementation for Rust - feature "serde"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0) >= 1.0.0
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust num-complex crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+std
+Summary:        Complex numbers implementation for Rust - feature "std" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(num-traits-0.2/i128) >= 0.2.19
+Requires:       crate(num-traits-0.2/std) >= 0.2.19
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description -n %{name}+std
+This metapackage enables feature "std" for the Rust num-complex crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "default" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-number-prefix-0.4/rust-number-prefix.spec
+++ b/SPECS/rust-number-prefix-0.4/rust-number-prefix.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name number_prefix
+%global full_version 0.4.0
+%global pkgname number-prefix-0.4
+
+Name:           rust-number-prefix-0.4
+Version:        0.4.0
+Release:        %autorelease
+Summary:        Rust crate "number_prefix"
+License:        MIT
+URL:            https://github.com/ogham/rust-number-prefix
+#!RemoteAsset:  sha256:830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description
+Source code for takopackized Rust crate "number_prefix"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-object-0.36/rust-object.spec
+++ b/SPECS/rust-object-0.36/rust-object.spec
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name object
+%global full_version 0.36.7
+%global pkgname object-0.36
+
+Name:           rust-object-0.36
+Version:        0.36.7
+Release:        %autorelease
+Summary:        Rust crate "object"
+License:        Apache-2.0 OR MIT
+URL:            https://github.com/gimli-rs/object
+#!RemoteAsset:  sha256:62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(memchr-2.0) >= 2.7.5
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/archive)
+Provides:       crate(%{pkgname}/cargo-all)
+Provides:       crate(%{pkgname}/coff)
+Provides:       crate(%{pkgname}/elf)
+Provides:       crate(%{pkgname}/macho)
+Provides:       crate(%{pkgname}/pe)
+Provides:       crate(%{pkgname}/read-core)
+Provides:       crate(%{pkgname}/unaligned)
+Provides:       crate(%{pkgname}/unstable)
+Provides:       crate(%{pkgname}/xcoff)
+
+%description
+Source code for takopackized Rust crate "object"
+
+%package     -n %{name}+build
+Summary:        Unified interface for reading and writing object file formats - feature "build"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/build-core)
+Requires:       crate(%{pkgname}/elf)
+Requires:       crate(%{pkgname}/write-std)
+Provides:       crate(%{pkgname}/build)
+
+%description -n %{name}+build
+This metapackage enables feature "build" for the Rust object crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+build-core
+Summary:        Unified interface for reading and writing object file formats - feature "build_core"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/read-core)
+Requires:       crate(%{pkgname}/write-core)
+Provides:       crate(%{pkgname}/build-core)
+
+%description -n %{name}+build-core
+This metapackage enables feature "build_core" for the Rust object crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+read
+Summary:        Unified interface for reading and writing object file formats - feature "read"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/archive)
+Requires:       crate(%{pkgname}/coff)
+Requires:       crate(%{pkgname}/elf)
+Requires:       crate(%{pkgname}/macho)
+Requires:       crate(%{pkgname}/pe)
+Requires:       crate(%{pkgname}/read-core)
+Requires:       crate(%{pkgname}/unaligned)
+Requires:       crate(%{pkgname}/xcoff)
+Provides:       crate(%{pkgname}/read)
+
+%description -n %{name}+read
+This metapackage enables feature "read" for the Rust object crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+std
+Summary:        Unified interface for reading and writing object file formats - feature "std"
+Requires:       crate(%{pkgname})
+Requires:       crate(memchr-2.0/std) >= 2.7.5
+Provides:       crate(%{pkgname}/std)
+
+%description -n %{name}+std
+This metapackage enables feature "std" for the Rust object crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+write
+Summary:        Unified interface for reading and writing object file formats - feature "write"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/coff)
+Requires:       crate(%{pkgname}/elf)
+Requires:       crate(%{pkgname}/macho)
+Requires:       crate(%{pkgname}/pe)
+Requires:       crate(%{pkgname}/write-std)
+Requires:       crate(%{pkgname}/xcoff)
+Provides:       crate(%{pkgname}/write)
+
+%description -n %{name}+write
+This metapackage enables feature "write" for the Rust object crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+write-core
+Summary:        Unified interface for reading and writing object file formats - feature "write_core"
+Requires:       crate(%{pkgname})
+Requires:       crate(crc32fast-1.0) >= 1.2
+Requires:       crate(hashbrown-0.15/default-hasher) >= 0.15.0
+Requires:       crate(indexmap-2.0) >= 2.0.0
+Provides:       crate(%{pkgname}/write-core)
+
+%description -n %{name}+write-core
+This metapackage enables feature "write_core" for the Rust object crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+write-std
+Summary:        Unified interface for reading and writing object file formats - feature "write_std"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/std)
+Requires:       crate(%{pkgname}/write-core)
+Requires:       crate(crc32fast-1.0/std) >= 1.2
+Requires:       crate(indexmap-2.0/std) >= 2.0.0
+Provides:       crate(%{pkgname}/write-std)
+
+%description -n %{name}+write-std
+This metapackage enables feature "write_std" for the Rust object crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-outref-0.5/rust-outref.spec
+++ b/SPECS/rust-outref-0.5/rust-outref.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name outref
+%global full_version 0.5.2
+%global pkgname outref-0.5
+
+Name:           rust-outref-0.5
+Version:        0.5.2
+Release:        %autorelease
+Summary:        Rust crate "outref"
+License:        MIT
+URL:            https://github.com/Nugine/outref
+#!RemoteAsset:  sha256:1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "outref"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-page-size-0.6/rust-page-size.spec
+++ b/SPECS/rust-page-size-0.6/rust-page-size.spec
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name page_size
+%global full_version 0.6.0
+%global pkgname page-size-0.6
+
+Name:           rust-page-size-0.6
+Version:        0.6.0
+Release:        %autorelease
+Summary:        Rust crate "page_size"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/Elzair/page_size_rs
+#!RemoteAsset:  sha256:30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(libc-0.2/default) >= 0.2.174
+Requires:       crate(winapi-0.3/default) >= 0.3.9
+Requires:       crate(winapi-0.3/sysinfoapi) >= 0.3.9
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "page_size"
+
+%package     -n %{name}+spin
+Summary:        Provides an easy, fast, cross-platform way to retrieve the memory page size - feature "spin" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(spin-0.9/default) >= 0.9.8
+Provides:       crate(%{pkgname}/no-std)
+Provides:       crate(%{pkgname}/spin)
+
+%description -n %{name}+spin
+This metapackage enables feature "spin" for the Rust page_size crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "no_std" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-pin-utils-0.1/rust-pin-utils.spec
+++ b/SPECS/rust-pin-utils-0.1/rust-pin-utils.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name pin-utils
+%global full_version 0.1.0
+%global pkgname pin-utils-0.1
+
+Name:           rust-pin-utils-0.1
+Version:        0.1.0
+Release:        %autorelease
+Summary:        Rust crate "pin-utils"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/rust-lang-nursery/pin-utils
+#!RemoteAsset:  sha256:8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "pin-utils"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-proc-macro-crate-3.0/rust-proc-macro-crate.spec
+++ b/SPECS/rust-proc-macro-crate-3.0/rust-proc-macro-crate.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name proc-macro-crate
+%global full_version 3.3.0
+%global pkgname proc-macro-crate-3.0
+
+Name:           rust-proc-macro-crate-3.0
+Version:        3.3.0
+Release:        %autorelease
+Summary:        Rust crate "proc-macro-crate"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/bkchr/proc-macro-crate
+#!RemoteAsset:  sha256:edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(toml-edit-0.22/parse) >= 0.22.27
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "proc-macro-crate"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-quinn-0.11/rust-quinn.spec
+++ b/SPECS/rust-quinn-0.11/rust-quinn.spec
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name quinn
+%global full_version 0.11.9
+%global pkgname quinn-0.11
+
+Name:           rust-quinn-0.11
+Version:        0.11.9
+Release:        %autorelease
+Summary:        Rust crate "quinn"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/quinn-rs/quinn
+#!RemoteAsset:  sha256:b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(bytes-1.0/default) >= 1.11.0
+Requires:       crate(cfg-aliases-0.2/default) >= 0.2.1
+Requires:       crate(pin-project-lite-0.2/default) >= 0.2.16
+Requires:       crate(quinn-proto-0.11) >= 0.11.13
+Requires:       crate(quinn-udp-0.5/tracing) >= 0.5.14
+Requires:       crate(rustc-hash-2.0/default) >= 2.1.1
+Requires:       crate(socket2-0.6/default) >= 0.6.1
+Requires:       crate(thiserror-2.0/default) >= 2.0.17
+Requires:       crate(tokio-1.0/default) >= 1.49.0
+Requires:       crate(tokio-1.0/sync) >= 1.49.0
+Requires:       crate(tracing-0.1/std) >= 0.1.44
+Requires:       crate(web-time-1.0/default) >= 1.1.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/lock-tracking)
+
+%description
+Source code for takopackized Rust crate "quinn"
+
+%package     -n %{name}+aws-lc-rs
+Summary:        Versatile QUIC transport protocol implementation - feature "aws-lc-rs"
+Requires:       crate(%{pkgname})
+Requires:       crate(quinn-proto-0.11/aws-lc-rs) >= 0.11.13
+Provides:       crate(%{pkgname}/aws-lc-rs)
+
+%description -n %{name}+aws-lc-rs
+This metapackage enables feature "aws-lc-rs" for the Rust quinn crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+futures-io
+Summary:        Versatile QUIC transport protocol implementation - feature "futures-io"
+Requires:       crate(%{pkgname})
+Requires:       crate(futures-io-0.3/default) >= 0.3.19
+Provides:       crate(%{pkgname}/futures-io)
+
+%description -n %{name}+futures-io
+This metapackage enables feature "futures-io" for the Rust quinn crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+log
+Summary:        Versatile QUIC transport protocol implementation - feature "log"
+Requires:       crate(%{pkgname})
+Requires:       crate(quinn-proto-0.11/log) >= 0.11.13
+Requires:       crate(quinn-udp-0.5/log) >= 0.5.14
+Requires:       crate(quinn-udp-0.5/tracing) >= 0.5.14
+Requires:       crate(tracing-0.1/log) >= 0.1.44
+Requires:       crate(tracing-0.1/std) >= 0.1.44
+Provides:       crate(%{pkgname}/log)
+
+%description -n %{name}+log
+This metapackage enables feature "log" for the Rust quinn crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+ring
+Summary:        Versatile QUIC transport protocol implementation - feature "ring"
+Requires:       crate(%{pkgname})
+Requires:       crate(quinn-proto-0.11/ring) >= 0.11.13
+Provides:       crate(%{pkgname}/ring)
+
+%description -n %{name}+ring
+This metapackage enables feature "ring" for the Rust quinn crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+runtime-tokio
+Summary:        Versatile QUIC transport protocol implementation - feature "runtime-tokio"
+Requires:       crate(%{pkgname})
+Requires:       crate(tokio-1.0/net) >= 1.49.0
+Requires:       crate(tokio-1.0/rt) >= 1.49.0
+Requires:       crate(tokio-1.0/sync) >= 1.49.0
+Requires:       crate(tokio-1.0/time) >= 1.49.0
+Provides:       crate(%{pkgname}/runtime-tokio)
+
+%description -n %{name}+runtime-tokio
+This metapackage enables feature "runtime-tokio" for the Rust quinn crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+rustls-aws-lc-rs
+Summary:        Versatile QUIC transport protocol implementation - feature "rustls-aws-lc-rs"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/aws-lc-rs)
+Requires:       crate(quinn-proto-0.11/aws-lc-rs) >= 0.11.13
+Requires:       crate(quinn-proto-0.11/rustls-aws-lc-rs) >= 0.11.13
+Requires:       crate(rustls-0.23/std) >= 0.23.36
+Provides:       crate(%{pkgname}/rustls-aws-lc-rs)
+
+%description -n %{name}+rustls-aws-lc-rs
+This metapackage enables feature "rustls-aws-lc-rs" for the Rust quinn crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+rustls-log
+Summary:        Versatile QUIC transport protocol implementation - feature "rustls-log"
+Requires:       crate(%{pkgname})
+Requires:       crate(rustls-0.23/logging) >= 0.23.36
+Requires:       crate(rustls-0.23/std) >= 0.23.36
+Provides:       crate(%{pkgname}/rustls-log)
+
+%description -n %{name}+rustls-log
+This metapackage enables feature "rustls-log" for the Rust quinn crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+rustls-ring
+Summary:        Versatile QUIC transport protocol implementation - feature "rustls-ring" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/ring)
+Requires:       crate(quinn-proto-0.11/ring) >= 0.11.13
+Requires:       crate(quinn-proto-0.11/rustls-ring) >= 0.11.13
+Requires:       crate(rustls-0.23/std) >= 0.23.36
+Provides:       crate(%{pkgname}/rustls)
+Provides:       crate(%{pkgname}/rustls-ring)
+
+%description -n %{name}+rustls-ring
+This metapackage enables feature "rustls-ring" for the Rust quinn crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "rustls" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-quinn-proto-0.11/rust-quinn-proto.spec
+++ b/SPECS/rust-quinn-proto-0.11/rust-quinn-proto.spec
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name quinn-proto
+%global full_version 0.11.13
+%global pkgname quinn-proto-0.11
+
+Name:           rust-quinn-proto-0.11
+Version:        0.11.13
+Release:        %autorelease
+Summary:        Rust crate "quinn-proto"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/quinn-rs/quinn
+#!RemoteAsset:  sha256:f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(bytes-1.0/default) >= 1.11.0
+Requires:       crate(getrandom-0.3/wasm-js) >= 0.3.4
+Requires:       crate(lru-slab-0.1/default) >= 0.1.2
+Requires:       crate(rand-0.9/default) >= 0.9.2
+Requires:       crate(ring-0.17/default) >= 0.17.14
+Requires:       crate(ring-0.17/wasm32-unknown-unknown-js) >= 0.17.14
+Requires:       crate(rustc-hash-2.0/default) >= 2.1.1
+Requires:       crate(rustls-pki-types-1.0/default) >= 1.13.2
+Requires:       crate(rustls-pki-types-1.0/web) >= 1.13.2
+Requires:       crate(slab-0.4/default) >= 0.4.11
+Requires:       crate(thiserror-2.0/default) >= 2.0.17
+Requires:       crate(tinyvec-1.0/alloc) >= 1.10.0
+Requires:       crate(tinyvec-1.0/default) >= 1.10.0
+Requires:       crate(tracing-0.1/std) >= 0.1.44
+Requires:       crate(web-time-1.0/default) >= 1.1.0
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "quinn-proto"
+
+%package     -n %{name}+aws-lc-rs
+Summary:        State machine for the QUIC transport protocol - feature "aws-lc-rs"
+Requires:       crate(%{pkgname})
+Requires:       crate(aws-lc-rs-1.0) >= 1.9
+Requires:       crate(aws-lc-rs-1.0/aws-lc-sys) >= 1.9
+Requires:       crate(aws-lc-rs-1.0/prebuilt-nasm) >= 1.9
+Provides:       crate(%{pkgname}/aws-lc-rs)
+
+%description -n %{name}+aws-lc-rs
+This metapackage enables feature "aws-lc-rs" for the Rust quinn-proto crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+log
+Summary:        State machine for the QUIC transport protocol - feature "log"
+Requires:       crate(%{pkgname})
+Requires:       crate(tracing-0.1/log) >= 0.1.44
+Requires:       crate(tracing-0.1/std) >= 0.1.44
+Provides:       crate(%{pkgname}/log)
+
+%description -n %{name}+log
+This metapackage enables feature "log" for the Rust quinn-proto crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+ring
+Summary:        State machine for the QUIC transport protocol - feature "ring"
+Requires:       crate(%{pkgname})
+Requires:       crate(ring-0.17/default) >= 0.17.14
+Requires:       crate(ring-0.17/wasm32-unknown-unknown-js) >= 0.17.14
+Provides:       crate(%{pkgname}/ring)
+
+%description -n %{name}+ring
+This metapackage enables feature "ring" for the Rust quinn-proto crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+rustls-aws-lc-rs
+Summary:        State machine for the QUIC transport protocol - feature "rustls-aws-lc-rs"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/aws-lc-rs)
+Requires:       crate(rustls-0.23/aws-lc-rs) >= 0.23.36
+Requires:       crate(rustls-0.23/std) >= 0.23.36
+Provides:       crate(%{pkgname}/rustls-aws-lc-rs)
+
+%description -n %{name}+rustls-aws-lc-rs
+This metapackage enables feature "rustls-aws-lc-rs" for the Rust quinn-proto crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+rustls-log
+Summary:        State machine for the QUIC transport protocol - feature "rustls-log"
+Requires:       crate(%{pkgname})
+Requires:       crate(rustls-0.23/logging) >= 0.23.36
+Requires:       crate(rustls-0.23/std) >= 0.23.36
+Provides:       crate(%{pkgname}/rustls-log)
+
+%description -n %{name}+rustls-log
+This metapackage enables feature "rustls-log" for the Rust quinn-proto crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+rustls-ring
+Summary:        State machine for the QUIC transport protocol - feature "rustls-ring" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/ring)
+Requires:       crate(rustls-0.23/ring) >= 0.23.36
+Requires:       crate(rustls-0.23/std) >= 0.23.36
+Provides:       crate(%{pkgname}/rustls)
+Provides:       crate(%{pkgname}/rustls-ring)
+
+%description -n %{name}+rustls-ring
+This metapackage enables feature "rustls-ring" for the Rust quinn-proto crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "rustls" feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-quinn-udp-0.5/rust-quinn-udp.spec
+++ b/SPECS/rust-quinn-udp-0.5/rust-quinn-udp.spec
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name quinn-udp
+%global full_version 0.5.14
+%global pkgname quinn-udp-0.5
+
+Name:           rust-quinn-udp-0.5
+Version:        0.5.14
+Release:        %autorelease
+Summary:        Rust crate "quinn-udp"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/quinn-rs/quinn
+#!RemoteAsset:  sha256:addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(cfg-aliases-0.2/default) >= 0.2.1
+Requires:       crate(libc-0.2/default) >= 0.2.180
+Requires:       crate(once-cell-1.0/default) >= 1.21.3
+Requires:       crate(socket2-0.6/default) >= 0.6.1
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/fast-apple-datapath)
+
+%description
+Source code for takopackized Rust crate "quinn-udp"
+
+%package     -n %{name}+default
+Summary:        UDP sockets with ECN information for the QUIC transport protocol - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/log)
+Requires:       crate(%{pkgname}/tracing)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust quinn-udp crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+direct-log
+Summary:        UDP sockets with ECN information for the QUIC transport protocol - feature "direct-log"
+Requires:       crate(%{pkgname})
+Requires:       crate(log-0.4/default) >= 0.4.0
+Provides:       crate(%{pkgname}/direct-log)
+
+%description -n %{name}+direct-log
+This metapackage enables feature "direct-log" for the Rust quinn-udp crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+log
+Summary:        UDP sockets with ECN information for the QUIC transport protocol - feature "log"
+Requires:       crate(%{pkgname})
+Requires:       crate(tracing-0.1/log) >= 0.1.44
+Requires:       crate(tracing-0.1/std) >= 0.1.44
+Provides:       crate(%{pkgname}/log)
+
+%description -n %{name}+log
+This metapackage enables feature "log" for the Rust quinn-udp crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+tracing
+Summary:        UDP sockets with ECN information for the QUIC transport protocol - feature "tracing"
+Requires:       crate(%{pkgname})
+Requires:       crate(tracing-0.1/std) >= 0.1.44
+Provides:       crate(%{pkgname}/tracing)
+
+%description -n %{name}+tracing
+This metapackage enables feature "tracing" for the Rust quinn-udp crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-rayon-cond-0.4/rust-rayon-cond.spec
+++ b/SPECS/rust-rayon-cond-0.4/rust-rayon-cond.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name rayon-cond
+%global full_version 0.4.0
+%global pkgname rayon-cond-0.4
+
+Name:           rust-rayon-cond-0.4
+Version:        0.4.0
+Release:        %autorelease
+Summary:        Rust crate "rayon-cond"
+License:        Apache-2.0 OR MIT
+URL:            https://github.com/cuviper/rayon-cond
+#!RemoteAsset:  sha256:2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(either-1.0/default) >= 1.15.0
+Requires:       crate(itertools-0.14/default) >= 0.14.0
+Requires:       crate(rayon-1.0/default) >= 1.11.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "rayon-cond"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-redox-users-0.4/rust-redox-users.spec
+++ b/SPECS/rust-redox-users-0.4/rust-redox-users.spec
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name redox_users
+%global full_version 0.4.6
+%global pkgname redox-users-0.4
+
+Name:           rust-redox-users-0.4
+Version:        0.4.6
+Release:        %autorelease
+Summary:        Rust crate "redox_users"
+License:        MIT
+URL:            https://gitlab.redox-os.org/redox-os/users
+#!RemoteAsset:  sha256:ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(getrandom-0.2/default) >= 0.2.16
+Requires:       crate(getrandom-0.2/std) >= 0.2.16
+Requires:       crate(libredox-0.1/call) >= 0.1.12
+Requires:       crate(libredox-0.1/std) >= 0.1.12
+Requires:       crate(thiserror-1.0/default) >= 1.0.69
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "redox_users"
+
+%package     -n %{name}+zeroize
+Summary:        Access Redox users and groups functionality - feature "zeroize"
+Requires:       crate(%{pkgname})
+Requires:       crate(zeroize-1.0/default) >= 1.4
+Requires:       crate(zeroize-1.0/zeroize-derive) >= 1.4
+Provides:       crate(%{pkgname}/zeroize)
+
+%description -n %{name}+zeroize
+This metapackage enables feature "zeroize" for the Rust redox_users crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-referencing-0.29/rust-referencing.spec
+++ b/SPECS/rust-referencing-0.29/rust-referencing.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name referencing
+%global full_version 0.29.1
+%global pkgname referencing-0.29
+
+Name:           rust-referencing-0.29
+Version:        0.29.1
+Release:        %autorelease
+Summary:        Rust crate "referencing"
+License:        MIT
+URL:            https://github.com/Stranger6667/jsonschema
+#!RemoteAsset:  sha256:40a64b3a635fad9000648b4d8a59c8710c523ab61a23d392a7d91d47683f5adc
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(ahash-0.8/default) >= 0.8.12
+Requires:       crate(ahash-0.8/serde) >= 0.8.12
+Requires:       crate(fluent-uri-0.3/default) >= 0.3.2
+Requires:       crate(fluent-uri-0.3/serde) >= 0.3.2
+Requires:       crate(once-cell-1.0/default) >= 1.21.3
+Requires:       crate(parking-lot-0.12/default) >= 0.12.4
+Requires:       crate(percent-encoding-2.0/default) >= 2.3.1
+Requires:       crate(serde-json-1.0/default) >= 1.0.140
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "referencing"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-relative-path-1.0/rust-relative-path.spec
+++ b/SPECS/rust-relative-path-1.0/rust-relative-path.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name relative-path
+%global full_version 1.9.3
+%global pkgname relative-path-1.0
+
+Name:           rust-relative-path-1.0
+Version:        1.9.3
+Release:        %autorelease
+Summary:        Rust crate "relative-path"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/udoprog/relative-path
+#!RemoteAsset:  sha256:ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "relative-path"
+
+%package     -n %{name}+serde
+Summary:        Portable, relative paths for Rust - feature "serde"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/default) >= 1.0.160
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust relative-path crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-rstest-0.25/rust-rstest.spec
+++ b/SPECS/rust-rstest-0.25/rust-rstest.spec
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name rstest
+%global full_version 0.25.0
+%global pkgname rstest-0.25
+
+Name:           rust-rstest-0.25
+Version:        0.25.0
+Release:        %autorelease
+Summary:        Rust crate "rstest"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/la10736/rstest
+#!RemoteAsset:  sha256:6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(rstest-macros-0.25) >= 0.25.0
+Requires:       crate(rustc-version-0.4/default) >= 0.4.1
+Provides:       crate(%{pkgname})
+
+%description
+It use procedural macro to implement fixtures and table based tests.
+Source code for takopackized Rust crate "rstest"
+
+%package     -n %{name}+async-timeout
+Summary:        Rust fixture based test framework - feature "async-timeout"
+Requires:       crate(%{pkgname})
+Requires:       crate(futures-timer-3.0/default) >= 3.0.3
+Requires:       crate(futures-util-0.3/default) >= 0.3.31
+Requires:       crate(rstest-macros-0.25/async-timeout) >= 0.25.0
+Provides:       crate(%{pkgname}/async-timeout)
+
+%description -n %{name}+async-timeout
+It use procedural macro to implement fixtures and table based tests.
+This metapackage enables feature "async-timeout" for the Rust rstest crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+crate-name
+Summary:        Rust fixture based test framework - feature "crate-name"
+Requires:       crate(%{pkgname})
+Requires:       crate(rstest-macros-0.25/crate-name) >= 0.25.0
+Provides:       crate(%{pkgname}/crate-name)
+
+%description -n %{name}+crate-name
+It use procedural macro to implement fixtures and table based tests.
+This metapackage enables feature "crate-name" for the Rust rstest crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+default
+Summary:        Rust fixture based test framework - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/async-timeout)
+Requires:       crate(%{pkgname}/crate-name)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+It use procedural macro to implement fixtures and table based tests.
+This metapackage enables feature "default" for the Rust rstest crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-rstest-macros-0.25/rust-rstest-macros.spec
+++ b/SPECS/rust-rstest-macros-0.25/rust-rstest-macros.spec
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name rstest_macros
+%global full_version 0.25.0
+%global pkgname rstest-macros-0.25
+
+Name:           rust-rstest-macros-0.25
+Version:        0.25.0
+Release:        %autorelease
+Summary:        Rust crate "rstest_macros"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/la10736/rstest
+#!RemoteAsset:  sha256:1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(cfg-if-1.0/default) >= 1.0.1
+Requires:       crate(glob-0.3/default) >= 0.3.2
+Requires:       crate(proc-macro2-1.0/default) >= 1.0.95
+Requires:       crate(quote-1.0/default) >= 1.0.40
+Requires:       crate(regex-1.0/default) >= 1.11.1
+Requires:       crate(relative-path-1.0/default) >= 1.9.3
+Requires:       crate(rustc-version-0.4/default) >= 0.4.1
+Requires:       crate(syn-2.0/default) >= 2.0.104
+Requires:       crate(syn-2.0/extra-traits) >= 2.0.104
+Requires:       crate(syn-2.0/full) >= 2.0.104
+Requires:       crate(syn-2.0/parsing) >= 2.0.104
+Requires:       crate(syn-2.0/visit) >= 2.0.104
+Requires:       crate(syn-2.0/visit-mut) >= 2.0.104
+Requires:       crate(unicode-ident-1.0/default) >= 1.0.18
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/async-timeout)
+
+%description
+It use procedural macro to implement fixtures and table based tests.
+Source code for takopackized Rust crate "rstest_macros"
+
+%package     -n %{name}+crate-name
+Summary:        Rust fixture based test framework - feature "crate-name"
+Requires:       crate(%{pkgname})
+Requires:       crate(proc-macro-crate-3.0/default) >= 3.3.0
+Provides:       crate(%{pkgname}/crate-name)
+
+%description -n %{name}+crate-name
+It use procedural macro to implement fixtures and table based tests.
+This metapackage enables feature "crate-name" for the Rust rstest_macros crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+default
+Summary:        Rust fixture based test framework - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/async-timeout)
+Requires:       crate(%{pkgname}/crate-name)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+It use procedural macro to implement fixtures and table based tests.
+This metapackage enables feature "default" for the Rust rstest_macros crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-rustc-hash-1.0/rust-rustc-hash.spec
+++ b/SPECS/rust-rustc-hash-1.0/rust-rustc-hash.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name rustc-hash
+%global full_version 1.1.0
+%global pkgname rustc-hash-1.0
+
+Name:           rust-rustc-hash-1.0
+Version:        1.1.0
+Release:        %autorelease
+Summary:        Rust crate "rustc-hash"
+License:        Apache-2.0 OR MIT
+URL:            https://github.com/rust-lang-nursery/rustc-hash
+#!RemoteAsset:  sha256:08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description
+Source code for takopackized Rust crate "rustc-hash"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-security-framework-2.0/rust-security-framework.spec
+++ b/SPECS/rust-security-framework-2.0/rust-security-framework.spec
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name security-framework
+%global full_version 2.11.1
+%global pkgname security-framework-2.0
+
+Name:           rust-security-framework-2.0
+Version:        2.11.1
+Release:        %autorelease
+Summary:        Rust crate "security-framework"
+License:        MIT OR Apache-2.0
+URL:            https://lib.rs/crates/security_framework
+#!RemoteAsset:  sha256:897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(bitflags-2.0/default) >= 2.9.1
+Requires:       crate(core-foundation-0.9/default) >= 0.9.4
+Requires:       crate(core-foundation-sys-0.8/default) >= 0.8.7
+Requires:       crate(libc-0.2/default) >= 0.2.174
+Requires:       crate(security-framework-sys-2.0) >= 2.14.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/alpn)
+Provides:       crate(%{pkgname}/job-bless)
+Provides:       crate(%{pkgname}/nightly)
+Provides:       crate(%{pkgname}/session-tickets)
+
+%description
+Source code for takopackized Rust crate "security-framework"
+
+%package     -n %{name}+osx-10-10
+Summary:        Security.framework bindings for macOS and iOS - feature "OSX_10_10"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/osx-10-9)
+Requires:       crate(security-framework-sys-2.0/osx-10-10) >= 2.14.0
+Provides:       crate(%{pkgname}/osx-10-10)
+
+%description -n %{name}+osx-10-10
+This metapackage enables feature "OSX_10_10" for the Rust security-framework crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+osx-10-11
+Summary:        Security.framework bindings for macOS and iOS - feature "OSX_10_11"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/osx-10-10)
+Requires:       crate(security-framework-sys-2.0/osx-10-11) >= 2.14.0
+Provides:       crate(%{pkgname}/osx-10-11)
+
+%description -n %{name}+osx-10-11
+This metapackage enables feature "OSX_10_11" for the Rust security-framework crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+osx-10-12
+Summary:        Security.framework bindings for macOS and iOS - feature "OSX_10_12" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/osx-10-11)
+Requires:       crate(security-framework-sys-2.0/osx-10-12) >= 2.14.0
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/osx-10-12)
+
+%description -n %{name}+osx-10-12
+This metapackage enables feature "OSX_10_12" for the Rust security-framework crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "default" feature.
+
+%package     -n %{name}+osx-10-13
+Summary:        Security.framework bindings for macOS and iOS - feature "OSX_10_13"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/alpn)
+Requires:       crate(%{pkgname}/osx-10-12)
+Requires:       crate(%{pkgname}/serial-number-bigint)
+Requires:       crate(%{pkgname}/session-tickets)
+Requires:       crate(security-framework-sys-2.0/osx-10-13) >= 2.14.0
+Provides:       crate(%{pkgname}/osx-10-13)
+
+%description -n %{name}+osx-10-13
+This metapackage enables feature "OSX_10_13" for the Rust security-framework crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+osx-10-14
+Summary:        Security.framework bindings for macOS and iOS - feature "OSX_10_14"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/osx-10-13)
+Requires:       crate(security-framework-sys-2.0/osx-10-14) >= 2.14.0
+Provides:       crate(%{pkgname}/osx-10-14)
+
+%description -n %{name}+osx-10-14
+This metapackage enables feature "OSX_10_14" for the Rust security-framework crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+osx-10-15
+Summary:        Security.framework bindings for macOS and iOS - feature "OSX_10_15"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/osx-10-14)
+Requires:       crate(security-framework-sys-2.0/osx-10-15) >= 2.14.0
+Provides:       crate(%{pkgname}/osx-10-15)
+
+%description -n %{name}+osx-10-15
+This metapackage enables feature "OSX_10_15" for the Rust security-framework crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+osx-10-9
+Summary:        Security.framework bindings for macOS and iOS - feature "OSX_10_9"
+Requires:       crate(%{pkgname})
+Requires:       crate(security-framework-sys-2.0/osx-10-9) >= 2.14.0
+Provides:       crate(%{pkgname}/osx-10-9)
+
+%description -n %{name}+osx-10-9
+This metapackage enables feature "OSX_10_9" for the Rust security-framework crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+log
+Summary:        Security.framework bindings for macOS and iOS - feature "log"
+Requires:       crate(%{pkgname})
+Requires:       crate(log-0.4/default) >= 0.4.20
+Provides:       crate(%{pkgname}/log)
+
+%description -n %{name}+log
+This metapackage enables feature "log" for the Rust security-framework crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+serial-number-bigint
+Summary:        Security.framework bindings for macOS and iOS - feature "serial-number-bigint"
+Requires:       crate(%{pkgname})
+Requires:       crate(num-bigint-0.4/default) >= 0.4.6
+Provides:       crate(%{pkgname}/serial-number-bigint)
+
+%description -n %{name}+serial-number-bigint
+This metapackage enables feature "serial-number-bigint" for the Rust security-framework crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-serde-json-fmt-0.1/rust-serde-json-fmt.spec
+++ b/SPECS/rust-serde-json-fmt-0.1/rust-serde-json-fmt.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name serde-json-fmt
+%global full_version 0.1.0
+%global pkgname serde-json-fmt-0.1
+
+Name:           rust-serde-json-fmt-0.1
+Version:        0.1.0
+Release:        %autorelease
+Summary:        Rust crate "serde-json-fmt"
+License:        MIT
+URL:            https://github.com/jwodder/serde-json-fmt
+#!RemoteAsset:  sha256:a4a33b7a5f52a26d520099339add40c48baf2e5ada194c8cc1b18cafa2b5e419
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(serde-1.0) >= 1.0.219
+Requires:       crate(serde-json-1.0/default) >= 1.0.140
+Requires:       crate(smartstring-1.0/default) >= 1.0.1
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "serde-json-fmt"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-serde-pyobject-0.8/rust-serde-pyobject.spec
+++ b/SPECS/rust-serde-pyobject-0.8/rust-serde-pyobject.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name serde-pyobject
+%global full_version 0.8.0
+%global pkgname serde-pyobject-0.8
+
+Name:           rust-serde-pyobject-0.8
+Version:        0.8.0
+Release:        %autorelease
+Summary:        Rust crate "serde-pyobject"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/Jij-Inc/serde-pyobject
+#!RemoteAsset:  sha256:5614e792b7c36d3feeb45b8287ea2dc615f063896e59258d11ef5015c18bdf6a
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(log-0.4/default) >= 0.4.29
+Requires:       crate(pyo3-0.27/default) >= 0.27.2
+Requires:       crate(serde-1.0/default) >= 1.0.228
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "serde-pyobject"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-smartstring-1.0/rust-smartstring.spec
+++ b/SPECS/rust-smartstring-1.0/rust-smartstring.spec
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name smartstring
+%global full_version 1.0.1
+%global pkgname smartstring-1.0
+
+Name:           rust-smartstring-1.0
+Version:        1.0.1
+Release:        %autorelease
+Summary:        Rust crate "smartstring"
+License:        MPL-2.0+
+URL:            https://github.com/bodil/smartstring
+#!RemoteAsset:  sha256:3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(autocfg-1.0/default) >= 1.5.0
+Requires:       crate(static-assertions-1.0/default) >= 1.1.0
+Requires:       crate(version-check-0.9/default) >= 0.9.5
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description
+Source code for takopackized Rust crate "smartstring"
+
+%package     -n %{name}+serde
+Summary:        Compact inlined strings - feature "serde"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/default) >= 1.0.0
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust smartstring crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-socket2-0.5/rust-socket2.spec
+++ b/SPECS/rust-socket2-0.5/rust-socket2.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name socket2
+%global full_version 0.5.10
+%global pkgname socket2-0.5
+
+Name:           rust-socket2-0.5
+Version:        0.5.10
+Release:        %autorelease
+Summary:        Rust crate "socket2"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/rust-lang/socket2
+#!RemoteAsset:  sha256:e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(libc-0.2/default) >= 0.2.174
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/all)
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "socket2"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-socks-0.3/rust-socks.spec
+++ b/SPECS/rust-socks-0.3/rust-socks.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name socks
+%global full_version 0.3.4
+%global pkgname socks-0.3
+
+Name:           rust-socks-0.3
+Version:        0.3.4
+Release:        %autorelease
+Summary:        Rust crate "socks"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/sfackler/rust-socks
+#!RemoteAsset:  sha256:f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(byteorder-1.0/default) >= 1.5.0
+Requires:       crate(libc-0.2/default) >= 0.2.180
+Requires:       crate(winapi-0.3/default) >= 0.3.9
+Requires:       crate(winapi-0.3/winsock2) >= 0.3.9
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "socks"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-spm-precompiled-0.1/rust-spm-precompiled.spec
+++ b/SPECS/rust-spm-precompiled-0.1/rust-spm-precompiled.spec
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name spm_precompiled
+%global full_version 0.1.4
+%global pkgname spm-precompiled-0.1
+
+Name:           rust-spm-precompiled-0.1
+Version:        0.1.4
+Release:        %autorelease
+Summary:        Rust crate "spm_precompiled"
+License:        Apache-2.0
+URL:            https://github.com/huggingface/spm_precompiled
+#!RemoteAsset:  sha256:5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(base64-0.13/default) >= 0.13.1
+Requires:       crate(nom-7.0/default) >= 7.1.3
+Requires:       crate(serde-1.0/default) >= 1.0.228
+Requires:       crate(serde-1.0/derive) >= 1.0.228
+Requires:       crate(unicode-segmentation-1.0/default) >= 1.12.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+This crate is highly specialized and not intended for general use.
+Source code for takopackized Rust crate "spm_precompiled"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-system-configuration-0.6/rust-system-configuration.spec
+++ b/SPECS/rust-system-configuration-0.6/rust-system-configuration.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name system-configuration
+%global full_version 0.6.1
+%global pkgname system-configuration-0.6
+
+Name:           rust-system-configuration-0.6
+Version:        0.6.1
+Release:        %autorelease
+Summary:        Rust crate "system-configuration"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/mullvad/system-configuration-rs
+#!RemoteAsset:  sha256:3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(bitflags-2.0/default) >= 2.9.1
+Requires:       crate(core-foundation-0.9/default) >= 0.9.4
+Requires:       crate(system-configuration-sys-0.6/default) >= 0.6.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "system-configuration"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-tiktoken-rs-0.7/rust-tiktoken-rs.spec
+++ b/SPECS/rust-tiktoken-rs-0.7/rust-tiktoken-rs.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name tiktoken-rs
+%global full_version 0.7.0
+%global pkgname tiktoken-rs-0.7
+
+Name:           rust-tiktoken-rs-0.7
+Version:        0.7.0
+Release:        %autorelease
+Summary:        Rust crate "tiktoken-rs"
+License:        MIT
+URL:            https://github.com/zurawiki/tiktoken-rs
+#!RemoteAsset:  sha256:25563eeba904d770acf527e8b370fe9a5547bacd20ff84a0b6c3bc41288e5625
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(anyhow-1.0/default) >= 1.0.98
+Requires:       crate(base64-0.22/default) >= 0.22.1
+Requires:       crate(bstr-1.0/default) >= 1.12.0
+Requires:       crate(fancy-regex-0.13/default) >= 0.13.0
+Requires:       crate(lazy-static-1.0/default) >= 1.5.0
+Requires:       crate(regex-1.0/default) >= 1.11.1
+Requires:       crate(rustc-hash-1.0/default) >= 1.1.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "tiktoken-rs"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-tokenizers-0.21/rust-tokenizers.spec
+++ b/SPECS/rust-tokenizers-0.21/rust-tokenizers.spec
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name tokenizers
+%global full_version 0.21.2
+%global pkgname tokenizers-0.21
+
+Name:           rust-tokenizers-0.21
+Version:        0.21.2
+Release:        %autorelease
+Summary:        Rust crate "tokenizers"
+License:        Apache-2.0
+URL:            https://github.com/huggingface/tokenizers
+#!RemoteAsset:  sha256:4c3846d8588abed0daba25a0e47edd58ea15e450a6088b2575f5116fdb0b27ca
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(ahash-0.8/default) >= 0.8.12
+Requires:       crate(ahash-0.8/serde) >= 0.8.12
+Requires:       crate(aho-corasick-1.0/default) >= 1.1.3
+Requires:       crate(compact-str-0.9/default) >= 0.9.0
+Requires:       crate(compact-str-0.9/serde) >= 0.9.0
+Requires:       crate(dary-heap-0.3/default) >= 0.3.7
+Requires:       crate(dary-heap-0.3/serde) >= 0.3.7
+Requires:       crate(derive-builder-0.20/default) >= 0.20.2
+Requires:       crate(esaxx-rs-0.1) >= 0.1.10
+Requires:       crate(getrandom-0.3/default) >= 0.3.3
+Requires:       crate(itertools-0.14/default) >= 0.14.0
+Requires:       crate(log-0.4/default) >= 0.4.27
+Requires:       crate(macro-rules-attribute-0.2/default) >= 0.2.2
+Requires:       crate(monostate-0.1/default) >= 0.1.14
+Requires:       crate(paste-1.0/default) >= 1.0.15
+Requires:       crate(rand-0.9/default) >= 0.9.4
+Requires:       crate(rayon-1.0/default) >= 1.10.0
+Requires:       crate(rayon-cond-0.4/default) >= 0.4.0
+Requires:       crate(regex-1.0/default) >= 1.11.1
+Requires:       crate(regex-syntax-0.8/default) >= 0.8.5
+Requires:       crate(serde-1.0/default) >= 1.0.219
+Requires:       crate(serde-1.0/derive) >= 1.0.219
+Requires:       crate(serde-json-1.0/default) >= 1.0.140
+Requires:       crate(spm-precompiled-0.1/default) >= 0.1.4
+Requires:       crate(thiserror-2.0/default) >= 2.0.12
+Requires:       crate(unicode-categories-0.1/default) >= 0.1.1
+Requires:       crate(unicode-normalization-alignments-0.1/default) >= 0.1.12
+Requires:       crate(unicode-segmentation-1.0/default) >= 1.12.0
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "tokenizers"
+
+%package     -n %{name}+default
+Summary:        Provides an implementation of today's most used tokenizers, with a focus on performances and versatility - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/esaxx-fast)
+Requires:       crate(%{pkgname}/onig)
+Requires:       crate(%{pkgname}/progressbar)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust tokenizers crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+esaxx-fast
+Summary:        Provides an implementation of today's most used tokenizers, with a focus on performances and versatility - feature "esaxx_fast"
+Requires:       crate(%{pkgname})
+Requires:       crate(esaxx-rs-0.1/cpp) >= 0.1.10
+Provides:       crate(%{pkgname}/esaxx-fast)
+
+%description -n %{name}+esaxx-fast
+This metapackage enables feature "esaxx_fast" for the Rust tokenizers crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+fancy-regex
+Summary:        Provides an implementation of today's most used tokenizers, with a focus on performances and versatility - feature "fancy-regex"
+Requires:       crate(%{pkgname})
+Requires:       crate(fancy-regex-0.14/default) >= 0.14.0
+Provides:       crate(%{pkgname}/fancy-regex)
+
+%description -n %{name}+fancy-regex
+This metapackage enables feature "fancy-regex" for the Rust tokenizers crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+hf-hub
+Summary:        Provides an implementation of today's most used tokenizers, with a focus on performances and versatility - feature "hf-hub" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(hf-hub-0.4/ureq) >= 0.4.1
+Provides:       crate(%{pkgname}/hf-hub)
+Provides:       crate(%{pkgname}/http)
+
+%description -n %{name}+hf-hub
+This metapackage enables feature "hf-hub" for the Rust tokenizers crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "http" feature.
+
+%package     -n %{name}+indicatif
+Summary:        Provides an implementation of today's most used tokenizers, with a focus on performances and versatility - feature "indicatif" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(indicatif-0.17/default) >= 0.17.0
+Provides:       crate(%{pkgname}/indicatif)
+Provides:       crate(%{pkgname}/progressbar)
+
+%description -n %{name}+indicatif
+This metapackage enables feature "indicatif" for the Rust tokenizers crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "progressbar" feature.
+
+%package     -n %{name}+onig
+Summary:        Provides an implementation of today's most used tokenizers, with a focus on performances and versatility - feature "onig"
+Requires:       crate(%{pkgname})
+Requires:       crate(onig-6.0) >= 6.5.1
+Provides:       crate(%{pkgname}/onig)
+
+%description -n %{name}+onig
+This metapackage enables feature "onig" for the Rust tokenizers crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+rustls-tls
+Summary:        Provides an implementation of today's most used tokenizers, with a focus on performances and versatility - feature "rustls-tls"
+Requires:       crate(%{pkgname})
+Requires:       crate(hf-hub-0.4/rustls-tls) >= 0.4.1
+Requires:       crate(hf-hub-0.4/ureq) >= 0.4.1
+Provides:       crate(%{pkgname}/rustls-tls)
+
+%description -n %{name}+rustls-tls
+This metapackage enables feature "rustls-tls" for the Rust tokenizers crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+unstable-wasm
+Summary:        Provides an implementation of today's most used tokenizers, with a focus on performances and versatility - feature "unstable_wasm"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/fancy-regex)
+Requires:       crate(getrandom-0.3/wasm-js) >= 0.3.3
+Provides:       crate(%{pkgname}/unstable-wasm)
+
+%description -n %{name}+unstable-wasm
+This metapackage enables feature "unstable_wasm" for the Rust tokenizers crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-tokenizers-0.22/rust-tokenizers.spec
+++ b/SPECS/rust-tokenizers-0.22/rust-tokenizers.spec
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name tokenizers
+%global full_version 0.22.2
+%global pkgname tokenizers-0.22
+
+Name:           rust-tokenizers-0.22
+Version:        0.22.2
+Release:        %autorelease
+Summary:        Rust crate "tokenizers"
+License:        Apache-2.0
+URL:            https://github.com/huggingface/tokenizers
+#!RemoteAsset:  sha256:b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(ahash-0.8/default) >= 0.8.12
+Requires:       crate(ahash-0.8/serde) >= 0.8.12
+Requires:       crate(aho-corasick-1.0/default) >= 1.1.4
+Requires:       crate(compact-str-0.9/default) >= 0.9.0
+Requires:       crate(compact-str-0.9/serde) >= 0.9.0
+Requires:       crate(dary-heap-0.3/default) >= 0.3.8
+Requires:       crate(dary-heap-0.3/serde) >= 0.3.8
+Requires:       crate(derive-builder-0.20/default) >= 0.20.2
+Requires:       crate(esaxx-rs-0.1) >= 0.1.10
+Requires:       crate(getrandom-0.3/default) >= 0.3.4
+Requires:       crate(itertools-0.14/default) >= 0.14.0
+Requires:       crate(log-0.4/default) >= 0.4.29
+Requires:       crate(macro-rules-attribute-0.2/default) >= 0.2.2
+Requires:       crate(monostate-0.1/default) >= 0.1.18
+Requires:       crate(paste-1.0/default) >= 1.0.15
+Requires:       crate(rand-0.9/default) >= 0.9.2
+Requires:       crate(rayon-1.0/default) >= 1.11.0
+Requires:       crate(rayon-cond-0.4/default) >= 0.4.0
+Requires:       crate(regex-1.0/default) >= 1.12.2
+Requires:       crate(regex-syntax-0.8/default) >= 0.8.8
+Requires:       crate(serde-1.0/default) >= 1.0.228
+Requires:       crate(serde-1.0/derive) >= 1.0.228
+Requires:       crate(serde-json-1.0/default) >= 1.0.149
+Requires:       crate(spm-precompiled-0.1/default) >= 0.1.4
+Requires:       crate(thiserror-2.0/default) >= 2.0.17
+Requires:       crate(unicode-categories-0.1/default) >= 0.1.1
+Requires:       crate(unicode-normalization-alignments-0.1/default) >= 0.1.12
+Requires:       crate(unicode-segmentation-1.0/default) >= 1.12.0
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "tokenizers"
+
+%package     -n %{name}+default
+Summary:        Provides an implementation of today's most used tokenizers, with a focus on performances and versatility - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/esaxx-fast)
+Requires:       crate(%{pkgname}/onig)
+Requires:       crate(%{pkgname}/progressbar)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust tokenizers crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+esaxx-fast
+Summary:        Provides an implementation of today's most used tokenizers, with a focus on performances and versatility - feature "esaxx_fast"
+Requires:       crate(%{pkgname})
+Requires:       crate(esaxx-rs-0.1/cpp) >= 0.1.10
+Provides:       crate(%{pkgname}/esaxx-fast)
+
+%description -n %{name}+esaxx-fast
+This metapackage enables feature "esaxx_fast" for the Rust tokenizers crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+fancy-regex
+Summary:        Provides an implementation of today's most used tokenizers, with a focus on performances and versatility - feature "fancy-regex"
+Requires:       crate(%{pkgname})
+Requires:       crate(fancy-regex-0.14/default) >= 0.14.0
+Provides:       crate(%{pkgname}/fancy-regex)
+
+%description -n %{name}+fancy-regex
+This metapackage enables feature "fancy-regex" for the Rust tokenizers crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+hf-hub
+Summary:        Provides an implementation of today's most used tokenizers, with a focus on performances and versatility - feature "hf-hub" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(hf-hub-0.4/ureq) >= 0.4.1
+Provides:       crate(%{pkgname}/hf-hub)
+Provides:       crate(%{pkgname}/http)
+
+%description -n %{name}+hf-hub
+This metapackage enables feature "hf-hub" for the Rust tokenizers crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "http" feature.
+
+%package     -n %{name}+indicatif
+Summary:        Provides an implementation of today's most used tokenizers, with a focus on performances and versatility - feature "indicatif" and 1 more
+Requires:       crate(%{pkgname})
+Requires:       crate(indicatif-0.18/default) >= 0.18.0
+Provides:       crate(%{pkgname}/indicatif)
+Provides:       crate(%{pkgname}/progressbar)
+
+%description -n %{name}+indicatif
+This metapackage enables feature "indicatif" for the Rust tokenizers crate, by pulling in any additional dependencies needed by that feature.
+
+Additionally, this package also provides the "progressbar" feature.
+
+%package     -n %{name}+onig
+Summary:        Provides an implementation of today's most used tokenizers, with a focus on performances and versatility - feature "onig"
+Requires:       crate(%{pkgname})
+Requires:       crate(onig-6.0) >= 6.5.1
+Provides:       crate(%{pkgname}/onig)
+
+%description -n %{name}+onig
+This metapackage enables feature "onig" for the Rust tokenizers crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+rustls-tls
+Summary:        Provides an implementation of today's most used tokenizers, with a focus on performances and versatility - feature "rustls-tls"
+Requires:       crate(%{pkgname})
+Requires:       crate(hf-hub-0.4/rustls-tls) >= 0.4.1
+Requires:       crate(hf-hub-0.4/ureq) >= 0.4.1
+Provides:       crate(%{pkgname}/rustls-tls)
+
+%description -n %{name}+rustls-tls
+This metapackage enables feature "rustls-tls" for the Rust tokenizers crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+unstable-wasm
+Summary:        Provides an implementation of today's most used tokenizers, with a focus on performances and versatility - feature "unstable_wasm"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/fancy-regex)
+Requires:       crate(getrandom-0.3/wasm-js) >= 0.3.4
+Provides:       crate(%{pkgname}/unstable-wasm)
+
+%description -n %{name}+unstable-wasm
+This metapackage enables feature "unstable_wasm" for the Rust tokenizers crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-tokio-native-tls-0.3/rust-tokio-native-tls.spec
+++ b/SPECS/rust-tokio-native-tls-0.3/rust-tokio-native-tls.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name tokio-native-tls
+%global full_version 0.3.1
+%global pkgname tokio-native-tls-0.3
+
+Name:           rust-tokio-native-tls-0.3
+Version:        0.3.1
+Release:        %autorelease
+Summary:        Rust crate "tokio-native-tls"
+License:        MIT
+URL:            https://tokio.rs
+#!RemoteAsset:  sha256:bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(native-tls-0.2/default) >= 0.2.14
+Requires:       crate(tokio-1.0/default) >= 1.46.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "tokio-native-tls"
+
+%package     -n %{name}+vendored
+Summary:        TLS/SSL streams for Tokio using native-tls giving an implementation of TLS for nonblocking I/O streams - feature "vendored"
+Requires:       crate(%{pkgname})
+Requires:       crate(native-tls-0.2/vendored) >= 0.2.14
+Provides:       crate(%{pkgname}/vendored)
+
+%description -n %{name}+vendored
+This metapackage enables feature "vendored" for the Rust tokio-native-tls crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-toml-datetime-0.6/rust-toml-datetime.spec
+++ b/SPECS/rust-toml-datetime-0.6/rust-toml-datetime.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name toml_datetime
+%global full_version 0.6.11
+%global pkgname toml-datetime-0.6
+
+Name:           rust-toml-datetime-0.6
+Version:        0.6.11
+Release:        %autorelease
+Summary:        Rust crate "toml_datetime"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/toml-rs/toml
+#!RemoteAsset:  sha256:22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "toml_datetime"
+
+%package     -n %{name}+serde
+Summary:        TOML-compatible datetime type - feature "serde"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/default) >= 1.0.145
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust toml_datetime crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-toml-edit-0.22/rust-toml-edit.spec
+++ b/SPECS/rust-toml-edit-0.22/rust-toml-edit.spec
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name toml_edit
+%global full_version 0.22.27
+%global pkgname toml-edit-0.22
+
+Name:           rust-toml-edit-0.22
+Version:        0.22.27
+Release:        %autorelease
+Summary:        Rust crate "toml_edit"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/toml-rs/toml
+#!RemoteAsset:  sha256:41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(indexmap-2.0/default) >= 2.10.0
+Requires:       crate(indexmap-2.0/std) >= 2.10.0
+Requires:       crate(toml-datetime-0.6/default) >= 0.6.11
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/unbounded)
+
+%description
+Source code for takopackized Rust crate "toml_edit"
+
+%package     -n %{name}+parse
+Summary:        Yet another format-preserving TOML parser - feature "parse"
+Requires:       crate(%{pkgname})
+Requires:       crate(winnow-0.7/default) >= 0.7.12
+Provides:       crate(%{pkgname}/parse)
+
+%description -n %{name}+parse
+This metapackage enables feature "parse" for the Rust toml_edit crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+perf
+Summary:        Yet another format-preserving TOML parser - feature "perf"
+Requires:       crate(%{pkgname})
+Requires:       crate(kstring-2.0/default) >= 2.0.0
+Requires:       crate(kstring-2.0/max-inline) >= 2.0.0
+Provides:       crate(%{pkgname}/perf)
+
+%description -n %{name}+perf
+This metapackage enables feature "perf" for the Rust toml_edit crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+unstable-debug
+Summary:        Yet another format-preserving TOML parser - feature "unstable-debug"
+Requires:       crate(%{pkgname})
+Requires:       crate(winnow-0.7/debug) >= 0.7.12
+Provides:       crate(%{pkgname}/unstable-debug)
+
+%description -n %{name}+unstable-debug
+This metapackage enables feature "unstable-debug" for the Rust toml_edit crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-unicode-categories-0.1/rust-unicode-categories.spec
+++ b/SPECS/rust-unicode-categories-0.1/rust-unicode-categories.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name unicode_categories
+%global full_version 0.1.1
+%global pkgname unicode-categories-0.1
+
+Name:           rust-unicode-categories-0.1
+Version:        0.1.1
+Release:        %autorelease
+Summary:        Rust crate "unicode_categories"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/swgillespie/unicode-categories
+#!RemoteAsset:  sha256:39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "unicode_categories"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-unicode-normalization-alignments-0.1/rust-unicode-normalization-alignments.spec
+++ b/SPECS/rust-unicode-normalization-alignments-0.1/rust-unicode-normalization-alignments.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name unicode-normalization-alignments
+%global full_version 0.1.12
+%global pkgname unicode-normalization-alignments-0.1
+
+Name:           rust-unicode-normalization-alignments-0.1
+Version:        0.1.12
+Release:        %autorelease
+Summary:        Rust crate "unicode-normalization-alignments"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/n1t0/unicode-normalization
+#!RemoteAsset:  sha256:43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(smallvec-1.0/default) >= 1.15.1
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "unicode-normalization-alignments"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-unty-0.0.4/rust-unty.spec
+++ b/SPECS/rust-unty-0.0.4/rust-unty.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name unty
+%global full_version 0.0.4
+%global pkgname unty-0.0.4
+
+Name:           rust-unty-0.0.4
+Version:        0.0.4
+Release:        %autorelease
+Summary:        Rust crate "unty"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/bincode-org/unty
+#!RemoteAsset:  sha256:6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "unty"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-ureq-2.0/rust-ureq.spec
+++ b/SPECS/rust-ureq-2.0/rust-ureq.spec
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name ureq
+%global full_version 2.12.1
+%global pkgname ureq-2.0
+
+Name:           rust-ureq-2.0
+Version:        2.12.1
+Release:        %autorelease
+Summary:        Rust crate "ureq"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/algesten/ureq
+#!RemoteAsset:  sha256:02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(base64-0.22/default) >= 0.22.1
+Requires:       crate(log-0.4/default) >= 0.4.29
+Requires:       crate(once-cell-1.0/default) >= 1.21.3
+Requires:       crate(url-2.0/default) >= 2.5.8
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/proxy-from-env)
+
+%description
+Source code for takopackized Rust crate "ureq"
+
+%package     -n %{name}+charset
+Summary:        Simple, safe HTTP client - feature "charset"
+Requires:       crate(%{pkgname})
+Requires:       crate(encoding-rs-0.8/default) >= 0.8.0
+Provides:       crate(%{pkgname}/charset)
+
+%description -n %{name}+charset
+This metapackage enables feature "charset" for the Rust ureq crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+default
+Summary:        Simple, safe HTTP client - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/gzip)
+Requires:       crate(%{pkgname}/tls)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust ureq crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+gzip
+Summary:        Simple, safe HTTP client - feature "gzip"
+Requires:       crate(%{pkgname})
+Requires:       crate(flate2-1.0/default) >= 1.1.5
+Provides:       crate(%{pkgname}/gzip)
+
+%description -n %{name}+gzip
+This metapackage enables feature "gzip" for the Rust ureq crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+http-crate
+Summary:        Simple, safe HTTP client - feature "http-crate"
+Requires:       crate(%{pkgname})
+Requires:       crate(http-1.0/default) >= 1.1
+Provides:       crate(%{pkgname}/http-crate)
+
+%description -n %{name}+http-crate
+This metapackage enables feature "http-crate" for the Rust ureq crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+json
+Summary:        Simple, safe HTTP client - feature "json"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/default) >= 1.0.228
+Requires:       crate(serde-json-1.0/default) >= 1.0.149
+Provides:       crate(%{pkgname}/json)
+
+%description -n %{name}+json
+This metapackage enables feature "json" for the Rust ureq crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+native-tls
+Summary:        Simple, safe HTTP client - feature "native-tls"
+Requires:       crate(%{pkgname})
+Requires:       crate(native-tls-0.2/default) >= 0.2.0
+Provides:       crate(%{pkgname}/native-tls)
+
+%description -n %{name}+native-tls
+This metapackage enables feature "native-tls" for the Rust ureq crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+socks-proxy
+Summary:        Simple, safe HTTP client - feature "socks-proxy"
+Requires:       crate(%{pkgname})
+Requires:       crate(socks-0.3/default) >= 0.3.4
+Provides:       crate(%{pkgname}/socks-proxy)
+
+%description -n %{name}+socks-proxy
+This metapackage enables feature "socks-proxy" for the Rust ureq crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+tls
+Summary:        Simple, safe HTTP client - feature "tls"
+Requires:       crate(%{pkgname})
+Requires:       crate(rustls-0.23/logging) >= 0.23.36
+Requires:       crate(rustls-0.23/ring) >= 0.23.36
+Requires:       crate(rustls-0.23/std) >= 0.23.36
+Requires:       crate(rustls-0.23/tls12) >= 0.23.36
+Requires:       crate(rustls-pki-types-1.0/default) >= 1.13.2
+Requires:       crate(webpki-roots-0.26/default) >= 0.26.11
+Provides:       crate(%{pkgname}/tls)
+
+%description -n %{name}+tls
+This metapackage enables feature "tls" for the Rust ureq crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-uuid-simd-0.8/rust-uuid-simd.spec
+++ b/SPECS/rust-uuid-simd-0.8/rust-uuid-simd.spec
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name uuid-simd
+%global full_version 0.8.0
+%global pkgname uuid-simd-0.8
+
+Name:           rust-uuid-simd-0.8
+Version:        0.8.0
+Release:        %autorelease
+Summary:        Rust crate "uuid-simd"
+License:        MIT
+URL:            https://github.com/Nugine/simd
+#!RemoteAsset:  sha256:23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(outref-0.5/default) >= 0.5.2
+Requires:       crate(vsimd-0.8/default) >= 0.8.0
+Provides:       crate(%{pkgname})
+
+%description
+Source code for takopackized Rust crate "uuid-simd"
+
+%package     -n %{name}+alloc
+Summary:        SIMD-accelerated UUID operations - feature "alloc"
+Requires:       crate(%{pkgname})
+Requires:       crate(vsimd-0.8/alloc) >= 0.8.0
+Provides:       crate(%{pkgname}/alloc)
+
+%description -n %{name}+alloc
+This metapackage enables feature "alloc" for the Rust uuid-simd crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+default
+Summary:        SIMD-accelerated UUID operations - feature "default"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/detect)
+Requires:       crate(%{pkgname}/std)
+Requires:       crate(%{pkgname}/uuid)
+Provides:       crate(%{pkgname}/default)
+
+%description -n %{name}+default
+This metapackage enables feature "default" for the Rust uuid-simd crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+detect
+Summary:        SIMD-accelerated UUID operations - feature "detect"
+Requires:       crate(%{pkgname})
+Requires:       crate(vsimd-0.8/detect) >= 0.8.0
+Provides:       crate(%{pkgname}/detect)
+
+%description -n %{name}+detect
+This metapackage enables feature "detect" for the Rust uuid-simd crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+std
+Summary:        SIMD-accelerated UUID operations - feature "std"
+Requires:       crate(%{pkgname})
+Requires:       crate(%{pkgname}/alloc)
+Requires:       crate(vsimd-0.8/std) >= 0.8.0
+Provides:       crate(%{pkgname}/std)
+
+%description -n %{name}+std
+This metapackage enables feature "std" for the Rust uuid-simd crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+unstable
+Summary:        SIMD-accelerated UUID operations - feature "unstable"
+Requires:       crate(%{pkgname})
+Requires:       crate(vsimd-0.8/unstable) >= 0.8.0
+Provides:       crate(%{pkgname}/unstable)
+
+%description -n %{name}+unstable
+This metapackage enables feature "unstable" for the Rust uuid-simd crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+uuid
+Summary:        SIMD-accelerated UUID operations - feature "uuid"
+Requires:       crate(%{pkgname})
+Requires:       crate(uuid-1.0/default) >= 1.17.0
+Provides:       crate(%{pkgname}/uuid)
+
+%description -n %{name}+uuid
+This metapackage enables feature "uuid" for the Rust uuid-simd crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-virtue-0.0.18/rust-virtue.spec
+++ b/SPECS/rust-virtue-0.0.18/rust-virtue.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name virtue
+%global full_version 0.0.18
+%global pkgname virtue-0.0.18
+
+Name:           rust-virtue-0.0.18
+Version:        0.0.18
+Release:        %autorelease
+Summary:        Rust crate "virtue"
+License:        MIT
+URL:            https://github.com/bincode-org/virtue
+#!RemoteAsset:  sha256:051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "virtue"
+
+%package     -n %{name}+proc-macro2
+Summary:        Sinless derive macro helper - feature "proc-macro2"
+Requires:       crate(%{pkgname})
+Requires:       crate(proc-macro2-1.0/default) >= 1.0.0
+Provides:       crate(%{pkgname}/proc-macro2)
+
+%description -n %{name}+proc-macro2
+This metapackage enables feature "proc-macro2" for the Rust virtue crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-vsimd-0.8/rust-vsimd.spec
+++ b/SPECS/rust-vsimd-0.8/rust-vsimd.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name vsimd
+%global full_version 0.8.0
+%global pkgname vsimd-0.8
+
+Name:           rust-vsimd-0.8
+Version:        0.8.0
+Release:        %autorelease
+Summary:        Rust crate "vsimd"
+License:        MIT
+URL:            https://github.com/Nugine/simd
+#!RemoteAsset:  sha256:5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/alloc)
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/detect)
+Provides:       crate(%{pkgname}/std)
+Provides:       crate(%{pkgname}/unstable)
+
+%description
+Source code for takopackized Rust crate "vsimd"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-wasi-0.14/rust-wasi.spec
+++ b/SPECS/rust-wasi-0.14/rust-wasi.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name wasi
+%global full_version 0.14.2+wasi-0.2.4
+%global pkgname wasi-0.14
+
+Name:           rust-wasi-0.14
+Version:        0.14.2
+Release:        %autorelease
+Summary:        Rust crate "wasi"
+License:        Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT
+URL:            https://github.com/bytecodealliance/wasi-rs
+#!RemoteAsset:  sha256:9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(wit-bindgen-rt-0.39/bitflags) >= 0.39.0
+Requires:       crate(wit-bindgen-rt-0.39/default) >= 0.39.0
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+Provides:       crate(%{pkgname}/std)
+
+%description
+Source code for takopackized Rust crate "wasi"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-wasm-bindgen-backend-0.2/rust-wasm-bindgen-backend.spec
+++ b/SPECS/rust-wasm-bindgen-backend-0.2/rust-wasm-bindgen-backend.spec
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name wasm-bindgen-backend
+%global full_version 0.2.100
+%global pkgname wasm-bindgen-backend-0.2
+
+Name:           rust-wasm-bindgen-backend-0.2
+Version:        0.2.100
+Release:        %autorelease
+Summary:        Rust crate "wasm-bindgen-backend"
+License:        MIT OR Apache-2.0
+URL:            https://rustwasm.github.io/wasm-bindgen/
+#!RemoteAsset:  sha256:2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(bumpalo-3.0/default) >= 3.19.0
+Requires:       crate(log-0.4/default) >= 0.4.27
+Requires:       crate(proc-macro2-1.0/default) >= 1.0.95
+Requires:       crate(quote-1.0/default) >= 1.0.40
+Requires:       crate(syn-2.0/default) >= 2.0.104
+Requires:       crate(syn-2.0/full) >= 2.0.104
+Requires:       crate(wasm-bindgen-shared-0.2/default) >= 0.2.100
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "wasm-bindgen-backend"
+
+%package     -n %{name}+extra-traits
+Summary:        Backend code generation of the wasm-bindgen tool - feature "extra-traits"
+Requires:       crate(%{pkgname})
+Requires:       crate(syn-2.0/extra-traits) >= 2.0.104
+Requires:       crate(syn-2.0/full) >= 2.0.104
+Provides:       crate(%{pkgname}/extra-traits)
+
+%description -n %{name}+extra-traits
+This metapackage enables feature "extra-traits" for the Rust wasm-bindgen-backend crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-wasm-streams-0.4/rust-wasm-streams.spec
+++ b/SPECS/rust-wasm-streams-0.4/rust-wasm-streams.spec
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name wasm-streams
+%global full_version 0.4.2
+%global pkgname wasm-streams-0.4
+
+Name:           rust-wasm-streams-0.4
+Version:        0.4.2
+Release:        %autorelease
+Summary:        Rust crate "wasm-streams"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/MattiasBuelens/wasm-streams/
+#!RemoteAsset:  sha256:15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(futures-util-0.3/default) >= 0.3.31
+Requires:       crate(futures-util-0.3/io) >= 0.3.31
+Requires:       crate(futures-util-0.3/sink) >= 0.3.31
+Requires:       crate(js-sys-0.3/default) >= 0.3.83
+Requires:       crate(wasm-bindgen-0.2/default) >= 0.2.106
+Requires:       crate(wasm-bindgen-futures-0.4/default) >= 0.4.56
+Requires:       crate(web-sys-0.3/abortsignal) >= 0.3.83
+Requires:       crate(web-sys-0.3/default) >= 0.3.83
+Requires:       crate(web-sys-0.3/queuingstrategy) >= 0.3.83
+Requires:       crate(web-sys-0.3/readablebytestreamcontroller) >= 0.3.83
+Requires:       crate(web-sys-0.3/readablestream) >= 0.3.83
+Requires:       crate(web-sys-0.3/readablestreambyobreader) >= 0.3.83
+Requires:       crate(web-sys-0.3/readablestreambyobrequest) >= 0.3.83
+Requires:       crate(web-sys-0.3/readablestreamdefaultcontroller) >= 0.3.83
+Requires:       crate(web-sys-0.3/readablestreamdefaultreader) >= 0.3.83
+Requires:       crate(web-sys-0.3/readablestreamgetreaderoptions) >= 0.3.83
+Requires:       crate(web-sys-0.3/readablestreamreadermode) >= 0.3.83
+Requires:       crate(web-sys-0.3/readablestreamreadresult) >= 0.3.83
+Requires:       crate(web-sys-0.3/readablestreamtype) >= 0.3.83
+Requires:       crate(web-sys-0.3/readablewritablepair) >= 0.3.83
+Requires:       crate(web-sys-0.3/streampipeoptions) >= 0.3.83
+Requires:       crate(web-sys-0.3/transformer) >= 0.3.83
+Requires:       crate(web-sys-0.3/transformstream) >= 0.3.83
+Requires:       crate(web-sys-0.3/transformstreamdefaultcontroller) >= 0.3.83
+Requires:       crate(web-sys-0.3/underlyingsink) >= 0.3.83
+Requires:       crate(web-sys-0.3/underlyingsource) >= 0.3.83
+Requires:       crate(web-sys-0.3/writablestream) >= 0.3.83
+Requires:       crate(web-sys-0.3/writablestreamdefaultcontroller) >= 0.3.83
+Requires:       crate(web-sys-0.3/writablestreamdefaultwriter) >= 0.3.83
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "wasm-streams"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-web-time-1.0/rust-web-time.spec
+++ b/SPECS/rust-web-time-1.0/rust-web-time.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name web-time
+%global full_version 1.1.0
+%global pkgname web-time-1.0
+
+Name:           rust-web-time-1.0
+Version:        1.1.0
+Release:        %autorelease
+Summary:        Rust crate "web-time"
+License:        MIT OR Apache-2.0
+URL:            https://github.com/daxpedda/web-time
+#!RemoteAsset:  sha256:5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(js-sys-0.3/default) >= 0.3.83
+Requires:       crate(wasm-bindgen-0.2) >= 0.2.106
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "web-time"
+
+%package     -n %{name}+serde
+Summary:        Drop-in replacement for std::time for Wasm in browsers - feature "serde"
+Requires:       crate(%{pkgname})
+Requires:       crate(serde-1.0/default) >= 1.0.0
+Provides:       crate(%{pkgname}/serde)
+
+%description -n %{name}+serde
+This metapackage enables feature "serde" for the Rust web-time crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-webpki-roots-0.26/rust-webpki-roots.spec
+++ b/SPECS/rust-webpki-roots-0.26/rust-webpki-roots.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name webpki-roots
+%global full_version 0.26.11
+%global pkgname webpki-roots-0.26
+
+Name:           rust-webpki-roots-0.26
+Version:        0.26.11
+Release:        %autorelease
+Summary:        Rust crate "webpki-roots"
+License:        CDLA-Permissive-2.0
+URL:            https://github.com/rustls/webpki-roots
+#!RemoteAsset:  sha256:521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "webpki-roots"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-webpki-roots-1.0/rust-webpki-roots.spec
+++ b/SPECS/rust-webpki-roots-1.0/rust-webpki-roots.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name webpki-roots
+%global full_version 1.0.5
+%global pkgname webpki-roots-1.0
+
+Name:           rust-webpki-roots-1.0
+Version:        1.0.5
+Release:        %autorelease
+Summary:        Rust crate "webpki-roots"
+License:        CDLA-Permissive-2.0
+URL:            https://github.com/rustls/webpki-roots
+#!RemoteAsset:  sha256:12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Requires:       crate(rustls-pki-types-1.0) >= 1.13.2
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "webpki-roots"
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog

--- a/SPECS/rust-wit-bindgen-rt-0.39/rust-wit-bindgen-rt.spec
+++ b/SPECS/rust-wit-bindgen-rt-0.39/rust-wit-bindgen-rt.spec
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global crate_name wit-bindgen-rt
+%global full_version 0.39.0
+%global pkgname wit-bindgen-rt-0.39
+
+Name:           rust-wit-bindgen-rt-0.39
+Version:        0.39.0
+Release:        %autorelease
+Summary:        Rust crate "wit-bindgen-rt"
+License:        Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT
+URL:            https://github.com/bytecodealliance/wit-bindgen
+#!RemoteAsset:  sha256:6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1
+Source:         https://static.crates.io/crates/%{crate_name}/%{full_version}/download#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    rustcrates
+
+BuildRequires:  rust-rpm-macros
+
+Provides:       crate(%{pkgname})
+Provides:       crate(%{pkgname}/default)
+
+%description
+Source code for takopackized Rust crate "wit-bindgen-rt"
+
+%package     -n %{name}+async
+Summary:        Runtime support for the `wit-bindgen` crate - feature "async"
+Requires:       crate(%{pkgname})
+Requires:       crate(futures-0.3/default) >= 0.3.30
+Requires:       crate(once-cell-1.0/default) >= 1.19.0
+Provides:       crate(%{pkgname}/async)
+
+%description -n %{name}+async
+This metapackage enables feature "async" for the Rust wit-bindgen-rt crate, by pulling in any additional dependencies needed by that feature.
+
+%package     -n %{name}+bitflags
+Summary:        Runtime support for the `wit-bindgen` crate - feature "bitflags"
+Requires:       crate(%{pkgname})
+Requires:       crate(bitflags-2.0/default) >= 2.9.1
+Provides:       crate(%{pkgname}/bitflags)
+
+%description -n %{name}+bitflags
+This metapackage enables feature "bitflags" for the Rust wit-bindgen-rt crate, by pulling in any additional dependencies needed by that feature.
+
+%files
+%{_datadir}/cargo/registry/%{crate_name}-%{version}/
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

This PR adds the Rust crate dependency closure needed for packaging several
Rust-backed Python extension packages in openRuyi, including:

- `python-cbor2`
- `python-watchfiles`
- `python-outlines-core`
- `python-llguidance`

These Python packages use Rust/PyO3/maturin or setuptools-rust build backends.
To build them reproducibly in OBS, their Cargo dependencies must be available
as distro-provided Rust crate packages instead of being fetched from crates.io
during the build.

`python-cbor2` provides high-performance CBOR serialization support, which is
useful for compact binary data exchange and edge/embedded use cases.  

`python-watchfiles` provides a modern high-performance file watching backend
used by Python development servers, hot-reload tooling, CLI utilities, and
workflow tools.

`python-outlines-core` and `python-llguidance` provide low-level structured
generation / constrained decoding primitives for LLM applications, including
grammar-guided generation, JSON schema constrained output, token masking, and
structured output support.

## Related Issue

NO

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.
- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.
