### PR TITLE
SPECS: gnutls: Add missing requires.

### DIFF
--- a/SPECS/gnutls/gnutls.spec
+++ b/SPECS/gnutls/gnutls.spec
@@ -58,6 +58,7 @@ Contains libraries used by the gnutls.
 
 %package        devel
 Summary:        Development files for GnuTLS
+Requires:       %{name}%{?_isa} = %{version}-%{release}
 Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 Requires:       %{name}-dane%{?_isa} = %{version}-%{release}
 Requires:       pkgconfig(libtasn1)


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

Currently, package swtpm has the build error:
```
[   14s] checking for certtool... no
[   14s] configure: error: "Could not find certtool. Is gnutls-utils/gnutls-bin installed?"
```

Package gnutl-devel already installed but no gnutls itself. Devel subpackage better depends on its main package, right?

