### PR TITLE
SPECS: Add Prometheus Go dependency specs

### DIFF
--- a/SPECS/go-github-hetznercloud-hcloud-go-v2/go-github-hetznercloud-hcloud-go-v2.spec
+++ b/SPECS/go-github-hetznercloud-hcloud-go-v2/go-github-hetznercloud-hcloud-go-v2.spec
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           hcloud-go
+%define go_import_path  github.com/hetznercloud/hcloud-go/v2
+
+Name:           go-github-hetznercloud-hcloud-go-v2
+Version:        2.42.0
+Release:        %autorelease
+Summary:        A Go library for the Hetzner Cloud API
+License:        MIT
+URL:            https://github.com/hetznercloud/hcloud-go
+#!RemoteAsset:  sha256:25cfa0ac028ede3b4e7f5970252feff8c0949fe7cc7e6eacb3fc15550ee3683d
+Source0:        https://github.com/hetznercloud/hcloud-go/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/google/go-cmp)
+BuildRequires:  go(github.com/prometheus/client_golang)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(golang.org/x/crypto)
+BuildRequires:  go(golang.org/x/net)
+
+Provides:       go(github.com/hetznercloud/hcloud-go/v2) = %{version}
+
+Requires:       go(github.com/google/go-cmp)
+Requires:       go(github.com/prometheus/client_golang)
+Requires:       go(github.com/stretchr/testify)
+Requires:       go(golang.org/x/crypto)
+Requires:       go(golang.org/x/net)
+
+%description
+This package provides the Go client library for the Hetzner Cloud API.
+It is used by Go programs to manage Hetzner Cloud resources.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-influxdata-influxdb-client-go-v2/go-github-influxdata-influxdb-client-go-v2.spec
+++ b/SPECS/go-github-influxdata-influxdb-client-go-v2/go-github-influxdata-influxdb-client-go-v2.spec
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           influxdb-client-go
+%define go_import_path  github.com/influxdata/influxdb-client-go/v2
+
+Name:           go-github-influxdata-influxdb-client-go-v2
+Version:        2.14.0
+Release:        %autorelease
+Summary:        InfluxDB 2 Go client library
+License:        MIT
+URL:            https://github.com/influxdata/influxdb-client-go
+#!RemoteAsset:  sha256:fed7f5df0f67e3b4606f2103cb920c2027ee886be2a92a6fc07b4e5d334089e4
+Source0:        https://github.com/influxdata/influxdb-client-go/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Upstream internal/write/service.go misuses a go vet error-wrapping directive
+# that newer go vet rejects as a build error; disable vet (tests still run).
+BuildOption(check):  -vet=off
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/influxdata/line-protocol)
+BuildRequires:  go(github.com/oapi-codegen/runtime)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(golang.org/x/net)
+
+Provides:       go(github.com/influxdata/influxdb-client-go/v2) = %{version}
+
+Requires:       go(github.com/influxdata/line-protocol)
+Requires:       go(github.com/oapi-codegen/runtime)
+Requires:       go(github.com/stretchr/testify)
+Requires:       go(golang.org/x/net)
+
+%description
+This package provides the Go client library for InfluxDB 2.x and Flux.
+It includes APIs for querying data, writing data, and using the InfluxDB
+2 management API from Go programs.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-influxdata-line-protocol/go-github-influxdata-line-protocol.spec
+++ b/SPECS/go-github-influxdata-line-protocol/go-github-influxdata-line-protocol.spec
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           line-protocol
+%define go_import_path  github.com/influxdata/line-protocol
+%define commit_id 2487e7298839615811464221244c572dc05b50ad
+
+Name:           go-github-influxdata-line-protocol
+Version:        0+git20260605.2487e729
+Release:        %autorelease
+Summary:        InfluxDB line protocol codec for Go
+License:        MIT
+URL:            https://github.com/influxdata/line-protocol
+#!RemoteAsset:  sha256:377f4303387074ceeb50e60c3a784abb4b07d7db850ac35513d252fbb05e7ef0
+Source0:        https://github.com/influxdata/line-protocol/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{_name}-%{commit_id}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/influxdata/line-protocol) = %{version}
+
+%description
+InfluxDB line-protocol codec
+
+This module implements a high performance Go codec for the line-protocol
+syntax as accepted by InfluxDB. Currently the API is low level - it's
+intended for converting line-protocol to some chosen concrete types that
+aren't specified here. (In future work, we'll define a Point type that
+implements a convenient but less performant type to encode or decode).
+
+The API documentation is here:
+(https://pkg.go.dev/github.com/influxdata/line-protocol/v2/lineprotocol)
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-ionos-cloud-sdk-go-v6/go-github-ionos-cloud-sdk-go-v6.spec
+++ b/SPECS/go-github-ionos-cloud-sdk-go-v6/go-github-ionos-cloud-sdk-go-v6.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           sdk-go
+%define go_import_path  github.com/ionos-cloud/sdk-go/v6
+# Upstream ships several independent example main programs in one directory.
+%global go_test_exclude_glob %{go_import_path}/examples*
+
+Name:           go-github-ionos-cloud-sdk-go-v6
+Version:        6.3.7
+Release:        %autorelease
+Summary:        Go SDK for the IONOS Cloud API
+License:        Apache-2.0
+URL:            https://github.com/ionos-cloud/sdk-go
+#!RemoteAsset:  sha256:ad914ab244da87d53ac4acbe4100b22e105b29c4317346e2452fbced0760301f
+Source0:        https://github.com/ionos-cloud/sdk-go/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(golang.org/x/oauth2)
+
+Provides:       go(github.com/ionos-cloud/sdk-go/v6) = %{version}
+
+Requires:       go(golang.org/x/oauth2)
+
+%description
+The IONOS Cloud SDK for Go provides client APIs for managing IONOS Cloud
+resources through the Cloud API, including data centers, servers,
+volumes, networks and related infrastructure resources.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-jarcoal-httpmock/go-github-jarcoal-httpmock.spec
+++ b/SPECS/go-github-jarcoal-httpmock/go-github-jarcoal-httpmock.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           httpmock
+%define go_import_path  github.com/jarcoal/httpmock
+
+Name:           go-github-jarcoal-httpmock
+Version:        1.4.1
+Release:        %autorelease
+Summary:        HTTP mocking for Golang
+License:        MIT
+URL:            https://github.com/jarcoal/httpmock
+#!RemoteAsset:  sha256:e3a047ce5ce64a49b32e5686404ce919b17eb52c4f79f3fe2faddf3701b3fec5
+Source0:        https://github.com/jarcoal/httpmock/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/maxatome/go-testdeep)
+
+Provides:       go(github.com/jarcoal/httpmock) = %{version}
+
+Requires:       go(github.com/maxatome/go-testdeep)
+
+%description
+Httpmock provides helpers for mocking HTTP responses in Go tests, allowing
+clients to be tested without reaching external services.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-linode-linodego/go-github-linode-linodego.spec
+++ b/SPECS/go-github-linode-linodego/go-github-linode-linodego.spec
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           linodego
+%define go_import_path  github.com/linode/linodego
+# Upstream integration tests require a real LINODE_TOKEN cloud credential.
+%global go_test_exclude_glob %{shrink:
+%{go_import_path}/test/integration*
+%{go_import_path}/test/unit*
+}
+
+Name:           go-github-linode-linodego
+Version:        1.66.0
+Release:        %autorelease
+Summary:        Go client for the Linode REST v4 API
+License:        MIT
+URL:            https://github.com/linode/linodego
+#!RemoteAsset:  sha256:5494525d4042a3a1541e133044267e1993242484abefdf22f8d11316a5745c1a
+Source0:        https://github.com/linode/linodego/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/dnaeon/go-vcr/cassette)
+BuildRequires:  go(github.com/dnaeon/go-vcr/recorder)
+BuildRequires:  go(github.com/go-resty/resty/v2)
+BuildRequires:  go(github.com/google/go-cmp)
+BuildRequires:  go(github.com/google/go-querystring)
+BuildRequires:  go(github.com/jarcoal/httpmock)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(golang.org/x/exp)
+BuildRequires:  go(golang.org/x/net)
+BuildRequires:  go(golang.org/x/oauth2)
+BuildRequires:  go(golang.org/x/text)
+BuildRequires:  go(gopkg.in/ini.v1)
+BuildRequires:  go(k8s.io/api)
+BuildRequires:  go(k8s.io/apimachinery)
+BuildRequires:  go(k8s.io/client-go)
+
+Provides:       go(github.com/linode/linodego) = %{version}
+
+Requires:       go(github.com/dnaeon/go-vcr/cassette)
+Requires:       go(github.com/dnaeon/go-vcr/recorder)
+Requires:       go(github.com/go-resty/resty/v2)
+Requires:       go(github.com/google/go-cmp)
+Requires:       go(github.com/google/go-querystring)
+Requires:       go(github.com/jarcoal/httpmock)
+Requires:       go(github.com/stretchr/testify)
+Requires:       go(golang.org/x/exp)
+Requires:       go(golang.org/x/net)
+Requires:       go(golang.org/x/oauth2)
+Requires:       go(golang.org/x/text)
+Requires:       go(gopkg.in/ini.v1)
+Requires:       go(k8s.io/api)
+Requires:       go(k8s.io/apimachinery)
+Requires:       go(k8s.io/client-go)
+
+%description
+Linodego is the Go client library for the Linode REST v4 API. It provides
+typed APIs for working with Linode cloud resources from Go programs.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-maxatome-go-testdeep/go-github-maxatome-go-testdeep.spec
+++ b/SPECS/go-github-maxatome-go-testdeep/go-github-maxatome-go-testdeep.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-testdeep
+%define go_import_path  github.com/maxatome/go-testdeep
+
+Name:           go-github-maxatome-go-testdeep
+Version:        1.15.0
+Release:        %autorelease
+Summary:        Flexible deep comparison helpers for Go tests
+License:        BSD-2-Clause
+URL:            https://github.com/maxatome/go-testdeep
+#!RemoteAsset:  sha256:ddc106b33e174f01e6536ea2a3c949547b95c28837749b5e62b53f7e01026269
+Source0:        https://github.com/maxatome/go-testdeep/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/maxatome/go-testdeep) = %{version}
+
+%description
+go-testdeep provides flexible deep comparison operators and helpers for
+writing Go tests.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-moby-docker-image-spec/go-github-moby-docker-image-spec.spec
+++ b/SPECS/go-github-moby-docker-image-spec/go-github-moby-docker-image-spec.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           docker-image-spec
+%define go_import_path  github.com/moby/docker-image-spec
+
+Name:           go-github-moby-docker-image-spec
+Version:        1.3.1
+Release:        %autorelease
+Summary:        Docker Image Specification v1
+License:        Apache-2.0
+URL:            https://github.com/moby/docker-image-spec
+#!RemoteAsset:  sha256:64d792e78c099b90194d18281dcbb45d7ef5edde5ebbdf39978436d1e57b829e
+Source0:        https://github.com/moby/docker-image-spec/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/opencontainers/image-spec)
+
+Provides:       go(github.com/moby/docker-image-spec) = %{version}
+
+Requires:       go(github.com/opencontainers/image-spec)
+
+%description
+Docker Image Specification v1 describes the legacy Docker image JSON and
+manifest formats used by Docker Engine and related tooling.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-oapi-codegen-runtime/go-github-oapi-codegen-runtime.spec
+++ b/SPECS/go-github-oapi-codegen-runtime/go-github-oapi-codegen-runtime.spec
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           runtime
+%define go_import_path  github.com/oapi-codegen/runtime
+# Optional strict middleware integrations need their web framework stacks.
+%global go_test_exclude_glob %{shrink:
+    %{go_import_path}/strictmiddleware/echo*
+    %{go_import_path}/strictmiddleware/gin*
+    %{go_import_path}/strictmiddleware/iris*
+}
+
+Name:           go-github-oapi-codegen-runtime
+Version:        1.0.0
+Release:        %autorelease
+Summary:        Runtime helpers for oapi-codegen generated Go code
+License:        Apache-2.0
+URL:            https://github.com/oapi-codegen/runtime
+#!RemoteAsset:  sha256:927082334aa76c0adc3799f2954fb4698407c94b73cba06a8a4539dff9f50e2c
+Source0:        https://github.com/oapi-codegen/runtime/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/apapsch/go-jsonmerge/v2)
+BuildRequires:  go(github.com/google/uuid)
+BuildRequires:  go(github.com/stretchr/testify)
+
+Provides:       go(github.com/oapi-codegen/runtime) = %{version}
+
+Requires:       go(github.com/apapsch/go-jsonmerge/v2)
+Requires:       go(github.com/google/uuid)
+Requires:       go(github.com/stretchr/testify)
+
+%description
+This package provides runtime helper functions used by Go code generated
+by oapi-codegen, including OpenAPI parameter and request handling helpers.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

Adds 9 Go dependency spec files required by the Prometheus dependency set.

- All sources use official GitHub release/commit archives (no proxy or mirror),
  with matching `go(...)` Provides for each module.
- Snapshot versions use the packaging date (`0+gitYYYYMMDD.shortcommit`).
- Only OBS-verified deliverables are included; the unresolved
  Consul / Nomad / Moby root candidates are intentionally excluded from this PR.

Validation:

- `pre-commit run --files <9 spec files>`: passed
- `git diff --check`: passed
- OBS: all 9 packages build on **x86_64** and **riscv64**
  (`home:cl_2:work-org-go-deps`, and `home:cl_2:prometheus-go-deps` for
  `go-github-hetznercloud-hcloud-go-v2`)

## Related Issue

- N/A

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: Claude Code:Opus 4.8

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
