### PR TITLE
SPECS: KDE: Update to 6.6.5

### DIFF
--- a/SPECS/breeze/breeze.spec
+++ b/SPECS/breeze/breeze.spec
@@ -13,13 +13,13 @@
 %{!?_plasma6_version: %define _plasma6_version %(echo %{_plasma6_bugfix} | awk -F. '{print $1"."$2}')}
 
 Name:           breeze
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        Plasma Desktop artwork, styles and assets
 License:        GPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/breeze
-#!RemoteAsset:  sha256:33c69d10454e1eb1c5908bb7b50a955eabf3264d836bd82dc02f3ba8d97692b0
+#!RemoteAsset:  sha256:1ad18862e585bfa1d51b20ab48feb00a7fd14705c6d771943bcc605ac348e970
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 

--- a/SPECS/discover/discover.spec
+++ b/SPECS/discover/discover.spec
@@ -11,13 +11,13 @@
 %bcond flatpak 0
 
 Name:           discover
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        Software store for the KDE Plasma desktop
 License:        GPL-2.0-only AND GPL-3.0-only AND GPL-3.0-or-later
 URL:            https://apps.kde.org/discover/
 VCS:            git:https://invent.kde.org/plasma/discover.git
-#!RemoteAsset:  sha256:42b86a17627adbde7b20500f6398e03bd5d3b0ea16db1f299ed6bce4be0b8f1e
+#!RemoteAsset:  sha256:4ddf2ee411cd32b1b3c3f2515b75d4242f13c215cbf934b09c50109c777d9992
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 

--- a/SPECS/kactivitymanagerd/kactivitymanagerd.spec
+++ b/SPECS/kactivitymanagerd/kactivitymanagerd.spec
@@ -5,13 +5,13 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 Name:           kactivitymanagerd
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        KDE Plasma Activities support
 License:        GPL-2.0-or-later
 URL:            https://invent.kde.org/plasma/kactivitymanagerd
 VCS:            git:https://invent.kde.org/plasma/kactivitymanagerd.git
-#!RemoteAsset:  sha256:ffb83efc69102d6e73ab7a327b6c4df30bad019493b97cdfd38ac55afde7f415
+#!RemoteAsset:  sha256:556488f9a8f56a07a0d8a94d632e9e11398f91037a251d33a16a0471e2dcdd2c
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 

--- a/SPECS/kde-cli-tools/kde-cli-tools.spec
+++ b/SPECS/kde-cli-tools/kde-cli-tools.spec
@@ -8,13 +8,13 @@
 %define qt6_version 6.9.0
 
 Name:           kde-cli-tools
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        Additional CLI tools for KDE applications
 License:        GPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/kde-cli-tools.git
-#!RemoteAsset:  sha256:e96d9ba8385a80758bf0e0958257cd11721e90b1cc835ee6edbad87e6a1afca1
+#!RemoteAsset:  sha256:a7d8cd8b6c0cf4fdc43b47d0edf5256bb1f8e7d30fe32855155afe4e70d61815
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 

--- a/SPECS/kde-gtk-config/kde-gtk-config.spec
+++ b/SPECS/kde-gtk-config/kde-gtk-config.spec
@@ -13,13 +13,13 @@
 %{!?_plasma6_version: %define _plasma6_version %(echo %{_plasma6_bugfix} | awk -F. '{print $1"."$2}')}
 
 Name:           kde-gtk-config
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        Daemon for GTK2 and GTK3 Applications Appearance Under KDE
 License:        GPL-3.0-or-later AND LGPL-3.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/kde-gtk-config.git
-#!RemoteAsset:  sha256:60807df37815b29587c5c9fd88045f0159c833c39a0884f1ba17f0ed236873ba
+#!RemoteAsset:  sha256:32da534b0d1fe1e2d677fc3116baf78c47b1e7937601e4c6637d825c6f33afe7
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 

--- a/SPECS/kdecoration/kdecoration.spec
+++ b/SPECS/kdecoration/kdecoration.spec
@@ -11,13 +11,13 @@
 %global private_sover 2
 
 Name:           kdecoration
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        KDE's window decorations library
 License:        GPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/kdecoration.git
-#!RemoteAsset:  sha256:2c65b9e030a01a5567dfe79b5f1dc4305ac8ee232abd3347bda213ed2639ca99
+#!RemoteAsset:  sha256:17625d6f3535ecb93370e8938610565e07c0f0471544b8bf409e771bd7b915d9
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 

--- a/SPECS/kglobalacceld/kglobalacceld.spec
+++ b/SPECS/kglobalacceld/kglobalacceld.spec
@@ -13,13 +13,13 @@
 %{!?_plasma6_version: %define _plasma6_version %(echo %{_plasma6_bugfix} | awk -F. '{print $1"."$2}')}
 
 Name:           kglobalacceld
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        Global keyboard shortcut daemon
 License:        LGPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/kglobalacceld.git
-#!RemoteAsset:  sha256:8127e9171e84437536e3a20ab889d33d72238ba61de9babddc1a59ce8dafe795
+#!RemoteAsset:  sha256:8b2b93ee7b22a3e809d0ab7927e93c9e4cf7f3b6cd435ea3fbea690742920bff
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 

