### PR TITLE
SPECS: supertuxkart: fix installation issues

### DIFF
--- a/SPECS/libsquish/libsquish.spec
+++ b/SPECS/libsquish/libsquish.spec
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Li Guan <guanli.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global OBCMake_version 0.3.12
+
+Name:           libsquish
+Version:        1.15.1.4
+Release:        %autorelease
+Summary:        Library for compressing images with the DXT/S3TC standard
+License:        MIT
+URL:            https://github.com/oblivioncth/libsquish
+#!RemoteAsset:  sha256:8ebe37feddfc4e640541dce6a09d6144eae4606ac0dc1648e8f225d002c9531b
+Source:         https://github.com/oblivioncth/libsquish/archive/refs/tags/v%{version}.tar.gz
+#!RemoteAsset:  sha256:8dbdbcd052b04c2ccf03d6c6578a65e75ef2187afb48059930e43fe6d92622da
+Source1:        https://github.com/oblivioncth/OBCMake/archive/refs/tags/v%{OBCMake_version}.tar.gz
+BuildSystem:    cmake
+
+BuildRequires:  cmake
+
+BuildOption(conf):  -DNO_VERBOSE_VERSION=ON
+BuildOption(conf):  -DBUILD_SHARED_LIBS=ON
+BuildOption(conf):  -DFETCHCONTENT_SOURCE_DIR_OBCMAKE=$PWD/OBCmake-%{OBCMake_version}
+
+%description
+Library for compressing images with the DXT/S3TC standard.
+
+%package        devel
+Summary:        Development files for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+The %{name}-devel package contains libraries and header files for
+developing applications that use %{name}.
+
+%prep -a
+%autosetup -p1
+tar -xf %{SOURCE1} -C .
+
+%install -a
+rm -f %{buildroot}%{_prefix}/LICENSE
+rm -f %{buildroot}%{_prefix}/README.md
+mkdir -p %{buildroot}%{_libdir}/cmake/libsquish
+mv %{buildroot}%{_prefix}/cmake/* %{buildroot}%{_libdir}/cmake/libsquish/
+rmdir %{buildroot}%{_prefix}/cmake
+
+%files
+%doc README.md
+%license LICENSE
+%{_libdir}/libsquish.so.*
+
+%files devel
+%{_includedir}/squish/
+%{_libdir}/libsquish.so
+%{_libdir}/cmake/libsquish/
+
+%changelog
+%autochangelog

--- a/SPECS/supertuxkart/supertuxkart.spec
+++ b/SPECS/supertuxkart/supertuxkart.spec
@@ -19,6 +19,9 @@ BuildOption(conf):  -DBUILD_RECORDER=OFF
 BuildOption(conf):  -DUSE_SYSTEM_ANGELSCRIPT=ON
 BuildOption(conf):  -DUSE_SYSTEM_WIIUSE=ON
 BuildOption(conf):  -DOpenGL_GL_PREFERENCE=GLVND
+BuildOption(conf):  -DUSE_SYSTEM_SQUISH=ON
+BuildOption(conf):  -DSQUISH_LIBRARY=%{_libdir}/libsquish.so
+BuildOption(conf):  -DSQUISH_INCLUDEDIR=${PWD}/stk-squish-compat
 
 BuildRequires:  cmake
 BuildRequires:  pkgconfig
@@ -41,6 +44,7 @@ BuildRequires:  pkgconfig(sdl2)
 BuildRequires:  pkgconfig(shaderc)
 BuildRequires:  pkgconfig(vorbis)
 BuildRequires:  pkgconfig(xrandr)
+BuildRequires:  cmake(libsquish)
 BuildRequires:  cmake(Angelscript)
 %ifnarch x86_64
 BuildRequires:  pkgconfig(egl)
@@ -60,6 +64,12 @@ BuildArch:      noarch
 
 %description    data
 Data files for SuperTuxKart a Free 3d kart racing game.
+
+%prep -a
+# supertuxkart expects <squish.h>, while this libsquish installs headers under /usr/include/squish/squish/.
+mkdir -p stk-squish-compat/squish
+ln -s %{_includedir}/squish/squish/squish.h stk-squish-compat/squish.h
+ln -s %{_includedir}/squish/squish/squish_export.h stk-squish-compat/squish/squish_export.h
 
 %files
 %doc CHANGELOG.md README.md


### PR DESCRIPTION
## Summary

This PR introduces libsquish into the repository and updates SuperTuxKart to use the system-provided libsquish during the build instead of the bundled copy in the source tree. This fixes the missing runtime dependency issue encountered when installing SuperTuxKart.

<img width="2784" height="1904" alt="image" src="https://github.com/user-attachments/assets/539051e2-0767-4c55-a201-390bd313f15d" />


## Related Issue

no issue.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
