### PR TITLE
Add python-routes for ceph CI

### DIFF
--- a/SPECS/python-repoze-lru/python-repoze-lru.spec
+++ b/SPECS/python-repoze-lru/python-repoze-lru.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: sunyuechi <sunyuechi@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname repoze-lru
+%global pypi_name repoze_lru
+
+Name:           python-%{srcname}
+Version:        0.8
+Release:        %autorelease
+Summary:        Tiny LRU cache implementation and decorator
+License:        LicenseRef-openRuyi-Repoze-BSD-derived
+URL:            https://github.com/repoze/repoze.lru
+VCS:            git:https://github.com/repoze/repoze.lru.git
+#!RemoteAsset:  sha256:a252408cd93fe670c88d6665b96fe5d42e071dba2507a1f21a1e609ae4fa891a
+Source0:        https://files.pythonhosted.org/packages/source/r/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l repoze
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+repoze.lru is a LRU (least recently used) cache implementation. Keys and
+values that are not used frequently will be evicted from the cache faster
+than keys and values that are used frequently. It works under CPython and
+PyPy, and provides a decorator for caching function results.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst CHANGES.rst
+
+%changelog
+%autochangelog

--- a/SPECS/python-routes/python-routes.spec
+++ b/SPECS/python-routes/python-routes.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: sunyuechi <sunyuechi@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname routes
+%global pypi_name Routes
+
+Name:           python-%{srcname}
+Version:        2.5.1
+Release:        %autorelease
+Summary:        Routing recognition and generation tools
+License:        MIT
+URL:            https://routes.readthedocs.io/
+VCS:            git:https://github.com/bbangert/routes.git
+#!RemoteAsset:  sha256:b6346459a15f0cbab01a45a90c3d25caf980d4733d628b4cc1952b865125d053
+Source0:        https://files.pythonhosted.org/packages/source/r/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+# routes.middleware imports webob (the middleware extra), needed by the
+# default import check
+BuildRequires:  python3dist(webob)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Routes is a Python re-implementation of the Rails routes system for mapping
+URLs to controllers/actions and generating URLs. Routes makes it easy to
+create pretty and concise URLs that are RESTful with little effort.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst CHANGELOG.rst
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

ceph CI currently installs routes via pip. Package it so ci can use system packages

```
BuildRequires: python3dist(routes)
    add python-routes
    add python-repoze-lru
```

## Related Issue

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy