### PR TITLE
SPECS: rpm-config-openruyi: Override _sbindir to _bindir

### DIFF
--- a/SPECS/rpm-config-openruyi/macros
+++ b/SPECS/rpm-config-openruyi/macros
@@ -1,6 +1,8 @@
 # directories
 %_infodir               %{_prefix}/share/info
 %_mandir                %{_prefix}/share/man
+# By default, we merge sbin and bin.
+%_sbindir               %{_bindir}
 %_sysconfdir            /etc
 %_localstatedir         /var
 %_defaultdocdir         %{_datadir}/doc

--- a/SPECS/rpm-config-openruyi/rpm-config-openruyi.spec
+++ b/SPECS/rpm-config-openruyi/rpm-config-openruyi.spec
@@ -17,7 +17,6 @@ License:        GPL-2.0-or-later
 URL:            https://git.openruyi.cn/openruyi/openruyi-repo
 BuildArch:      noarch
 
-BuildRequires:  gzip
 #!BuildIgnore:  rpm-config-openruyi
 
 Provides:       rpm-config


### PR DESCRIPTION
## Summary

Place the configuration in OBS into the rpm-config-openruyi macro

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy