### PR TITLE
SPECS: KDE: Remove outdated dependencies

### DIFF
--- a/SPECS/openruyi-desktop-setup-kde/openruyi-desktop-setup-kde.spec
+++ b/SPECS/openruyi-desktop-setup-kde/openruyi-desktop-setup-kde.spec
@@ -27,7 +27,7 @@ Requires:       dolphin
 Requires:       kf6-kwindowsystem
 Requires:       kf6-kcoreaddons
 Requires:       kf6-kcmutils
-Requires:       kf6-kconfig-imports
+Requires:       kf6-kconfig
 Requires:       kf6-qqc2-desktop-style
 
 Recommends:     discover

--- a/SPECS/powerdevil/powerdevil.spec
+++ b/SPECS/powerdevil/powerdevil.spec
@@ -67,7 +67,7 @@ BuildRequires:  pkgconfig(xcb-dpms)
 BuildRequires:  pkgconfig(xcb-randr)
 
 Requires:       kf6-kidletime-plugins
-Requires:       kf6-knotifications-imports
+Requires:       kf6-knotifications
 %requires_ge    plasma-workspace-libs
 
 Recommends:     upower


### PR DESCRIPTION
## Summary

Deprecated dependencies have been removed. These dependencies no longer exist after the update at https://github.com/openRuyi-Project/openRuyi/pull/538.

## Related Issue

no

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.


[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
