### PR TITLE
ci: fix rpm glob in install job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,5 +98,7 @@ jobs:
         dnf update --assumeyes
     - name: Install all
       run: |
-        ls -lah **.rpm
-        dnf install --assumeyes **.rpm
+        rpms=$(find . -name '*.rpm')
+        [ -n "$rpms" ]
+        ls -lah $rpms
+        dnf install --assumeyes $rpms


### PR DESCRIPTION
## Summary

`**.rpm` doesn't recurse in sh, (https://github.com/openRuyi-Project/openRuyi/actions/runs/27335782141/job/80762397437 https://github.com/openRuyi-Project/openRuyi/pull/675). Use `find` instead, like [linux-package.yml](https://github.com/BOINC/boinc/blob/master/.github/workflows/linux-package.yml).

## Related Issue

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy