### PR TITLE
SPECS: perl-XML-Parser: Add missing requires.

### DIFF
--- a/SPECS/perl-XML-Parser/perl-XML-Parser.spec
+++ b/SPECS/perl-XML-Parser/perl-XML-Parser.spec
@@ -29,6 +29,7 @@ BuildRequires:  perl(LWP::UserAgent)
 BuildRequires:  perl(Test::More)
 BuildRequires:  perl(warnings)
 BuildRequires:  perl(File::ShareDir::Install)
+Requires:       perl(File::ShareDir)
 
 %description
 This module provides ways to parse XML documents. It is built on top of


### PR DESCRIPTION
From version 2.48, it requires File::ShareDir in runtime[1]. Without this it might fail to run like:
```
[    6s] Can't locate File/ShareDir.pm in @INC (you may need to install the File::ShareDir module) (@INC entries checked: /usr/local/lib/perl5/5.42 /usr/local/share/perl5/5.42 /usr/lib/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib/perl5 /usr/share/perl5) at /usr/lib/perl5/vendor_perl/XML/Parser/Expat.pm line 16.
```

1. https://metacpan.org/dist/XML-Parser/changes
