### PR TITLE
SPECS: autossh: require openssh-clients for /usr/bin/ssh

### DIFF
--- a/SPECS/autossh/autossh.spec
+++ b/SPECS/autossh/autossh.spec
@@ -22,15 +22,13 @@ BuildRequires:  automake
 BuildRequires:  libtool
 BuildRequires:  openssh-clients
 
-Requires:       openssh
+Requires:       openssh-clients
 
 %description
 Autossh is a program to start a copy of ssh and monitor it, restarting
 it as necessary should it die or stop passing traffic.
 
 %prep -a
-tar xzf %{SOURCE0} --strip-components=1
-
 # Create a sysusers.d config file
 cat >autossh.sysusers.conf <<EOF
 u autossh - 'autossh service account' %{_sysconfdir}/autossh -
@@ -74,4 +72,4 @@ fi
 %{_sysusersdir}/autossh.conf
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
## Summary

`autossh[662705]: /bin/ssh: No such file or directory`

`autossh` needs `/usr/bin/ssh`, which is in the `openssh-clients`

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy