### PR TITLE
SPECS: coreutils: install /usr/bin/arch

### DIFF
--- a/SPECS/coreutils/coreutils.spec
+++ b/SPECS/coreutils/coreutils.spec
@@ -17,6 +17,7 @@ Source0:        https://ftpmirror.gnu.org/gnu/coreutils/coreutils-%{version}.tar
 BuildSystem:    autotools
 
 BuildOption(conf):  DEFAULT_POSIX2_VERSION=200112
+BuildOption(conf):  --enable-install-program=arch
 BuildOption(conf):  --enable-no-install-program=kill
 
 BuildRequires:  pkgconfig(gmp)


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

By default, `coreutils` is built without `/usr/bin/arch`.
While `uname -m` is the preferred alternative, many packages still depend on `/usr/bin/arch`, so we need to enable `arch` for `coreutils`.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: DeepSeek:deepseek-v4-pro

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
