### PR TITLE
Add missing runtime dependencies for ceph

### DIFF
--- a/SPECS/python-durationpy/python-durationpy.spec
+++ b/SPECS/python-durationpy/python-durationpy.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: sunyuechi <sunyuechi@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname durationpy
+
+Name:           python-%{srcname}
+Version:        0.10
+Release:        %autorelease
+Summary:        Module for converting between datetime.timedelta and Go's Duration strings
+License:        MIT
+URL:            https://github.com/icholy/durationpy
+VCS:            git:https://github.com/icholy/durationpy.git
+#!RemoteAsset:  sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba
+Source0:        https://files.pythonhosted.org/packages/source/d/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Python module for converting between datetime.timedelta and Go's
+Duration strings.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-kubernetes/python-kubernetes.spec
+++ b/SPECS/python-kubernetes/python-kubernetes.spec
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: sunyuechi <sunyuechi@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname kubernetes
+
+Name:           python-%{srcname}
+Version:        36.0.2
+Release:        %autorelease
+Summary:        Kubernetes python client
+License:        Apache-2.0
+URL:            https://github.com/kubernetes-client/python
+VCS:            git:https://github.com/kubernetes-client/python.git
+#!RemoteAsset:  sha256:03551fcb49cae1f708f63624041e37403545b7aaed10cbf54e2b01a37a5438e3
+Source0:        https://files.pythonhosted.org/packages/source/k/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+# test modules shipped inside the package import pytest and mock
+BuildOption(check):  -e 'kubernetes.*_test' -e 'kubernetes.*.test_*'
+# kubernetes.aio needs aiohttp, which upstream treats as optional
+BuildOption(check):  -e 'kubernetes.aio*'
+# demo script, loads kube config at import time
+BuildOption(check):  -e 'kubernetes.leaderelection.example'
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Python client for the kubernetes API. It allows users to interact with
+a Kubernetes cluster from Python: manage resources, watch for changes,
+load cluster and kubeconfig based configuration.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-natsort/python-natsort.spec
+++ b/SPECS/python-natsort/python-natsort.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: sunyuechi <sunyuechi@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname natsort
+
+Name:           python-%{srcname}
+Version:        8.4.0
+Release:        %autorelease
+Summary:        Simple yet flexible natural sorting in Python
+License:        MIT
+URL:            https://github.com/SethMMorton/natsort
+VCS:            git:https://github.com/SethMMorton/natsort.git
+#!RemoteAsset:  sha256:45312c4a0e5507593da193dedd04abb1469253b601ecaf63445ad80f0a1ea581
+Source0:        https://files.pythonhosted.org/packages/source/n/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+When you try to sort a list of strings that contain numbers, the normal
+python sort algorithm sorts lexicographically, which is often not what
+you want. natsort provides a function natsorted that helps sort lists
+"naturally" ("naturally" is rather ill-defined, but in general it means
+sorting based on meaning and not computer code point).
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+%{_bindir}/natsort
+
+%changelog
+%autochangelog

--- a/SPECS/python-pyyaml/python-pyyaml.spec
+++ b/SPECS/python-pyyaml/python-pyyaml.spec
@@ -9,12 +9,12 @@
 %global pypi_name pyyaml
 
 Name:           python-pyyaml
-Version:        6.0.2
+Version:        6.0.3
 Release:        %autorelease
 Summary:        YAML parser and emitter for Python
 License:        MIT
 URL:            https://github.com/yaml/pyyaml
-#!RemoteAsset:  sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e
+#!RemoteAsset:  sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f
 Source0:        https://files.pythonhosted.org/packages/source/p/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
 BuildSystem:    pyproject
 
@@ -44,9 +44,6 @@ configuration files to object serialization and persistence.
 
 %prep -a
 chmod a-x examples/yaml-highlight/yaml_hl.py
-
-# remove pre-generated file
-rm -rf ext/_yaml.c
 
 %generate_buildrequires
 %pyproject_buildrequires

