### PR TITLE
SPECS: dropbear: Update to 2026.91 [security-fixes].

### DIFF
--- a/SPECS/dropbear/dropbear.spec
+++ b/SPECS/dropbear/dropbear.spec
@@ -6,13 +6,13 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 Name:           dropbear
-Version:        2025.89
+Version:        2026.91
 Release:        %autorelease
 Summary:        A lightweight SSH server and client
 License:        MIT
 URL:            https://matt.ucc.asn.au/dropbear/dropbear.html
 VCS:            git:https://github.com/mkj/dropbear
-#!RemoteAsset
+#!RemoteAsset:  sha256:defa924475abf6bc1e74abc00173e46bfdc804bd47caafa14f5a4ef0cc76da34
 Source0:        https://matt.ucc.asn.au/dropbear/releases/dropbear-%{version}.tar.bz2
 Source1:        dropbear.service
 Source2:        dropbear-keygen.service
@@ -75,4 +75,4 @@ install -pm644 %{SOURCE2} %{buildroot}%{_unitdir}/dropbear-keygen.service
 %{_mandir}/man8/*.8*
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
## Summary

Update dropbear from 2025.89 to 2026.91.

Fix CVE-2026-35385, CVE-2019-6111 in OpenSSH which also affected Dropbear.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.
- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: DeepSeek:DeepSeek-V4-Pro

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy