### PR TITLE
Add cherrypy runtime dependencies

### DIFF
--- a/SPECS/python-cheroot/python-cheroot.spec
+++ b/SPECS/python-cheroot/python-cheroot.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: sunyuechi <sunyuechi@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname cheroot
+
+Name:           python-%{srcname}
+Version:        11.1.2
+Release:        %autorelease
+Summary:        Highly-optimized, pure-python HTTP server
+License:        BSD-3-Clause
+URL:            https://cheroot.cherrypy.dev/
+VCS:            git:https://github.com/cherrypy/cheroot.git
+#!RemoteAsset:  sha256:bfb70c49663f63b0440f2b54dbc6b0d1650e56dfe4e2641f59b2c6f727b44aca
+Source0:        https://files.pythonhosted.org/packages/source/c/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l cheroot +auto
+# cheroot.test* and cheroot.testing import pytest, which is not packaged
+BuildOption(check):  -e 'cheroot.test*'
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Cheroot is the high-performance, pure-Python HTTP server used by CherryPy.
+It can be used as a generic, production-ready WSGI server.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE.md
+
+%changelog
+%autochangelog

--- a/SPECS/python-jaraco-collections/python-jaraco-collections.spec
+++ b/SPECS/python-jaraco-collections/python-jaraco-collections.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: sunyuechi <sunyuechi@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname jaraco-collections
+%global pypi_name jaraco_collections
+
+Name:           python-%{srcname}
+Version:        5.2.1
+Release:        %autorelease
+Summary:        Collection objects similar to those in stdlib by jaraco
+License:        MIT
+URL:            https://github.com/jaraco/jaraco.collections
+VCS:            git:https://github.com/jaraco/jaraco.collections.git
+#!RemoteAsset:  sha256:dab81970bad6f0ab53b20745f1b01da37926e4c0fcd425046aa45e0d8efa18ed
+Source0:        https://files.pythonhosted.org/packages/source/j/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l jaraco +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Collection objects similar to those in the standard library, collected in the
+jaraco namespace.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-jaraco-context/python-jaraco-context.spec
+++ b/SPECS/python-jaraco-context/python-jaraco-context.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: sunyuechi <sunyuechi@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname jaraco-context
+%global pypi_name jaraco_context
+
+Name:           python-%{srcname}
+Version:        6.1.2
+Release:        %autorelease
+Summary:        Useful decorators and context managers
+License:        MIT
+URL:            https://github.com/jaraco/jaraco.context
+VCS:            git:https://github.com/jaraco/jaraco.context.git
+#!RemoteAsset:  sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3
+Source0:        https://files.pythonhosted.org/packages/source/j/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l jaraco +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Context managers and decorators collected in the jaraco namespace.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-jaraco-functools/python-jaraco-functools.spec
+++ b/SPECS/python-jaraco-functools/python-jaraco-functools.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: sunyuechi <sunyuechi@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname jaraco-functools
+%global pypi_name jaraco_functools
+
+Name:           python-%{srcname}
+Version:        4.5.0
+Release:        %autorelease
+Summary:        Functools like those found in stdlib
+License:        MIT
+URL:            https://github.com/jaraco/jaraco.functools
+VCS:            git:https://github.com/jaraco/jaraco.functools.git
+#!RemoteAsset:  sha256:3bb5665ea4a020cf78a7040e89154c77edadb3ca74f366479669c5999aa70b03
+Source0:        https://files.pythonhosted.org/packages/source/j/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l jaraco +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Additional functools in the spirit of stdlib's functools, collected in the
+jaraco namespace.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-jaraco-text/python-jaraco-text.spec
+++ b/SPECS/python-jaraco-text/python-jaraco-text.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: sunyuechi <sunyuechi@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname jaraco-text
+%global pypi_name jaraco_text
+
+Name:           python-%{srcname}
+Version:        4.2.0
+Release:        %autorelease
+Summary:        Module for text manipulation
+License:        MIT
+URL:            https://github.com/jaraco/jaraco.text
+VCS:            git:https://github.com/jaraco/jaraco.text.git
+#!RemoteAsset:  sha256:194e386aa5b15a6616019df87a6b29c00fd3c9c8b0475731b64633ca7afd495b
+Source0:        https://files.pythonhosted.org/packages/source/j/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l jaraco +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Text manipulation utilities collected in the jaraco namespace.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-portend/python-portend.spec
+++ b/SPECS/python-portend/python-portend.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: sunyuechi <sunyuechi@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname portend
+
+Name:           python-%{srcname}
+Version:        3.2.1
+Release:        %autorelease
+Summary:        TCP port monitoring and discovery
+License:        MIT
+URL:            https://github.com/jaraco/portend
+VCS:            git:https://github.com/jaraco/portend.git
+#!RemoteAsset:  sha256:aa9d40ab1f9e14bdb7d401f42210df35d017c9b97991baeb18568cedfb8c6489
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l portend +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+portend monitors TCP ports for bound or unbound states, useful for waiting
+until a service is ready or has shut down.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-tempora/python-tempora.spec
+++ b/SPECS/python-tempora/python-tempora.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: sunyuechi <sunyuechi@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname tempora
+
+Name:           python-%{srcname}
+Version:        5.9.0
+Release:        %autorelease
+Summary:        Objects and routines pertaining to date and time
+License:        MIT
+URL:            https://github.com/jaraco/tempora
+VCS:            git:https://github.com/jaraco/tempora.git
+#!RemoteAsset:  sha256:66e6ddee320c38f4b253a7d8039337424c699916451b9271e0ccce770a4e8f62
+Source0:        https://files.pythonhosted.org/packages/source/t/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l tempora +auto
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Objects and routines pertaining to date and time, such as timing, scheduling
+and rate-limiting utilities.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-zc-lockfile/python-zc-lockfile.spec
+++ b/SPECS/python-zc-lockfile/python-zc-lockfile.spec
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: sunyuechi <sunyuechi@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname zc-lockfile
+%global pypi_name zc_lockfile
+
+Name:           python-%{srcname}
+Version:        4.0
+Release:        %autorelease
+Summary:        Basic inter-process locks
+License:        ZPL-2.1
+URL:            https://github.com/zopefoundation/zc.lockfile
+VCS:            git:https://github.com/zopefoundation/zc.lockfile.git
+#!RemoteAsset:  sha256:d3ab0f53974296a806db3219b9191ba0e6d5cbbd1daa2e0d17208cb9b29d2102
+Source0:        https://files.pythonhosted.org/packages/source/z/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l zc +auto
+# zc.lockfile.tests imports zope.testing, which is not packaged
+BuildOption(check):  -e 'zc.lockfile.tests'
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+zc.lockfile provides a basic, cross-platform, inter-process lock implemented
+with a lock file.
+
+%prep -a
+# Upstream pins an exact setuptools build version; relax it to build against
+# the setuptools shipped by openRuyi.
+sed -i -E 's/setuptools *== *[0-9.]+/setuptools/' pyproject.toml
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE.txt
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

`BuildRequires: python3dist(cherrypy)`

```
nothing provides python3.13dist(jaraco-collections) needed by python-cherrypy
nothing provides python3.13dist(zc-lockfile) needed by python-cherrypy
nothing provides python3.13dist(cheroot) >= 8.2.1 needed by python-cherrypy
nothing provides python3.13dist(portend) >= 2.1.1 needed by python-cherrypy
```

## Related Issue

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.
- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy