### PR TITLE
SPECS: add Pytorch ROCm BuildRequires

### DIFF
--- a/SPECS/amdsmi/0001-Fix-compilation-with-libdrm-2.4.130.patch
+++ b/SPECS/amdsmi/0001-Fix-compilation-with-libdrm-2.4.130.patch
@@ -1,0 +1,38 @@
+From b8b4a6bcfe35ba9539a120cfd16573123ddd9241 Mon Sep 17 00:00:00 2001
+From: "Sv. Lockal" <lockalsash@gmail.com>
+Date: Mon, 15 Dec 2025 03:46:35 +0800
+Subject: [PATCH] Fix compilation with libdrm-2.4.130
+
+Fix error: redefinition of 'struct drm_color_ctm_3x4'.
+
+drm_color_ctm_3x4 structure is now defined in https://github.com/torvalds/linux/commit/e5719e7f19009d4fbedf685fc22eec9cd8de154f#diff-4c51fb416ec7cc69566cd7b795ee57eb070aa1006ad65d6962081f039ffb2718
+
+As this structure is unused and not a part of amdsmi public interface,
+it is safe to remove it.
+---
+ include/amd_smi/impl/amdgpu_drm.h | 9 ---------
+ 1 file changed, 9 deletions(-)
+
+diff --git a/include/amd_smi/impl/amdgpu_drm.h b/include/amd_smi/impl/amdgpu_drm.h
+index b56a5ac4b20a..0e483d13b382 100644
+--- a/include/amd_smi/impl/amdgpu_drm.h
++++ b/include/amd_smi/impl/amdgpu_drm.h
+@@ -1625,15 +1625,6 @@ struct drm_amdgpu_info_uq_metadata {
+ #define AMDGPU_FAMILY_GC_11_5_0			150 /* GC 11.5.0 */
+ #define AMDGPU_FAMILY_GC_12_0_0			152 /* GC 12.0.0 */
+ 
+-/* FIXME wrong namespace! */
+-struct drm_color_ctm_3x4 {
+-	/*
+-	 * Conversion matrix with 3x4 dimensions in S31.32 sign-magnitude
+-	 * (not two's complement!) format.
+-	 */
+-	__u64 matrix[12];
+-};
+-
+ #if defined(__cplusplus)
+ }
+ #endif
+-- 
+2.51.1
+

--- a/SPECS/amdsmi/2001-Disable-goamdsmi_shim-when-ESMI-is-off.patch
+++ b/SPECS/amdsmi/2001-Disable-goamdsmi_shim-when-ESMI-is-off.patch
@@ -1,0 +1,36 @@
+From 21afd2c2d58b8c7895df47f6a16a0781a7f0024a Mon Sep 17 00:00:00 2001
+From: Sakura286 <sakura286@outlook.com>
+Date: Sat, 6 Jun 2026 20:38:13 +0800
+Subject: [PATCH 1/2] Disable goamdsmi_shim when ESMI is off
+
+The Go shim in goamdsmi_shim/smiwrapper/amdsmi_go_shim.c calls CPU-only
+APIs such as amdsmi_get_cpu_core_energy, amdsmi_get_threads_per_core
+and amdsmi_get_processor_handles_by_type. In include/amd_smi/amdsmi.h
+these are all guarded by `#ifdef ENABLE_ESMI_LIB`, so when ESMI is
+disabled (e.g. on riscv64 / non-x86 architectures) the declarations
+disappear and the shim fails to build with implicit-function-declaration
+errors.
+---
+ CMakeLists.txt | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1b7375f..013c1ad 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -363,8 +363,10 @@ install(
+     PATTERN "build*" EXCLUDE
+     PATTERN ".cache*" EXCLUDE)
+ 
+-# Make for goamdsmi_shim library
+-add_subdirectory(goamdsmi_shim)
++# The Go shim uses CPU APIs gated by ENABLE_ESMI_LIB; only build it when ESMI is on
++if(ENABLE_ESMI_LIB)
++    add_subdirectory(goamdsmi_shim)
++endif()
+ 
+ #Debian package specific variables
+ set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "python3-argcomplete, libdrm-dev, libdrm-amdgpu-dev")
+-- 
+2.53.0
+

--- a/SPECS/amdsmi/2002-Tolerate-missing-CPU-E-SMI-symbols-on-non-x86_64.patch
+++ b/SPECS/amdsmi/2002-Tolerate-missing-CPU-E-SMI-symbols-on-non-x86_64.patch
@@ -1,0 +1,77 @@
+From 41740f15ede6e04e46ff736bcc85ca8fd1aae641 Mon Sep 17 00:00:00 2001
+From: Sakura286 <sakura286@outlook.com>
+Date: Sat, 6 Jun 2026 21:55:37 +0800
+Subject: [PATCH 2/2] Tolerate missing CPU/E-SMI symbols on non-x86_64
+
+With ENABLE_ESMI_LIB=OFF (non-x86_64), libamd_smi.so omits the CPU API,
+but the ctypesgen wrapper binds every symbol at import time, so the
+missing CPU symbols make `import amdsmi` fail with AttributeError.
+
+Wrap the loaded CDLL in a proxy so missing symbols resolve to a lazy
+stub that only raises when actually called. `import amdsmi` then works
+and GPU consumers (e.g. PyTorch with ROCM EP, which never calls the CPU
+API) are unaffected. The library object is wrapped instead of ctypes.CDLL
+itself so callers hooking ctypes.CDLL keep working.
+---
+ py-interface/amdsmi_wrapper.py | 38 +++++++++++++++++++++++++++++++++-
+ 1 file changed, 37 insertions(+), 1 deletion(-)
+
+diff --git a/py-interface/amdsmi_wrapper.py b/py-interface/amdsmi_wrapper.py
+index 99ed017..0626b72 100644
+--- a/py-interface/amdsmi_wrapper.py
++++ b/py-interface/amdsmi_wrapper.py
+@@ -176,6 +176,42 @@ from pathlib import Path
+ # 3. Relative to amdsmi_wrapper.py
+ #    - parent directory
+ #    - current directory
++class _AmdsmiMissingSymbol:
++    # Placeholder for a symbol absent from libamd_smi.so (e.g. the CPU/E-SMI
++    # API when the library is built with ENABLE_ESMI_LIB=OFF on non-x86_64).
++    # It accepts the restype/argtypes the wrapper assigns at import time and
++    # only raises if the symbol is ever actually called.
++    def __init__(self, name):
++        object.__setattr__(self, "_amdsmi_name", name)
++
++    def __setattr__(self, key, value):
++        object.__setattr__(self, key, value)
++
++    def __call__(self, *args, **kwargs):
++        name = object.__getattribute__(self, "_amdsmi_name")
++        raise NotImplementedError(
++            "amdsmi symbol " + repr(name) + " is unavailable: it is not "
++            "exported by this build of libamd_smi.so")
++
++
++class _AmdsmiTolerantLib:
++    # Proxy around the loaded CDLL so that binding a symbol the library does
++    # not export resolves to a stub instead of raising AttributeError at
++    # import time. We wrap the already-constructed library object rather than
++    # the ctypes.CDLL() call so that callers hooking ctypes.CDLL (e.g.
++    # PyTorch's libamd_smi.so loader) keep working.
++    def __init__(self, lib):
++        object.__setattr__(self, "_amdsmi_lib", lib)
++
++    def __getattr__(self, name):
++        try:
++            return getattr(object.__getattribute__(self, "_amdsmi_lib"), name)
++        except AttributeError:
++            if name.startswith("__"):
++                raise
++            return _AmdsmiMissingSymbol(name)
++
++
+ def find_smi_library():
+     err = OSError("Could not load libamd_smi.so")
+     possible_locations = []
+@@ -194,7 +230,7 @@ def find_smi_library():
+     for location in possible_locations:
+         try:
+             lib = ctypes.CDLL(location)
+-            return lib, location
++            return _AmdsmiTolerantLib(lib), location
+         except OSError as e:
+             err = e
+             continue
+-- 
+2.53.0
+

