### PR TITLE
SPECS: Add several modules for prometheus - 14

### DIFF
--- a/SPECS/go-github-bradfitz-gomemcache-memcache/go-github-bradfitz-gomemcache-memcache.spec
+++ b/SPECS/go-github-bradfitz-gomemcache-memcache/go-github-bradfitz-gomemcache-memcache.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           memcache
+%define go_import_path  github.com/bradfitz/gomemcache
+%define commit_id 4d751bb6e37cf0da5fd57a86b880f76791307adf
+
+Name:           go-github-bradfitz-gomemcache-memcache
+Version:        0+git20260607.4d751bb
+Release:        %autorelease
+Summary:        Memcache client library for Go
+License:        Apache-2.0
+URL:            https://github.com/bradfitz/gomemcache
+#!RemoteAsset:  sha256:f3d462db42a6a87739046ba9740fd9a37769b0071af27f37e4069faf4c2f1776
+Source0:        https://github.com/bradfitz/gomemcache/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/bradfitz/gomemcache/memcache) = %{version}
+
+%description
+This package provides a memcache client library for Go.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-edsrzf-mmap-go/go-github-edsrzf-mmap-go.spec
+++ b/SPECS/go-github-edsrzf-mmap-go/go-github-edsrzf-mmap-go.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           mmap-go
+%define go_import_path  github.com/edsrzf/mmap-go
+
+Name:           go-github-edsrzf-mmap-go
+Version:        1.2.0
+Release:        %autorelease
+Summary:        A portable mmap package for Go
+License:        BSD-3-Clause
+URL:            https://github.com/edsrzf/mmap-go
+#!RemoteAsset:  sha256:9e92e9a7daeac05b86e15a5cf301767dad5a47648a33e05527911ccfa055d244
+Source0:        https://github.com/edsrzf/mmap-go/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(golang.org/x/sys)
+
+Provides:       go(github.com/edsrzf/mmap-go) = %{version}
+
+Requires:       go(golang.org/x/sys)
+
+%description
+mmap-go provides a portable memory-mapped file package for Go.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-elazarl-goproxy/go-github-elazarl-goproxy.spec
+++ b/SPECS/go-github-elazarl-goproxy/go-github-elazarl-goproxy.spec
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           goproxy
+%define go_import_path  github.com/elazarl/goproxy
+# Nested Go modules have their own module path/dependencies. The main package
+# tests are also not hermetic in OBS: TestHttpProxyAddrsFromEnv uses
+# process-wide proxy environment caching, and TestSimpleHttpRequest binds fixed
+# localhost:5000. - HNO3Miracle
+%define go_test_exclude_glob %{shrink:
+    %{go_import_path}
+    %{go_import_path}/examples*
+    %{go_import_path}/ext*
+}
+
+Name:           go-github-elazarl-goproxy
+Version:        1.8.3
+Release:        %autorelease
+Summary:        Customizable HTTP/HTTPS proxy library for Go
+License:        BSD-3-Clause
+URL:            https://github.com/elazarl/goproxy
+#!RemoteAsset:  sha256:265928cc5d79b863f7c050f1807528e82e37a10f161dae866a5e1a6b40c63d2e
+Source0:        https://github.com/elazarl/goproxy/archive/refs/tags/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/coder/websocket)
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(golang.org/x/net)
+BuildRequires:  go(golang.org/x/text)
+BuildRequires:  go(gopkg.in/yaml.v3)
+
+Provides:       go(github.com/elazarl/goproxy) = %{version}
+
+Requires:       go(golang.org/x/net)
+Requires:       go(golang.org/x/text)
+
+%description
+goproxy is a Go library for building customizable HTTP and HTTPS proxy
+servers. It provides hooks for request and response manipulation, CONNECT
+handling, MITM proxying, and custom transports.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+# Nested Go modules are packaged separately; do not let this module own
+# their source directories, otherwise RPM can hit file conflicts.
+%exclude %{go_sys_gopath}/%{go_import_path}/examples
+%exclude %{go_sys_gopath}/%{go_import_path}/ext
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-go-resty-resty-v2/go-github-go-resty-resty-v2.spec
+++ b/SPECS/go-github-go-resty-resty-v2/go-github-go-resty-resty-v2.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           resty
+%define go_import_path  github.com/go-resty/resty/v2
+
+Name:           go-github-go-resty-resty-v2
+Version:        2.17.2
+Release:        %autorelease
+Summary:        Simple HTTP, REST, and SSE client library for Go
+License:        MIT
+URL:            https://github.com/go-resty/resty
+#!RemoteAsset:  sha256:1548d7af5e8236ec394b672f603f3bd3f89211cdc69e26bb62f5117a42d10e74
+Source0:        https://github.com/go-resty/resty/archive/refs/tags/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(golang.org/x/net)
+BuildRequires:  go(golang.org/x/time)
+
+Provides:       go(github.com/go-resty/resty/v2) = %{version}
+
+Requires:       go(golang.org/x/net)
+
+%description
+resty provides a simple HTTP, REST, and SSE client library for Go.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-golang-groupcache/go-github-golang-groupcache.spec
+++ b/SPECS/go-github-golang-groupcache/go-github-golang-groupcache.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           groupcache
+%define go_import_path  github.com/golang/groupcache
+%define commit_id       2c02b8208cf8c02a3e358cb1d9b60950647543fc
+
+Name:           go-github-golang-groupcache
+Version:        0+git20260607.2c02b82
+Release:        %autorelease
+Summary:        Groupcache caching and cache-filling library for Go
+License:        Apache-2.0
+URL:            https://github.com/golang/groupcache
+#!RemoteAsset:  sha256:6a4d1b422304807fe23e5b6fa54036e78feede7d4db20f80da352ec19f53c1ca
+Source0:        https://github.com/golang/groupcache/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/golang/protobuf)
+BuildRequires:  go(google.golang.org/protobuf)
+
+Provides:       go(github.com/golang/groupcache) = %{version}
+
+Requires:       go(github.com/golang/protobuf)
+Requires:       go(google.golang.org/protobuf)
+
+%description
+groupcache provides a distributed caching and cache-filling library for Go.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-gregjones-httpcache/go-github-gregjones-httpcache.spec
+++ b/SPECS/go-github-gregjones-httpcache/go-github-gregjones-httpcache.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           httpcache
+%define go_import_path  github.com/gregjones/httpcache
+%define commit_id 901d90724c7919163f472a9812253fb26761123d
+
+Name:           go-github-gregjones-httpcache
+Version:        0+git20260607.901d907
+Release:        %autorelease
+Summary:        HTTP caching transport for Go
+License:        MIT
+URL:            https://github.com/gregjones/httpcache
+#!RemoteAsset:  sha256:a376d4c6c17fdf7659b3952dbba20295563b767d79b6aab2fbac94c00cee0bf2
+Source0:        https://github.com/gregjones/httpcache/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/bradfitz/gomemcache/memcache)
+BuildRequires:  go(github.com/gomodule/redigo)
+BuildRequires:  go(github.com/peterbourgon/diskv)
+BuildRequires:  go(github.com/syndtr/goleveldb)
+
+Provides:       go(github.com/gregjones/httpcache) = %{version}
+
+Requires:       go(github.com/bradfitz/gomemcache/memcache)
+Requires:       go(github.com/gomodule/redigo)
+Requires:       go(github.com/peterbourgon/diskv)
+Requires:       go(github.com/syndtr/goleveldb)
+
+%description
+This package provides an HTTP caching transport for Go.
+
+%files
+%doc README.md
+%license LICENSE.txt
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-hashicorp-go-retryablehttp/0001-fix-tests-for-current-go-and-hermetic-transport-failure.patch
+++ b/SPECS/go-github-hashicorp-go-retryablehttp/0001-fix-tests-for-current-go-and-hermetic-transport-failure.patch
@@ -1,0 +1,89 @@
+From 01ef9eb2d8aa20aff96930143430971dfae4f104 Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Thu, 11 Jun 2026 17:11:35 +0800
+Subject: [PATCH] Fix tests for current Go and hermetic transport failure
+
+---
+ client_test.go       |  4 ++--
+ roundtripper_test.go | 30 ++++++++++++++----------------
+ 2 files changed, 16 insertions(+), 18 deletions(-)
+
+diff --git a/client_test.go b/client_test.go
+index c20dcb2..d62fbab 100644
+--- a/client_test.go
++++ b/client_test.go
+@@ -676,7 +676,7 @@ func testClientResponseLogHook(t *testing.T, l interface{}, buf *bytes.Buffer) {
+ 			successLog := "test_log_pass"
+ 			// Log something when we get a 200
+ 			if logger != nil {
+-				logger.Printf(successLog)
++				logger.Printf("%s", successLog)
+ 			} else {
+ 				buf.WriteString(successLog)
+ 			}
+@@ -688,7 +688,7 @@ func testClientResponseLogHook(t *testing.T, l interface{}, buf *bytes.Buffer) {
+ 			}
+ 			failLog := string(body)
+ 			if logger != nil {
+-				logger.Printf(failLog)
++				logger.Printf("%s", failLog)
+ 			} else {
+ 				buf.WriteString(failLog)
+ 			}
+diff --git a/roundtripper_test.go b/roundtripper_test.go
+index 8d468c9..4905201 100644
+--- a/roundtripper_test.go
++++ b/roundtripper_test.go
+@@ -11,7 +11,6 @@ import (
+ 	"net/http"
+ 	"net/http/httptest"
+ 	"net/url"
+-	"reflect"
+ 	"sync/atomic"
+ 	"testing"
+ )
+@@ -110,27 +109,26 @@ func TestRoundTripper_TransportFailureErrorHandling(t *testing.T) {
+ 
+ 	retryClient.ErrorHandler = PassthroughErrorHandler
+ 
+-	expectedError := &url.Error{
+-		Op:  "Get",
+-		URL: "http://999.999.999.999:999/",
+-		Err: &net.OpError{
+-			Op:  "dial",
+-			Net: "tcp",
+-			Err: &net.DNSError{
+-				Name:       "999.999.999.999",
+-				Err:        "no such host",
+-				IsNotFound: true,
+-			},
+-		},
++	ln, err := net.Listen("tcp", "127.0.0.1:0")
++	if err != nil {
++		t.Fatal(err)
++	}
++	targetURL := "http://" + ln.Addr().String() + "/"
++	if err := ln.Close(); err != nil {
++		t.Fatal(err)
+ 	}
+ 
+ 	// Get the standard client and execute the request.
+ 	client := retryClient.StandardClient()
+-	_, err := client.Get("http://999.999.999.999:999/")
++	_, err = client.Get(targetURL)
+ 
+ 	// assert expectations
+-	if !reflect.DeepEqual(expectedError, normalizeError(err)) {
+-		t.Fatalf("expected %q, got %q", expectedError, err)
++	var urlErr *url.Error
++	if !errors.As(err, &urlErr) {
++		t.Fatalf("expected url.Error, got %T: %v", err, err)
++	}
++	if urlErr.Op != "Get" || urlErr.URL != targetURL {
++		t.Fatalf("expected Get %q error, got %q %q", targetURL, urlErr.Op, urlErr.URL)
+ 	}
+ }
+ 
+-- 
+2.43.0
+

--- a/SPECS/go-github-hashicorp-go-retryablehttp/go-github-hashicorp-go-retryablehttp.spec
+++ b/SPECS/go-github-hashicorp-go-retryablehttp/go-github-hashicorp-go-retryablehttp.spec
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-retryablehttp
+%define go_import_path  github.com/hashicorp/go-retryablehttp
+
+Name:           go-github-hashicorp-go-retryablehttp
+Version:        0.7.8
+Release:        %autorelease
+Summary:        Retryable HTTP client in Go
+License:        MPL-2.0
+URL:            https://github.com/hashicorp/go-retryablehttp
+#!RemoteAsset:  sha256:a556692913b852c228fbfca680bb6660bc851485155dd2c1c5f4017497398823
+Source0:        https://github.com/hashicorp/go-retryablehttp/archive/refs/tags/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Upstreamable test fixes for current Go vet and hermetic transport failure
+# handling without depending on external DNS behavior. - HNO3Miracle
+Patch0:         0001-fix-tests-for-current-go-and-hermetic-transport-failure.patch
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/fatih/color)
+BuildRequires:  go(github.com/hashicorp/go-cleanhttp)
+BuildRequires:  go(github.com/hashicorp/go-hclog)
+BuildRequires:  go(github.com/mattn/go-colorable)
+BuildRequires:  go(github.com/mattn/go-isatty)
+BuildRequires:  go(golang.org/x/sys)
+
+Provides:       go(github.com/hashicorp/go-retryablehttp) = %{version}
+
+Requires:       go(github.com/hashicorp/go-cleanhttp)
+
+%description
+The retryablehttp package provides a familiar HTTP client interface with
+automatic retries and exponential backoff. It is a thin wrapper over the
+standard net/http client library and exposes nearly the same public API.
+
+%files
+%doc CHANGELOG.md
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-mdlayher-socket/go-github-mdlayher-socket.spec
+++ b/SPECS/go-github-mdlayher-socket/go-github-mdlayher-socket.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           socket
+%define go_import_path  github.com/mdlayher/socket
+
+Name:           go-github-mdlayher-socket
+Version:        0.6.0
+Release:        %autorelease
+Summary:        Low-level network connection helpers for Go
+License:        MIT
+URL:            https://github.com/mdlayher/socket
+#!RemoteAsset:  sha256:4832cc911767d0a22f3b7c4288518d51c522ed43ee0b3128554952c1b9016c6e
+Source0:        https://github.com/mdlayher/socket/archive/refs/tags/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/google/go-cmp)
+BuildRequires:  go(golang.org/x/net)
+BuildRequires:  go(golang.org/x/sync)
+BuildRequires:  go(golang.org/x/sys)
+
+Provides:       go(github.com/mdlayher/socket) = %{version}
+
+Requires:       go(golang.org/x/net)
+Requires:       go(golang.org/x/sync)
+Requires:       go(golang.org/x/sys)
+
+%description
+Package socket provides low-level network connection types that integrate with
+Go's runtime network poller for asynchronous I/O and deadline support.
+
+%files
+%doc CHANGELOG.md
+%doc README.md
+%license LICENSE.md
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-mdlayher-vsock/go-github-mdlayher-vsock.spec
+++ b/SPECS/go-github-mdlayher-vsock/go-github-mdlayher-vsock.spec
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           vsock
+%define go_import_path  github.com/mdlayher/vsock
+
+Name:           go-github-mdlayher-vsock
+Version:        1.2.1
+Release:        %autorelease
+Summary:        Linux VM socket support for Go
+License:        MIT
+URL:            https://github.com/mdlayher/vsock
+#!RemoteAsset:  sha256:0abaf26f54abec90f6387c2ab0824d9ede750b920231aef60820175bb4b843ac
+Source0:        https://github.com/mdlayher/vsock/archive/refs/tags/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/google/go-cmp)
+BuildRequires:  go(github.com/mdlayher/socket)
+BuildRequires:  go(golang.org/x/net)
+BuildRequires:  go(golang.org/x/sync)
+BuildRequires:  go(golang.org/x/sys)
+
+Provides:       go(github.com/mdlayher/vsock) = %{version}
+
+Requires:       go(github.com/mdlayher/socket)
+Requires:       go(golang.org/x/net)
+Requires:       go(golang.org/x/sync)
+Requires:       go(golang.org/x/sys)
+
+%description
+Package vsock provides access to Linux VM sockets (AF_VSOCK) for communication
+between a hypervisor and its virtual machines.
+
+%files
+%doc CHANGELOG.md
+%doc README.md
+%license LICENSE.md
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-mxk-go-flowrate/0001-make-status-tests-tolerate-scheduler-jitter.patch
+++ b/SPECS/go-github-mxk-go-flowrate/0001-make-status-tests-tolerate-scheduler-jitter.patch
@@ -1,0 +1,86 @@
+From 0ee7ce8d45e5ac5198d88846a8083cd44cf905de Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Thu, 11 Jun 2026 17:09:13 +0800
+Subject: [PATCH] Make flowrate status tests tolerate scheduler jitter
+
+---
+ flowrate/io_test.go | 38 +++++++++++++++++++++++++++++++++++---
+ 1 file changed, 35 insertions(+), 3 deletions(-)
+
+diff --git a/flowrate/io_test.go b/flowrate/io_test.go
+index fa7f4b4..e6a78ad 100644
+--- a/flowrate/io_test.go
++++ b/flowrate/io_test.go
+@@ -6,11 +6,12 @@ package flowrate
+ 
+ import (
+ 	"bytes"
+-	"reflect"
+ 	"testing"
+ 	"time"
+ )
+ 
++const statusTimeTolerance = 25 * time.Millisecond
++
+ const (
+ 	_50ms  = 50 * time.Millisecond
+ 	_100ms = 100 * time.Millisecond
+@@ -31,6 +32,37 @@ func nextStatus(m *Monitor) Status {
+ 	return m.Status()
+ }
+ 
++func statusEqual(got, want Status) bool {
++	if got.Start != want.Start || got.Active != want.Active ||
++		got.Bytes != want.Bytes || got.Samples != want.Samples ||
++		got.BytesRem != want.BytesRem || got.Progress != want.Progress {
++		return false
++	}
++	if absDuration(got.Duration-want.Duration) > statusTimeTolerance ||
++		absDuration(got.Idle-want.Idle) > statusTimeTolerance ||
++		absDuration(got.TimeRem-want.TimeRem) > statusTimeTolerance {
++		return false
++	}
++	return absInt(got.InstRate-want.InstRate) <= 10 &&
++		absInt(got.CurRate-want.CurRate) <= 15 &&
++		absInt(got.AvgRate-want.AvgRate) <= 15 &&
++		absInt(got.PeakRate-want.PeakRate) <= 10
++}
++
++func absDuration(d time.Duration) time.Duration {
++	if d < 0 {
++		return -d
++	}
++	return d
++}
++
++func absInt(v int64) int64 {
++	if v < 0 {
++		return -v
++	}
++	return v
++}
++
+ func TestReader(t *testing.T) {
+ 	in := make([]byte, 100)
+ 	for i := range in {
+@@ -90,7 +122,7 @@ func TestReader(t *testing.T) {
+ 		Status{false, start, _300ms, 0, 20, 3, 0, 0, 67, 100, 0, 0, 0},
+ 	}
+ 	for i, s := range status {
+-		if !reflect.DeepEqual(&s, &want[i]) {
++		if !statusEqual(s, want[i]) {
+ 			t.Errorf("r.Status(%v) expected %v; got %v", i, want[i], s)
+ 		}
+ 	}
+@@ -136,7 +168,7 @@ func TestWriter(t *testing.T) {
+ 		Status{true, start, _500ms, _100ms, 100, 5, 200, 200, 200, 200, 0, 0, 100000},
+ 	}
+ 	for i, s := range status {
+-		if !reflect.DeepEqual(&s, &want[i]) {
++		if !statusEqual(s, want[i]) {
+ 			t.Errorf("w.Status(%v) expected %v; got %v", i, want[i], s)
+ 		}
+ 	}
+-- 
+2.43.0
+

--- a/SPECS/go-github-mxk-go-flowrate/go-github-mxk-go-flowrate.spec
+++ b/SPECS/go-github-mxk-go-flowrate/go-github-mxk-go-flowrate.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-flowrate
+%define go_import_path  github.com/mxk/go-flowrate
+%define commit_id       cca7078d478f8520f85629ad7c68962d31ed7682
+
+Name:           go-github-mxk-go-flowrate
+Version:        0+git20260607.cca7078
+Release:        %autorelease
+Summary:        Reader and writer wrappers with flow rate control
+License:        BSD-2-Clause
+URL:            https://github.com/mxk/go-flowrate
+#!RemoteAsset:  sha256:04d0e2ebb1b66b203697ec4161d66fa9cb833071b3393d655aee0c3ab9e7298e
+Source0:        https://github.com/mxk/go-flowrate/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Upstreamable test fix: exact timing/rate assertions are sensitive to CI
+# scheduler jitter even when flow control works correctly. - HNO3Miracle
+Patch0:         0001-make-status-tests-tolerate-scheduler-jitter.patch
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/mxk/go-flowrate) = %{version}
+
+%description
+This package provides Go reader and writer wrappers with flow rate
+control.
+
+%files
+%doc README
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-nytimes-gziphandler/go-github-nytimes-gziphandler.spec
+++ b/SPECS/go-github-nytimes-gziphandler/go-github-nytimes-gziphandler.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           gziphandler
+%define go_import_path  github.com/NYTimes/gziphandler
+
+Name:           go-github-nytimes-gziphandler
+Version:        1.1.1
+Release:        %autorelease
+Summary:        Gzip middleware for Go HTTP handlers
+License:        Apache-2.0
+URL:            https://github.com/NYTimes/gziphandler
+#!RemoteAsset:  sha256:c236c216a16e4286338e66e0947938944992f918fe827c31f8745c0be98818d2
+Source0:        https://github.com/NYTimes/gziphandler/archive/refs/tags/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/stretchr/testify)
+
+Provides:       go(github.com/NYTimes/gziphandler) = %{version}
+
+%description
+gziphandler provides middleware for serving compressed HTTP responses from Go
+HTTP handlers.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-shurcool-httpfs/go-github-shurcool-httpfs.spec
+++ b/SPECS/go-github-shurcool-httpfs/go-github-shurcool-httpfs.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           httpfs
+%define go_import_path  github.com/shurcooL/httpfs
+%define commit_id f1e31cf0ba5cd0d9306d6bae7602feadf4ad65cb
+# The remaining packages either import golang.org/x/tools/godoc/vfs/httpfs,
+# which is not provided by the current go-golang-x-tools package in openRuyi,
+# or contain no tests after those packages are excluded. - HNO3Miracle
+%define go_test_exclude_glob %{go_import_path}*
+
+Name:           go-github-shurcool-httpfs
+Version:        0+git20260607.f1e31cf
+Release:        %autorelease
+Summary:        Helpers for Go http.FileSystem implementations
+License:        MIT
+URL:            https://github.com/shurcooL/httpfs
+#!RemoteAsset:  sha256:9b5be5b56221d99817d758193290521e12a9c8d981b117751fecae9209744b74
+Source0:        https://github.com/shurcooL/httpfs/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/shurcooL/httpgzip)
+BuildRequires:  go(golang.org/x/tools)
+
+Provides:       go(github.com/shurcooL/httpfs) = %{version}
+
+Requires:       go(github.com/shurcooL/httpgzip)
+
+%description
+httpfs provides Go packages for working with the http.FileSystem interface.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-shurcool-httpgzip/0001-drop-x-tools-test-deps.patch
+++ b/SPECS/go-github-shurcool-httpgzip/0001-drop-x-tools-test-deps.patch
@@ -1,0 +1,47 @@
+From 15b20feb4a1bc64ed72023b39f784225f763df50 Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Mon, 25 May 2026 16:46:12 +0800
+Subject: [PATCH] Drop x/tools test fixtures
+
+Replace x/tools godoc VFS fixtures with standard-library test files to avoid pulling obsolete x/tools packages into tests.
+---
+ fs_test.go | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/fs_test.go b/fs_test.go
+index d54d31f..6606067 100644
+--- a/fs_test.go
++++ b/fs_test.go
+@@ -4,12 +4,12 @@ import (
+ 	"io"
+ 	"net/http"
+ 	"net/http/httptest"
++	"os"
++	"path/filepath"
+ 	"strings"
+ 	"testing"
+ 
+ 	"github.com/shurcooL/httpgzip"
+-	"golang.org/x/tools/godoc/vfs/httpfs"
+-	"golang.org/x/tools/godoc/vfs/mapfs"
+ )
+ 
+ func ExampleFileServer() {
+@@ -26,9 +26,11 @@ func ExampleFileServer() {
+ // See https://github.com/shurcooL/httpgzip/pull/3
+ // and https://github.com/golang/go/commit/3745716bc3940f471137bf06fbe8c042257a43d3.
+ func TestFileServerImplicitLeadingSlash(t *testing.T) {
+-	fs := httpfs.New(mapfs.New(map[string]string{
+-		"foo.txt": "Hello world",
+-	}))
++	dir := t.TempDir()
++	if err := os.WriteFile(filepath.Join(dir, "foo.txt"), []byte("Hello world"), 0o644); err != nil {
++		t.Fatal(err)
++	}
++	fs := http.FS(os.DirFS(dir))
+ 	ts := httptest.NewServer(http.StripPrefix("/bar/", httpgzip.FileServer(fs, httpgzip.FileServerOptions{})))
+ 	defer ts.Close()
+ 	get := func(suffix string) string {
+-- 
+2.43.0
+

--- a/SPECS/go-github-shurcool-httpgzip/go-github-shurcool-httpgzip.spec
+++ b/SPECS/go-github-shurcool-httpgzip/go-github-shurcool-httpgzip.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           httpgzip
+%define go_import_path  github.com/shurcooL/httpgzip
+%define commit_id d1585fc322fa7cad2956ba8e01a41a39d09d6b31
+
+Name:           go-github-shurcool-httpgzip
+Version:        0+git20260607.d1585fc
+Release:        %autorelease
+Summary:        Gzip-enabled net/http primitives for Go
+License:        MIT
+URL:            https://github.com/shurcooL/httpgzip
+#!RemoteAsset:  sha256:71f30f4c752880fc5746024af93d73c5d82f016322850a572391e6d2f35b0045
+Source0:        https://github.com/shurcooL/httpgzip/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Upstreamable test fixture modernization: replace obsolete x/tools godoc VFS
+# fixtures with standard-library filesystem fixtures.
+# - HNO3Miracle
+Patch0:         0001-drop-x-tools-test-deps.patch
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(golang.org/x/net)
+
+Provides:       go(github.com/shurcooL/httpgzip) = %{version}
+
+Requires:       go(golang.org/x/net)
+
+%description
+Package httpgzip provides net/http-like primitives that use gzip compression
+when serving HTTP requests.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-syndtr-goleveldb/go-github-syndtr-goleveldb.spec
+++ b/SPECS/go-github-syndtr-goleveldb/go-github-syndtr-goleveldb.spec
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           leveldb
+%define go_import_path  github.com/syndtr/goleveldb
+%define commit_id 126854af5e6d8295ef8e8bee3040dd8380ae72e8
+
+Name:           go-github-syndtr-goleveldb
+Version:        0+git20260607.126854a
+Release:        %autorelease
+Summary:        LevelDB implementation in Go
+License:        BSD-2-Clause
+URL:            https://github.com/syndtr/goleveldb
+#!RemoteAsset:  sha256:97137477d1483e84021a3d4ec0920f4ebceda9494e1b8758a1a81a64fb3890fe
+Source0:        https://github.com/syndtr/goleveldb/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/fsnotify/fsnotify)
+BuildRequires:  go(github.com/golang/snappy)
+BuildRequires:  go(github.com/nxadm/tail)
+BuildRequires:  go(github.com/onsi/ginkgo)
+BuildRequires:  go(github.com/onsi/gomega)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(golang.org/x/net)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(golang.org/x/text)
+BuildRequires:  go(gopkg.in/tomb.v1)
+BuildRequires:  go(gopkg.in/yaml.v2)
+BuildRequires:  go(gopkg.in/yaml.v3)
+
+Provides:       go(github.com/syndtr/goleveldb) = %{version}
+
+Requires:       go(github.com/fsnotify/fsnotify)
+Requires:       go(github.com/golang/snappy)
+Requires:       go(github.com/nxadm/tail)
+Requires:       go(golang.org/x/net)
+Requires:       go(golang.org/x/sys)
+Requires:       go(golang.org/x/text)
+Requires:       go(gopkg.in/tomb.v1)
+Requires:       go(gopkg.in/yaml.v2)
+
+%description
+This package provides a LevelDB implementation written in Go.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-tv42-httpunix/go-github-tv42-httpunix.spec
+++ b/SPECS/go-github-tv42-httpunix/go-github-tv42-httpunix.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           httpunix
+%define go_import_path  github.com/tv42/httpunix
+%define commit_id 2ba4b9c3382c77e7b9ea89d00746e6111d142a22
+
+Name:           go-github-tv42-httpunix
+Version:        0+git20260607.2ba4b9c
+Release:        %autorelease
+Summary:        Go library to talk HTTP over Unix domain sockets
+License:        MIT
+URL:            https://github.com/tv42/httpunix
+#!RemoteAsset:  sha256:cebdb837a242a4f4a50c2a5a834d64ecf0fb35d34c1f37e45b2db34651a87901
+Source0:        https://github.com/tv42/httpunix/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/tv42/httpunix) = %{version}
+
+%description
+httpunix provides helpers for sending HTTP requests over Unix domain sockets.
+
+%files
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

This PR is composed of several network modules for prometheus.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: ChatGPT:GPT-5.5 High

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy


## Dependency relationship

This PR provides prerequisites for other Prometheus Go package groups, including `go(github.com/hashicorp/go-retryablehttp)`, `go(github.com/tv42/httpunix)`, and `go(github.com/nxadm/tail)`.
