### PR TITLE
SPECS: openruyi-release: add %openruyi guard macro

### DIFF
--- a/SPECS/openruyi-release/macros.openruyi
+++ b/SPECS/openruyi-release/macros.openruyi
@@ -1,0 +1,3 @@
+# Distribution-guard flag for spec `%if 0%{?openruyi}`. A presence flag (1)
+# rather than a version number, since VERSION_ID is a codename ("Creek").
+%openruyi 1

--- a/SPECS/openruyi-release/openruyi-release.spec
+++ b/SPECS/openruyi-release/openruyi-release.spec
@@ -12,6 +12,7 @@ License:        MulanPSL-2.0
 URL:            https://www.openruyi.cn
 Source0:        issue.conf
 Source1:        os-release.conf
+Source2:        macros.openruyi
 
 Provides:       system-release
 Provides:       openRuyi-release
@@ -31,6 +32,8 @@ echo -e "openRuyi (%{_target_cpu}) - Kernel %%r (%%t)." > %{buildroot}%{_sysconf
 install -c -m 644 %{SOURCE1} %{buildroot}%{_prefix}/lib/os-release
 ln -s ../usr/lib/os-release %{buildroot}%{_sysconfdir}/os-release
 touch %{buildroot}%{_sysconfdir}/motd
+mkdir -p %{buildroot}%{_rpmconfigdir}/macros.d
+install -c -m 644 %{SOURCE2} %{buildroot}%{_rpmconfigdir}/macros.d/macros.openruyi
 
 %files
 %defattr(644,root,root,755)
@@ -39,6 +42,7 @@ touch %{buildroot}%{_sysconfdir}/motd
 %config(noreplace) %{_sysconfdir}/motd
 %config(noreplace) %{_sysconfdir}/issue
 %config(noreplace) %{_sysconfdir}/issue.net
+%{_rpmconfigdir}/macros.d/macros.openruyi
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
## Summary

Add an `%openruyi` macro so specs can detect openRuyi with `%if 0%{?openruyi}`,
like the `0%{?fedora}` / `0%{?rhel}` guards other distros use. Without it the
only option is `%if "%{_vendor}" == "openruyi"`.

ceph's [`ceph.spec.in`](https://github.com/ceph/ceph/blob/main/ceph.spec.in) is
one case — it gates per-distro `BuildRequires` with
`%if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}`, and this lets openRuyi go in
the same line.

## Related Issue

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy