### PR TITLE
SPECS: systemd: add a patch to restrict RV extensions for systemd-boot

### DIFF
--- a/SPECS/systemd/0001-boot-enable-only-IMAFDCZicsrZifencei-for-RISC-V.patch
+++ b/SPECS/systemd/0001-boot-enable-only-IMAFDCZicsrZifencei-for-RISC-V.patch
@@ -1,0 +1,38 @@
+From 49bee10722510689b90e968ea29be249c750d448 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
+Date: Thu, 4 Jun 2026 00:35:41 +0800
+Subject: [PATCH] boot: enable only IMAFDCZicsrZifencei for RISC-V
+
+The UEFI specification only defines A/C/I/M/Zicsr/Zifencei as mandatory
+extensions in boot services. However, on systems with everything built
+with F/D support, its difficult to disable F/D without changing a
+toolchain. In addition, both EDK2 and U-Boot enable F/D on boot,
+although they neither enable nor disable V. EDK2 comments even claim the
+enablement of FPU is "to be compliant with UEFI spec" despite the spec
+requires dynamic detection before using F/D.
+
+Add corresponding -march flags to prevent systemd-boot from using other
+extensions on RISC-V, and a comment for the temporary enablement of F/D.
+
+Signed-off-by: Icenowy Zheng <zhengxingda@iscas.ac.cn>
+---
+ src/boot/meson.build | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/boot/meson.build b/src/boot/meson.build
+index d2524145d0..6da1ae6e2f 100644
+--- a/src/boot/meson.build
++++ b/src/boot/meson.build
+@@ -270,6 +270,9 @@ efi_arch_c_args = {
+         'arm'         : ['-mgeneral-regs-only'],
+         # Until -mgeneral-regs-only is supported in LoongArch, use the following option instead:
+         'loongarch64' : ['-mno-lsx', '-mno-lasx'],
++        # Assume F/D is usable on RISC-V because they're difficult to disable
++        'riscv32'     : ['-march=rv32imafdc_zicsr_zifencei'],
++        'riscv64'     : ['-march=rv64imafdc_zicsr_zifencei'],
+         # Pass -m64/32 explicitly to make building on x32 work.
+         'x86_64'      : ['-m64', '-march=x86-64', '-mno-red-zone', '-mgeneral-regs-only'],
+         'x86'         : ['-m32', '-march=i686', '-mgeneral-regs-only', '-malign-double'],
+-- 
+2.52.0
+

--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -59,6 +59,10 @@ Source0:        https://github.com/systemd/systemd/archive/v%{version}/%{name}-%
 Source1:        systemd-user.pam
 BuildSystem:    meson
 
+# Enable only mandatory RV extensions in UEFI spec for systemd-boot
+# Picked from https://github.com/systemd/systemd/pull/42467
+Patch0:         0001-boot-enable-only-IMAFDCZicsrZifencei-for-RISC-V.patch
+
 BuildOption(conf):  -Dmode=release
 BuildOption(conf):  -Dsbat-distro-url='%{_vendor_url}'
 BuildOption(conf):  -Drc-local=/etc/rc.d/rc.local


### PR DESCRIPTION
## Summary 

The UEFI spec defines only IMACZicsrZifencei as unconditionally available for UEFI firmwares, and it's possible for firmwares to not enable V.

Add a patch to restrict the RV extensions used for systemd-boot to comply UEFI spec.

## Related Issue

- Resolves #602 .

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.
- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.