--- a/SPECS/python-requests-oauthlib/python-requests-oauthlib.spec
+++ b/SPECS/python-requests-oauthlib/python-requests-oauthlib.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: sunyuechi <sunyuechi@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname requests-oauthlib
+
+Name:           python-%{srcname}
+Version:        2.0.0
+Release:        %autorelease
+Summary:        OAuthlib authentication support for Requests
+License:        ISC
+URL:            https://github.com/requests/requests-oauthlib
+VCS:            git:https://github.com/requests/requests-oauthlib.git
+#!RemoteAsset:  sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9
+Source0:        https://files.pythonhosted.org/packages/source/r/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l requests_oauthlib
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+This project provides first-class OAuth library support for Requests,
+making it easy to authenticate against OAuth 1.0/a and OAuth 2.0
+protected resources.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/xmlstarlet/1000-fix-xxe.patch
+++ b/SPECS/xmlstarlet/1000-fix-xxe.patch
@@ -1,0 +1,62 @@
+diff -Naur xmlstarlet-1.6.1.orig/examples/tests.mk xmlstarlet-1.6.1/examples/tests.mk
+--- xmlstarlet-1.6.1.orig/examples/tests.mk	2013-06-22 17:36:56.000000000 +0200
++++ xmlstarlet-1.6.1/examples/tests.mk	2026-05-26 13:31:13.886894244 +0200
+@@ -98,7 +98,13 @@
+ 
+ XFAIL_TESTS =\
+ examples/bigxml-dtd\
+-examples/ed-namespace
++examples/ed-namespace\
++examples/external-entity\
++examples/bigxml-embed-ref\
++examples/bigxml-embed\
++examples/bigxml-relaxng\
++examples/bigxml-well-formed\
++examples/bigxml-xsd
+ 
+ if !HAVE_EXSLT_XPATH_REGISTER
+ XFAIL_TESTS += examples/exslt-ed
+diff -Naur xmlstarlet-1.6.1.orig/src/trans.c xmlstarlet-1.6.1/src/trans.c
+--- xmlstarlet-1.6.1.orig/src/trans.c	2012-08-12 17:18:59.000000000 +0200
++++ xmlstarlet-1.6.1/src/trans.c	2026-05-26 13:31:20.240064967 +0200
+@@ -174,7 +174,10 @@
+     int i, options = 0;
+ 
+     options = XSLT_PARSE_OPTIONS;
+-     
++    /* Disable entity expansion to prevent XXE attacks */
++    options &= ~XML_PARSE_NOENT;
++    options |= XML_PARSE_NONET;
++
+     /*
+      * Compile XSLT Sylesheet
+      */
+diff -Naur xmlstarlet-1.6.1.orig/src/xml_C14N.c xmlstarlet-1.6.1/src/xml_C14N.c
+--- xmlstarlet-1.6.1.orig/src/xml_C14N.c	2012-08-12 17:18:59.000000000 +0200
++++ xmlstarlet-1.6.1/src/xml_C14N.c	2026-05-26 13:31:20.240173256 +0200
+@@ -62,8 +62,8 @@
+      */
+ 
+     doc = xmlReadFile(xml_filename, NULL,
+-        XML_PARSE_NOENT | XML_PARSE_DTDLOAD |
+-        XML_PARSE_DTDATTR | (nonet? XML_PARSE_NONET:0));
++        XML_PARSE_DTDLOAD |
++        XML_PARSE_DTDATTR | XML_PARSE_NONET);
+     if (doc == NULL) {
+         fprintf(stderr, "Error: unable to parse file \"%s\"\n", xml_filename);
+         return(EXIT_BAD_FILE);
+diff -Naur xmlstarlet-1.6.1.orig/src/xml_select.c xmlstarlet-1.6.1/src/xml_select.c
+--- xmlstarlet-1.6.1.orig/src/xml_select.c	2014-03-03 01:15:08.000000000 +0100
++++ xmlstarlet-1.6.1/src/xml_select.c	2026-05-26 13:31:20.240276580 +0200
+@@ -708,9 +708,9 @@
+     selInitOptions(&ops);
+     xsltInitOptions(&xsltOps);
+     start = selParseOptions(&ops, argc, argv);
+-    xml_options |= XML_PARSE_NOENT; /* substitute entities */
++    /* XML_PARSE_NOENT removed to prevent XXE attacks */
+     xml_options |= XML_PARSE_DTDATTR; /* use default attrib values */
+-    xml_options |= ops.nonet? XML_PARSE_NONET : 0;
++    xml_options |= XML_PARSE_NONET;
+     xsltOps.nonet = ops.nonet;
+     xsltOps.noblanks = ops.noblanks;
+     xsltInitLibXml(&xsltOps);

--- a/SPECS/xmlstarlet/2000-Define-ATTRIBUTE_UNUSED-fallback-for-libxml2-2.13.patch
+++ b/SPECS/xmlstarlet/2000-Define-ATTRIBUTE_UNUSED-fallback-for-libxml2-2.13.patch
@@ -1,0 +1,36 @@
+From 822f300e480c0bf47a6faf7a22059290f6ac7c7c Mon Sep 17 00:00:00 2001
+From: Sun Yuechi <sunyuechi@iscas.ac.cn>
+Date: Thu, 11 Jun 2026 02:51:12 +0800
+Subject: [PATCH] Define ATTRIBUTE_UNUSED fallback for libxml2 2.13+
+
+libxml2 2.13 removed the ATTRIBUTE_UNUSED macro from its public headers,
+so provide a local fallback definition.
+
+Signed-off-by: Sun Yuechi <sunyuechi@iscas.ac.cn>
+---
+ src/xml_pyx.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/xml_pyx.c b/src/xml_pyx.c
+index ab295f1..b4aa5f6 100644
+--- a/src/xml_pyx.c
++++ b/src/xml_pyx.c
+@@ -21,6 +21,15 @@
+ 
+ #include "xmlstar.h"
+ 
++/* libxml2 2.13 removed ATTRIBUTE_UNUSED from its public headers */
++#ifndef ATTRIBUTE_UNUSED
++# ifdef __GNUC__
++#  define ATTRIBUTE_UNUSED __attribute__((unused))
++# else
++#  define ATTRIBUTE_UNUSED
++# endif
++#endif
++
+ /**
+  *  Output newline and tab characters as escapes
+  *  Required both for attribute values and character data (#PCDATA)
+-- 
+2.54.0
+

--- a/SPECS/xmlstarlet/xmlstarlet.spec
+++ b/SPECS/xmlstarlet/xmlstarlet.spec
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: sunyuechi <sunyuechi@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           xmlstarlet
+Version:        1.6.1
+Release:        %autorelease
+Summary:        Command line XML toolkit
+License:        MIT
+URL:            https://xmlstar.sourceforge.net/
+VCS:            git:https://git.code.sf.net/p/xmlstar/code
+#!RemoteAsset:  sha256:15d838c4f3375332fd95554619179b69e4ec91418a3a5296e7c631b7ed19e7ca
+Source0:        https://downloads.sourceforge.net/xmlstar/%{name}-%{version}.tar.gz
+BuildSystem:    autotools
+
+BuildRequires:  autoconf
+BuildRequires:  automake
+BuildRequires:  libtool
+BuildRequires:  make
+BuildRequires:  pkgconfig(libexslt)
+BuildRequires:  pkgconfig(libxml-2.0)
+BuildRequires:  pkgconfig(libxslt)
+
+%patchlist
+# disable entity expansion to prevent XXE attacks, and mark tests broken
+# by newer libxml2 as expected failures
+# https://src.fedoraproject.org/rpms/xmlstarlet/blob/rawhide/f/xmlstarlet-1.6.1-fix-xxe.patch
+1000-fix-xxe.patch
+# libxml2 2.13 removed ATTRIBUTE_UNUSED from its public headers
+2000-Define-ATTRIBUTE_UNUSED-fallback-for-libxml2-2.13.patch
+
+%description
+XMLStarlet is a set of command line utilities (tools) which can be used
+to transform, query, validate, and edit XML documents and files using a
+simple set of shell commands in a way similar to how it is done for
+plain text files using UNIX grep, sed, awk, diff, patch, join, etc.
+
+%conf -p
+autoreconf -fiv
+
+%install -a
+# upstream installs the binary under the generic name xml
+mv %{buildroot}%{_bindir}/xml %{buildroot}%{_bindir}/xmlstarlet
+
+%files
+%doc AUTHORS ChangeLog NEWS README TODO
+%doc %{_pkgdocdir}/html.css
+%doc %{_pkgdocdir}/xmlstarlet-ug.html
+%doc %{_pkgdocdir}/xmlstarlet.txt
+%license COPYING
+%{_bindir}/xmlstarlet
+%{_mandir}/man1/xmlstarlet.1*
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

ceph.spec

```
Requires: xmlstarlet
    add xmlstarlet

Requires: python3dist(natsort)
    add python-natsort

Requires: python3dist(kubernetes)
    add python-kubernetes
    update python-pyyaml to 6.0.3
    add python-requests-oauthlib
    add python-durationpy
```

## Related Issue

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy