### PR TITLE
Add missing devel header dependencies

### DIFF
--- a/SPECS/dolphin/dolphin.spec
+++ b/SPECS/dolphin/dolphin.spec
@@ -80,6 +80,8 @@ This package contains the libraries used by Dolphin and Konqueror.
 %package        devel
 Summary:        KDE File Manager
 Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       cmake(Qt6Core) >= %{qt6_version}
+Requires:       cmake(Qt6Gui) >= %{qt6_version}
 
 %description    devel
 This package contains the libraries used by Dolphin and Konqueror.

--- a/SPECS/hipblas/hipblas.spec
+++ b/SPECS/hipblas/hipblas.spec
@@ -13,7 +13,7 @@ Release:        %autorelease
 Summary:        ROCm BLAS marshalling library
 License:        MIT
 Url:            https://github.com/ROCm/hipBLAS
-#!RemoteAsset
+#!RemoteAsset:  sha256:4a77f19a6229a6135fc9e2ea8e7694efda984c654a11a8c650fa9480aaf1ca84
 Source0:        %{url}/archive/rocm-%{rocm_version}.tar.gz
 BuildSystem:    cmake
 
@@ -49,6 +49,7 @@ hipBLAS supports rocBLAS and cuBLAS as backends.
 %package        devel
 Summary:        Libraries and headers for %{name}
 Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       cmake(hip)
 Requires:       cmake(hipblas-common)
 
 %description    devel
@@ -72,4 +73,4 @@ rm -f %{buildroot}%{_prefix}/share/doc/hipblas/LICENSE.md
 %{_libdir}/cmake/hipblas/
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/ima-evm-utils/ima-evm-utils.spec
+++ b/SPECS/ima-evm-utils/ima-evm-utils.spec
@@ -12,7 +12,7 @@ Summary:        IMA/EVM support utilities
 License:        GPL-2.0-or-later
 URL:            https://github.com/linux-integrity/ima-evm-utils
 VCS:            git:https://github.com/linux-integrity/ima-evm-utils
-#!RemoteAsset
+#!RemoteAsset:  sha256:9346a5ccd5ca77caf6a9d2ac0d83873c04d0372414a632126df4e7a88bedff4a
 Source0:        %{url}/releases/download/v%{version}/%{name}-%{version}.tar.gz
 BuildSystem:    autotools
 
@@ -41,6 +41,7 @@ ima-evm-utils is used to prepare the file system for these extended attributes.
 %package        devel
 Summary:        Development files for %{name}
 Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       pkgconfig(openssl)
 
 %description    devel
 This package provides the header files for %{name}
@@ -62,4 +63,4 @@ rm -rf %{buildroot}%{_datadir}/doc
 %{_libdir}/libimaevm.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/isl/isl.spec
+++ b/SPECS/isl/isl.spec
@@ -12,7 +12,7 @@ Summary:        Integer Set Library
 License:        MIT
 URL:            https://libisl.sourceforge.io/
 VCS:            git:https://repo.or.cz/isl.git
-#!RemoteAsset
+#!RemoteAsset:  sha256:6d8babb59e7b672e8cb7870e874f3f7b813b6e00e6af3f8b04f7579965643d5c
 Source:         https://libisl.sourceforge.io/isl-%{version}.tar.xz
 BuildSystem:    autotools
 
@@ -29,6 +29,7 @@ It is used by Cloog and the GCC Graphite optimization framework.
 %package        devel
 Summary:        Development tools for ISL
 Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       pkgconfig(gmp)
 
 %description    devel
 Development tools and headers for the ISL.
@@ -48,4 +49,4 @@ rm -f  %{buildroot}%{_libdir}/libisl.so.*-gdb.py
 %{_libdir}/pkgconfig/%{name}.pc
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kdsoap-ws-discovery-client/kdsoap-ws-discovery-client.spec
+++ b/SPECS/kdsoap-ws-discovery-client/kdsoap-ws-discovery-client.spec
@@ -30,6 +30,7 @@ Library for finding WS-Discovery devices in the network using Qt6 and KDSoap.
 Summary:        Development libraries and header files for %{name}
 Requires:       %{name}%{?_isa} = %{version}-%{release}
 Requires:       cmake(KDSoap-qt6)
+Requires:       cmake(Qt6Core)
 
 %description    devel
 Development files for %{name}.
@@ -48,4 +49,4 @@ Development files for %{name}.
 %{_libdir}/libKDSoapWSDiscoveryClient.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/kf6-baloo/kf6-baloo.spec
+++ b/SPECS/kf6-baloo/kf6-baloo.spec
@@ -78,6 +78,7 @@ package contains aditional command line utilities.
 Summary:        Development package for baloo6
 Requires:       %{name}%{?_isa} = %{version}-%{release}
 Requires:       lmdb-devel
+Requires:       cmake(KF6Config) >= %{_kf6_version}
 Requires:       cmake(KF6CoreAddons) >= %{_kf6_version}
 Requires:       cmake(KF6FileMetaData) >= %{_kf6_version}
 Requires:       cmake(Qt6Core) >= %{qt6_version}

--- a/SPECS/kf6-kidletime/kf6-kidletime.spec
+++ b/SPECS/kf6-kidletime/kf6-kidletime.spec
@@ -57,6 +57,7 @@ notified upon idle time events, such as custom timeouts, or user activity.
 %package        devel
 Summary:        Build environment for kidletime, an idle time singleton
 Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       cmake(Qt6Core) >= %{qt6_version}
 
 %description    devel
 Development files for KIdleTime, which is a singleton reporting

--- a/SPECS/poppler/poppler.spec
+++ b/SPECS/poppler/poppler.spec
@@ -66,6 +66,8 @@ BuildRequires:  pkgconfig(Qt6Xml)
 %package        devel
 Summary:        Libraries and headers for poppler
 Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       pkgconfig(Qt6Core)
+Requires:       pkgconfig(Qt6Gui)
 
 %description    devel
 You should install the poppler-devel package if you would like to

--- a/SPECS/protobuf/protobuf.spec
+++ b/SPECS/protobuf/protobuf.spec
@@ -71,6 +71,7 @@ RPC protocols and file formats.
 %package        devel
 Summary:        Header files, libraries and development documentation for %{name}
 Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       pkgconfig(zlib)
 Provides:       libprotobuf-devel = %{version}-%{release}
 Provides:       protobuf-compiler = %{version}-%{release}
 

--- a/SPECS/pybind11/pybind11.spec
+++ b/SPECS/pybind11/pybind11.spec
@@ -37,6 +37,7 @@ C++ code.
 
 %package        devel
 Summary:        Development headers for pybind11
+Requires:       pkgconfig(python3)
 
 %description    devel
 This package contains the development headers for pybind11.
@@ -78,4 +79,4 @@ This package contains the Python 3 files for pybind11.
 %files -n python-%{srcname} -f %{pyproject_files}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/python-dbus-python/python-dbus-python.spec
+++ b/SPECS/python-dbus-python/python-dbus-python.spec
@@ -48,6 +48,7 @@ This is a metapackage that requires the main Python 3 package.
 
 %package        devel
 Summary:        Libraries and headers for dbus-python
+Requires:       pkgconfig(python3)
 
 %description    devel
 This package contains the header files and static libraries needed for

--- a/SPECS/python-pycairo/python-pycairo.spec
+++ b/SPECS/python-pycairo/python-pycairo.spec
@@ -33,6 +33,7 @@ Python bindings for the cairo library.
 %package        devel
 Summary:        Development files for embedding pycairo
 Requires:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+Requires:       pkgconfig(python3)
 
 %description    devel
 This package contains files required to embed pycairo support

--- a/SPECS/python-pygobject/python-pygobject.spec
+++ b/SPECS/python-pygobject/python-pygobject.spec
@@ -44,6 +44,7 @@ for use in Python programs.
 %package        devel
 Summary:        Development files for embedding PyGObject introspection support
 Requires:       python3-gobject%{?_isa} = %{version}-%{release}
+Requires:       pkgconfig(python3)
 
 %description    devel
 This package contains files required to embed PyGObject introspection

--- a/SPECS/qt6-qtlanguageserver/qt6-qtlanguageserver.spec
+++ b/SPECS/qt6-qtlanguageserver/qt6-qtlanguageserver.spec
@@ -15,7 +15,7 @@ Summary:        Qt6 - LanguageServer component
 License:        GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://github.com/qt/qtlanguageserver
-#!RemoteAsset
+#!RemoteAsset:  sha256:3360526b4f4d556673b31e29a49e15d02da52d5eaa53b0204d56a0ba160a556c
 Source0:        https://download.qt.io/official_releases/qt/%{short_version}/%{real_version}/submodules/%{qt_module}-everywhere-src-%{real_version}.tar.xz
 BuildSystem:    cmake
 
@@ -32,6 +32,7 @@ Server protocol.
 
 %package        devel
 Summary:        Development files for %{name}
+Requires:       pkgconfig(Qt6Core)
 
 %description    devel
 Development files for %{name}.
@@ -55,4 +56,4 @@ Development files for %{name}.
 %{_qt6_archdatadir}/sbom/%{qt_module}-%{real_version}.spdx
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/source-highlight/source-highlight.spec
+++ b/SPECS/source-highlight/source-highlight.spec
@@ -36,6 +36,7 @@ easily extended for handling new languages and output formats.
 %package        devel
 Summary:        Header files and development libraries for source-highlight
 Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       boost-devel
 
 %description    devel
 This package contains the header files, pkg-config files, and development libraries

--- a/SPECS/wlroots/wlroots.spec
+++ b/SPECS/wlroots/wlroots.spec
@@ -71,7 +71,9 @@ Wayland protocols and features.
 %package        devel
 Summary:        Development files for %{name}
 Requires:       %{name}%{?_isa} = %{version}-%{release}
-Recommends:     pkgconfig(xcb-icccm)
+# wlr/xwayland/xwayland.h is installed even with xwayland disabled
+Requires:       pkgconfig(xcb-ewmh)
+Requires:       pkgconfig(xcb-icccm)
 
 %description    devel
 Development files for %{name}.


### PR DESCRIPTION
## Summary

Add missing devel header dependencies, fixes the same kind of problem as https://github.com/openRuyi-Project/openRuyi/pull/706

## Related Issue

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy