### PR TITLE
Avoid python-ruamel-yaml-clib and python-ruamel-yaml circular dependency

### DIFF
--- a/SPECS/python-ruamel-yaml-clib/python-ruamel-yaml-clib.spec
+++ b/SPECS/python-ruamel-yaml-clib/python-ruamel-yaml-clib.spec
@@ -19,19 +19,16 @@ Source0:        https://files.pythonhosted.org/packages/source/r/%{pypi_name}/%{
 BuildSystem:    pyproject
 
 BuildOption(install):  -l _ruamel_yaml
-BuildOption(check):  _ruamel_yaml
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(cython)
 # For %check
-BuildRequires:  python3dist(ruamel-yaml)
+# BuildRequires:  python3dist(ruamel-yaml)
 
 Provides:       python3-ruamel-yaml-clib = %{version}-%{release}
 Provides:       python3-ruamel-yaml-clib%{?_isa} = %{version}-%{release}
 %python_provide python3-ruamel-yaml-clib
-
-Requires:       python3dist(ruamel-yaml)
 
 %description
 ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of
@@ -57,6 +54,10 @@ mv *.pyx ruamel.yaml.clib
 cythonize -j${RPM_BUILD_NCPUS} -3 ruamel.yaml.clib/*.pyx
 mv ruamel.yaml.clib/* .
 rmdir ruamel.yaml.clib
+
+# Here, we skip the test to avoid the dependency of python-ruamel-yaml-clib on
+# python-ruamel-yaml, which leads to a circular dependency.
+%check
 
 %files -f %{pyproject_files}
 %doc README.md


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy

<!-- Message of single commit: -->

SPECS: python-ruamel-yaml-clib: avoid circular dependency