--- a/SPECS/kinfocenter/kinfocenter.spec
+++ b/SPECS/kinfocenter/kinfocenter.spec
@@ -15,13 +15,13 @@
 %{!?_plasma6_version: %define _plasma6_version %(echo %{_plasma6_bugfix} | awk -F. '{print $1"."$2}')}
 
 Name:           kinfocenter
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        Utility that provides information about a computer system
 License:        GPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/kinfocenter.git
-#!RemoteAsset:  sha256:7978653cbfcc8118cc01aa774c245c9623c8812416f2602ddf37f13410026fd0
+#!RemoteAsset:  sha256:d1072adfc92fbe0616a1f59504ef995aec6ef06d1b417fdd9e69b7c665c3de01
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 

--- a/SPECS/kmenuedit/kmenuedit.spec
+++ b/SPECS/kmenuedit/kmenuedit.spec
@@ -13,13 +13,13 @@
 %{!?_plasma6_version: %define _plasma6_version %(echo %{_plasma6_bugfix} | awk -F. '{print $1"."$2}')}
 
 Name:           kmenuedit
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        Provides the interface and basic tools for the KDE workspace
 License:        GPL-2.0-only
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/kmenuedit.git
-#!RemoteAsset:  sha256:21f32f33263d57091f51ff32d9a68ba2728249eee1b42868ac8514f737816ade
+#!RemoteAsset:  sha256:879056bf139b2b00729b093019416011c8b7234b5f39395d686f47a42cae9175
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 

--- a/SPECS/knighttime/knighttime.spec
+++ b/SPECS/knighttime/knighttime.spec
@@ -14,13 +14,13 @@
 %{!?_plasma6_version: %define _plasma6_version %(echo %{_plasma6_bugfix} | awk -F. '{print $1"."$2}')}
 
 Name:           knighttime
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        Day-night cycle helper library
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/knighttime.git
-#!RemoteAsset:  sha256:70f84c9f4b45036e02d35cdff9d0d1f5cfbb5be973d3fe5af423a2dd07571918
+#!RemoteAsset:  sha256:dcc12f901c0809c0a290b84dca70762c87666331450ebe878da59d69a6d3d140
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 

--- a/SPECS/kpipewire/kpipewire.spec
+++ b/SPECS/kpipewire/kpipewire.spec
@@ -15,13 +15,13 @@
 %{!?_plasma6_version: %define _plasma6_version %(echo %{_plasma6_bugfix} | awk -F. '{print $1"."$2}')}
 
 Name:           kpipewire
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        PipeWire integration for KDE Plasma
 License:        LGPL-2.0-only AND LGPL-3.0-only
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/kpipewire.git
-#!RemoteAsset:  sha256:4ed4ad8cbc3524e2ee1eeb23f52b85979434972c3289e79de5407c618b1a3c66
+#!RemoteAsset:  sha256:ca35be322c83dd1021c126d30ea7b33653c83f6bd397f76aa0e3e333ef2aa858
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 
@@ -32,7 +32,7 @@ BuildRequires:  pkgconfig
 BuildRequires:  qt6-qtbase-private-devel >= %{qt6_version}
 BuildRequires:  cmake(KF6CoreAddons) >= %{kf6_version}
 BuildRequires:  cmake(KF6I18n) >= %{kf6_version}
-BuildRequires:  cmake(KWayland) >= %{_plasma6_version}
+BuildRequires:  cmake(KWayland) >= %{_plasma6_bugfix}
 BuildRequires:  cmake(PlasmaWaylandProtocols)
 BuildRequires:  cmake(Qt6DBus) >= %{qt6_version}
 BuildRequires:  cmake(Qt6OpenGL) >= %{qt6_version}

--- a/SPECS/kscreen/kscreen.spec
+++ b/SPECS/kscreen/kscreen.spec
@@ -15,19 +15,20 @@
 %{!?_plasma6_version: %define _plasma6_version %(echo %{_plasma6_bugfix} | awk -F. '{print $1"."$2}')}
 
 Name:           kscreen
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        Screen management software by KDE
 License:        GPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/kscreen.git
-#!RemoteAsset:  sha256:76d68c91c8700d3a7607618944bd08bda861936d6f890004f32c227cf7736995
+#!RemoteAsset:  sha256:ab629c7d8b271bc4741d73f5aa67c99c3c28d2c9b5f4313a38aad7b933b82c51
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF
 
 BuildRequires:  kf6-extra-cmake-modules >= %{kf6_version}
+BuildRequires:  cmake(KF6KirigamiPlatform) >= %{kf6_version}
 BuildRequires:  pkgconfig
 BuildRequires:  qt6-qtbase-private-devel >= %{qt6_version}
 BuildRequires:  qt6-qtwayland-devel >= %{qt6_version}

--- a/SPECS/kscreenlocker/kscreenlocker.spec
+++ b/SPECS/kscreenlocker/kscreenlocker.spec
@@ -15,13 +15,13 @@
 %{!?_plasma6_version: %define _plasma6_version %(echo %{_plasma6_bugfix} | awk -F. '{print $1"."$2}')}
 
 Name:           kscreenlocker
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        Library and components for secure lock screen architecture
 License:        GPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/kscreenlocker.git
-#!RemoteAsset:  sha256:dfb84f4fe0bee107dfbd81be3873ecb7c545b1beeaa68e059caa97ef9845769d
+#!RemoteAsset:  sha256:212613c8104f9bb3837dfbdb0f3890168681783236e69b9c04939966e1724f49
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 Source1:        kde
 Source2:        kde-fingerprint