--- a/SPECS/amdsmi/amdsmi.spec
+++ b/SPECS/amdsmi/amdsmi.spec
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: CHEN Xuan <chenxuan@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%bcond test 0
+%if %{with test}
+%global build_test ON
+%else
+%global build_test OFF
+%endif
+
+%global rocm_release 7.2
+%global rocm_patch 1
+%global rocm_version %{rocm_release}.%{rocm_patch}
+
+# esmi_ib_library is not suitable for packaging
+# https://github.com/amd/esmi_ib_library/issues/13
+# This tag was chosen by the amdsmi project because 4.0+ introduced variables
+# not found in the upstream kernel.
+%global esmi_ver 4.2
+%global pkg_library_version 26
+
+Name:           amdsmi
+Version:        %{rocm_version}
+Release:        %autorelease
+Summary:        AMD System Management Interface
+License:        MIT AND (GPL-2.0-only WITH Linux-syscall-note) AND NSCA
+# Main license is MIT
+#
+# This file is GPL-2.0:
+# include/amd_smi/impl/amd_hsmp.h
+# esmi_ib_library/include/asm/amd_hsmp.h
+# Both carry: SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note
+#
+# NSCA covers the bundled esmi_ib_library
+Url:            https://github.com/ROCm/rocm-systems
+#!RemoteAsset:  sha256:23c31cd787d86ee35c82746fcde705eacc46517815110376f28417909ef46406
+Source0:        %{url}/releases/download/rocm-%{version}/%{name}.tar.gz
+#!RemoteAsset:  sha256:de19d222d09e2171f47f8bbd6608e5648bd547c82543379bb8fb5ed2e379e141
+Source1:        https://github.com/amd/esmi_ib_library/archive/refs/tags/esmi_pkg_ver-%{esmi_ver}.tar.gz
+BuildSystem:    cmake
+
+# Support libdrm 2.4.130+
+# https://github.com/ROCm/amdsmi/pull/165
+Patch0:         0001-Fix-compilation-with-libdrm-2.4.130.patch
+# -DENABLE_ESMI_LIB=OFF is not enough.
+# Goamdshim references CPU/ESMI-only APIs; only build it when ESMI is on
+Patch1:         2001-Disable-goamdsmi_shim-when-ESMI-is-off.patch
+# Without ESMI (non-x86_64) libamd_smi.so omits the CPU API; let the ctypesgen
+# wrapper tolerate the missing symbols so `import amdsmi` still works
+Patch2:         2002-Tolerate-missing-CPU-E-SMI-symbols-on-non-x86_64.patch
+
+BuildOption(conf):  -G Ninja
+BuildOption(conf):  -DBUILD_TESTS=%{build_test}
+BuildOption(conf):  -DCMAKE_SKIP_INSTALL_RPATH=TRUE
+%ifnarch x86_64
+BuildOption(conf):  -DENABLE_ESMI_LIB=OFF
+%endif
+
+BuildRequires:  cmake
+%if %{with test}
+BuildRequires:  cmake(GTest)
+%endif
+BuildRequires:  ninja
+BuildRequires:  pkgconfig(libdrm)
+BuildRequires:  pkgconfig(libdrm_amdgpu)
+BuildRequires:  pkgconfig(python3)
+
+Requires:       python3dist(pyyaml)
+
+%description
+The AMD System Management Interface Library, or AMD SMI library, is a C
+library for Linux that provides a user space interface for applications
+to monitor and control AMD devices.
+
+%package        devel
+Summary:        Libraries and headers for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+%{summary}
+
+%if %{with test}
+%package        test
+Summary:        Tests for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    test
+%{summary}
+%endif
+
+%prep
+%autosetup -p1 -N -n %{name}
+%patch 0 -p1
+%patch 1 -p1
+%ifnarch x86_64
+%patch 2 -p1
+%endif
+
+# ESMI - EPYC System Management Interface
+# esmi_ib_library uses x86-only cpuid.h; guard it for non-x86 builds
+%ifarch x86_64
+tar xf %{SOURCE1}
+mv esmi_ib_library-* esmi_ib_library
+mv esmi_ib_library/License.txt esmi_ib_library_License.txt
+# The esmi version check uses git tags, but we use tar's without git files.
+# Just inject in the tag that we've pulled into the version check:
+sed -i 's/NOT latest_esmi_tag/NOT "esmi_pkg_ver-%{esmi_ver}"/' CMakeLists.txt
+%endif
+
+# /usr/libexec/amdsmi_cli/BDF.py:126: SyntaxWarning: invalid escape sequence '\.'
+sed -i -e 's@bdf_regex = "@bdf_regex = r"@' amdsmi_cli/BDF.py
+
+# Fix script shebang
+sed -i -e 's@env python3@python3@' amdsmi_cli/*.py
+
+%install -a
+mkdir -p %{buildroot}%{python3_sitearch}
+mv %{buildroot}%{_datadir}/amdsmi %{buildroot}%{python3_sitearch}
+mv %{buildroot}%{_datadir}/pyproject.toml %{buildroot}%{python3_sitearch}/amdsmi/
+
+# W: unstripped-binary-or-object .../amdsmi/libamd_smi.so
+# Does an explicit open, so can not just rm it; strip it instead
+strip %{buildroot}%{python3_sitearch}/amdsmi/*.so
+# E: non-executable-script .../amdsmi_cli/amdsmi_cli_exceptions.py 644 /usr/bin/env python3
+chmod a+x %{buildroot}%{_libexecdir}/amdsmi_cli/amdsmi_*.py
+
+rm -rf %{buildroot}%{_datadir}/example
+rm -rf %{buildroot}%{_datadir}/amd_smi/example
+rm -f %{buildroot}%{_datadir}/_version.py
+rm -f %{buildroot}%{_datadir}/amd_smi/_version.py
+rm -f %{buildroot}%{_datadir}/setup.py
+rm -f %{buildroot}%{_datadir}/amd_smi/setup.py
+rm -f %{buildroot}%{_docdir}/amd_smi-asan/LICENSE.txt
+rm -f %{buildroot}%{_docdir}/amd-smi-lib/LICENSE.txt
+rm -f %{buildroot}%{_docdir}/amd-smi-lib/README.md
+rm -rf %{buildroot}%{_docdir}/amd-smi-lib/copyright
+
+if [ -e %{buildroot}%{_datadir}/amd_smi/tests ]; then
+    mkdir -p %{buildroot}%{_datadir}/amdsmi
+    mv %{buildroot}%{_datadir}/amd_smi/tests %{buildroot}%{_datadir}/amdsmi/
+fi
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/amd-smi
+%{_libdir}/libamd_smi.so.%{pkg_library_version}{,.*}
+%{_libexecdir}/amdsmi_cli
+%{python3_sitearch}/amdsmi
+
+%ifarch x86_64
+%license esmi_ib_library_License.txt
+%{_libdir}/libgoamdsmi_shim64.so.1{,.*}
+%endif
+
+%files devel
+%{_includedir}/amd_smi/
+%{_libdir}/cmake/amd_smi/
+%{_libdir}/libamd_smi.so
+
+%ifarch x86_64
+%{_includedir}/*.h
+%{_libdir}/libgoamdsmi_shim64.so
+%endif
+
+%if %{with test}
+%files test
+%{_datadir}/amdsmi/
+%endif
+
+%changelog
+%autochangelog

--- a/SPECS/fplus/fplus.spec
+++ b/SPECS/fplus/fplus.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: CHEN Xuan <chenxuan@iscas.ac.cn>
+# SPDX-FileContributor: Yifan Xu <xuyifan@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           fplus
+Version:        0.2.28
+Release:        %autorelease
+Summary:        Helps you write concise and readable C++ code
+Url:            https://github.com/Dobiasd/FunctionalPlus
+License:        BSL-1.0
+#!RemoteAsset:  sha256:8864a3e9bebde6ebed71b49ac2a036cedf9ae0f02ce758bc28c21e6a2ae15803
+Source0:         %{url}/archive/v%{version}.tar.gz
+BuildSystem:    cmake
+
+BuildRequires:  cmake
+
+%description
+FunctionalPlus is a small header-only library supporting you in
+reducing code noise and in dealing with only one single level
+of abstraction at a time. By increasing brevity and maintainability
+of your code it can improve productivity (and fun!) in the long
+run. It pursues these goals by providing pure and easy-to-use
+functions that free you from implementing commonly used flows of
+control over and over again.
+
+%files
+%doc README.md
+%license LICENSE
+%{_includedir}/fplus/
+%{_libdir}/cmake/FunctionalPlus/
+
+%changelog
+%autochangelog

--- a/SPECS/half/half.spec
+++ b/SPECS/half/half.spec
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: CHEN Xuan <chenxuan@iscas.ac.cn>
+# SPDX-FileContributor: Yifan Xu <xuyifan@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global rocm_release 7.1
+%global rocm_patch   1
+%global rocm_version %{rocm_release}.%{rocm_patch}
+
+Name:           half
+Version:        %{rocm_version}
+Release:        %autorelease
+Summary:        ROCm half-precision floating point library
+License:        MIT
+Url:            https://github.com/ROCm/half
+#!RemoteAsset:  sha256:1b5de9e50513560265a79022fd74322b77216f9bf938be688709a8e7d1d8d09d
+Source0:         %{url}/archive/rocm-%{version}.tar.gz
+BuildSystem:    cmake
+
+BuildRequires:  cmake
+BuildRequires:  rocm-cmake
+
+%description
+half is a C++ header-only library providing an IEEE-754 conformant
+half-precision floating point type along with arithmetic operators,
+type conversions, and common mathematical functions. It is part of
+the ROCm software stack.
+
+%install -a
+rm -f %{buildroot}%{_datadir}/doc/half/LICENSE.txt
+
+%files
+%license LICENSE.txt
+%doc README.txt
+%{_includedir}/half/
+
+%changelog
+%autochangelog

--- a/SPECS/hipblaslt/0001-hipblaslt-find-origami-package.patch
+++ b/SPECS/hipblaslt/0001-hipblaslt-find-origami-package.patch
@@ -1,0 +1,25 @@
+From 43c4a61c5d8836a16feb8e53c72f255790523ff3 Mon Sep 17 00:00:00 2001
+From: Tom Rix <Tom.Rix@amd.com>
+Date: Mon, 3 Nov 2025 06:11:40 -0800
+Subject: [PATCH] hipblaslt find origami package
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index dbccca92c84f..d02df50540c2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -218,7 +218,7 @@ if(HIPBLASLT_ENABLE_MSGPACK)
+     endif()
+ endif()
+ 
+-add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../../shared/origami" origami)
++find_package(origami CONFIG REQUIRED)
+ add_subdirectory(tensilelite)
+ 
+ if(HIPBLASLT_ENABLE_HOST)
+-- 
+2.52.0
+

--- a/SPECS/hipblaslt/0001-hipblaslt-tensilelite-remove-yappi-dependency.patch
+++ b/SPECS/hipblaslt/0001-hipblaslt-tensilelite-remove-yappi-dependency.patch
@@ -1,0 +1,57 @@
+From 72521fcca77c010b9c8b9ce91cde925164502d6f Mon Sep 17 00:00:00 2001
+From: Tom Rix <Tom.Rix@amd.com>
+Date: Thu, 25 Sep 2025 13:02:55 -0700
+Subject: [PATCH] hipblaslt tensilelite remove yappi dependency
+
+Signed-off-by: Tom Rix <Tom.Rix@amd.com>
+---
+ tensilelite/Tensile/TensileCreateLibrary/Run.py | 15 ---------------
+ tensilelite/requirements.txt                    |  2 +-
+ 2 files changed, 1 insertion(+), 16 deletions(-)
+
+diff --git a/tensilelite/Tensile/TensileCreateLibrary/Run.py b/tensilelite/Tensile/TensileCreateLibrary/Run.py
+index 835ed9c01916..a02705f6554a 100644
+--- a/tensilelite/Tensile/TensileCreateLibrary/Run.py
++++ b/tensilelite/Tensile/TensileCreateLibrary/Run.py
+@@ -231,12 +231,6 @@ def writeSolutionsAndKernels(
+     generateSourcesAndExit=False,
+     compress=True,
+ ):
+-    if globalParameters["PythonProfile"]:
+-        globalParameters["CpuThreads"] = 0
+-        printWarning("Python profiling is enabled. CpuThreads set to 0.")
+-        import yappi
+-        yappi.start()
+-
+     codeObjectFiles = []
+ 
+     outputPath = Path(outputPath)
+@@ -299,15 +293,6 @@ def writeSolutionsAndKernels(
+     writeHelpers(outputPath, kernelHelperObjs, KERNEL_HELPER_FILENAME_CPP, KERNEL_HELPER_FILENAME_H)
+     srcKernelFile = Path(outputPath) / "Kernels.cpp"
+ 
+-    if globalParameters["PythonProfile"]:
+-        yappi.stop()
+-        yappi.get_func_stats().save("yappi_results.profile", type="callgrind")
+-        with open("yappi_results.txt", "w") as f:
+-            yappi.get_func_stats().print_all(out=f)
+-        if globalParameters["CpuThreads"] != 0:
+-            with open("yappi_thread_stats.txt", "w") as f:
+-                yappi.get_thread_stats().print_all(out=f)
+-
+     if not generateSourcesAndExit:
+         codeObjectFiles += buildAssemblyCodeObjectFiles(
+             asmToolchain.linker,
+diff --git a/tensilelite/requirements.txt b/tensilelite/requirements.txt
+index 60c4c1144537..e87db8445411 100644
+--- a/tensilelite/requirements.txt
++++ b/tensilelite/requirements.txt
+@@ -7,4 +7,4 @@ joblib>=1.1.1; python_version < '3.8'
+ simplejson
+ ujson
+ orjson
+-yappi
++
+-- 
+2.52.0
+

--- a/SPECS/hipblaslt/0001-hipblaslt-tensilelite-use-system-paths.patch
+++ b/SPECS/hipblaslt/0001-hipblaslt-tensilelite-use-system-paths.patch
@@ -1,0 +1,41 @@
+From 1ac117ac0591a0f1bb67c34f537354c21412b2d8 Mon Sep 17 00:00:00 2001
+From: Tom Rix <Tom.Rix@amd.com>
+Date: Sat, 1 Nov 2025 09:43:58 -0700
+Subject: [PATCH] hipblaslt tensilelite use fedora paths
+
+---
+ tensilelite/Tensile/Common/GlobalParameters.py | 2 +-
+ tensilelite/Tensile/Toolchain/Validators.py    | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/tensilelite/Tensile/Common/GlobalParameters.py b/tensilelite/Tensile/Common/GlobalParameters.py
+index 567188da59bd..1f8037c183a6 100644
+--- a/tensilelite/Tensile/Common/GlobalParameters.py
++++ b/tensilelite/Tensile/Common/GlobalParameters.py
+@@ -538,7 +538,7 @@ def assignGlobalParameters(config, isaInfoMap: Dict[IsaVersion, IsaInfo]):
+         else:
+             print2(" %24s: %8s (unspecified)" % (key, defaultValue))
+ 
+-    globalParameters["ROCmPath"] = "/opt/rocm"
++    globalParameters["ROCmPath"] = "/usr"
+     if "ROCM_PATH" in os.environ:
+         globalParameters["ROCmPath"] = os.environ.get("ROCM_PATH")
+     if "TENSILE_ROCM_PATH" in os.environ:
+diff --git a/tensilelite/Tensile/Toolchain/Validators.py b/tensilelite/Tensile/Toolchain/Validators.py
+index fd5dab5324c0..3ce024d31f52 100644
+--- a/tensilelite/Tensile/Toolchain/Validators.py
++++ b/tensilelite/Tensile/Toolchain/Validators.py
+@@ -30,8 +30,8 @@ from typing import List, NamedTuple, Union
+ 
+ from Tensile.Common.Utilities import isRhel8
+ 
+-DEFAULT_ROCM_BIN_PATH_POSIX = Path("/opt/rocm/bin")
+-DEFAULT_ROCM_LLVM_BIN_PATH_POSIX = Path("/opt/rocm/lib/llvm/bin")
++DEFAULT_ROCM_BIN_PATH_POSIX = Path("/usr/bin")
++DEFAULT_ROCM_LLVM_BIN_PATH_POSIX = Path("/usr/lib64/rocm/llvm/bin")
+ DEFAULT_ROCM_BIN_PATH_WINDOWS = Path("C:/Program Files/AMD/ROCm")
+ 
+ 
+-- 
+2.52.0
+

--- a/SPECS/hipblaslt/2001-hipblaslt-tensilelite-use-system-nanobind.patch
+++ b/SPECS/hipblaslt/2001-hipblaslt-tensilelite-use-system-nanobind.patch
@@ -1,0 +1,31 @@
+From 9aa4664e02e27b50083be08e5b495cbef02d6f08 Mon Sep 17 00:00:00 2001
+From: Sakura286 <sakura286@outlook.com>
+Date: Mon, 8 Jun 2026 09:00:08 +0800
+Subject: [PATCH] hipblaslt tensilelite use system nanobind
+
+---
+ tensilelite/rocisa/CMakeLists.txt | 8 +-------
+ 1 file changed, 1 insertion(+), 7 deletions(-)
+
+diff --git a/tensilelite/rocisa/CMakeLists.txt b/tensilelite/rocisa/CMakeLists.txt
+index 3918f18..9c6fcd3 100644
+--- a/tensilelite/rocisa/CMakeLists.txt
++++ b/tensilelite/rocisa/CMakeLists.txt
+@@ -17,13 +17,7 @@ target_include_directories(rocisa-cpp
+ )
+ 
+ if(HIPBLASLT_BUNDLE_PYTHON_DEPS)
+-    include(FetchContent)
+-    FetchContent_Declare(
+-      nanobind
+-      GIT_REPOSITORY https://github.com/wjakob/nanobind.git
+-      GIT_TAG        9b3afa9dbdc23641daf26fadef7743e7127ff92f # v2.6.1
+-    )
+-    FetchContent_MakeAvailable(nanobind)
++    find_package(nanobind CONFIG REQUIRED)
+ 
+     set(ROCISAINST_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/rocisa/src/instruction/instruction.cpp"
+                           "${CMAKE_CURRENT_SOURCE_DIR}/rocisa/src/instruction/common.cpp"
+-- 
+2.53.0
+

--- a/SPECS/hipblaslt/hipblaslt.spec
+++ b/SPECS/hipblaslt/hipblaslt.spec
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: CHEN Xuan <chenxuan@iscas.ac.cn>
+# SPDX-FileContributor: Yifan Xu <xuyifan@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global rocm_release 7.1
+%global rocm_patch 1
+%global rocm_version %{rocm_release}.%{rocm_patch}
+
+%global toolchain clang
+
+%bcond build_test 0
+%if %{with build_test}
+%global cmake_test ON
+%else
+%global cmake_test OFF
+%endif
+
+%global tensile_version 4.33.0
+# The upstream hipBLASTLt project has a hard fork of the python-tensile package
+# The rocBLAS uses.  The two versions are incompatible.  It appears that the
+# fork happened around version 4.33.0.  Unfortunately hipBLASLt can no longer be
+# build without using this fork.
+# https://github.com/ROCm/hipBLASLt/issues/535
+# The problem with the fork has been raised here.
+# https://github.com/ROCm/hipBLASLt/issues/908
+
+%global tensile_verbose 1
+
+Name:           hipblaslt
+Version:        %{rocm_version}
+Release:        %autorelease
+Summary:        ROCm general matrix operations beyond BLAS
+License:        MIT AND BSD-3-Clause
+URL:            https://github.com/ROCm/rocm-libraries
+#!RemoteAsset:  sha256:05d73038b1b4f66f3df4eb595b7cb0c8935f7aa18d0e07dbe5cc740a4b691898
+Source0:        %{url}/releases/download/rocm-%{version}/%{name}.tar.gz
+BuildSystem:    cmake
+
+BuildOption(conf):  -DBUILD_CLIENTS_TESTS=%{cmake_test}
+BuildOption(conf):  -DCMAKE_VERBOSE_MAKEFILE=ON
+BuildOption(conf):  -DGPU_TARGETS=%{rocm_gpu_list_default}
+BuildOption(conf):  -DHIPBLASLT_ENABLE_CLIENT=%{cmake_test}
+BuildOption(conf):  -DHIPBLASLT_ENABLE_MARKER=OFF
+BuildOption(conf):  -DHIPBLASLT_ENABLE_OPENMP=OFF
+BuildOption(conf):  -DHIPBLASLT_ENABLE_ROCROLLER=OFF
+BuildOption(conf):  -DHIPBLASLT_ENABLE_SAMPLES=OFF
+BuildOption(conf):  -DTensile_LIBRARY_FORMAT=msgpack
+BuildOption(conf):  -DTensile_VERBOSE=%{tensile_verbose}
+BuildOption(conf):  -DVIRTUALENV_BIN_DIR=%{_bindir}
+BuildOption(conf):  -Dnanobind_ROOT=%(python3 -m nanobind --cmake_dir)
+BuildOption(conf):  -G Ninja
+
+# yappi is used in tensilelite to generate profiling data, we are not using that in the build
+Patch0:         0001-hipblaslt-tensilelite-remove-yappi-dependency.patch
+# Patch from Fedora, change hard coded vendor paths
+Patch1:         0001-hipblaslt-tensilelite-use-system-paths.patch
+# https://github.com/ROCm/rocm-libraries/issues/2422
+Patch2:         0001-hipblaslt-find-origami-package.patch
+# use the distribution-provided nanobind instead of fetching/bundling it
+Patch3:         2001-hipblaslt-tensilelite-use-system-nanobind.patch
+
+BuildRequires:  clang
+BuildRequires:  clang-tools-extra
+BuildRequires:  cmake
+BuildRequires:  cmake(amd_comgr)
+BuildRequires:  cmake(hip)
+BuildRequires:  cmake(hipblas)
+BuildRequires:  cmake(hsa-runtime64)
+BuildRequires:  cmake(msgpack)
+BuildRequires:  cmake(origami)
+BuildRequires:  cmake(rocblas)
+BuildRequires:  cmake(rocm_smi)
+BuildRequires:  compiler-rt
+BuildRequires:  gcc-fortran
+BuildRequires:  hipcc
+BuildRequires:  lld
+BuildRequires:  llvm
+BuildRequires:  ninja
+BuildRequires:  pkgconfig(libzstd)
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pkgconfig(zlib)
+# https://github.com/ROCm/hipBLASLt/issues/1734
+BuildRequires:  python3dist(msgpack)
+# nanobind is used to build the rocisa native module (build-time only)
+BuildRequires:  python3dist(nanobind)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(pyyaml)
+BuildRequires:  python3dist(joblib)
+BuildRequires:  rocm-cmake
+BuildRequires:  rocm-device-libs
+BuildRequires:  rocm-llvm-macros
+BuildRequires:  rocminfo
+
+%if %{with build_test}
+BuildRequires:  cmake(openblas)
+BuildRequires:  cmake(GMock)
+BuildRequires:  cmake(GTest)
+%endif
+
+%description
+hipBLASLt is a library that provides general matrix-matrix
+operations. It has a flexible API that extends functionalities
+beyond a traditional BLAS library, such as adding flexibility
+to matrix data layouts, input types, compute types, and
+algorithmic implementations and heuristics.
+
+%package        devel
+Summary:        Libraries and headers for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+%{summary}
+
+%if %{with build_test}
+%package        test
+Summary:        Tests for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    test
+%{summary}
+%endif
+
+%prep -a
+# Use PATH to find where TensileGetPath and other tensile bins are
+sed -i -e 's@${Tensile_PREFIX}/bin/TensileGetPath@TensileGetPath@g'            tensilelite/Tensile/cmake/TensileConfig.cmake
+
+# defer to cmdline
+sed -i -e 's@set(CMAKE_INSTALL_LIBDIR@#set(CMAKE_INSTALL_LIBDIR@' CMakeLists.txt
+
+# Do not use virtualenv_install
+sed -i -e 's@virtualenv_install@#virtualenv_install@'                          CMakeLists.txt
+
+# Disable trying to download rocm-cmake
+sed -i -e 's@if(NOT ROCmCMakeBuildTools_FOUND)@if(FALSE)@' cmake/dependencies.cmake
+
+# HIPBLASLT_ENABLE_OPENMP is OFF yet it is still being used
+# https://github.com/ROCm/rocm-libraries/issues/3201
+sed -i -e '/OpenMP::OpenMP_CXX/d' clients/CMakeLists.txt
+sed -i -e '/omp/d'                clients/common/src/blis_interface.cpp
+sed -i -e '/#include <omp.h>/d'   clients/common/include/testing_matmul.hpp
+sed -i -e '/#include <omp.h>/d'   clients/common/include/hipblaslt_init.hpp
+sed -i -e '/#include <omp.h>/d'   clients/common/src/cblas_interface.cpp
+
+# We are building from a tarball, not a git repo
+sed -i -e 's@find_package(Git REQUIRED)@#find_package(Git REQUIRED)@' cmake/dependencies.cmake
+
+# Forcefully replace all mentions of 'amdclang' with 'clang' in the Tensile Python files
+find tensilelite -type f -name "*.py" -exec sed -i 's/amdclang++/clang++/g; s/amdclang/clang/g' {} +
+
+%build -p
+# Do a manual install instead of cmake's virtualenv
+cd tensilelite
+TL=$PWD
+
+python3 setup.py install --root $TL
+cd ..
+
+# Should not have to do this
+CLANG_PATH=`hipconfig --hipclangpath`
+ROCM_CLANG=${CLANG_PATH}/clang
+RESOURCE_DIR=`${ROCM_CLANG} -print-resource-dir`
+export DEVICE_LIB_PATH=${RESOURCE_DIR}/amdgcn/bitcode
+export TENSILE_ROCM_ASSEMBLER_PATH=${CLANG_PATH}/clang++
+export TENSILE_ROCM_OFFLOAD_BUNDLER_PATH=${CLANG_PATH}/clang-offload-bundler
+
+# Look for the just built tensilelite
+export PATH=${TL}/%{_bindir}:$PATH
+export PYTHONPATH=${TL}%{python3_sitelib}:$PYTHONPATH
+export Tensile_DIR=${TL}%{python3_sitelib}/Tensile
+
+%install -a
+rm -f %{buildroot}%{_datadir}/doc/hipblaslt/LICENSE.md
+
+%files
+%doc README.md
+%license LICENSE.md
+%{_libdir}/libhipblaslt.so.*
+%{_libdir}/hipblaslt/
+
+%files devel
+%{_includedir}/hipblaslt/
+%{_includedir}/hipblaslt-export.h
+%{_includedir}/hipblaslt-version.h
+%{_libdir}/cmake/hipblaslt/
+%{_libdir}/libhipblaslt.so
+
+%if %{with build_test}
+%files test
+%{_bindir}/hipblaslt*
+%{_bindir}/sequence.yaml
+%endif
+
+%changelog
+%autochangelog

--- a/SPECS/hipcub/hipcub.spec
+++ b/SPECS/hipcub/hipcub.spec
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: CHEN Xuan <chenxuan@iscas.ac.cn>
+# SPDX-FileContributor: Yifan Xu <xuyifan@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%bcond test 0
+%if %{with test}
+%global build_test ON
+%else
+%global build_test OFF
+%endif
+
+%global toolchain clang
+
+%global rocm_release 7.1
+%global rocm_patch 1
+%global rocm_version %{rocm_release}.%{rocm_patch}
+
+Name:           hipcub
+Version:        %{rocm_version}
+Release:        %autorelease
+Summary:        ROCm port of CUDA CUB (header-only)
+License:        BSD-3-Clause AND MIT
+Url:            https://github.com/ROCm/rocm-libraries
+#!RemoteAsset:  sha256:6dadbb7689c7906493ec42f56792d9557f0293670a86059c9c188851f399647b
+Source:         %{url}/releases/download/rocm-%{version}/hipcub.tar.gz
+BuildSystem:    cmake
+
+BuildOption(conf):  -G Ninja
+BuildOption(conf):  -DGPU_TARGETS=%{rocm_gpu_list_default}
+BuildOption(conf):  -DBUILD_TEST=%{build_test}
+
+BuildRequires:  clang
+BuildRequires:  clang-tools-extra
+BuildRequires:  cmake
+BuildRequires:  cmake(amd_comgr)
+BuildRequires:  cmake(hip)
+BuildRequires:  cmake(hsa-runtime64)
+BuildRequires:  cmake(rocprim)
+BuildRequires:  compiler-rt
+BuildRequires:  lld
+BuildRequires:  llvm
+BuildRequires:  ninja
+BuildRequires:  rocm-cmake
+BuildRequires:  rocm-llvm-macros
+
+%description
+hipCUB is a thin header-only wrapper library on top of rocPRIM which enables
+developers to render portable HIP code. Existing CUDA CUB source code can
+be recompiled in HIP using hipCUB.
+
+%if %{with test}
+%package        test
+Summary:        Tests for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    test
+%{summary}
+%endif
+
+%prep -a
+# Fix cmake install lib directory
+sed -i -e 's/ROCM_INSTALL_LIBDIR lib/ROCM_INSTALL_LIBDIR %{_lib}/' \
+    cmake/ROCMExportTargetsHeaderOnly.cmake
+
+%install -a
+rm -f %{buildroot}/%{_datadir}/doc/hipcub/LICENSE.txt
+
+%files
+%doc README.md
+%license LICENSE.txt
+%{_includedir}/hipcub/
+%{_libdir}/cmake/hipcub/
+
+%if %{with test}
+%files test
+%{_bindir}/test_*
+%{_bindir}/hipcub/
+%endif
+
+%changelog
+%autochangelog

--- a/SPECS/hipfft/0001-hipfft-hipfftw-soversion.patch
+++ b/SPECS/hipfft/0001-hipfft-hipfftw-soversion.patch
@@ -1,0 +1,24 @@
+From cfa8e85698486f791008fcade4ec2dff8ddd99d9 Mon Sep 17 00:00:00 2001
+From: Tom Rix <Tom.Rix@amd.com>
+Date: Fri, 31 Oct 2025 09:10:07 -0700
+Subject: [PATCH] hipfft hipfftw soversion
+
+---
+ library/CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/library/CMakeLists.txt b/library/CMakeLists.txt
+index 8c97cc4eeb97..97cacb3451d3 100644
+--- a/library/CMakeLists.txt
++++ b/library/CMakeLists.txt
+@@ -164,6 +164,7 @@ endif()
+ # nvcc can not recognize shared library file name with suffix other than *.so when linking.
+ if (NOT BUILD_WITH_COMPILER STREQUAL "HIP-NVCC")
+   rocm_set_soversion(hipfft ${hipfft_SOVERSION})
++  rocm_set_soversion(hipfftw ${hipfft_SOVERSION})
+ endif()
+ 
+ # Generate export header
+-- 
+2.51.0
+

--- a/SPECS/hipfft/hipfft.spec
+++ b/SPECS/hipfft/hipfft.spec
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: CHEN Xuan <chenxuan@iscas.ac.cn>
+# SPDX-FileContributor: Yifan Xu <xuyifan@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%bcond test 1
+
+%global rocm_release 7.1
+%global rocm_patch 1
+%global rocm_version %{rocm_release}.%{rocm_patch}
+
+# rocm stack builds with clang
+%global toolchain clang
+
+Name:           hipfft
+Version:        %{rocm_version}
+Release:        %autorelease
+Summary:        ROCm FFT marshalling library
+Url:            https://github.com/ROCm/rocm-libraries
+VCS:            git:https://github.com/ROCm/hipFFT.git
+License:        MIT
+#!RemoteAsset:  sha256:f6f0352b5f9ffe53c88cea5fa40572eef0c0c1e2e50dce6f85d2c68e47afc63e
+Source:         %{url}/releases/download/rocm-%{version}/hipfft.tar.gz
+Patch1:         0001-hipfft-hipfftw-soversion.patch
+BuildSystem:    cmake
+
+BuildOption(conf):  -G Ninja
+BuildOption(conf):  -DGPU_TARGETS=%{rocm_gpu_list_default}
+BuildOption(conf):  -DBUILD_CLIENTS_TESTS=ON
+BuildOption(conf):  -DBUILD_CLIENTS_TESTS_OPENMP=OFF
+
+BuildRequires:  boost-devel
+BuildRequires:  clang
+BuildRequires:  clang-tools-extra
+BuildRequires:  cmake
+BuildRequires:  cmake(amd_comgr)
+BuildRequires:  cmake(GTest)
+BuildRequires:  cmake(hip)
+BuildRequires:  cmake(hiprand)
+BuildRequires:  cmake(hsa-runtime64)
+BuildRequires:  cmake(rocfft)
+BuildRequires:  cmake(rocrand)
+BuildRequires:  compiler-rt
+BuildRequires:  lld
+BuildRequires:  llvm
+BuildRequires:  ninja
+BuildRequires:  pkgconfig(fftw3)
+BuildRequires:  rocm-cmake
+BuildRequires:  rocm-device-libs
+BuildRequires:  rocm-llvm-macros
+
+%description
+hipFFT is a FFT marshalling library. Currently, hipFFT supports either
+rocFFT or cuFFT as backends. hipFFT exports an interface that does not
+require the client to change, regardless of the chosen backend.
+
+%package        devel
+Summary:        The hipFFT development package
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       cmake(rocfft)
+
+%description    devel
+The hipFFT development package.
+
+%package        test
+Summary:        Tests for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    test
+%{summary}
+
+%prep -a
+# CMake Error at clients/tests/CMakeLists.txt:87 (find_package):
+#   No "FindHIP.cmake" found in CMAKE_MODULE_PATH.
+# Remove MODULE
+sed -i -e 's@find_package( HIP MODULE REQUIRED )@find_package( HIP REQUIRED )@' \
+    clients/tests/CMakeLists.txt
+
+%install -a
+rm -f %{buildroot}/%{_datadir}/doc/hipfft/LICENSE.md
+
+%if %{with test}
+%check -p
+export LD_LIBRARY_PATH=$PWD/%{__cmake_builddir}/library:$LD_LIBRARY_PATH
+%endif
+
+%files
+%doc README.md
+%license LICENSE.md
+%{_libdir}/libhipfft.so.0{,.*}
+%{_libdir}/libhipfftw.so.0{,.*}
+
+%files devel
+%{_includedir}/hipfft/
+%{_libdir}/cmake/hipfft/
+%{_libdir}/libhipfft.so
+%{_libdir}/libhipfftw.so
+
+%files test
+%{_bindir}/hipfft-test
+
+%changelog
+%autochangelog

--- a/SPECS/hiprand/hiprand.spec
+++ b/SPECS/hiprand/hiprand.spec
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: CHEN Xuan <chenxuan@iscas.ac.cn>
+# SPDX-FileContributor: Yifan Xu <xuyifan@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+# HIP error 100: no ROCm-capable device is detected
+# hipRAND needs a GPU to run tests, but we could still
+# keep the test cases for packagers who have a GPU, so make it optional.
+%bcond run_test 0
+
+%global rocm_release 7.1
+%global rocm_patch 1
+%global rocm_version %{rocm_release}.%{rocm_patch}
+
+# rocm stack builds with clang
+%global toolchain clang
+
+Name:           hiprand
+Version:        %{rocm_version}
+Release:        %autorelease
+Summary:        HIP random number generator
+License:        MIT AND BSD-3-Clause
+Url:            https://github.com/ROCm/rocm-libraries
+#!RemoteAsset:  sha256:41e4053a3c16ea4bdc6e94fff428d8ffe7279e9cfa7ec142afc50169aae2c1f8
+Source:         %{url}/releases/download/rocm-%{version}/hiprand.tar.gz
+BuildSystem:    cmake
+
+BuildOption(conf):  -G Ninja
+BuildOption(conf):  -DCMAKE_VERBOSE_MAKEFILE=ON
+BuildOption(conf):  -DAMDGPU_TARGETS=%{rocm_gpu_list_default}
+BuildOption(conf):  -DBUILD_TEST=ON
+
+BuildRequires:  clang
+BuildRequires:  clang-tools-extra
+BuildRequires:  cmake
+BuildRequires:  cmake(amd_comgr)
+BuildRequires:  cmake(GTest)
+BuildRequires:  cmake(hip)
+BuildRequires:  cmake(hsa-runtime64)
+BuildRequires:  cmake(rocrand)
+BuildRequires:  compiler-rt
+BuildRequires:  lld
+BuildRequires:  llvm
+BuildRequires:  ninja
+BuildRequires:  rocm-cmake
+BuildRequires:  rocm-device-libs
+BuildRequires:  rocm-llvm-macros
+
+%description
+hipRAND is a RAND marshalling library, with multiple supported backends. It
+sits between the application and the backend RAND library, marshalling inputs
+into the backend and results back to the application. hipRAND exports an
+interface that does not require the client to change, regardless of the chosen
+backend. Currently, hipRAND supports either rocRAND or cuRAND.
+
+%package        devel
+Summary:        The hipRAND development package
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       cmake(rocrand)
+
+%description    devel
+The hipRAND development package.
+
+%package        test
+Summary:        Tests for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    test
+%{summary}
+
+%prep -a
+# Remove RPATH
+sed -i '/INSTALL_RPATH/d' CMakeLists.txt
+
+%install -a
+rm -f %{buildroot}%{_datadir}/doc/hiprand/LICENSE.md
+rm -f %{buildroot}%{_bindir}/hipRAND/CTestTestfile.cmake
+
+%check -p
+export LD_LIBRARY_PATH=$PWD/%{__cmake_builddir}/library:$LD_LIBRARY_PATH
+
+%if %{without run_test}
+%check
+%endif
+
+%files
+%doc README.md
+%license LICENSE.md
+%{_libdir}/libhiprand.so.1{,.*}
+
+%files devel
+%{_includedir}/hiprand/
+%{_libdir}/cmake/hiprand/
+%{_libdir}/libhiprand.so
+
+%files test
+%{_bindir}/test*
+
+%changelog
+%autochangelog

--- a/SPECS/hipsolver/0001-hipsolver-so-version-fortran-bindings.patch
+++ b/SPECS/hipsolver/0001-hipsolver-so-version-fortran-bindings.patch
@@ -1,0 +1,24 @@
+From 2d228ee883a538d67af24e944a2a24a95d779345 Mon Sep 17 00:00:00 2001
+From: Tom Rix <Tom.Rix@amd.com>
+Date: Sun, 21 Sep 2025 08:37:33 -0700
+Subject: [PATCH] hipsolver so version fortran bindings
+
+---
+ library/src/CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/library/src/CMakeLists.txt b/library/src/CMakeLists.txt
+index a4e8649cdcae..69437d603d7a 100644
+--- a/library/src/CMakeLists.txt
++++ b/library/src/CMakeLists.txt
+@@ -75,6 +75,7 @@ set(hipsolver_f90_source
+ if(BUILD_FORTRAN_BINDINGS)
+   # Create hipSOLVER Fortran module
+   add_library(hipsolver_fortran ${hipsolver_f90_source})
++  rocm_set_soversion(hipsolver_fortran ${hipsolver_SOVERSION})
+   rocm_install(TARGETS hipsolver_fortran)
+ endif()
+ 
+-- 
+2.51.0
+

--- a/SPECS/hipsolver/hipsolver.spec
+++ b/SPECS/hipsolver/hipsolver.spec
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: CHEN Xuan <chenxuan@iscas.ac.cn>
+# SPDX-FileContributor: Yifan Xu <xuyifan@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+# TODO: hipSOLVER need lapack to build test/benchmark/sample
+# But openblas on openRuyi does not provide this
+%bcond build_test 0
+%if %{with build_test}
+%global cmake_test ON
+%else
+%global cmake_test OFF
+%endif
+
+# hipSOLVER needs a GPU to run tests, but we could still
+# keep the test cases for packagers who have a GPU.
+%bcond run_test 0
+
+%global rocm_release 7.1
+%global rocm_patch 1
+%global rocm_version %{rocm_release}.%{rocm_patch}
+
+# rocm stack builds with clang
+%global toolchain clang
+
+# Fortran is only used in testing
+# clang and gfortran fedora toolchain args do not mix
+%global build_fflags %{nil}
+
+Name:           hipsolver
+Version:        %{rocm_version}
+Release:        %autorelease
+Summary:        ROCm SOLVER marshalling library (LAPACK)
+License:        MIT
+Url:            https://github.com/ROCm/hipSOLVER
+#!RemoteAsset:  sha256:bd664e3cd43bfcc7e94d5a387c27262c4b218d6d2e71e086992b174349dd1c10
+Source:         %{url}/archive/rocm-%{version}.tar.gz
+BuildSystem:    cmake
+
+BuildOption(conf):  -G Ninja
+BuildOption(conf):  -DBUILD_CLIENTS_TESTS=%{cmake_test}
+BuildOption(conf):  -DBUILD_CLIENTS_BENCHMARKS=%{cmake_test}
+
+BuildRequires:  clang
+BuildRequires:  clang-tools-extra
+BuildRequires:  cmake
+BuildRequires:  cmake(amd_comgr)
+BuildRequires:  cmake(hip)
+BuildRequires:  cmake(hsa-runtime64)
+BuildRequires:  cmake(rocblas)
+BuildRequires:  cmake(rocsolver)
+BuildRequires:  cmake(rocsparse)
+BuildRequires:  compiler-rt
+BuildRequires:  gcc-fortran
+BuildRequires:  lld
+BuildRequires:  llvm
+BuildRequires:  ninja
+BuildRequires:  rocm-cmake
+BuildRequires:  rocm-device-libs
+BuildRequires:  rocm-llvm-macros
+%if %{with build_test}
+BuildRequires:  cmake(GTest)
+BuildRequires:  cmake(hipsparse)
+BuildRequires:  pkgconfig(openblas)
+%endif
+
+%description
+hipSOLVER is a LAPACK marshalling library, with multiple supported backends.
+It sits between the application and a "worker" SOLVER library, marshalling
+inputs into the backend library and results back to the application. hipSOLVER
+exports an interface that does not require the client to change, regardless of
+the chosen backend.
+
+%package        devel
+Summary:        The hipSOLVER development package
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       cmake(rocblas)
+Requires:       cmake(rocsolver)
+Requires:       cmake(rocsparse)
+
+%description    devel
+The hipSOLVER development package.
+
+%if %{with build_test}
+%package        test
+Summary:        Tests for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    test
+%{summary}
+%endif
+
+%install -a
+rm -f %{buildroot}%{_datadir}/doc/hipsolver/LICENSE.md
+
+%check -p
+export LD_LIBRARY_PATH=$PWD/%{__cmake_builddir}/library:$LD_LIBRARY_PATH
+
+%if %{without test}
+%check
+%endif
+
+%files
+%doc README.md
+%license LICENSE.md
+%{_libdir}/libhipsolver.so.1{,.*}
+%{_libdir}/libhipsolver_fortran.so.1{,.*}
+
+%files devel
+%{_includedir}/hipsolver/
+%{_libdir}/libhipsolver.so
+%{_libdir}/libhipsolver_fortran.so
+%{_libdir}/cmake/hipsolver/
+
+%if %{with build_test}
+%files test
+%{_datadir}/hipsolver/
+%{_bindir}/hipsolver*
+%endif
+
+%changelog
+%autochangelog

--- a/SPECS/hipsparse/hipsparse.spec
+++ b/SPECS/hipsparse/hipsparse.spec
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: CHEN Xuan <chenxuan@iscas.ac.cn>
+# SPDX-FileContributor: Yifan Xu <xuyifan@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+# hipSPARSE need to download about 19 testing matrix
+# It is verbose to add them to SOURCE and %%prep section
+%bcond build_test 0
+%if %{with build_test}
+%global cmake_test ON
+%else
+%global cmake_test OFF
+%endif
+
+# hipSPARSE needs a GPU to run tests, but we could still
+# keep the test cases for packagers who have a GPU.
+%bcond run_test 0
+
+# This ROCm package is built with clang by default
+%global toolchain clang
+
+%global rocm_release 7.1
+%global rocm_patch 1
+%global rocm_version %{rocm_release}.%{rocm_patch}
+
+Name:           hipsparse
+Version:        %{rocm_version}
+Release:        %autorelease
+Summary:        ROCm SPARSE marshalling library
+License:        MIT
+Url:            https://github.com/ROCm/hipSPARSE
+#!RemoteAsset:  sha256:b001834d8e65c3878d1a69d08803d5b6ce4fe623e78099fe51cb146d0ffa10e7
+Source:         %{url}/archive/rocm-%{version}.tar.gz
+BuildSystem:    cmake
+
+BuildOption(conf):  -G Ninja
+BuildOption(conf):  -DCMAKE_VERBOSE_MAKEFILE=ON
+BuildOption(conf):  -DGPU_TARGETS=%{rocm_gpu_list_default}
+BuildOption(conf):  -DBUILD_CLIENTS_SAMPLES=OFF
+BuildOption(conf):  -DBUILD_CLIENTS_BENCHMARKS=ON
+BuildOption(conf):  -DBUILD_CLIENTS_TESTS=%{cmake_test}
+
+BuildRequires:  clang
+BuildRequires:  clang-tools-extra
+BuildRequires:  cmake
+BuildRequires:  cmake(amd_comgr)
+%if %{with build_test}
+BuildRequires:  cmake(GTest)
+%endif
+BuildRequires:  cmake(hip)
+BuildRequires:  cmake(hsa-runtime64)
+BuildRequires:  cmake(rocprim)
+BuildRequires:  cmake(rocsparse)
+BuildRequires:  compiler-rt
+BuildRequires:  gcc-fortran
+BuildRequires:  lld
+BuildRequires:  llvm
+BuildRequires:  ninja
+BuildRequires:  rocm-cmake
+BuildRequires:  rocm-device-libs
+BuildRequires:  rocm-llvm-macros
+
+%description
+hipSPARSE is a SPARSE marshalling library with multiple
+supported backends. It sits between your application and
+a 'worker' SPARSE library, where it marshals inputs to
+the backend library and marshals results to your
+application. hipSPARSE exports an interface that doesn't
+require the client to change, regardless of the chosen
+backend. Currently, hipSPARSE supports rocSPARSE and
+cuSPARSE backends.
+
+%package        benchmark
+Summary:        Benchmark for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    benchmark
+%{summary}
+
+%package        devel
+Summary:        Libraries and headers for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+%{summary}
+
+%if %{with build_test}
+%package        test
+Summary:        Tests for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    test
+%{summary}
+%endif
+
+%install -a
+rm -f %{buildroot}%{_datadir}/doc/hipsparse/LICENSE.md
+
+%check -p
+export LD_LIBRARY_PATH=$PWD/%{__cmake_builddir}/library:$LD_LIBRARY_PATH
+
+%if %{without run_test}
+%check
+%endif
+
+%files
+%doc README.md
+%license LICENSE.md
+%{_libdir}/libhipsparse.so.4{,.*}
+
+%files benchmark
+%{_bindir}/hipsparse-bench
+
+%files devel
+%{_includedir}/hipsparse/
+%{_libdir}/cmake/hipsparse/
+%{_libdir}/libhipsparse.so
+
+%if %{with build_test}
+%files test
+%{_bindir}/hipsparse*
+%{_datadir}/hipsparse/
+%endif
+
+%changelog
+%autochangelog

--- a/SPECS/hipsparselt/0001-hipblaslt-find-origami-package.patch
+++ b/SPECS/hipsparselt/0001-hipblaslt-find-origami-package.patch
@@ -1,0 +1,25 @@
+From 43c4a61c5d8836a16feb8e53c72f255790523ff3 Mon Sep 17 00:00:00 2001
+From: Tom Rix <Tom.Rix@amd.com>
+Date: Mon, 3 Nov 2025 06:11:40 -0800
+Subject: [PATCH] hipblaslt find origami package
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index dbccca92c84f..d02df50540c2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -218,7 +218,7 @@ if(HIPBLASLT_ENABLE_MSGPACK)
+     endif()
+ endif()
+ 
+-add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../../shared/origami" origami)
++find_package(origami CONFIG REQUIRED)
+ add_subdirectory(tensilelite)
+ 
+ if(HIPBLASLT_ENABLE_HOST)
+-- 
+2.52.0
+

--- a/SPECS/hipsparselt/0001-hipblaslt-tensilelite-remove-yappi-dependency.patch
+++ b/SPECS/hipsparselt/0001-hipblaslt-tensilelite-remove-yappi-dependency.patch
@@ -1,0 +1,57 @@
+From c20b846b6d594464eccf865045ef0ef10384f407 Mon Sep 17 00:00:00 2001
+From: Tom Rix <Tom.Rix@amd.com>
+Date: Thu, 25 Sep 2025 13:02:55 -0700
+Subject: [PATCH] hipblaslt tensilelite remove yappi dependency
+
+Signed-off-by: Tom Rix <Tom.Rix@amd.com>
+---
+ tensilelite/Tensile/TensileCreateLibrary/Run.py | 15 ---------------
+ tensilelite/requirements.txt                    |  2 +-
+ 2 files changed, 1 insertion(+), 16 deletions(-)
+
+diff --git a/tensilelite/Tensile/TensileCreateLibrary/Run.py b/tensilelite/Tensile/TensileCreateLibrary/Run.py
+index f0bbe8acd127..fc076e6935e8 100644
+--- a/tensilelite/Tensile/TensileCreateLibrary/Run.py
++++ b/tensilelite/Tensile/TensileCreateLibrary/Run.py
+@@ -231,12 +231,6 @@ def writeSolutionsAndKernels(
+     generateSourcesAndExit=False,
+     compress=True,
+ ):
+-    if globalParameters["PythonProfile"]:
+-        globalParameters["CpuThreads"] = 0
+-        printWarning("Python profiling is enabled. CpuThreads set to 0.")
+-        import yappi
+-        yappi.start()
+-
+     codeObjectFiles = []
+ 
+     outputPath = Path(outputPath)
+@@ -299,15 +293,6 @@ def writeSolutionsAndKernels(
+     writeHelpers(outputPath, kernelHelperObjs, KERNEL_HELPER_FILENAME_CPP, KERNEL_HELPER_FILENAME_H)
+     srcKernelFile = Path(outputPath) / "Kernels.cpp"
+ 
+-    if globalParameters["PythonProfile"]:
+-        yappi.stop()
+-        yappi.get_func_stats().save("yappi_results.profile", type="callgrind")
+-        with open("yappi_results.txt", "w") as f:
+-            yappi.get_func_stats().print_all(out=f)
+-        if globalParameters["CpuThreads"] != 0:
+-            with open("yappi_thread_stats.txt", "w") as f:
+-                yappi.get_thread_stats().print_all(out=f)
+-
+     if not generateSourcesAndExit:
+         codeObjectFiles += buildAssemblyCodeObjectFiles(
+             asmToolchain.linker,
+diff --git a/tensilelite/requirements.txt b/tensilelite/requirements.txt
+index 60c4c1144537..e87db8445411 100644
+--- a/tensilelite/requirements.txt
++++ b/tensilelite/requirements.txt
+@@ -7,4 +7,4 @@ joblib>=1.1.1; python_version < '3.8'
+ simplejson
+ ujson
+ orjson
+-yappi
++
+-- 
+2.51.0
+

--- a/SPECS/hipsparselt/0001-hipblaslt-tensilelite-use-clang.patch
+++ b/SPECS/hipsparselt/0001-hipblaslt-tensilelite-use-clang.patch
@@ -1,0 +1,16 @@
+--- ./hipBLASLt/tensilelite/Tensile/Toolchain/Validators.py	2025-11-14 05:43:51
++++ ./hipBLASLt/tensilelite/Tensile/Toolchain/Validators.py.mod	2026-03-04 16:10:09
+@@ -114,11 +114,11 @@
+
+
+ class ToolchainDefaults(NamedTuple):
+-    CXX_COMPILER = osSelect(linux="amdclang++", windows="clang++.exe")
+-    C_COMPILER = osSelect(linux="amdclang", windows="clang.exe")
++    CXX_COMPILER = osSelect(linux="clang++", windows="clang++.exe")
++    C_COMPILER = osSelect(linux="clang", windows="clang.exe")
+     OFFLOAD_BUNDLER = osSelect(linux="clang-offload-bundler", windows="clang-offload-bundler.exe")
+     DEVICE_ENUMERATOR = osSelect(linux="rocm_agent_enumerator" if isRhel8() else "amdgpu-arch", windows="hipinfo")
+-    ASSEMBLER = osSelect(linux="amdclang++", windows="clang++.exe")
++    ASSEMBLER = osSelect(linux="clang++", windows="clang++.exe")
+     HIP_CONFIG = osSelect(linux="hipconfig", windows="hipconfig.exe")
+

--- a/SPECS/hipsparselt/0001-hipblaslt-tensilelite-use-system-paths.patch
+++ b/SPECS/hipsparselt/0001-hipblaslt-tensilelite-use-system-paths.patch
@@ -1,0 +1,41 @@
+From 1ac117ac0591a0f1bb67c34f537354c21412b2d8 Mon Sep 17 00:00:00 2001
+From: Tom Rix <Tom.Rix@amd.com>
+Date: Sat, 1 Nov 2025 09:43:58 -0700
+Subject: [PATCH] hipblaslt tensilelite use fedora paths
+
+---
+ tensilelite/Tensile/Common/GlobalParameters.py | 2 +-
+ tensilelite/Tensile/Toolchain/Validators.py    | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/tensilelite/Tensile/Common/GlobalParameters.py b/tensilelite/Tensile/Common/GlobalParameters.py
+index 567188da59bd..1f8037c183a6 100644
+--- a/tensilelite/Tensile/Common/GlobalParameters.py
++++ b/tensilelite/Tensile/Common/GlobalParameters.py
+@@ -538,7 +538,7 @@ def assignGlobalParameters(config, isaInfoMap: Dict[IsaVersion, IsaInfo]):
+         else:
+             print2(" %24s: %8s (unspecified)" % (key, defaultValue))
+ 
+-    globalParameters["ROCmPath"] = "/opt/rocm"
++    globalParameters["ROCmPath"] = "/usr"
+     if "ROCM_PATH" in os.environ:
+         globalParameters["ROCmPath"] = os.environ.get("ROCM_PATH")
+     if "TENSILE_ROCM_PATH" in os.environ:
+diff --git a/tensilelite/Tensile/Toolchain/Validators.py b/tensilelite/Tensile/Toolchain/Validators.py
+index fd5dab5324c0..3ce024d31f52 100644
+--- a/tensilelite/Tensile/Toolchain/Validators.py
++++ b/tensilelite/Tensile/Toolchain/Validators.py
+@@ -30,8 +30,8 @@ from typing import List, NamedTuple, Union
+ 
+ from Tensile.Common.Utilities import isRhel8
+ 
+-DEFAULT_ROCM_BIN_PATH_POSIX = Path("/opt/rocm/bin")
+-DEFAULT_ROCM_LLVM_BIN_PATH_POSIX = Path("/opt/rocm/lib/llvm/bin")
++DEFAULT_ROCM_BIN_PATH_POSIX = Path("/usr/bin")
++DEFAULT_ROCM_LLVM_BIN_PATH_POSIX = Path("/usr/lib64/rocm/llvm/bin")
+ DEFAULT_ROCM_BIN_PATH_WINDOWS = Path("C:/Program Files/AMD/ROCm")
+ 
+ 
+-- 
+2.52.0
+

--- a/SPECS/hipsparselt/hipsparselt.spec
+++ b/SPECS/hipsparselt/hipsparselt.spec
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: CHEN Xuan <chenxuan@iscas.ac.cn>
+# SPDX-FileContributor: Yifan Xu <xuyifan@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global rocm_release 7.1
+%global rocm_patch 1
+%global rocm_version %{rocm_release}.%{rocm_patch}
+
+%global toolchain clang
+
+%global tensile_version 4.33.0
+%global tensile_verbose 1
+
+%bcond build_test 0
+%if %{with build_test}
+%global cmake_test ON
+%else
+%global cmake_test OFF
+%endif
+
+Name:           hipsparselt
+Version:        %{rocm_version}
+Release:        %autorelease
+Summary:        A SPARSE marshaling library
+License:        MIT
+URL:            https://github.com/ROCm/rocm-libraries
+#!RemoteAsset:  sha256:7672d1ac94d2694999b6937d19f5e92e67fb844eea394b4e8525c531fd1acd8c
+Source0:        %{url}/releases/download/rocm-%{version}/%{name}.tar.gz
+#!RemoteAsset:  sha256:05d73038b1b4f66f3df4eb595b7cb0c8935f7aa18d0e07dbe5cc740a4b691898
+Source1:        %{url}/releases/download/rocm-%{version}/hipblaslt.tar.gz
+# Patches for hipBLASLt's tensilelite (applied during prep inside hipBLASLt/)
+Source2:        0001-hipblaslt-tensilelite-remove-yappi-dependency.patch
+Source3:        0001-hipblaslt-tensilelite-use-system-paths.patch
+Source4:        0001-hipblaslt-find-origami-package.patch
+BuildSystem:    cmake
+
+BuildOption(conf):  -DBLAS_INCLUDE_DIR=%{_includedir}/flexiblas
+BuildOption(conf):  -DBUILD_CLIENTS_TESTS=%{cmake_test}
+BuildOption(conf):  -DBUILD_FILE_REORG_BACKWARD_COMPATIBILITY=OFF
+BuildOption(conf):  -DBUILD_VERBOSE=ON
+BuildOption(conf):  -DCMAKE_Fortran_COMPILER=gcc-fortran
+BuildOption(conf):  -DCMAKE_VERBOSE_MAKEFILE=ON
+BuildOption(conf):  -DGPU_TARGETS=%{rocm_gpu_list_default}
+BuildOption(conf):  -DTensile_COMPILER=clang++
+BuildOption(conf):  -DTensile_LIBRARY_FORMAT=msgpack
+BuildOption(conf):  -DTensile_VERBOSE=%{tensile_verbose}
+BuildOption(conf):  -DVIRTUALENV_BIN_DIR=%{_bindir}
+BuildOption(conf):  -Dnanobind_ROOT=%(python3 -m nanobind --cmake_dir)
+BuildOption(conf):  -G Ninja
+
+BuildRequires:  clang
+BuildRequires:  clang-tools-extra
+BuildRequires:  cmake
+BuildRequires:  cmake(amd_comgr)
+BuildRequires:  cmake(hip)
+BuildRequires:  cmake(hipsparse)
+BuildRequires:  cmake(hsa-runtime64)
+BuildRequires:  cmake(origami)
+BuildRequires:  cmake(rocm_smi)
+BuildRequires:  cmake(rocsparse)
+BuildRequires:  compiler-rt
+BuildRequires:  gcc-fortran
+BuildRequires:  lld
+BuildRequires:  llvm
+BuildRequires:  ninja
+BuildRequires:  pkgconfig(libzstd)
+BuildRequires:  pkgconfig(msgpack)
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pkgconfig(zlib)
+BuildRequires:  python3dist(joblib)
+BuildRequires:  python3dist(msgpack)
+# nanobind is used to build the rocisa native module (build-time only)
+BuildRequires:  python3dist(nanobind)
+BuildRequires:  python3dist(pyyaml)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  rocm-cmake
+BuildRequires:  rocm-device-libs
+BuildRequires:  rocminfo
+BuildRequires:  rocm-llvm-macros
+BuildRequires:  roctracer-devel
+
+%if %{with build_test}
+BuildRequires:  chrpath
+BuildRequires:  pkgconfig(openblas)
+BuildRequires:  pkgconfig(gtest)
+BuildRequires:  pkgconfig(gmock)
+%endif
+
+%description
+hipSPARSELt is a SPARSE marshaling library that provides general sparse
+matrix-matrix multiplication using structured sparsity. It offers a flexible
+API and supports multiple backends.
+
+%package        devel
+Summary:        The hipSPARSELt development package
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+The hipSPARSELt development package.
+
+%if %{with build_test}
+%package        test
+Summary:        Tests for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    test
+%{summary}
+%endif
+
+%prep
+%autosetup -p1 -n %{name}
+
+tar xf %{SOURCE1}
+cd hipblaslt
+
+patch -p1 < %{SOURCE2}
+patch -p1 < %{SOURCE3}
+patch -p1 < %{SOURCE4}
+
+# Use PATH to find where TensileGetPath and other tensile bins are
+sed -i -e 's@${Tensile_PREFIX}/bin/TensileGetPath@TensileGetPath@g' \
+    tensilelite/Tensile/cmake/TensileConfig.cmake
+
+# Make sure hip/hip_runtime.h is found
+sed -i -e 's@-x hip @-I%{_includedir} -x hip @' device-library/matrix-transform/CMakeLists.txt
+sed -i -e 's@"-D__HIP_HCC_COMPAT_MODE__=1"@"-D__HIP_HCC_COMPAT_MODE__=1","-I%{_includedir}"@' \
+    tensilelite/Tensile/Toolchain/Component.py
+
+# Use the distribution-provided nanobind instead of fetching/bundling it
+sed -i -e 's@FetchContent_MakeAvailable(nanobind)@find_package(nanobind CONFIG REQUIRED)@' \
+    tensilelite/rocisa/CMakeLists.txt
+
+# disable openmp in hipBLASLt
+sed -i -e 's@option(HIPBLASLT_ENABLE_OPENMP "Use OpenMP to improve performance." ON)@option(HIPBLASLT_ENABLE_OPENMP "Use OpenMP to improve performance." OFF)@' CMakeLists.txt
+
+cd ..
+
+# Point hipBLASLt path at the bundled in-source copy (default looks in ../hipblaslt)
+sed -i -e 's@${CMAKE_CURRENT_SOURCE_DIR}/../hipblaslt@${CMAKE_CURRENT_SOURCE_DIR}/hipblaslt@' CMakeLists.txt
+
+# Prevent the virtualenv install from cmake
+sed -i -e 's@virtualenv_install@#virtualenv_install@' CMakeLists.txt
+
+# Unforce the setting of libdir
+sed -i -e 's@set(CMAKE_INSTALL_LIBDIR@#set(CMAKE_INSTALL_LIBDIR@' CMakeLists.txt
+
+# Change looking for cblas to flexiblas
+sed -i -e 's@find_package( cblas REQUIRED CONFIG )@#find_package( cblas REQUIRED CONFIG )@' clients/CMakeLists.txt
+sed -i -e 's@set( BLAS_LIBRARY "blas" )@set( BLAS_LIBRARY "flexiblas" )@' clients/CMakeLists.txt
+sed -i -e 's@lapack cblas@flexiblas@' clients/gtest/CMakeLists.txt
+
+# We are building from a tarball, not a git repo
+sed -i -e 's@find_package(Git REQUIRED)@#find_package(Git REQUIRED)@' hipblaslt/cmake/dependencies.cmake
+sed -i -e 's@find_package(Git REQUIRED)@#find_package(Git REQUIRED)@' cmake/Dependencies.cmake
+
+# Replace all mentions of 'amdclang' with 'clang' in Tensile Python files
+find hipblaslt/tensilelite -type f -name "*.py" -exec sed -i 's/amdclang++/clang++/g; s/amdclang/clang/g' {} +
+
+%build -p
+# Do a manual install of tensilelite instead of cmake's virtualenv, then point
+# Tensile at it for build-time kernel generation (same approach as hipblaslt)
+cd hipblaslt/tensilelite
+TL=$PWD
+python3 setup.py install --root $TL
+cd ../..
+
+export PATH=%{_prefix}/bin:%{rocmllvm_bindir}:$PATH
+CLANG_PATH=`hipconfig --hipclangpath`
+ROCM_CLANG=${CLANG_PATH}/clang
+RESOURCE_DIR=`${ROCM_CLANG} -print-resource-dir`
+export DEVICE_LIB_PATH=${RESOURCE_DIR}/amdgcn/bitcode
+export TENSILE_ROCM_ASSEMBLER_PATH=${CLANG_PATH}/clang++
+export TENSILE_ROCM_OFFLOAD_BUNDLER_PATH=${CLANG_PATH}/clang-offload-bundler
+export PATH=${TL}/%{_bindir}:$PATH
+export PYTHONPATH=${TL}%{python3_sitelib}:$PYTHONPATH
+export Tensile_DIR=${TL}%{python3_sitelib}/Tensile
+
+%install -a
+rm -f %{buildroot}%{_datadir}/doc/hipsparselt/LICENSE.md
+
+# Strip and fix permissions on hsaco kernel files
+%{rocmllvm_bindir}/llvm-strip %{buildroot}%{_libdir}/hipsparselt/library/Kernels*.hsaco
+chmod a+x %{buildroot}%{_libdir}/hipsparselt/library/Kernels*.hsaco
+
+%files
+%doc README.md
+%license LICENSE.md
+%{_libdir}/libhipsparselt.so.*
+%{_libdir}/hipsparselt/
+
+%files devel
+%{_includedir}/hipsparselt/
+%{_libdir}/cmake/hipsparselt/
+%{_libdir}/libhipsparselt.so
+
+%if %{with build_test}
+%files test
+%{_bindir}/hipsparselt*
+%endif
+
+%changelog
+%autochangelog

--- a/SPECS/magma/magma.spec
+++ b/SPECS/magma/magma.spec
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: CHEN Xuan <chenxuan@iscas.ac.cn>
+# SPDX-FileContributor: Yifan Xu <xuyifan@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+# rocm toolchain uses the hipcc wrapper of clang
+%global toolchain clang
+
+%bcond test 0
+
+Name:           magma
+Version:        2.10.0
+Release:        %autorelease
+Summary:        Matrix Algebra on GPU and Multi-core Architectures
+License:        BSD-3-Clause
+Url:            https://icl.utk.edu/magma/
+VCS:            git:https://github.com/icl-utk-edu/magma.git
+#!RemoteAsset:  sha256:26347adbccbe7a6693d6b3f3c0ab5620037eb3a62b5ef69d05e40289472a82a4
+Source0:        https://github.com/icl-utk-edu/%{name}/archive/v%{version}.tar.gz
+
+BuildOption(conf):  -G Ninja
+BuildOption(conf):  -DBLA_VENDOR=OpenBLAS
+BuildOption(conf):  -DAMDGPU_TARGETS=%{rocm_gpu_list_default}
+BuildOption(conf):  -DMAGMA_ENABLE_HIP=ON
+BuildOption(conf):  -DUSE_FORTRAN=OFF
+
+BuildRequires:  clang
+BuildRequires:  clang-tools-extra
+BuildRequires:  cmake
+BuildRequires:  cmake(amd_comgr)
+BuildRequires:  cmake(hip)
+BuildRequires:  cmake(hipblas)
+BuildRequires:  cmake(hipsparse)
+BuildRequires:  cmake(hsa-runtime64)
+BuildRequires:  cmake(openblas)
+BuildRequires:  compiler-rt
+BuildRequires:  gcc-c++
+BuildRequires:  hipcc
+BuildRequires:  lld
+BuildRequires:  llvm
+BuildRequires:  ninja
+BuildRequires:  python3
+BuildRequires:  rocm-cmake
+BuildRequires:  rocm-device-libs
+BuildRequires:  rocm-llvm-macros
+
+%description
+Matrix Algebra on GPU and Multi-core Architectures (MAGMA) is a collection
+of next-generation linear algebra libraries for heterogeneous computing.
+The MAGMA package supports interfaces for current linear algebra packages
+and standards (e.g., LAPACK and BLAS) to enable computational scientists
+to easily port any linear algebra–reliant software component to
+heterogeneous computing systems. MAGMA enables applications to fully
+exploit the power of current hybrid systems of many-core CPUs and
+multi-GPUs/coprocessors to deliver the fastest possible time to accurate
+solutions within given energy constraints.
+
+MAGMA features LAPACK-compliant routines for multi-core CPUs enhanced with
+NVIDIA or AMD GPUs. MAGMA 2.7.2 now includes more than 400 routines that
+cover one-sided dense matrix factorizations and solvers, two-sided
+factorizations, and eigen/singular-value problem solvers, as well as a
+subset of highly optimized BLAS for GPUs. A MagmaDNN package has been
+added and further enhanced to provide high-performance data analytics,
+including functionalities for machine learning applications that use MAGMA
+as their computational back end. The MAGMA Sparse and MAGMA Batched
+packages have been included since MAGMA 1.6.
+
+%package        devel
+Summary:        Libraries and headers for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+%{summary}
+
+%prep -a
+# Add newer gfx targets to Makefile's valid arch whitelist
+# https://bitbucket.org/icl/magma/issues/76/a-few-new-rocm-gpus
+sed -i -e 's@1032 1033@1032 1033 1100 1101 1102 1103 1150 1151 1152 1153 1200 1201@' Makefile
+
+%if %{with test}
+# Remove a test that fails to link (undefined magma_generate_matrix)
+sed -i -e '/testing_zgenerate.cpp/d' testing/Makefile.src
+%else
+# Disable building tests
+sed -i -e 's@include_directories( testing )@#include_directories( testing )@' CMakeLists.txt
+sed -i -e 's@foreach( filename ${testing_all} )@foreach( filename ${no_testing_all} )@' CMakeLists.txt
+sed -i -e 's@add_custom_target( testing DEPENDS ${testing} )@#add_custom_target( testing DEPENDS ${testing} )@' CMakeLists.txt
+sed -i -e 's@foreach( TEST ${sparse_testing_all} )@foreach( TEST ${no_sparse_testing_all} )@' CMakeLists.txt
+sed -i -e 's@add_custom_target( sparse-testing DEPENDS ${sparse-testing} )@#add_custom_target( sparse-testing DEPENDS ${sparse-testing} )@' CMakeLists.txt
+%endif
+
+# Change the bin,lib install locations
+sed -i -e 's@DESTINATION lib@DESTINATION ${CMAKE_INSTALL_LIBDIR}@' CMakeLists.txt
+sed -i -e 's@DESTINATION bin@DESTINATION ${CMAKE_INSTALL_BINDIR}@' CMakeLists.txt
+
+# python to python3, need env to find local bits like magmasubs.py
+sed -i -e 's@env python@env python3@' tools/checklist_run_tests.py
+sed -i -e 's@env python@env python3@' tools/check-style.py
+sed -i -e 's@env python@env python3@' tools/parse-magma.py
+
+# Remove some files we do not need to similify licenses
+# GPL, results for cuda
+rm -rf results/*
+# ICS, Copy of strlcpy - just use strlcpy
+sed -i -e '/strlcpy/d' control/Makefile.src
+sed -i -e '/strlcpy/d' include/magma_auxiliary.h
+sed -i -e 's@magma_strlcpy@strlcpy@' control/trace.cpp
+rm control/strlcpy.cpp
+
+%build -p
+echo "BACKEND = hip"                          > make.inc
+echo "FORT = false"                          >> make.inc
+echo "GPU_TARGET = gfx1100;gfx1200;gfx1201"  >> make.inc
+
+make generate
+%if %{with test}
+%check
+%{_vpath_builddir}/testing/testing_sgemm
+%endif
+
+%files
+%license COPYRIGHT
+%{_libdir}/libmagma.so{,.*}
+%{_libdir}/libmagma_sparse.so{,.*}
+
+%files devel
+%{_includedir}/*.h
+%{_libdir}/pkgconfig/%{name}.pc
+%{_libdir}/libmagma.so
+%{_libdir}/libmagma_sparse.so
+
+%changelog
+%autochangelog

--- a/SPECS/miopen/miopen.spec
+++ b/SPECS/miopen/miopen.spec
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: CHEN Xuan <chenxuan@iscas.ac.cn>
+# SPDX-FileContributor: Yifan Xu <xuyifan@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+# Tests require an AMD GPU; keep the bcond for packagers with hardware.
+%bcond test 0
+
+%global rocm_release 7.1
+%global rocm_patch   1
+%global rocm_version %{rocm_release}.%{rocm_patch}
+
+# rocm stack builds with clang
+%global toolchain clang
+
+Name:           miopen
+Version:        %{rocm_version}
+Release:        %autorelease
+Summary:        AMD's Machine Intelligence Library
+License:        MIT AND BSD-2-Clause AND Apache-2.0
+Url:            https://github.com/ROCm/MIOpen
+#!RemoteAsset:  sha256:98c72a2b5ca541d6c172facdf0f15729207ab52ca9af36c00e2480c5b27c5b99
+Source:         %{url}/archive/rocm-%{version}.tar.gz
+BuildSystem:    cmake
+
+# Adds MIOPEN_PARALLEL_{COMPILE,LINK}_JOBS options to limit Ninja job pools
+# and avoid OOM on memory-constrained build hosts (upstream patch)
+Patch0:         0001-miopen-add-link-and-compile-pools.patch
+
+BuildOption(conf):  -G Ninja
+BuildOption(conf):  -DGPU_TARGETS=%{rocm_gpu_list_default}
+BuildOption(conf):  -DBoost_USE_STATIC_LIBS=OFF
+BuildOption(conf):  -DMIOPEN_BUILD_DRIVER=OFF
+BuildOption(conf):  -DMIOPEN_ENABLE_AI_IMMED_MODE_FALLBACK=OFF
+BuildOption(conf):  -DMIOPEN_ENABLE_AI_KERNEL_TUNING=OFF
+%if %{with test}
+BuildOption(conf):  -DBUILD_TESTING=ON
+BuildOption(conf):  -DMIOPEN_TEST_ALL=ON
+%else
+BuildOption(conf):  -DBUILD_TESTING=OFF
+%endif
+# Disable optional backends not yet packaged on openRuyi
+BuildOption(conf):  -DMIOPEN_USE_COMPOSABLEKERNEL=OFF
+BuildOption(conf):  -DMIOPEN_USE_MLIR=OFF
+
+BuildRequires:  boost-devel
+BuildRequires:  cmake
+BuildRequires:  cmake(amd_comgr)
+BuildRequires:  cmake(hip)
+BuildRequires:  cmake(hipblaslt)
+BuildRequires:  cmake(hsa-runtime64)
+BuildRequires:  cmake(rocblas)
+BuildRequires:  cmake(rocrand)
+%if %{with test}
+BuildRequires:  cmake(GTest)
+%endif
+BuildRequires:  clang
+BuildRequires:  clang-tools-extra
+BuildRequires:  compiler-rt
+BuildRequires:  half
+BuildRequires:  hipcc
+BuildRequires:  hipblas-common-devel
+BuildRequires:  lld
+BuildRequires:  llvm
+BuildRequires:  ninja
+BuildRequires:  pkgconfig(bzip2)
+BuildRequires:  pkgconfig(libzstd)
+BuildRequires:  pkgconfig(nlohmann_json)
+BuildRequires:  pkgconfig(sqlite3)
+BuildRequires:  rocm-cmake
+BuildRequires:  rocm-device-libs
+BuildRequires:  rocm-llvm-macros
+# roctracer uses find_path/find_library rather than find_package; no cmake()/pkgconfig() provided
+# FIXME
+BuildRequires:  roctracer-devel
+
+Requires:       cmake(hip)
+Requires:       cmake(rocrand)
+Requires:       gcc-c++
+
+%description
+AMD's library for high performance machine learning primitives.
+MIOpen supports convolution, batch normalization, activation, pooling,
+RNN/LSTM/GRU, and attention/transformer operations for the HIP backend.
+
+%package        devel
+Summary:        Libraries and headers for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+%{summary}
+
+%if %{with test}
+%package        test
+Summary:        Tests for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    test
+%{summary}
+%endif
+
+%prep -a
+# clang-tidy is brittle and not needed when rebuilding from a tarball
+sed -i -e 's@clang-tidy@true@' cmake/ClangTidy.cmake
+
+# half_float::detail::expr is not present in all half versions
+sed -i -e 's@std::is_same_v<T, half_float::detail::expr>@0@' test/verify.hpp
+
+# MIOpen tries to download googletest; disable when not needed
+%if %{without test}
+sed -i -e 's@add_subdirectory(test)@#add_subdirectory(test)@' CMakeLists.txt
+sed -i -e 's@add_subdirectory(speedtests)@#add_subdirectory(speedtests)@' CMakeLists.txt
+%endif
+
+# Use the standard data directory for the MIOpen kernel database
+sed -i -e 's@GetLibPath().parent_path() / "share/miopen/db"@"%{_datadir}/miopen/db"@' src/db_path.cpp.in
+
+# -fno-offload-uniform-block is unsupported on this ROCm version
+sed -i -e 's@opts.push_back("-fno-offload-uniform-block");@//opts.push_back("-fno-offload-uniform-block");@' src/comgr.cpp
+
+# Fix the path used to locate the ROCm clang binary at build time
+sed -i -e 's@llvm/bin/clang@bin/clang@' src/hip/hip_build_utils.cpp
+
+%install -a
+rm -f %{buildroot}%{_datadir}/doc/miopen-hip/LICENSE.md
+
+%files
+%doc README.md
+%license LICENSE.md
+%{_libdir}/libMIOpen.so.1{,.*}
+%{_libexecdir}/miopen/
+
+%files devel
+%{_datadir}/miopen/
+%{_includedir}/miopen/
+%{_libdir}/cmake/miopen/
+%{_libdir}/libMIOpen.so
+
+%if %{with test}
+%files test
+%{_bindir}/test*
+%endif
+
+%changelog
+%autochangelog

--- a/SPECS/rccl/rccl.spec
+++ b/SPECS/rccl/rccl.spec
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: CHEN Xuan <chenxuan@iscas.ac.cn>
+# SPDX-FileContributor: Yifan Xu <xuyifan@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global rocm_release 7.1
+%global rocm_patch 1
+%global rocm_version %{rocm_release}.%{rocm_patch}
+
+# rocm stack builds with clang
+%global toolchain clang
+
+Name:           rccl
+Version:        %{rocm_version}
+Release:        %autorelease
+Summary:        ROCm Communication Collectives Library
+License:        BSD-3-Clause AND MIT AND Apache-2.0
+# From License.txt the main license is BSD 3
+# Modifications from Microsoft is MIT
+# The NVIDIA based header files below are Apache-2.0
+#  src/include/nvtx3/nv*.h and similar
+# The URL for NVIDIA in the License.txt https://github.com/NVIDIA/NVTX is Apache-2.0
+Url:            https://github.com/ROCm/rccl
+#!RemoteAsset:  sha256:eaa60bcf62feb3198553f2bcf6dcbfdfcecd0fdfabda41f1dae7d3f15fadbd68
+Source0:        %{url}/archive/rocm-%{rocm_version}.tar.gz
+BuildSystem:    cmake
+
+BuildOption(conf):  -G Ninja
+BuildOption(conf):  -DGPU_TARGETS=%{rocm_gpu_list_default}
+BuildOption(conf):  -DEXPLICIT_ROCM_VERSION=%{rocm_version}
+BuildOption(conf):  -DROCM_PATH=%{_prefix}
+BuildOption(conf):  -DCMAKE_VERBOSE_MAKEFILE=ON
+BuildOption(conf):  -DBUILD_TESTS=ON
+
+BuildRequires:  clang
+BuildRequires:  clang-tools-extra
+BuildRequires:  cmake
+BuildRequires:  cmake(amd_comgr)
+BuildRequires:  cmake(fmt)
+BuildRequires:  cmake(GTest)
+BuildRequires:  cmake(hip)
+BuildRequires:  cmake(hsa-runtime64)
+BuildRequires:  cmake(rocm_smi)
+BuildRequires:  cmake(rocm-core)
+BuildRequires:  cmake(rocprofiler-register)
+BuildRequires:  compiler-rt
+BuildRequires:  hipify
+BuildRequires:  lld
+BuildRequires:  llvm
+BuildRequires:  ninja
+BuildRequires:  python3
+BuildRequires:  rocm-cmake
+BuildRequires:  rocm-llvm-macros
+
+Requires:       %{name}-data = %{version}-%{release}
+
+%description
+RCCL (pronounced "Rickle") is a stand-alone library of standard
+collective communication routines for GPUs, implementing all-reduce,
+all-gather, reduce, broadcast, reduce-scatter, gather, scatter, and
+all-to-all. There is also initial support for direct GPU-to-GPU
+send and receive operations. It has been optimized to achieve high
+bandwidth on platforms using PCIe, xGMI as well as networking using
+InfiniBand Verbs or TCP/IP sockets. RCCL supports an arbitrary
+number of GPUs installed in a single node or multiple nodes, and
+can be used in either single- or multi-process (e.g., MPI)
+applications.
+
+The collective operations are implemented using ring and tree
+algorithms and have been optimized for throughput and latency. For
+best performance, small operations can be either batched into
+larger operations or aggregated through the API.
+
+%package        devel
+Summary:        Headers and libraries for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+Provides:       rccl-devel = %{version}-%{release}
+
+%description    devel
+Headers and libraries for %{name}
+
+%package        data
+Summary:        Data for %{name}
+BuildArch:      noarch
+
+%description    data
+Data for %{name}
+
+%package        test
+Summary:        Tests for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    test
+%{summary}
+
+%prep -a
+# Do not force install
+sed -i -e 's@set(CMAKE_INSTALL_LIBDIR@#set(CMAKE_INSTALL_LIBDIR@' cmake/Dependencies.cmake
+
+# Compilation error: Branch Size exceed simm16
+# This is a bug introduced in llvm-21 and fixed at 2026-02
+# https://github.com/llvm/llvm-project/pull/180386
+# The workaround is to set
+# -amdgpu-s-branch-bits and -amdgpu-long-branch-factor=2
+#
+# Set --lto-partitions to accelerate linking time
+sed -i -e 's@target_link_options(rccl PRIVATE "SHELL:-Xoffload-linker -mllvm=-amdgpu-kernarg-preload-count=16")@target_link_options(rccl PRIVATE "SHELL:-Xoffload-linker -mllvm=-amdgpu-s-branch-bits=15" "SHELL:-Xoffload-linker -mllvm=-amdgpu-long-branch-factor=2" "SHELL:-Xoffload-linker -mllvm=-amdgpu-kernarg-preload-count=16" "SHELL:-Xoffload-linker --lto-partitions=%(nproc)" "SHELL:-Xoffload-linker --verbose")@' CMakeLists.txt
+
+%build
+# AMDGPU device linker runs as a process that produces no stdout for about 8~12 hours on riscv64
+timeout 12h bash -c 'while sleep 300; do echo "[heartbeat] $(date)"; done' & TIME_OUT=$!
+%cmake_build
+kill $TIME_OUT 2>/dev/null || true
+
+%install -a
+rm -f %{buildroot}%{_datadir}/doc/rccl/LICENSE.txt
+
+%files
+%license LICENSE.txt
+%{_libdir}/librccl.so.*
+%{_bindir}/rcclras
+
+%files data
+%{_datadir}/rccl/msccl-algorithms/
+%{_datadir}/rccl/msccl-unit-test-algorithms/
+
+%files devel
+%doc README.md
+%{_includedir}/rccl/
+%{_libdir}/cmake/rccl/
+%{_libdir}/librccl.so
+
+%files test
+%{_bindir}/rccl-UnitTests
+
+%changelog
+%autochangelog

--- a/SPECS/rocfft/0001-cmake-use-gnu-installdirs.patch
+++ b/SPECS/rocfft/0001-cmake-use-gnu-installdirs.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 14bb20b..a5b1ee4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -49,6 +49,8 @@ set( ROCFFT_BUILD_SCOPE ON )
+ 
+ project( rocfft LANGUAGES CXX C )
+ 
++include(GNUInstallDirs)
++
+ # This finds the rocm-cmake project, and installs it if not found
+ # rocm-cmake contains common cmake code for rocm projects to help setup and install
+ set( PROJECT_EXTERN_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern )

--- a/SPECS/rocfft/rocfft.spec
+++ b/SPECS/rocfft/rocfft.spec
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: CHEN Xuan <chenxuan@iscas.ac.cn>
+# SPDX-FileContributor: Yifan Xu <xuyifan@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+# Without a GPU, the test cases will fail with `what():  hipGetDeviceCount failed`
+# rocFFT needs a GPU to run tests, but we could still
+# keep the test cases for packagers who have a GPU, so make it optional.
+%bcond test 0
+
+%global rocm_release 7.1
+%global rocm_patch 1 
+%global rocm_version %{rocm_release}.%{rocm_patch}
+
+# rocm stack builds with clang
+%global toolchain clang
+
+Name:           rocfft
+Version:        %{rocm_version}
+Release:        %autorelease
+Summary:        ROCm Fast Fourier Transforms library
+License:        MIT
+Url:            https://github.com/ROCm/rocFFT
+#!RemoteAsset:  sha256:047e4e93e0b12869bf42136b5eb683df3a1635b01a58bbb25c8861df291ab285
+Source:         %{url}/archive/rocm-%{version}.tar.gz
+BuildSystem:    cmake
+
+Patch0:         0001-cmake-use-gnu-installdirs.patch
+
+BuildOption(conf):  -G Ninja
+BuildOption(conf):  -DAMDGPU_TARGETS=%{rocm_gpu_list_default}
+BuildOption(conf):  -DBUILD_CLIENTS_TESTS=ON
+BuildOption(conf):  -DROCFFT_BUILD_OFFLINE_TUNER=OFF
+BuildOption(conf):  -DROCFFT_KERNEL_CACHE_ENABLE=OFF
+BuildOption(conf):  -DSQLITE_USE_SYSTEM_PACKAGE=ON
+
+BuildRequires:  boost-devel
+BuildRequires:  clang
+BuildRequires:  clang-tools-extra
+BuildRequires:  cmake
+BuildRequires:  cmake(amd_comgr)
+BuildRequires:  cmake(hip)
+BuildRequires:  cmake(hiprand)
+BuildRequires:  cmake(hsa-runtime64)
+BuildRequires:  cmake(GTest)
+BuildRequires:  cmake(rocrand)
+BuildRequires:  compiler-rt
+BuildRequires:  libomp-devel
+BuildRequires:  lld
+BuildRequires:  llvm
+BuildRequires:  ninja
+BuildRequires:  pkgconfig(fftw3)
+BuildRequires:  pkgconfig(sqlite3)
+BuildRequires:  python3
+BuildRequires:  rocm-cmake
+BuildRequires:  rocm-device-libs
+BuildRequires:  rocm-llvm-macros
+
+%description
+rocFFT is a software library for computing fast Fourier transforms (FFTs) written
+in HIP. It is part of AMD's software ecosystem based on ROCm. In addition to
+AMD GPU hardware, rocFFT also works on CPU devices to facilitate testing.
+
+%package        devel
+Summary:        The rocFFT development package
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       cmake(hip)
+
+%description    devel
+The rocFFT development package.
+
+%package        test
+Summary:        Tests for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    test
+%{summary}
+
+%prep -a
+# Do not care so much about the sqlite version
+sed -i -e 's@SQLite3 3.50.2 @SQLite3 @' cmake/sqlite.cmake
+
+%install -a
+# we don't need the rocfft_rtc_helper binary and client-info file
+find %{buildroot} -type f -name "rocfft_rtc_helper" -print0 | xargs -0 -I {} /usr/bin/rm -rf "{}"
+rm -rf %{buildroot}/%{_prefix}/.info
+rm -f %{buildroot}%{_datadir}/doc/rocfft/LICENSE.md
+
+%if %{with test}
+%check
+%{_vpath_builddir}/clients/staging/rocfft-test
+%endif
+
+%files
+%doc README.md
+%license LICENSE.md
+%{_libdir}/librocfft.so.0{,.*}
+
+%files devel
+%{_includedir}/rocfft/
+%{_libdir}/cmake/rocfft/
+%{_libdir}/librocfft.so
+
+%files test
+%{_bindir}/rocfft-test
+%{_bindir}/rtc_helper_crash
+
+%changelog
+%autochangelog

--- a/SPECS/rocm-core/rocm-core.spec
+++ b/SPECS/rocm-core/rocm-core.spec
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Sakura286 <chenxuan@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global rocm_version 7.1.1
+
+Name:           rocm-core
+Version:        %{rocm_version}
+Release:        %autorelease
+Summary:        A utility to get the ROCm release version
+License:        MIT
+URL:            https://github.com/ROCm/rocm-core
+#!RemoteAsset:  sha256:0171b82a4d028d57035d0d57a01a058f50f1a23959d230cdeab14972dcd94da8
+Source0:        %{url}/archive/refs/tags/rocm-%{version}.tar.gz
+BuildSystem:    cmake
+
+BuildOption(conf):  -DROCM_VERSION=%{rocm_version}
+
+BuildRequires:  cmake
+
+Provides:       rocm-core = %{version}-%{release}
+
+%description
+%{summary}
+
+%package        devel
+Summary:        Libraries and headers for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+%{summary}
+
+%install -a
+rm -rvf %{buildroot}/%{_exec_prefix}/.info
+rm -rvf %{buildroot}/%{_exec_prefix}/libexec/rocm-core
+rm -rvf %{buildroot}/%{_exec_prefix}/share/doc/*/LICENSE.md
+rm -rvf %{buildroot}/%{_libdir}/rocmmod
+
+%files
+%doc README.md
+%license LICENSE.md
+%{_libdir}/librocm-core.so.*
+
+%files devel
+%{_includedir}/rocm-core/*.h
+%{_libdir}/cmake/rocm-core/*.cmake
+%{_libdir}/librocm-core.so
+
+%changelog
+%{?autochangelog}

--- a/SPECS/rocm-origami/0001-rocm-origami-remove-scope-for-variables.patch
+++ b/SPECS/rocm-origami/0001-rocm-origami-remove-scope-for-variables.patch
@@ -1,0 +1,32 @@
+From 3d470b52d1cc06a3e33cbf38bdde6d3f4f008a25 Mon Sep 17 00:00:00 2001
+From: Tom Rix <Tom.Rix@amd.com>
+Date: Mon, 3 Nov 2025 06:33:31 -0800
+Subject: [PATCH] rocm-origami remove scope for variables
+
+---
+ cmake/origami-config.cmake.in | 12 ------------
+ 1 file changed, 12 deletions(-)
+
+diff --git a/cmake/origami-config.cmake.in b/cmake/origami-config.cmake.in
+index d6c8000d0261..19370e7dd5bd 100644
+--- a/cmake/origami-config.cmake.in
++++ b/cmake/origami-config.cmake.in
+@@ -6,15 +6,4 @@ find_dependency(hip REQUIRED)
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/origami-targets.cmake")
+ 
+-block(SCOPE_FOR VARIABLES)
+-    if(NOT TARGET origami::origami)
+-        message(FATAL_ERROR "origami::origami target is missing")
+-    endif()
+-    
+-    get_target_property(link_libraries origami::origami INTERFACE_LINK_LIBRARIES)
+-
+-    if(link_libraries AND "hip::device" IN_LIST link_libraries)
+-        message(FATAL_ERROR "Do not export targets with hip::device as an interface link library")
+-    endif()
+-endblock()
+ 
+-- 
+2.51.0
+

--- a/SPECS/rocm-origami/rocm-origami.spec
+++ b/SPECS/rocm-origami/rocm-origami.spec
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: CHEN Xuan <chenxuan@iscas.ac.cn>
+# SPDX-FileContributor: Yifan Xu <xuyifan@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global rocm_release 7.1
+%global rocm_patch 1
+%global rocm_version %{rocm_release}.%{rocm_patch}
+
+Name:           rocm-origami
+Version:        %{rocm_version}
+Release:        %autorelease
+Summary:        Analytical GEMM Solution Selection
+License:        MIT
+Url:            https://github.com/ROCm/rocm-libraries
+#!RemoteAsset:  sha256:1fb56e620a06e198aeec2cf37c11e6879d0c67c62e295b48779b7f486e34acb4
+Source0:        %{url}/releases/download/rocm-%{version}/origami.tar.gz
+# License file is not included in the release tarball
+#!RemoteAsset:  sha256:b185aaa652b0bf066c37a0d6314ce4bf4521e4a3c9bf46edd2f6a777ac522223
+Source1:        https://raw.githubusercontent.com/ROCm/rocm-libraries/develop/shared/origami/LICENSE.md
+BuildSystem:    cmake
+
+BuildOption(conf):  -G Ninja
+BuildOption(conf):  -DCMAKE_VERBOSE_MAKEFILE=ON
+
+# Workaround hipblaslt build issue:
+#   origami::origami target is missing
+# https://github.com/ROCm/rocm-libraries/issues/2422
+Patch0:         0001-rocm-origami-remove-scope-for-variables.patch
+
+BuildRequires:  clang
+BuildRequires:  cmake
+BuildRequires:  cmake(hip)
+BuildRequires:  lld
+BuildRequires:  llvm
+BuildRequires:  rocm-cmake
+BuildRequires:  rocm-llvm-macros
+BuildRequires:  ninja
+
+%description
+The name "origami" still evokes the elegance of transforming
+a flat (2-D) sheet into intricate higher dimensional
+structures. In this context, however, Origami has evolved
+into a tool set for GEMM solution selection and optimization.
+Inspired by the art of paper folding, the library now enables
+users to explore a range of tiling and mapping configurations
+and to make informed decisions on data and computation mapping
+for high-performance GEMM operations.
+
+%package        devel
+Summary:        Libraries and headers for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+%{summary}
+
+%prep -a
+# License file is not in the tarball
+cp %{SOURCE1} .
+# Use system rocm-cmake, no downloading
+sed -i -e 's@if(NOT ROCM_FOUND)@if(FALSE)@' cmake/dependencies.cmake
+# We are building from a tarball, not a git repo
+sed -i -e 's@find_package(Git REQUIRED)@#find_package(Git REQUIRED)@' cmake/dependencies.cmake
+
+%install -a
+rm -f %{buildroot}%{_datadir}/doc/origami/LICENSE.md
+
+%files
+%doc README.md
+%license LICENSE.md
+%{_libdir}/liborigami.so.0{,.*}
+
+%files devel
+%{_includedir}/origami/
+%{_libdir}/cmake/origami/
+%{_libdir}/liborigami.so
+
+%changelog
+%autochangelog

--- a/SPECS/rocrand/rocrand.spec
+++ b/SPECS/rocrand/rocrand.spec
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Sakura286 <chenxuan@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+# rocRAND need a GPU to run tests, but we could still
+# keep the test cases for packagers who have a GPU, so make it optional.
+%bcond test 0
+%if %{with test}
+%global build_test ON
+%else
+%global build_test OFF
+%endif
+
+%global rocm_release 7.1
+%global rocm_patch 1
+%global rocm_version %{rocm_release}.%{rocm_patch}
+
+# rocm builds with clang
+%global toolchain clang
+
+Name:           rocrand
+Version:        %{rocm_version}
+Release:        %autorelease
+Summary:        ROCm random number generator
+License:        MIT AND BSD-3-Clause
+Url:            https://github.com/ROCm/rocRAND
+#!RemoteAsset:  sha256:15c33c595aa8e4de1d8b3736df9eaf2ceba7914ffebe718f0997b0da28215d9e
+Source:         %{url}/archive/rocm-%{version}.tar.gz
+BuildSystem:    cmake
+
+BuildOption(conf):  -G Ninja
+BuildOption(conf):  -DAMDGPU_TARGETS=%{rocm_gpu_list_default}
+BuildOption(conf):  -DBUILD_TEST=%{build_test}
+
+BuildRequires:  clang
+BuildRequires:  clang-tools-extra
+BuildRequires:  cmake
+BuildRequires:  cmake(amd_comgr)
+%if %{with test}
+BuildRequires:  cmake(GTest)
+%endif
+BuildRequires:  cmake(hip)
+BuildRequires:  cmake(hsa-runtime64)
+BuildRequires:  compiler-rt
+BuildRequires:  lld
+BuildRequires:  llvm
+BuildRequires:  ninja
+BuildRequires:  rocm-cmake
+BuildRequires:  rocm-device-libs
+BuildRequires:  rocm-llvm-macros
+
+%description
+The rocRAND project provides functions that generate pseudo-random and
+quasi-random numbers.
+
+The rocRAND library is implemented in the HIP programming language and
+optimized for AMD's latest discrete GPUs. It is designed to run on top of AMD's
+Radeon Open Compute ROCm runtime, but it also works on CUDA enabled GPUs.
+
+%package        devel
+Summary:        The rocRAND development package
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+The rocRAND development package.
+
+%if %{with test}
+%package        test
+Summary:        Tests for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    test
+%{summary}
+%endif
+
+%install -a
+rm -f %{buildroot}%{_datadir}/doc/rocrand/LICENSE.md
+
+%files
+%doc README.md
+%license LICENSE.md
+%{_libdir}/librocrand.so.1{,.*}
+
+%files devel
+%{_includedir}/rocrand/
+%{_libdir}/cmake/rocrand/
+%{_libdir}/librocrand.so
+
+%if %{with test}
+%files test
+%{_bindir}/rocRAND/
+%{_bindir}/test_*
+%endif
+
+%changelog
+%autochangelog

--- a/SPECS/rocthrust/rocthrust.spec
+++ b/SPECS/rocthrust/rocthrust.spec
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: CHEN Xuan <chenxuan@iscas.ac.cn>
+# SPDX-FileContributor: Yifan Xu <xuyifan@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+# rocThrust needs a GPU to run tests, but we could still
+# keep the test cases for packagers who have a GPU, so make it optional.
+%bcond test 0
+%if %{with test}
+%global build_test ON
+%else
+%global build_test OFF
+%endif
+
+%global rocm_release 7.1
+%global rocm_patch 1
+%global rocm_version %{rocm_release}.%{rocm_patch}
+
+# rocm builds with clang
+%global toolchain clang
+
+Name:           rocthrust
+Version:        %{rocm_version}
+Release:        %autorelease
+Summary:        ROCm Thrust library
+
+Url:            https://github.com/ROCm/rocThrust
+VCS:            git:https://github.com/ROCm/rocThrust.git
+License:        Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND BSL-1.0 AND MIT
+# All files are Apache 2.0 with some exceptions:
+# ./cmake contains only files under MIT
+# ./internal/benchmark/*.py are dual licensed Apache 2.0 and Boost 1.0
+# ./thrust/ contain some header files that are Boost 1.0 licensed
+# ./thrust/ contain some headers that are dual Apache 2.0 and Boost 1.0
+# ./thrust/cmake/FindTBB.cmake is public domain
+# ./thrust/detail/allocator/allocator_traits.h is dual Apache 2.0 and MIT
+# ./thrust/detail/complex contains BSD 2 clause licensed headers
+#!RemoteAsset:  sha256:995f9498402f207d04aac1edeb845abea295f6f132151ae1e04a6f0d0dc5edf5
+Source:         %{url}/archive/rocm-%{version}.tar.gz
+BuildSystem:    cmake
+
+BuildOption(conf):  -G Ninja
+BuildOption(conf):  -DAMDGPU_TARGETS=%{rocm_gpu_list_default}
+BuildOption(conf):  -DBUILD_TEST=%{build_test}
+
+BuildRequires:  clang
+BuildRequires:  clang-tools-extra
+BuildRequires:  cmake
+%if %{with test}
+BuildRequires:  cmake(GTest)
+%endif
+BuildRequires:  cmake(hip)
+BuildRequires:  cmake(rocprim)
+BuildRequires:  compiler-rt
+BuildRequires:  lld
+BuildRequires:  llvm
+BuildRequires:  ninja
+BuildRequires:  rocm-cmake
+BuildRequires:  rocm-device-libs
+BuildRequires:  rocm-llvm-macros
+
+%description
+Thrust is a parallel algorithm library. This library has been
+ported to HIP/ROCm platform, which uses the rocPRIM library.
+
+%package        devel
+Summary:        Libraries and headers for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+%{summary}
+
+%if %{with test}
+%package        test
+Summary:        Tests for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    test
+%{summary}
+%endif
+
+%prep -a
+# ROCMExportTargetsHeaderOnly.cmake hardcodes 'lib' as the library directory.
+# Change it to the correct platform-specific library directory.
+sed -i -e 's/ROCM_INSTALL_LIBDIR lib/ROCM_INSTALL_LIBDIR %{_lib}/' cmake/ROCMExportTargetsHeaderOnly.cmake
+
+%install -a
+rm -f %{buildroot}%{_docdir}/rocthrust/LICENSE
+
+%files
+%doc README.md
+%license LICENSE
+%license NOTICES.txt
+
+%files devel
+%{_includedir}/thrust/
+%{_libdir}/cmake/rocthrust/
+
+%if %{with test}
+%files test
+%{_bindir}/test_*
+%{_bindir}/rocthrust/
+%endif
+
+%changelog
+%autochangelog

--- a/SPECS/roctracer/roctracer.spec
+++ b/SPECS/roctracer/roctracer.spec
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: CHEN Xuan <chenxuan@iscas.ac.cn>
+# SPDX-FileContributor: Yifan Xu <xuyifan@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+# roctracer needs a GPU to run tests, but we could still
+# keep the test cases for packagers who have a GPU, so make it optional.
+%bcond test 0
+%if %{with test}
+%global build_test ON
+%else
+%global build_test OFF
+%endif
+
+%global rocm_release 7.1
+%global rocm_patch 1
+%global rocm_version %{rocm_release}.%{rocm_patch}
+
+# rocm stack builds with clang
+%global toolchain clang
+
+Name:           roctracer
+Version:        %{rocm_version}
+Release:        %autorelease
+Summary:        ROCm Tracer Callback/Activity Library
+Url:            https://github.com/ROCm/roctracer
+VCS:            git:https://github.com/ROCm/roctracer.git
+License:        MIT
+#!RemoteAsset:  sha256:dec80803c6d2d684759172145177849efda65672645b95a2f2ad1a84335043bb
+Source:         %{url}/archive/rocm-%{version}.tar.gz
+BuildSystem:    cmake
+
+BuildOption(conf):  -G Ninja
+BuildOption(conf):  -DGPU_TARGETS=%{rocm_gpu_list_default}
+
+BuildRequires:  clang
+BuildRequires:  clang-tools-extra
+BuildRequires:  cmake
+BuildRequires:  cmake(amd_comgr)
+BuildRequires:  cmake(hip)
+BuildRequires:  cmake(hsa-runtime64)
+BuildRequires:  compiler-rt
+BuildRequires:  lld
+BuildRequires:  llvm
+BuildRequires:  ninja
+BuildRequires:  pkgconfig(atomic_ops)
+BuildRequires:  python3dist(cppheaderparser)
+BuildRequires:  rocm-cmake
+BuildRequires:  rocm-device-libs
+BuildRequires:  rocm-llvm-macros
+
+%description
+roctracer is a callback and activity tracing library for ROCm. It provides
+function call tracing for HIP and other ROCm runtimes, activity (asynchronous)
+tracing, and ROCTx user-defined event markers.
+
+%package        devel
+Summary:        The roctracer development package
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+The roctracer development package.
+
+%if %{with test}
+%package        test
+Summary:        Tests for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    test
+%{summary}
+%endif
+
+%prep -a
+# No knob in cmake to turn off testing
+%if %{without test}
+sed -i -e 's@add_subdirectory(test)@#add_subdirectory(test)@' CMakeLists.txt
+%else
+# Adjust test running script lib dir
+sed -i -e 's@../lib/@../%{_lib}/@' test/run.sh
+%endif
+
+%install -a
+rm -f %{buildroot}%{_datadir}/doc/%{name}/LICENSE.md
+rm -rf %{buildroot}%{_datadir}/doc/%{name}-asan
+
+%files
+%license LICENSE.md
+%doc README.md
+%{_libdir}/libroctracer64.so.*
+%{_libdir}/libroctx64.so.*
+%{_libdir}/roctracer/
+
+%files devel
+%{_includedir}/roctracer/
+%{_libdir}/libroctracer64.so
+%{_libdir}/libroctx64.so
+
+%if %{with test}
+%files test
+%{_datadir}/roctracer/
+%endif
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

This PR adds all the additional buildrequires needed by PyTorch ROCm backend.

## Related Issue

- No issues are related

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: Claude-Opus-4.8

When fixing `rccl` for compilation error `branch-size exceeds simm16`, claude found the bug caused by llvm-21 from llvm upstream PRs and gives workaround for it. This error occurs on PyTorch 2.10.0 compilation and the workaround has been tested on it.

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
