### PR TITLE
SPECS: lz4: add a patch to enable LZ4_FAST_DEC_LOOP for RISC-V

### DIFF
--- a/SPECS/lz4/Enable-LZ4_FAST_DEC_LOOP-for-RISC-V.patch
+++ b/SPECS/lz4/Enable-LZ4_FAST_DEC_LOOP-for-RISC-V.patch
@@ -1,0 +1,21 @@
+From dfb1cb6147eb8e1fe2c6ea49054ec30f1e2dc0d4 Mon Sep 17 00:00:00 2001
+From: Huang Shangcheng <huang.shangcheng@zte.com.cn>
+Date: Thu, 30 Apr 2026 15:51:03 +0800
+Subject: [PATCH] Enable LZ4_FAST_DEC_LOOP for RISC-V
+
+---
+ lib/lz4.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/lib/lz4.c b/lib/lz4.c
+--- a/lib/lz4.c
++++ b/lib/lz4.c
+@@ -477,6 +477,8 @@
+       * on certain mobile chipsets, performance is reduced with clang. For
+       * more information refer to https://github.com/lz4/lz4/pull/707 */
+ #    define LZ4_FAST_DEC_LOOP 1
++#  elif defined(__riscv) && (__riscv_xlen == 64)
++#    define LZ4_FAST_DEC_LOOP 1
+ #  else
+ #    define LZ4_FAST_DEC_LOOP 0
+ #  endif

--- a/SPECS/lz4/lz4.spec
+++ b/SPECS/lz4/lz4.spec
@@ -17,6 +17,8 @@ Source:         https://github.com/lz4/lz4/releases/download/v%{version}/lz4-%{v
 BuildSystem:    autotools
 
 Patch0:         lz4-export.diff
+# Submitted to upstream: https://github.com/lz4/lz4/pull/1739
+Patch1:         Enable-LZ4_FAST_DEC_LOOP-for-RISC-V.patch
 
 BuildOption(build):  PREFIX=%{_prefix}
 BuildOption(install):  PREFIX=%{_prefix} LIBDIR=%{_libdir}


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->
This PR enables `LZ4_FAST_DEC_LOOP` for the **64-bit RISC-V architecture** (`__riscv` with `__riscv_xlen == 64`).

Modern RISC-V cores are increasingly capable of handling unaligned memory accesses and 32-byte copies efficiently. Enabling the fast decode loop provides a modest but consistent performance improvement for decompression on these platforms.

### Test Environment
* **Hardware:** SpacemiT K1-X RISC-V Board
* **OS:** 64-bit Linux (Debian)
* **Compiler:** GCC 13.2.0
* **Benchmark Tool:** `lzbench 2.1` (`-t0,0 -i5,5 -elz4`)
* **Dataset:** `silesia.tar`

### Benchmark Results

| | Avg. Compress | Avg. Decompress |
|:---|:---|:---|
| **Before** | 80.1 MB/s | 633 MB/s |
| **After** | 80.5 MB/s | 639.5 MB/s |
| **Delta** | +0.5% | **+1.0%** |

### Conclusion
Decompression speed improves by approximately **+1.0%** (~+6.5 MB/s) on RV64, with no measurable regression in compression speed or output ratio.


## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