@@ -32,6 +32,7 @@ BuildOption(conf):  -DBUILD_TESTING=OFF
 
 BuildRequires:  cmake >= 3.16
 BuildRequires:  kf6-extra-cmake-modules >= %{kf6_version}
+BuildRequires:  cmake(KF6KirigamiPlatform) >= %{kf6_version}
 BuildRequires:  pkgconfig(pam)
 BuildRequires:  pkgconfig
 BuildRequires:  qt6-qtbase-private-devel >= %{qt6_version}

--- a/SPECS/ksystemstats/ksystemstats.spec
+++ b/SPECS/ksystemstats/ksystemstats.spec
@@ -13,13 +13,13 @@
 %{!?_plasma6_version: %define _plasma6_version %(echo %{_plasma6_bugfix} | awk -F. '{print $1"."$2}')}
 
 Name:           ksystemstats
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        Plugin based system monitoring daemon
 License:        BSD-2-Clause AND BSD-3-Clause AND CC0-1.0 AND GPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/ksystemstats.git
-#!RemoteAsset:  sha256:c74e875d2c7a0867cb6002afb79d866c985995c49b5a160881e789dd09a8bcdc
+#!RemoteAsset:  sha256:8f01446bd157ae20ae392c272d9a6a7465cd7d5e48e27536981d1be9826280a6
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 

--- a/SPECS/kwayland6/kwayland6.spec
+++ b/SPECS/kwayland6/kwayland6.spec
@@ -10,17 +10,20 @@
 %define rname kwayland
 
 Name:           kwayland6
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        KDE Wayland library
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/kwayland
-#!RemoteAsset
+#!RemoteAsset:  sha256:afbcd53ca8a5fb501038415f1473c3d11556eb56ed8f653ece03f77d799cad01
 Source:         https://download.kde.org/stable/plasma/%{version}/%{rname}-%{version}.tar.xz
+BuildSystem:    cmake
+
+BuildOption(conf):  -DBUILD_TESTING=OFF
+BuildOption(conf):  -DBUILD_QCH:BOOL=TRUE
 
 BuildRequires:  doxygen
-BuildRequires:  fdupes
 BuildRequires:  kf6-extra-cmake-modules >= %{kf6_version}
 BuildRequires:  pkgconfig
 BuildRequires:  xcb-util
@@ -51,17 +54,6 @@ Requires:       %{name}%{?_isa} = %{version}-%{release}
 KWayland provides a Qt-style Client and Server library wrapper for the Wayland
 libraries.
 
