### PR TITLE
SPECS: protobuf: Add protobuf-compiler provides.

### DIFF
--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -71,7 +71,8 @@ RPC protocols and file formats.
 %package        devel
 Summary:        Header files, libraries and development documentation for %{name}
 Requires:       %{name}%{?_isa} = %{version}-%{release}
-Provides:       libprotobuf-devel
+Provides:       libprotobuf-devel = %{version}-%{release}
+Provides:       protobuf-compiler = %{version}-%{release}
 
 %description    devel
 Protocol Buffers are a way of encoding structured data in an efficient yet


### PR DESCRIPTION
## Summary

compatibility with specs that use this name
[ceph.spec.in](https://github.com/ceph/ceph/blob/main/ceph.spec.in).

```
BuildRequires:  protobuf-compiler
```

## Related Issue

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy