### PR TITLE
SPECS: qemu: add two patches fixing ACPI tables for RV KVM

### DIFF
--- a/SPECS/qemu/0007-hw-riscv-virt-acpi-build.c-Use-kvm-timer-fr.patch
+++ b/SPECS/qemu/0007-hw-riscv-virt-acpi-build.c-Use-kvm-timer-fr.patch
@@ -1,0 +1,52 @@
+From 42da1ad0c1ae52426b24086a0ac1838a50db2c3c Mon Sep 17 00:00:00 2001
+From: Yicong Yang <yang.yicong@picoheart.com>
+Date: Wed, 25 Mar 2026 16:13:14 +0800
+Subject: [PATCH 1/2] hw/riscv/virt-acpi-build.c: Use kvm timer
+ frequency when kvm enabled
+
+The timer frequency is decided by the host(kvm) rather than a fixed
+RISCV_ACLINT_DEFAULT_TIMEBASE_FREQ on kvm accelerated VM. So build
+RCHT with KVM provided timer frequency if KVM is enabled, just like
+how we build the timer node on DT based VM.
+
+Fixes: ebfd39289370 ("hw/riscv/virt: virt-acpi-build.c: Add RHCT Table")
+Signed-off-by: Yicong Yang <yang.yicong@picoheart.com>
+Reviewed-by: Andrew Jones <andrew.jones@oss.qualcomm.com>
+Message-ID: <20260325081314.57089-1-yang.yicong@picoheart.com>
+Signed-off-by: Alistair Francis <alistair.francis@wdc.com>
+(cherry picked from commit 4cb2f91773e8ec9511002de851734820f7ba64fe)
+---
+ hw/riscv/virt-acpi-build.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/hw/riscv/virt-acpi-build.c b/hw/riscv/virt-acpi-build.c
+index f1406cb683..fd6ca5dbc4 100644
+--- a/hw/riscv/virt-acpi-build.c
++++ b/hw/riscv/virt-acpi-build.c
+@@ -35,9 +35,11 @@
+ #include "hw/riscv/virt.h"
+ #include "hw/riscv/numa.h"
+ #include "hw/virtio/virtio-acpi.h"
++#include "kvm/kvm_riscv.h"
+ #include "migration/vmstate.h"
+ #include "qapi/error.h"
+ #include "qemu/error-report.h"
++#include "system/kvm.h"
+ #include "system/reset.h"
+ 
+ #define ACPI_BUILD_TABLE_SIZE             0x20000
+@@ -296,7 +298,10 @@ static void build_rhct(GArray *table_data,
+ 
+     /* Time Base Frequency */
+     build_append_int_noprefix(table_data,
+-                              RISCV_ACLINT_DEFAULT_TIMEBASE_FREQ, 8);
++                              kvm_enabled() ?
++                              kvm_riscv_get_timebase_frequency(&s->soc->harts[0]) :
++                              RISCV_ACLINT_DEFAULT_TIMEBASE_FREQ,
++                              8);
+ 
+     /* ISA + N hart info */
+     num_rhct_nodes = 1 + ms->smp.cpus;
+-- 
+2.52.0
+

--- a/SPECS/qemu/0008-hw-riscv-virt-acpi-build-Fix-RINTC-PLIC-con.patch
+++ b/SPECS/qemu/0008-hw-riscv-virt-acpi-build-Fix-RINTC-PLIC-con.patch
@@ -1,0 +1,47 @@
+From 5145d4686ffc7b36aea82c83a0812f8beb3235c7 Mon Sep 17 00:00:00 2001
+From: Qingwei Hu <qingwei.hu@bytedance.com>
+Date: Thu, 4 Jun 2026 20:00:17 +0800
+Subject: [PATCH 2/2] hw/riscv/virt-acpi-build: Fix RINTC PLIC
+ context ID for KVM
+
+Each RISC-V MADT RINTC entry contains an External Interrupt Controller
+ID field. On the virt machine without AIA, this field identifies the
+S-mode PLIC context associated with the hart.
+
+TCG virt has both M-mode and S-mode PLIC contexts, so the S-mode context
+ID is odd and 2 * local_cpu_id + 1 is correct. KVM virt exposes only
+S-mode PLIC contexts, and those contexts are numbered contiguously from
+0. Reporting the TCG context ID for KVM makes the guest enable a
+different PLIC context from the one used by QEMU.
+
+With ACPI enabled, this can leave PCI INTx interrupts pending in QEMU
+while the guest-programmed PLIC context remains disabled. A virtio-blk
+root disk can then stall during boot because its first interrupt is never
+delivered.
+
+Use local_cpu_id for KVM and keep the existing odd S-mode context ID for
+TCG.
+
+Fixes: d641da6ed43 ("hw/riscv/virt-acpi-build.c: Add PLIC in MADT")
+Signed-off-by: Qingwei Hu <qingwei.hu@bytedance.com>
+Link: https://lore.kernel.org/qemu-devel/20260604120017.398890-1-qingwei.hu@bytedance.com/
+---
+ hw/riscv/virt-acpi-build.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/hw/riscv/virt-acpi-build.c b/hw/riscv/virt-acpi-build.c
+index fd6ca5dbc4..504a93025b 100644
+--- a/hw/riscv/virt-acpi-build.c
++++ b/hw/riscv/virt-acpi-build.c
+@@ -100,6 +100,8 @@ static void riscv_acpi_madt_add_rintc(uint32_t uid,
+         build_append_int_noprefix(entry,
+                                   ACPI_BUILD_INTC_ID(
+                                       arch_ids->cpus[uid].props.node_id,
++                                      kvm_enabled() ?
++                                      local_cpu_id :
+                                       2 * local_cpu_id + 1),
+                                   4);
+     } else {
+-- 
+2.52.0
+

--- a/SPECS/qemu/qemu.spec
+++ b/SPECS/qemu/qemu.spec
@@ -201,6 +201,10 @@ Patch4:         0004-hw-riscv-server_platform_ref.c-add-riscv-iommu-sys.patch
 Patch5:         0005-docs-add-rvsp-ref.rst.patch
 Patch6:         0006-target-riscv-update-satp_mode-to-SV48-for-rvsp-ref.patch
 
+# RISC-V KVM virt machine ACPI table fixes
+Patch7:         0007-hw-riscv-virt-acpi-build.c-Use-kvm-timer-fr.patch
+Patch8:         0008-hw-riscv-virt-acpi-build-Fix-RINTC-PLIC-con.patch
+
 BuildRequires:  hostname
 BuildRequires:  meson
 BuildRequires:  bison


### PR DESCRIPTION
## Summary

These patches fix the timebase frequency and PLIC context IDs for ACPI tables generated for RISC-V virt machine when running under KVM.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.
- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.