-%prep
-%autosetup -p1 -n %{rname}-%{version}
-
-%build
-%cmake_kf6 -DBUILD_QCH:BOOL=TRUE
-
-%kf6_build
-
-%install
-%kf6_install
-
 %files
 %license LICENSES/*
 %doc README.md
@@ -77,4 +69,4 @@ libraries.
 %{_kf6_pkgconfigdir}/KWaylandClient.pc
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kwin/kwin.spec
+++ b/SPECS/kwin/kwin.spec
@@ -16,13 +16,13 @@
 %{!?_plasma6_version: %define _plasma6_version %(echo %{_plasma6_bugfix} | awk -F. '{print $1"."$2}')}
 
 Name:           kwin
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        KDE Window Manager
 License:        GPL-2.0-or-later AND GPL-3.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/kwin.git
-#!RemoteAsset:  sha256:8c4aab73edd7b289468e52beac34e490bc43187476d8621cdde8701e6c7d5640
+#!RemoteAsset:  sha256:c99ca0affeaf9e6bdacfb06cac86677fcf3e4d93aae09b05f1f8986a12ec5e65
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 
@@ -217,6 +217,7 @@ This package provides development files.
 %{_kf6_plugindir}/kwin/plugins/KeyNotificationPlugin.so
 %{_kf6_plugindir}/kwin/plugins/StickyKeysPlugin.so
 %{_kf6_plugindir}/kwin/plugins/buttonsrebind.so
+%{_kf6_plugindir}/kwin/plugins/SlowKeysPlugin.so
 %{_kf6_plugindir}/kwin/plugins/eis.so
 %{_kf6_plugindir}/kwin/plugins/krunnerintegration.so
 %{_kf6_plugindir}/kwin/plugins/nightlight.so

--- a/SPECS/layer-shell-qt/layer-shell-qt.spec
+++ b/SPECS/layer-shell-qt/layer-shell-qt.spec
@@ -5,13 +5,14 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 Name:           layer-shell-qt
-Version:        6.5.91
+Version:        6.6.5
 Release:        %autorelease
 Summary:        Library to easily use clients based on wlr-layer-shell
 License:        BSD-3-Clause AND CC0-1.0 AND LGPL-3.0-or-later AND MIT
-URL:            https://invent.kde.org/plasma/layer-shell-qt
-#!RemoteAsset:  sha256:57a4812334e330d995011b21395eae55113a1a40f02e7fb905105a098c769d4e
-Source0:        https://download.kde.org/unstable/plasma/%{version}/layer-shell-qt-%{version}.tar.xz
+URL:            https://www.kde.org
+VCS:            git:https://invent.kde.org/plasma/layer-shell-qt.git
+#!RemoteAsset:  sha256:b663c697ce1ed96347115d367238978217a29c60bba75491a7223bbb6782e619
+Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 
 BuildRequires:  extra-cmake-modules
@@ -49,4 +50,4 @@ Developer files for layer-shell-qt.
 %{_libdir}/cmake/LayerShellQt/
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/libkscreen/libkscreen.spec
+++ b/SPECS/libkscreen/libkscreen.spec
@@ -15,13 +15,13 @@
 %{!?_plasma6_version: %define _plasma6_version %(echo %{_plasma6_bugfix} | awk -F. '{print $1"."$2}')}
 
 Name:           libkscreen
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        Plasma screen management library
 License:        GPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/libkscreen.git
-#!RemoteAsset:  sha256:f90b83e120fabb2881ec7706254fd05a089b167fbf49fe16631aeb34b579c160
+#!RemoteAsset:  sha256:e59e1f10c84ffaa42e1eb5d312da33dd472a2895ccabc90bee8b238f3b4b842e
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 
@@ -46,6 +46,7 @@ BuildRequires:  cmake(Qt6WaylandClient) >= %{qt6_version}
 BuildRequires:  qt6-qttools
 BuildRequires:  qt6-doctools
 BuildRequires:  qt6-linguist
+BuildRequires:  python
 BuildRequires:  pkgconfig(wayland-client) >= 1.9
 BuildRequires:  pkgconfig(xcb)
 BuildRequires:  pkgconfig(xcb-randr)

--- a/SPECS/libksysguard/libksysguard.spec
+++ b/SPECS/libksysguard/libksysguard.spec
@@ -7,22 +7,20 @@
 %define kf6_version 6.18.0
 %define qt6_version 6.9.0
 
-%define rname libksysguard
-
 # Full Plasma 5 version (e.g. 5.8.95)
 %{!?_plasma6_bugfix: %define _plasma6_bugfix %{version}}
 # Latest ABI-stable Plasma (e.g. 5.8 in KF6, but 5.8.95 in KUF)
 %{!?_plasma6_version: %define _plasma6_version %(echo %{_plasma6_bugfix} | awk -F. '{print $1"."$2}')}
 
 Name:           libksysguard
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        Task management and system monitoring library
 License:        GPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/libksysguard.git
-#!RemoteAsset:  sha256:22b8e4812b1dfa6aef18f27d2ba66d6d7702b3e4db250cae48ab946196da734d
-Source:         https://download.kde.org/stable/plasma/%{version}/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:539438c4b92c105ca228df7ed89258059cb3328a170ceecf0cc2b7a2e70d63d4
+Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/libplasma/libplasma.spec
+++ b/SPECS/libplasma/libplasma.spec
@@ -13,13 +13,13 @@
 %{!?_plasma6_version: %define _plasma6_version %(echo %{_plasma6_bugfix} | awk -F. '{print $1"."$2}')}
 
 Name:           libplasma
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        Plasma library and runtime components based upon KF6 and Qt6
 License:        GPL-2.0-or-later AND LGPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/libplasma
-#!RemoteAsset:  sha256:f19128fd9b96edebf44fbf9995bd1afa33ec817dfc6c52edc3b2d3f600b61fee
+#!RemoteAsset:  sha256:380576afee2160560f559184e32bd02eb1caeb7dd95899d92e50832bc358502c
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 

--- a/SPECS/milou/milou.spec
+++ b/SPECS/milou/milou.spec
@@ -13,19 +13,20 @@
 %{!?_plasma6_version: %define _plasma6_version %(echo %{_plasma6_bugfix} | awk -F. '{print $1"."$2}')}
 
 Name:           milou
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        Dedicated search application built on top of Baloo
 License:        GPL-2.0-or-later AND LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/milou.git
-#!RemoteAsset:  sha256:15bbb74ec3f7a64e02c1e881ee25025c0b738fbfc387e225c8064e94faecf6ae
+#!RemoteAsset:  sha256:700c77213622e9f914f407e6c5e42dad28846b6704d40cfc8cbdfb8f316ba96f
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF
 
 BuildRequires:  kf6-extra-cmake-modules >= %{kf6_version}
+BuildRequires:  cmake(KF6KirigamiPlatform) >= %{kf6_version}
 BuildRequires:  cmake(KF6CoreAddons) >= %{kf6_version}
 BuildRequires:  cmake(KF6I18n) >= %{kf6_version}
 BuildRequires:  cmake(KF6ItemModels) >= %{kf6_version}
@@ -52,7 +53,7 @@ rm -rf $RPM_BUILD_ROOT%{_kf6_htmldir}/*@*
 %files -f %{name}.lang
 %license LICENSES/*
 %{_kf6_qmldir}/org/kde/milou/
-%{_kf6_plasmadir}/plasmoids/org.kde.milou/
+%{_kf6_plugindir}/plasma/applets/org.kde.milou.so
 
 %changelog
 %autochangelog

--- a/SPECS/plasma-activities-stats/plasma-activities-stats.spec
+++ b/SPECS/plasma-activities-stats/plasma-activities-stats.spec
@@ -12,13 +12,13 @@
 %{!?_plasma6_version: %define _plasma6_version %(echo %{_plasma6_bugfix} | awk -F. '{print $1"."$2}')}
 
 Name:           plasma-activities-stats
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        KDE Plasma Activities support
 License:        LGPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/plasma-activities-stats
-#!RemoteAsset:  sha256:47a33b06c3c794ca48ae016ae932cf22cfa23956e7960dbf25b8a03dea22606c
+#!RemoteAsset:  sha256:cc49ff6f2909baba210105643af836b90514e39c5526e0ebae109c521de94068
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 

--- a/SPECS/plasma-activities/plasma-activities.spec
+++ b/SPECS/plasma-activities/plasma-activities.spec
@@ -9,13 +9,13 @@
 %define sover 7
 
 Name:           plasma-activities
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        Plasma Activities support
 License:        GPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/plasma-activities
-#!RemoteAsset:  sha256:9c8a6580f0b459f74de74a03898ea22988cae120f03a9d380e3bb584fdb12a90
+#!RemoteAsset:  sha256:a02781459cefeef5c1c4290b3099a09bfbb3e52e293bb8d50bd873eb9cd45a2b
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 

--- a/SPECS/plasma-desktop/2001-Remove-discover-from-taskmanager-default-launchers.patch
+++ b/SPECS/plasma-desktop/2001-Remove-discover-from-taskmanager-default-launchers.patch
@@ -5,13 +5,13 @@ Subject: [PATCH] Remove Discover from taskmanager default launchers
 
 Avoid pinning Discover by default in taskmanager launcher list.
 ---
- applets/taskmanager/package/contents/config/main.xml | 2 +-
+ applets/taskmanager/main.xml | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/applets/taskmanager/package/contents/config/main.xml b/applets/taskmanager/package/contents/config/main.xml
+diff --git a/applets/taskmanager/main.xml b/applets/taskmanager/main.xml
 index 022f6d6..88caa7e 100644
---- a/applets/taskmanager/package/contents/config/main.xml
-+++ b/applets/taskmanager/package/contents/config/main.xml
+--- a/applets/taskmanager/main.xml
++++ b/applets/taskmanager/main.xml
 @@ -103,7 +103,7 @@
      </entry>
      <entry name="launchers" type="StringList">

--- a/SPECS/plasma-desktop/plasma-desktop.spec
+++ b/SPECS/plasma-desktop/plasma-desktop.spec
@@ -19,13 +19,13 @@
 %{!?_plasma6_version: %define _plasma6_version %(echo %{_plasma6_bugfix} | awk -F. '{print $1"."$2}')}
 
 Name:           plasma-desktop
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        The KDE Plasma Workspace Components
 License:        GPL-2.0-only
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/plasma-desktop.git
-#!RemoteAsset:  sha256:db3fc69388f752aa18d62f449880d7f75a2f65fab5d4bffec3d8a896459d3a4d
+#!RemoteAsset:  sha256:9b79d12c42fff8cbe7c63b41aae340d4ff7ba8c94f2bd335cdcce248bbf40385
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 
@@ -272,8 +272,15 @@ rm -rf $RPM_BUILD_ROOT%{_kf6_htmldir}/*@*
 %{_kf6_plugindir}/kf6/kded/kded_touchpad.so
 %{_kf6_plugindir}/kf6/krunner/
 %{_kf6_plugindir}/plasma/applets/org.kde.panel.so
+%{_kf6_plugindir}/plasma/applets/org.kde.plasma.keyboardlayout.so
 %{_kf6_plugindir}/plasma/applets/org.kde.plasma.kicker.so
 %{_kf6_plugindir}/plasma/applets/org.kde.plasma.kickoff.so
+%{_kf6_plugindir}/plasma/applets/org.kde.plasma.kimpanel.so
+%{_kf6_plugindir}/plasma/applets/org.kde.plasma.marginsseparator.so
+%{_kf6_plugindir}/plasma/applets/org.kde.plasma.pager.so
+%{_kf6_plugindir}/plasma/applets/org.kde.plasma.showActivityManager.so
+%{_kf6_plugindir}/plasma/applets/org.kde.plasma.showdesktop.so
+%{_kf6_plugindir}/plasma/applets/org.kde.plasma.taskmanager.so
 %{_kf6_plugindir}/plasma/applets/org.kde.plasma.trash.so
 %{_kf6_plugindir}/plasma/applets/org.kde.plasma.windowlist.so
 %dir %{_kf6_plugindir}/plasma/kcms/desktop/

--- a/SPECS/plasma-integration/plasma-integration.spec
+++ b/SPECS/plasma-integration/plasma-integration.spec
@@ -13,13 +13,13 @@
 %{!?_plasma6_version: %define _plasma6_version %(echo %{_plasma6_bugfix} | awk -F. '{print $1"."$2}')}
 
 Name:           plasma-integration
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        Plugins responsible for better integration of Qt applications in KDE Workspace
 License:        GPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/plasma-integration.git
-#!RemoteAsset:  sha256:8fe9eefe9ca8c1957c4bf8a2a3986b56ea2f15d6c5b49b190cb8bde385ed3256
+#!RemoteAsset:  sha256:7a5220f2bb40f4dc3e4dad8945563aa88bf045b918fd784a7445612c697e73ed
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 

--- a/SPECS/plasma-nm/plasma-nm.spec
+++ b/SPECS/plasma-nm/plasma-nm.spec
@@ -15,13 +15,13 @@
 %{!?_plasma6_version: %define _plasma6_version %(echo %{_plasma6_bugfix} | awk -F. '{print $1"."$2}')}
 
 Name:           plasma-nm
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        Plasma applet written in QML for managing network connections
 License:        (GPL-2.0-only OR GPL-3.0-only) AND (LGPL-2.1-only OR LGPL-3.0-only)
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/plasma-nm.git
-#!RemoteAsset:  sha256:de4e18c227b6481c6d968cce2737ef3c7dc3b6a4ab7cca905e8077c9401abcef
+#!RemoteAsset:  sha256:9dc99c1849970c6925ca47723a5832add25f21ed1defd414fa5cccf9401ef21a
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 
@@ -227,6 +227,7 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %endif
 %{_kf6_applicationsdir}/kcm_cellular_network.desktop
 %{_kf6_applicationsdir}/kcm_mobile_hotspot.desktop
+%{_kf6_applicationsdir}/kcm_mobile_wired.desktop
 %{_kf6_applicationsdir}/kcm_mobile_wifi.desktop
 %{_kf6_applicationsdir}/kcm_networkmanagement.desktop
 %{_kf6_applicationsdir}/org.kde.vpnimport.desktop
@@ -237,6 +238,7 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_kf6_plugindir}/kf6/kded/networkmanagement.so
 %{_kf6_plugindir}/plasma/kcms/systemsettings/kcm_cellular_network.so
 %{_kf6_plugindir}/plasma/kcms/systemsettings/kcm_mobile_hotspot.so
+%{_kf6_plugindir}/plasma/kcms/systemsettings/kcm_mobile_wired.so
 %{_kf6_plugindir}/plasma/kcms/systemsettings/kcm_mobile_wifi.so
 %{_kf6_plugindir}/plasma/kcms/systemsettings_qwidgets/kcm_networkmanagement.so
 %dir %{_kf6_plugindir}/plasma/applets/

--- a/SPECS/plasma-systemmonitor/plasma-systemmonitor.spec
+++ b/SPECS/plasma-systemmonitor/plasma-systemmonitor.spec
@@ -13,13 +13,13 @@
 %{!?_plasma6_version: %define _plasma6_version %(echo %{_plasma6_bugfix} | awk -F. '{print $1"."$2}')}
 
 Name:           plasma-systemmonitor
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        An application for monitoring system resources
 License:        GPL-3.0-only
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/plasma-systemmonitor.git
-#!RemoteAsset:  sha256:311bc4434b57869da0ae4f737697d73327172729da8eb4d9947f5aa9400c0f39
+#!RemoteAsset:  sha256:beb5a0cbcb877fcbfb57c95c963574c2465b810350e6d517f69128e7fb54670a
 Source0:        https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 

--- a/SPECS/plasma-wayland-protocols/plasma-wayland-protocols.spec
+++ b/SPECS/plasma-wayland-protocols/plasma-wayland-protocols.spec
@@ -5,16 +5,18 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 Name:           plasma-wayland-protocols
-Version:        1.19.0
+Version:        1.20.0
 Release:        %autorelease
 Summary:        Wayland protocols used by Plasma
 License:        BSD-3-Clause AND LGPL-2.1-only AND LGPL-2.1-or-later AND MIT
 URL:            https://www.kde.org
 VCS:            https://invent.kde.org/libraries/plasma-wayland-protocols
-#!RemoteAsset
+#!RemoteAsset:  sha256:9818bb1462211ce5982e670abf0d964eb11fe1d0c02a1c26084db30695a79d6a
 Source0:        https://download.kde.org/stable/plasma-wayland-protocols/plasma-wayland-protocols-%{version}.tar.xz
+BuildSystem:    cmake
 
-BuildRequires:  fdupes
+BuildOption(conf):  -DBUILD_TESTING=OFF
+
 BuildRequires:  kf6-extra-cmake-modules
 BuildRequires:  pkgconfig(wayland-scanner)
 
@@ -22,22 +24,11 @@ BuildRequires:  pkgconfig(wayland-scanner)
 This package contains the non-standard Wayland protocol definitions used by
 KDE Plasma.
 
-%prep
-%autosetup -p1
-
-%build
-%cmake_kf6
-
-%kf6_build
-
-%install
-%kf6_install
-%fdupes %{buildroot}
-
 %files
 %license COPYING* LICENSES/*.txt
 %{_kf6_sharedir}/plasma-wayland-protocols/
-%{_kf6_cmakedir}/PlasmaWaylandProtocols/
+%dir %{_kf6_sharedir}/cmake/
+%{_kf6_sharedir}/cmake/PlasmaWaylandProtocols/
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/plasma-workspace/plasma-workspace.spec
+++ b/SPECS/plasma-workspace/plasma-workspace.spec
@@ -20,13 +20,13 @@
 %{!?_plasma6_version: %define _plasma6_version %(echo %{_plasma6_bugfix} | awk -F. '{print $1"."$2}')}
 
 Name:           plasma-workspace
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        The KDE Plasma Workspace Components
 License:        GPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/plasma-workspace.git
-#!RemoteAsset:  sha256:102ef093fb21e73b4a3f11edcc6934c5f1763366a31e5c049afb719840a4323f
+#!RemoteAsset:  sha256:2cb458d0830bdc1a49ffa404e8042f80efeeed575b111df929e8a87f3f7bd2f4
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 Source1:        sddm.conf
 Source2:        waitforkded.conf
@@ -373,7 +373,6 @@ install -Dm 0644 %{SOURCE2} %{buildroot}%{_userunitdir}/plasma-plasmashell.servi
 %dir %{_kf6_configdir}/menus
 %config %{_kf6_configdir}/menus/plasma-applications.menu
 %config %{_kf6_configdir}/plasmanotifyrc
-%config %{_kf6_configdir}/taskmanagerrulesrc
 %doc %lang(en) %{_kf6_htmldir}/en/PolicyKit-kde/
 %doc %lang(en) %{_kf6_htmldir}/en/kcontrol/
 %doc %lang(en) %{_kf6_htmldir}/en/klipper/
@@ -401,6 +400,8 @@ install -Dm 0644 %{SOURCE2} %{buildroot}%{_userunitdir}/plasma-plasmashell.servi
 %{_kf6_applicationsdir}/kcm_style.desktop
 %{_kf6_applicationsdir}/kcm_users.desktop
 %{_kf6_applicationsdir}/kcm_wallpaper.desktop
+%{_kf6_applicationsdir}/org.kde.baloorunner.desktop
+%{_kf6_applicationsdir}/org.kde.secretprompter.desktop
 %{_kf6_applicationsdir}/org.kde.plasma-interactiveconsole.desktop
 %{_kf6_applicationsdir}/org.kde.kcolorschemeeditor.desktop
 %{_kf6_applicationsdir}/org.kde.kfontinst.desktop
@@ -482,7 +483,6 @@ install -Dm 0644 %{SOURCE2} %{buildroot}%{_userunitdir}/plasma-plasmashell.servi
 %{_kf6_notificationsdir}/freespacenotifier.notifyrc
 %{_kf6_notificationsdir}/libnotificationmanager.notifyrc
 %{_kf6_notificationsdir}/oom-notifier.notifyrc
-%{_kf6_notificationsdir}/phonon.notifyrc
 %{_kf6_plasmadir}/avatars/
 %{_kf6_plasmadir}/look-and-feel/
 %{_kf6_plasmadir}/plasmoids/
@@ -494,9 +494,7 @@ install -Dm 0644 %{SOURCE2} %{buildroot}%{_userunitdir}/plasma-plasmashell.servi
 %{_kf6_plugindir}/kf6/packagestructure/
 %{_kf6_plugindir}/kf6/parts/
 %{_kf6_plugindir}/kf6/thumbcreator/
-%{_kf6_plugindir}/phonon_platform/
 %{_kf6_plugindir}/plasma/
-%{_kf6_plugindir}/plasma5support/
 %{_kf6_plugindir}/plasmacalendarplugins/
 %{_kf6_qmldir}/org/kde/breeze/
 %{_kf6_qmldir}/org/kde/notificationmanager/
@@ -509,6 +507,7 @@ install -Dm 0644 %{SOURCE2} %{buildroot}%{_userunitdir}/plasma-plasmashell.servi
 %{_kf6_sharedir}/dbus-1/services/org.kde.krunner.service
 %{_kf6_sharedir}/dbus-1/services/org.kde.plasma.Notifications.service
 %{_kf6_sharedir}/dbus-1/services/org.kde.runners.baloo.service
+%{_kf6_sharedir}/dbus-1/services/org.kde.secretprompter.service
 %{_kf6_sharedir}/dbus-1/system-services/org.kde.fontinst.service
 %{_kf6_sharedir}/dbus-1/system.d/org.kde.fontinst.conf
 %{_kf6_sharedir}/desktop-directories/
@@ -522,7 +521,6 @@ install -Dm 0644 %{SOURCE2} %{buildroot}%{_userunitdir}/plasma-plasmashell.servi
 %{_kf6_sharedir}/konqsidebartng/
 %{_kf6_sharedir}/krunner/dbusplugins/plasma-runner-baloosearch.desktop
 %{_kf6_sharedir}/kstyle/
-%{_kf6_sharedir}/plasma5support/
 %{_kf6_sharedir}/polkit-1/actions/org.kde.fontinst.policy
 %{_kf6_sharedir}/solid/
 %dir %{_kf6_sharedir}/timezonefiles/
@@ -530,6 +528,7 @@ install -Dm 0644 %{SOURCE2} %{buildroot}%{_userunitdir}/plasma-plasmashell.servi
 %dir %{_kf6_sharedir}/xdg-desktop-portal/
 %{_kf6_sharedir}/xdg-desktop-portal/kde-portals.conf
 %{_libexecdir}/baloorunner
+%{_libexecdir}/ksecretprompter
 %{_kf6_libexecdir}/kauth/fontinst
 %{_kf6_libexecdir}/kauth/fontinst_helper
 %if %{with x11}

--- a/SPECS/plasma5support/plasma5support.spec
+++ b/SPECS/plasma5support/plasma5support.spec
@@ -14,13 +14,13 @@
 %{!?_kf6_bugfix_version: %define _kf6_bugfix_version %(echo %{_kf6_version} | awk -F. '{print $1"."$2}')}
 
 Name:           plasma5support
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        KF6 Porting aid
 License:        LGPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/plasma5support
-#!RemoteAsset:  sha256:20f28a6e10b9909cc6e4c28eaa0c3ccbaf5e2ab92733f62c12bebabce3032606
+#!RemoteAsset:  sha256:f954f2a8f80d977d96ead252da31054f01adfff0a5fcd9f15e13b0cfc37aa93c
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 
@@ -113,6 +113,8 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_kf6_plugindir}/plasma5support/dataengine/plasma_engine_noaa.so
 %{_kf6_plugindir}/plasma5support/dataengine/plasma_engine_weather.so
 %{_kf6_plugindir}/plasma5support/dataengine/plasma_engine_wettercom.so
+%{_kf6_plugindir}/plasma5support/dataengine/plasma_engine_executable.so
+%{_kf6_plugindir}/plasma5support/dataengine/plasma_engine_time.so
 %dir %{_kf6_plugindir}/plasma5support/geolocationprovider
 %{_kf6_plugindir}/plasma5support/geolocationprovider/plasma-geolocation-gps.so
 %{_kf6_plugindir}/plasma5support/geolocationprovider/plasma-geolocation-ip.so

--- a/SPECS/polkit-kde-agent-1/polkit-kde-agent-1.spec
+++ b/SPECS/polkit-kde-agent-1/polkit-kde-agent-1.spec
@@ -8,13 +8,13 @@
 %define qt6_version 6.9.0
 
 Name:           polkit-kde-agent-1
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        PolicyKit authentication agent for Plasma
 License:        GPL-2.0-only AND LGPL-2.1-or-later
 URL:            https://www.kde.org/
 VCS:            git:https://invent.kde.org/plasma/polkit-kde-agent-1.git
-#!RemoteAsset:  sha256:bd6f23462478e11808591eff698b8c026779379ffcc7fc68f3769d060d16ca4a
+#!RemoteAsset:  sha256:a5d80462970bd987fc386f1445c6451e13786edaab6ad7741b44dabce7e387a1
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 

--- a/SPECS/powerdevil/powerdevil.spec
+++ b/SPECS/powerdevil/powerdevil.spec
@@ -13,13 +13,13 @@
 %{!?_plasma6_version: %define _plasma6_version %(echo %{_plasma6_bugfix} | awk -F. '{print $1"."$2}')}
 
 Name:           powerdevil
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        KDE Power Management module
 License:        GPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/powerdevil.git
-#!RemoteAsset:  sha256:fa5d19ebf8be6ec205a3f5c164b0d3142327ec48042d62f58dbdcbcf274d3778
+#!RemoteAsset:  sha256:5682eeb597cf67783e188096ac600a95d32d8002fd7eda5e268c234c4f0d29c6
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 

--- a/SPECS/qqc2-breeze-style/qqc2-breeze-style.spec
+++ b/SPECS/qqc2-breeze-style/qqc2-breeze-style.spec
@@ -8,13 +8,13 @@
 %define qt6_version 6.9.0
 
 Name:           qqc2-breeze-style
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        Breeze Style for Qt Quick
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/qqc2-breeze-style.git
-#!RemoteAsset:  sha256:7971af2289da682c16e810266b3f640a1203bbc1b0c7360404fb230e7b308396
+#!RemoteAsset:  sha256:c22987091431e7edd6c172901166c0abdc0fc90a76c7288f0e5e6a644d9d5fcb
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 

--- a/SPECS/sddm-kcm/sddm-kcm.spec
+++ b/SPECS/sddm-kcm/sddm-kcm.spec
@@ -8,13 +8,13 @@
 %define qt6_version 6.9.0
 
 Name:           sddm-kcm
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        A sddm control module for KDE
 License:        GPL-2.0-only
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/sddm-kcm.git
-#!RemoteAsset:  sha256:4026abbbba4ebaa654bca2a52dbc5f07519f69684e5c94f7d91644888f307570
+#!RemoteAsset:  sha256:e94ff27dd0a3a701eb04b5a87041795137f5624d3bea986f950403af79f0370b
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 

--- a/SPECS/systemsettings/systemsettings.spec
+++ b/SPECS/systemsettings/systemsettings.spec
@@ -15,13 +15,13 @@
 %{!?_plasma6_version: %define _plasma6_version %(echo %{_plasma6_bugfix} | awk -F. '{print $1"."$2}')}
 
 Name:           systemsettings
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        KDE's control center
 License:        GPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/systemsettings.git
-#!RemoteAsset:  sha256:687e4fde851f769c04f8366d94a0fc3176364551e1f2dc4e9e4471698da2e430
+#!RemoteAsset:  sha256:92ee2038e1cebc463ec576707490c6fc54bc9b179f215909808b9f672bec178d
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 

--- a/SPECS/xdg-desktop-portal-kde/xdg-desktop-portal-kde.spec
+++ b/SPECS/xdg-desktop-portal-kde/xdg-desktop-portal-kde.spec
@@ -16,13 +16,13 @@
 %{!?_plasma6_version: %define _plasma6_version %(echo %{_plasma6_bugfix} | awk -F. '{print $1"."$2}')}
 
 Name:           xdg-desktop-portal-kde
-Version:        6.5.5
+Version:        6.6.5
 Release:        %autorelease
 Summary:        QT/KF6 backend for xdg-desktop-portal
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/plasma/xdg-desktop-portal-kde.git
-#!RemoteAsset:  sha256:d2798d6946a46ba75f16bfaa82b97a1c4e62254d527b0aa90119182b9d69c02a
+#!RemoteAsset:  sha256:2a9bd4d26aae95189c6121500945d10c2a0e49082e0c1c6400747d64cf3ad024
 Source:         https://invent.kde.org/plasma/%{name}/-/archive/v%{version}/%{name}-v%{version}.tar.gz
 BuildSystem:    cmake
 


### PR DESCRIPTION
## Summary

This commit primarily includes updates to Plasma, bringing it to version 6.6.5, and also upgrades some dependencies.

Some legacy components have been migrated to the CMake BuildSystem.

https://kde.org/announcements/plasma/6/6.6.5/

## Related Issue

no

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
