### PR TITLE
SPECS: Add i3 and full test dependencies

### DIFF
--- a/SPECS/i3/i3.spec
+++ b/SPECS/i3/i3.spec
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+# Docs and man pages ship pre-generated in the release tarball and are installed
+# by default; enable this to regenerate them from source (needs asciidoc/xmlto).
+%bcond docs 0
+
+Name:           i3
+Version:        4.25.1
+Release:        %autorelease
+Summary:        Improved tiling window manager
+License:        BSD-3-Clause
+URL:            https://i3wm.org
+VCS:            git:https://github.com/i3/i3.git
+#!RemoteAsset:  sha256:4a742bbe81b9e5ee6057f42a8e3c691d88894e93f1a5d81fe239128512ac05c0
+Source0:        https://i3wm.org/downloads/%{name}-%{version}.tar.xz
+BuildSystem:    meson
+
+%if %{with docs}
+BuildOption(conf):  -Ddocs=true
+BuildOption(conf):  -Dmans=true
+%else
+BuildOption(conf):  -Ddocs=false
+BuildOption(conf):  -Dmans=false
+%endif
+
+BuildRequires:  bash
+BuildRequires:  desktop-file-utils
+BuildRequires:  git
+BuildRequires:  libev-devel >= 4.0
+BuildRequires:  meson >= 0.53
+BuildRequires:  perl
+BuildRequires:  perl-devel
+BuildRequires:  perl(AnyEvent)
+BuildRequires:  perl(ExtUtils::MakeMaker)
+BuildRequires:  perl(ExtUtils::PkgConfig)
+BuildRequires:  perl(Inline)
+BuildRequires:  perl(Inline::C)
+BuildRequires:  perl(IPC::Run)
+BuildRequires:  perl(JSON::XS)
+BuildRequires:  perl(TAP::Harness)
+BuildRequires:  perl(Test::More) >= 0.94
+BuildRequires:  perl(Types::Serialiser)
+BuildRequires:  perl(X11::XCB) >= 0.12
+BuildRequires:  perl(common::sense)
+BuildRequires:  pkgconfig(cairo) >= 1.14.4
+BuildRequires:  pkgconfig(glib-2.0)
+BuildRequires:  pkgconfig(gobject-2.0)
+BuildRequires:  pkgconfig(libpcre2-8) >= 10
+BuildRequires:  pkgconfig(libstartup-notification-1.0)
+BuildRequires:  pkgconfig(pangocairo)
+BuildRequires:  pkgconfig(xcb) >= 1.1.93
+BuildRequires:  pkgconfig(xcb-cursor)
+BuildRequires:  pkgconfig(xcb-icccm)
+BuildRequires:  pkgconfig(xcb-keysyms)
+BuildRequires:  pkgconfig(xcb-randr)
+BuildRequires:  pkgconfig(xcb-shape)
+BuildRequires:  pkgconfig(xcb-util)
+BuildRequires:  pkgconfig(xcb-xinerama)
+BuildRequires:  pkgconfig(xcb-xkb)
+BuildRequires:  pkgconfig(xcb-xtest)
+BuildRequires:  pkgconfig(xcb-xrm)
+BuildRequires:  pkgconfig(xkbcommon) >= 0.4.0
+BuildRequires:  pkgconfig(xkbcommon-x11) >= 0.4.0
+BuildRequires:  pkgconfig(yajl) >= 2.0.1
+BuildRequires:  xorg-server-xephyr
+BuildRequires:  xorg-server-xvfb
+# Only needed when regenerating docs/man pages from source (see %%bcond docs).
+%if %{with docs}
+BuildRequires:  asciidoc
+BuildRequires:  xmlto
+%endif
+
+Requires:       perl
+Requires:       perl(AnyEvent::I3) >= 0.19
+Requires:       perl(JSON::XS)
+Requires:       xkeyboard-config
+
+# Applications referenced by the upstream default configuration, when packaged:
+# Recommends:     dmenu
+# Recommends:     i3lock
+# Recommends:     i3status
+
+%description
+i3 is a tiling window manager for X11. It uses xcb for asynchronous
+communication with X11 and focuses on predictable, documented behavior.
+
+%package        devel
+Summary:        Development files for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+Header files for applications that use the i3 IPC interface.
+
+%prep -a
+# These scripts are installed into %%{_bindir}; use the system Perl path.
+find . -maxdepth 1 -type f -name 'i3*' -exec sed -i -e '1s;^#!/usr/bin/env perl;#!/usr/bin/perl;' {} +
+# Keep the upstream tests complete, but run them serially in OBS to avoid
+# spawning excessive nested X servers on build workers.
+sed -i -e 's/my $parallel = undef;/my $parallel = 1;/' testcases/complete-run.pl.in
+
+%check
+mkdir -p /tmp/.X11-unix
+chmod 1777 /tmp/.X11-unix
+mkdir -p i3-test-bin
+cat > i3-test-bin/xvfb-run <<'EOF'
+#!/bin/sh
+if [ "$1" = "--help" ]; then
+    exit 0
+fi
+exec "$@"
+EOF
+chmod +x i3-test-bin/xvfb-run
+PATH="$PWD/i3-test-bin:$PATH" %meson_test --timeout-multiplier 10 --print-errorlogs || {
+    cat %{_vpath_builddir}/latest/complete-run.log || true
+    find %{_vpath_builddir}/latest -maxdepth 1 -type f -name 'output-for-*' -print -exec cat {} \; || true
+    exit 1
+}
+desktop-file-validate %{buildroot}%{_datadir}/applications/i3.desktop
+
+%files
+%doc RELEASE-NOTES-%{version}
+%license LICENSE
+%dir %{_sysconfdir}/%{name}
+%config(noreplace) %{_sysconfdir}/%{name}/config
+%config(noreplace) %{_sysconfdir}/%{name}/config.keycodes
+%{_bindir}/%{name}*
+%{_docdir}/%{name}/*.css
+%{_docdir}/%{name}/*.html
+%{_docdir}/%{name}/*.png
+%{_datadir}/applications/%{name}.desktop
+%{_datadir}/xsessions/%{name}.desktop
+%{_datadir}/xsessions/%{name}-with-shmlog.desktop
+%{_mandir}/man1/%{name}*.1*
+
+%files devel
+%license LICENSE
+%{_includedir}/%{name}/ipc.h
+
+%changelog
+%autochangelog

--- a/SPECS/perl-AnyEvent-I3/perl-AnyEvent-I3.spec
+++ b/SPECS/perl-AnyEvent-I3/perl-AnyEvent-I3.spec
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           perl-AnyEvent-I3
+Version:        0.19
+Release:        %autorelease
+Summary:        Communicate with the i3 window manager
+License:        GPL-1.0-or-later OR Artistic-1.0-Perl
+URL:            https://metacpan.org/dist/AnyEvent-I3
+#!RemoteAsset:  sha256:1bcd3b60db3d5560148de791353e8af1172264f5a85e77197b9ffc041dac483a
+Source0:        https://www.cpan.org/authors/id/M/MS/MSTPLBG/AnyEvent-I3-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    perlmaker
+
+BuildOption(build):  INSTALLDIRS=vendor
+
+BuildRequires:  make
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-macros
+BuildRequires:  perl-devel
+BuildRequires:  perl(AnyEvent)
+BuildRequires:  perl(AnyEvent::Handle)
+BuildRequires:  perl(AnyEvent::Socket)
+BuildRequires:  perl(ExtUtils::MakeMaker)
+BuildRequires:  perl(JSON::XS)
+BuildRequires:  perl(Test::More)
+BuildRequires:  perl(Types::Serialiser)
+BuildRequires:  perl(common::sense)
+
+Requires:       perl(AnyEvent)
+Requires:       perl(JSON::XS)
+Requires:       perl(Types::Serialiser)
+Requires:       perl(common::sense)
+
+%description
+AnyEvent::I3 connects to the i3 window manager through its UNIX socket based
+IPC interface.
+
+%files -f %{name}.files
+%doc Changes README
+
+%changelog
+%autochangelog

--- a/SPECS/perl-AnyEvent/perl-AnyEvent.spec
+++ b/SPECS/perl-AnyEvent/perl-AnyEvent.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           perl-AnyEvent
+Version:        7.17
+Release:        %autorelease
+Summary:        Framework for multiple event loops
+License:        GPL-1.0-or-later OR Artistic-1.0-Perl
+URL:            https://metacpan.org/dist/AnyEvent
+#!RemoteAsset:  sha256:50beea689c098fe4aaeb83806c40b9fe7f946d5769acf99f849f099091a4b985
+Source0:        https://www.cpan.org/authors/id/M/ML/MLEHMANN/AnyEvent-%{version}.tar.gz
+BuildSystem:    perlmaker
+
+BuildOption(build):  INSTALLDIRS=vendor
+
+BuildRequires:  make
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-macros
+BuildRequires:  perl-devel
+BuildRequires:  perl(Canary::Stability)
+BuildRequires:  perl(ExtUtils::MakeMaker)
+BuildRequires:  perl(JSON::XS)
+BuildRequires:  perl(Net::SSLeay)
+BuildRequires:  perl(Task::Weaken)
+BuildRequires:  perl(Test::More)
+BuildRequires:  perl(Time::HiRes)
+
+%description
+AnyEvent provides a common API for multiple Perl event loops.
+
+%files -f %{name}.files
+%doc Changes README
+
+%changelog
+%autochangelog

--- a/SPECS/perl-Cwd-Guard/perl-Cwd-Guard.spec
+++ b/SPECS/perl-Cwd-Guard/perl-Cwd-Guard.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           perl-Cwd-Guard
+Version:        0.05
+Release:        %autorelease
+Summary:        Temporary changing working directory
+License:        GPL-1.0-or-later OR Artistic-1.0-Perl
+URL:            https://metacpan.org/dist/Cwd-Guard
+#!RemoteAsset:  sha256:7afc7ca2b9502e440241938ad97a3e7ebd550180ebd6142e1db394186b268e77
+Source0:        https://cpan.metacpan.org/authors/id/K/KA/KAZEBURO/Cwd-Guard-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    perlbuild
+
+BuildOption(build):  --installdirs=vendor
+BuildOption(install):  --destdir=%{buildroot} --create_packlist=0
+
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-macros
+BuildRequires:  perl(Module::Build) >= 0.38
+BuildRequires:  perl(Test::More)
+BuildRequires:  perl(Test::Requires)
+
+%description
+Cwd::Guard changes the current working directory for a limited scope and
+restores the previous directory when the guard object is destroyed.
+
+%files -f %{name}.files
+%doc Changes README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/perl-ExtUtils-Depends/perl-ExtUtils-Depends.spec
+++ b/SPECS/perl-ExtUtils-Depends/perl-ExtUtils-Depends.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           perl-ExtUtils-Depends
+Version:        0.8002
+Release:        %autorelease
+Summary:        Easily build XS extensions that depend on XS extensions
+License:        GPL-1.0-or-later OR Artistic-1.0-Perl
+URL:            https://metacpan.org/dist/ExtUtils-Depends
+#!RemoteAsset:  sha256:02b9a46450050ce19b325b23e46bb4ec644229d7f2d95044f67a86d8efacdc29
+Source0:        https://cpan.metacpan.org/authors/id/E/ET/ETJ/ExtUtils-Depends-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    perlmaker
+
+BuildOption(build):  INSTALLDIRS=vendor
+
+BuildRequires:  make
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-macros
+BuildRequires:  perl(ExtUtils::MakeMaker) >= 7.44
+BuildRequires:  perl(Test::More) >= 0.88
+
+Requires:       perl(ExtUtils::MakeMaker) >= 7.44
+
+%description
+ExtUtils::Depends helps XS extensions declare and consume build information
+from other XS extensions.
+
+%files -f %{name}.files
+%doc Changes README
+
+%changelog
+%autochangelog

--- a/SPECS/perl-File-Copy-Recursive-Reduced/perl-File-Copy-Recursive-Reduced.spec
+++ b/SPECS/perl-File-Copy-Recursive-Reduced/perl-File-Copy-Recursive-Reduced.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           perl-File-Copy-Recursive-Reduced
+Version:        0.008
+Release:        %autorelease
+Summary:        Recursive copying of files and directories
+License:        GPL-1.0-or-later OR Artistic-1.0-Perl
+URL:            https://metacpan.org/dist/File-Copy-Recursive-Reduced
+#!RemoteAsset:  sha256:462bd66bf55e74b78f29ebdc9626af622d4f0115b5191b03167e82164db98f5a
+Source0:        https://cpan.metacpan.org/authors/id/J/JK/JKEENAN/File-Copy-Recursive-Reduced-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    perlmaker
+
+BuildOption(build):  INSTALLDIRS=vendor
+
+BuildRequires:  make
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-macros
+BuildRequires:  perl(ExtUtils::MakeMaker)
+BuildRequires:  perl(Capture::Tiny)
+BuildRequires:  perl(Path::Tiny)
+BuildRequires:  perl(Test::More) >= 0.44
+
+%description
+File::Copy::Recursive::Reduced provides recursive file and directory copying
+for Perl toolchain code.
+
+%files -f %{name}.files
+%doc Changes README Todo
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/perl-IO-Tty/perl-IO-Tty.spec
+++ b/SPECS/perl-IO-Tty/perl-IO-Tty.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           perl-IO-Tty
+Version:        1.31
+Release:        %autorelease
+Summary:        Pseudo ttys and constants
+License:        GPL-1.0-or-later OR Artistic-1.0-Perl
+URL:            https://metacpan.org/dist/IO-Tty
+#!RemoteAsset:  sha256:d597af221628571cbecf35b44520148c44798dfc8a9867774e60453f79d25ff7
+Source0:        https://cpan.metacpan.org/authors/id/T/TO/TODDR/IO-Tty-%{version}.tar.gz
+BuildSystem:    perlmaker
+
+BuildOption(build):  INSTALLDIRS=vendor OPTIMIZE="%{optflags}"
+
+BuildRequires:  make
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-macros
+BuildRequires:  perl-devel
+BuildRequires:  perl(ExtUtils::MakeMaker)
+BuildRequires:  perl(Test::More)
+
+%description
+IO::Tty provides pseudo terminal support and terminal related constants for
+Perl programs.
+
+%files -f %{name}.files
+%doc AI_POLICY.md ChangeLog CONTRIBUTING.md README.md SECURITY.md try
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/perl-IPC-Run/perl-IPC-Run.spec
+++ b/SPECS/perl-IPC-Run/perl-IPC-Run.spec
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           perl-IPC-Run
+Version:        20260402.0
+Release:        %autorelease
+Summary:        System and background process runner with piping
+License:        GPL-1.0-or-later OR Artistic-1.0-Perl
+URL:            https://metacpan.org/dist/IPC-Run
+#!RemoteAsset:  sha256:d6a326a8b1ffb19495dea4ff5a09ef138bf3562ab1b069d3fb7efbc77b9f6aca
+Source0:        https://cpan.metacpan.org/authors/id/T/TO/TODDR/IPC-Run-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    perlmaker
+
+BuildOption(build):  INSTALLDIRS=vendor
+
+BuildRequires:  make
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-macros
+BuildRequires:  perl(ExtUtils::MakeMaker)
+BuildRequires:  perl(IO::Pty) >= 1.25
+BuildRequires:  perl(Readonly::Array)
+BuildRequires:  perl(Test::More)
+
+Requires:       perl(IO::Pty) >= 1.25
+
+%description
+IPC::Run starts child processes with flexible piping, redirection and pseudo
+terminal support.
+
+%files -f %{name}.files
+%doc AI_POLICY.md Changelog README.md eg
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/perl-Module-Build-XSUtil/perl-Module-Build-XSUtil.spec
+++ b/SPECS/perl-Module-Build-XSUtil/perl-Module-Build-XSUtil.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           perl-Module-Build-XSUtil
+Version:        0.19
+Release:        %autorelease
+Summary:        Module::Build class for building XS modules
+License:        GPL-1.0-or-later OR Artistic-1.0-Perl
+URL:            https://metacpan.org/dist/Module-Build-XSUtil
+#!RemoteAsset:  sha256:9063b3c346edeb422807ffe49ffb23038c4f900d4a77b845ce4b53d97bf29400
+Source0:        https://cpan.metacpan.org/authors/id/H/HI/HIDEAKIO/Module-Build-XSUtil-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    perlbuild
+
+BuildOption(build):  --installdirs=vendor
+BuildOption(install):  --destdir=%{buildroot} --create_packlist=0
+
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-macros
+BuildRequires:  perl(Module::Build) >= 0.4005
+BuildRequires:  perl(Capture::Tiny)
+BuildRequires:  perl(Cwd::Guard)
+BuildRequires:  perl(Devel::CheckCompiler)
+BuildRequires:  perl(Devel::PPPort)
+BuildRequires:  perl(ExtUtils::CBuilder)
+BuildRequires:  perl(File::Copy::Recursive::Reduced) >= 0.002
+BuildRequires:  perl(Test::More) >= 0.98
+
+Requires:       perl(Devel::CheckCompiler)
+Requires:       perl(Devel::PPPort)
+Requires:       perl(ExtUtils::CBuilder)
+
+%description
+Module::Build::XSUtil extends Module::Build with helpers for XS module
+configuration and compilation.
+
+%files -f %{name}.files
+%doc Changes README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/perl-Mouse/perl-Mouse.spec
+++ b/SPECS/perl-Mouse/perl-Mouse.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           perl-Mouse
+Version:        2.6.2
+Release:        %autorelease
+Summary:        Moose minus the antlers
+License:        GPL-1.0-or-later OR Artistic-1.0-Perl
+URL:            https://metacpan.org/dist/Mouse
+#!RemoteAsset:  sha256:3ab8b0f9f96cbe43ff23498d900f91add52455dc9a7d6613a0a8186142bdeecf
+Source0:        https://cpan.metacpan.org/authors/id/S/SY/SYOHEX/Mouse-v%{version}.tar.gz
+BuildSystem:    perlbuild
+
+BuildOption(prep):  -n Mouse-v%{version}
+BuildOption(build):  --installdirs=vendor
+BuildOption(install):  --destdir=%{buildroot} --create_packlist=0
+
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-macros
+BuildRequires:  perl-devel
+BuildRequires:  perl(Devel::PPPort) >= 3.59
+BuildRequires:  perl(ExtUtils::ParseXS) >= 3.22
+BuildRequires:  perl(Module::Build) >= 0.4005
+BuildRequires:  perl(Module::Build::XSUtil) >= 0.19
+BuildRequires:  perl(Test::Exception)
+BuildRequires:  perl(Test::Fatal)
+BuildRequires:  perl(Test::LeakTrace)
+BuildRequires:  perl(Test::More) >= 0.88
+BuildRequires:  perl(Test::Output)
+BuildRequires:  perl(Test::Requires)
+BuildRequires:  perl(Try::Tiny)
+
+%description
+Mouse is a lightweight object system for Perl with a Moose-like interface.
+
+%files -f %{name}.files
+%doc Changes README.md example
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/perl-X11-XCB/perl-X11-XCB.spec
+++ b/SPECS/perl-X11-XCB/perl-X11-XCB.spec
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           perl-X11-XCB
+Version:        0.25
+Release:        %autorelease
+Summary:        Perl bindings for libxcb
+License:        GPL-1.0-or-later OR Artistic-1.0-Perl
+URL:            https://metacpan.org/dist/X11-XCB
+#!RemoteAsset:  sha256:094dd60e7c0040958f320c9bb22eb88e488a29914fea30a7d30998ec23be447b
+Source0:        https://cpan.metacpan.org/authors/id/Z/ZH/ZHMYLOVE/X11-XCB-%{version}.tar.gz
+BuildSystem:    perlmaker
+
+BuildOption(build):  INSTALLDIRS=vendor OPTIMIZE="%{optflags}"
+
+BuildRequires:  make
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-macros
+BuildRequires:  perl-devel
+BuildRequires:  perl(Data::Dump)
+BuildRequires:  perl(Devel::PPPort) >= 3.19
+BuildRequires:  perl(ExtUtils::Depends)
+BuildRequires:  perl(ExtUtils::MakeMaker) >= 6.59
+BuildRequires:  perl(ExtUtils::ParseXS) >= 3.18
+BuildRequires:  perl(ExtUtils::PkgConfig)
+BuildRequires:  perl(Mouse)
+BuildRequires:  perl(Test::Deep)
+BuildRequires:  perl(Test::Exception)
+BuildRequires:  perl(Test::More)
+BuildRequires:  perl(Try::Tiny)
+BuildRequires:  perl(XML::Descent)
+BuildRequires:  perl(XML::Simple)
+BuildRequires:  perl(XS::Object::Magic)
+BuildRequires:  pkgconfig(xcb) >= 1.2
+BuildRequires:  xcb-proto
+BuildRequires:  pkgconfig(xcb-composite)
+BuildRequires:  pkgconfig(xcb-icccm)
+BuildRequires:  pkgconfig(xcb-randr)
+BuildRequires:  pkgconfig(xcb-util)
+BuildRequires:  pkgconfig(xcb-xinerama)
+BuildRequires:  pkgconfig(xcb-xkb)
+
+Requires:       perl(Data::Dump)
+Requires:       perl(Mouse)
+Requires:       perl(Try::Tiny)
+Requires:       perl(XML::Descent)
+Requires:       perl(XML::Simple)
+Requires:       perl(XS::Object::Magic)
+
+%description
+X11::XCB provides Perl bindings for libxcb and selected XCB extension helper
+libraries.
+
+%files -f %{name}.files
+%doc Changes INSTALL.md README.md
+
+%changelog
+%autochangelog

--- a/SPECS/perl-XML-Descent/perl-XML-Descent.spec
+++ b/SPECS/perl-XML-Descent/perl-XML-Descent.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           perl-XML-Descent
+Version:        1.04
+Release:        %autorelease
+Summary:        Recursive descent XML parsing
+License:        GPL-1.0-or-later OR Artistic-1.0-Perl
+URL:            https://metacpan.org/dist/XML-Descent
+#!RemoteAsset:  sha256:a711b856f8cdf5e647a44c71f967d48c096035b9dbd3f1efbdbea40605afbd50
+Source0:        https://cpan.metacpan.org/authors/id/A/AN/ANDYA/XML-Descent-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    perlmaker
+
+BuildOption(build):  INSTALLDIRS=vendor
+
+BuildRequires:  make
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-macros
+BuildRequires:  perl(ExtUtils::MakeMaker)
+BuildRequires:  perl(Test::Differences)
+BuildRequires:  perl(Test::More)
+BuildRequires:  perl(XML::TokeParser)
+
+Requires:       perl(XML::TokeParser)
+
+%description
+XML::Descent implements recursive descent XML parsing for applications that
+want structured callbacks over XML tokens.
+
+%files -f %{name}.files
+%doc Changes README
+
+%changelog
+%autochangelog

--- a/SPECS/perl-XML-TokeParser/perl-XML-TokeParser.spec
+++ b/SPECS/perl-XML-TokeParser/perl-XML-TokeParser.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           perl-XML-TokeParser
+Version:        0.05
+Release:        %autorelease
+Summary:        Simplified interface to XML::Parser
+License:        GPL-1.0-or-later OR Artistic-1.0-Perl
+URL:            https://metacpan.org/dist/XML-TokeParser
+#!RemoteAsset:  sha256:8539b4f98436b1a6d088341a8b4530b7922acd651f3f29377f8b1948c7e2d7c2
+Source0:        https://cpan.metacpan.org/authors/id/P/PO/PODMASTER/XML-TokeParser-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    perlmaker
+
+BuildOption(build):  INSTALLDIRS=vendor
+
+BuildRequires:  make
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-macros
+BuildRequires:  perl(ExtUtils::MakeMaker)
+BuildRequires:  perl(XML::Parser) >= 2
+
+Requires:       perl(XML::Parser) >= 2
+
+%description
+XML::TokeParser provides a token oriented interface built on top of
+XML::Parser.
+
+%files -f %{name}.files
+%doc Changes README TODO TokeParser.xml
+
+%changelog
+%autochangelog

--- a/SPECS/perl-XS-Object-Magic/perl-XS-Object-Magic.spec
+++ b/SPECS/perl-XS-Object-Magic/perl-XS-Object-Magic.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           perl-XS-Object-Magic
+Version:        0.05
+Release:        %autorelease
+Summary:        Opaque extensible XS pointer-backed objects
+License:        GPL-1.0-or-later OR Artistic-1.0-Perl
+URL:            https://metacpan.org/dist/XS-Object-Magic
+#!RemoteAsset:  sha256:3dc9e460cee92e11744062754643a33778ca52a54d205fcaffa4ab0f3cf15e5a
+Source0:        https://cpan.metacpan.org/authors/id/E/ET/ETHER/XS-Object-Magic-%{version}.tar.gz
+BuildSystem:    perlmaker
+
+BuildOption(build):  INSTALLDIRS=vendor OPTIMIZE="%{optflags}"
+
+BuildRequires:  make
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-macros
+BuildRequires:  perl-devel
+BuildRequires:  perl(ExtUtils::Depends) >= 0.302
+BuildRequires:  perl(ExtUtils::MakeMaker)
+BuildRequires:  perl(Test::Fatal)
+BuildRequires:  perl(Test::More)
+
+%description
+XS::Object::Magic provides a small XS helper for opaque pointer-backed objects
+using Perl magic.
+
+%files -f %{name}.files
+%doc Changes CONTRIBUTING INSTALL README
+%license LICENCE
+
+%changelog
+%autochangelog

--- a/SPECS/startup-notification/0001-fix-test-xmessage-atom-types.patch
+++ b/SPECS/startup-notification/0001-fix-test-xmessage-atom-types.patch
@@ -1,0 +1,153 @@
+Fix type mismatch in test programs: intern atom names before broadcast
+
+The test programs test-send-xmessage.c and test-send-xmessage-xcb.c pass
+the command-line arguments argv[1]/argv[2] (atom *name* strings) straight
+to sn_internal_broadcast_xmessage(), whose corresponding parameters are
+xcb_atom_t (numeric atom IDs), not strings. Modern toolchains (GCC 14+
+treats implicit pointer-to-integer conversion as an error) therefore fail
+to compile the test directory, which breaks the whole package build.
+
+Add an intern_atom() helper that resolves each atom name to a real
+xcb_atom_t via xcb_intern_atom() before the broadcast call, pull in
+<stdlib.h>/<string.h> for strlen()/free(), and bail out on a NULL reply.
+
+These test sources are also installed as -devel examples (see %prep), so
+this keeps the shipped example code correct as well.
+
+Downstream fix: startup-notification 0.12 is the last upstream release and
+is effectively unmaintained, so there is no upstream commit to backport.
+
+Signed-off-by: yihong <yihong.or@isrc.iscas.ac.cn>
+---
+diff -ruN startup-notification-0.12.orig/test/test-send-xmessage-xcb.c startup-notification-0.12/test/test-send-xmessage-xcb.c
+--- startup-notification-0.12.orig/test/test-send-xmessage-xcb.c	2026-06-15 01:52:51
++++ startup-notification-0.12/test/test-send-xmessage-xcb.c	2026-06-15 01:52:51
+@@ -24,16 +24,42 @@
+  */
+ 
+ #include <config.h>
++#include <stdlib.h>
++#include <string.h>
+ #include <libsn/sn.h>
+ #include <libsn/sn-xmessages.h>
+ 
+ #include "test-boilerplate.h"
+ 
++static xcb_atom_t
++intern_atom (SnDisplay  *display,
++             const char *name)
++{
++  xcb_connection_t *xconnection;
++  xcb_intern_atom_cookie_t cookie;
++  xcb_intern_atom_reply_t *reply;
++  xcb_atom_t atom;
++
++  xconnection = sn_display_get_x_connection (display);
++  cookie = xcb_intern_atom (xconnection, 0, strlen (name), name);
++  reply = xcb_intern_atom_reply (xconnection, cookie, NULL);
++
++  if (reply == NULL)
++    return XCB_ATOM_NONE;
++
++  atom = reply->atom;
++  free (reply);
++
++  return atom;
++}
++
+ int
+ main (int argc, char **argv)
+ {
+   xcb_connection_t *xconnection;
+   SnDisplay *display;
++  xcb_atom_t message_type;
++  xcb_atom_t message_type_begin;
+ 
+   if (argc != 4)
+     {
+@@ -51,9 +77,17 @@
+ 
+   display = sn_xcb_display_new (xconnection, NULL, NULL);
+ 
++  message_type = intern_atom (display, argv[1]);
++  message_type_begin = intern_atom (display, argv[2]);
++  if (message_type == XCB_ATOM_NONE || message_type_begin == XCB_ATOM_NONE)
++    {
++      fprintf (stderr, "Could not intern message atoms\n");
++      return 1;
++    }
++
+   sn_internal_broadcast_xmessage (display, screen,
+-                                  argv[1],
+-                                  argv[2],
++                                  message_type,
++                                  message_type_begin,
+                                   argv[3]);
+ 
+   return 0;
+diff -ruN startup-notification-0.12.orig/test/test-send-xmessage.c startup-notification-0.12/test/test-send-xmessage.c
+--- startup-notification-0.12.orig/test/test-send-xmessage.c	2026-06-15 01:52:51
++++ startup-notification-0.12/test/test-send-xmessage.c	2026-06-15 01:52:51
+@@ -23,16 +23,42 @@
+  */
+ 
+ #include <config.h>
++#include <stdlib.h>
++#include <string.h>
+ #include <libsn/sn.h>
+ #include <libsn/sn-xmessages.h>
+ 
+ #include "test-boilerplate.h"
+ 
++static xcb_atom_t
++intern_atom (SnDisplay  *display,
++             const char *name)
++{
++  xcb_connection_t *xconnection;
++  xcb_intern_atom_cookie_t cookie;
++  xcb_intern_atom_reply_t *reply;
++  xcb_atom_t atom;
++
++  xconnection = sn_display_get_x_connection (display);
++  cookie = xcb_intern_atom (xconnection, 0, strlen (name), name);
++  reply = xcb_intern_atom_reply (xconnection, cookie, NULL);
++
++  if (reply == NULL)
++    return XCB_ATOM_NONE;
++
++  atom = reply->atom;
++  free (reply);
++
++  return atom;
++}
++
+ int
+ main (int argc, char **argv)
+ {
+   Display *xdisplay;
+   SnDisplay *display;
++  xcb_atom_t message_type;
++  xcb_atom_t message_type_begin;
+ 
+   if (argc != 4)
+     {
+@@ -56,9 +82,17 @@
+                             error_trap_push,
+                             error_trap_pop);
+   
++  message_type = intern_atom (display, argv[1]);
++  message_type_begin = intern_atom (display, argv[2]);
++  if (message_type == XCB_ATOM_NONE || message_type_begin == XCB_ATOM_NONE)
++    {
++      fprintf (stderr, "Could not intern message atoms\n");
++      return 1;
++    }
++
+   sn_internal_broadcast_xmessage (display, DefaultScreen (xdisplay),
+-                                  argv[1],
+-                                  argv[2],
++                                  message_type,
++                                  message_type_begin,
+                                   argv[3]);
+   
+   return 0;

--- a/SPECS/startup-notification/startup-notification.spec
+++ b/SPECS/startup-notification/startup-notification.spec
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           startup-notification
+Version:        0.12
+Release:        %autorelease
+Summary:        Library for tracking application startup
+License:        LGPL-2.0-or-later AND MIT
+URL:            https://www.freedesktop.org/wiki/Software/startup-notification/
+# Upstream freedesktop.org release dir now returns HTTP 418; use Debian's
+# byte-identical orig tarball (same sha256) as a reliable mirror.
+#!RemoteAsset:  sha256:3c391f7e930c583095045cd2d10eb73a64f085c7fde9d260f2652c7cb3cfbe4a
+Source0:        https://deb.debian.org/debian/pool/main/s/startup-notification/%{name}_%{version}.orig.tar.gz#/%{name}-%{version}.tar.gz
+BuildSystem:    autotools
+
+Patch0:         0001-fix-test-xmessage-atom-types.patch
+
+BuildOption(conf):  --disable-static
+
+BuildRequires:  make
+BuildRequires:  pkgconfig(x11)
+BuildRequires:  pkgconfig(x11-xcb)
+BuildRequires:  pkgconfig(xcb) >= 1.6
+BuildRequires:  pkgconfig(xcb-aux)
+BuildRequires:  pkgconfig(xcb-event)
+BuildRequires:  pkgconfig(xt)
+
+%description
+startup-notification implements the startup notification protocol used by
+desktop environments and window managers to track launched applications.
+
+%package        devel
+Summary:        Development files for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+This package contains headers and library links for developing applications
+that use startup-notification.
+
+%prep -a
+mkdir -p examples
+cp -p test/*.c test/*.h examples
+
+%files
+%doc AUTHORS ChangeLog NEWS README doc/startup-notification.txt
+%license COPYING
+%{_libdir}/libstartup-notification-1.so.0*
+
+%files devel
+%doc examples
+%license COPYING
+%{_includedir}/startup-notification-1.0/
+%{_libdir}/libstartup-notification-1.so
+%{_libdir}/pkgconfig/libstartup-notification-1.0.pc
+
+%changelog
+%autochangelog

--- a/SPECS/xcb-util-xrm/xcb-util-xrm.spec
+++ b/SPECS/xcb-util-xrm/xcb-util-xrm.spec
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: yihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global libname xcb-xrm
+
+Name:           xcb-util-xrm
+Version:        1.3
+Release:        %autorelease
+Summary:        XCB utility functions for the X resource manager
+License:        MIT
+URL:            https://github.com/Airblader/xcb-util-xrm
+VCS:            git:https://github.com/Airblader/xcb-util-xrm.git
+#!RemoteAsset:  sha256:0129f74c327ae65e2f4ad4002f300b4f02c9aff78c00997f1f1c5a430f922f34
+Source0:        https://github.com/Airblader/%{name}/releases/download/v%{version}/%{name}-%{version}.tar.gz
+BuildSystem:    autotools
+
+BuildOption(conf):  --disable-static
+
+BuildRequires:  autoconf
+BuildRequires:  automake
+BuildRequires:  libtool
+BuildRequires:  make
+BuildRequires:  pkgconfig(x11)
+BuildRequires:  pkgconfig(xcb-aux)
+BuildRequires:  pkgconfig(xorg-macros)
+
+%description
+XCB utility functions for loading and querying X resource manager data.
+
+%package        devel
+Summary:        Development files for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+This package contains headers and library links for developing applications
+that use xcb-util-xrm.
+
+%conf -p
+autoreconf -fiv
+
+%install -a
+rm -f %{buildroot}%{_libdir}/lib%{libname}.la
+
+%files
+%doc ChangeLog README
+%license COPYING
+%{_libdir}/lib%{libname}.so.*
+
+%files devel
+%license COPYING
+%{_includedir}/xcb/xcb_xrm.h
+%{_libdir}/lib%{libname}.so
+%{_libdir}/pkgconfig/%{libname}.pc
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

Add i3 and the missing runtime/build/test dependencies required to build it in openRuyi:

- i3: https://github.com/i3/i3
- yajl, xcb-util-xrm, startup-notification
- Perl test/runtime modules required by i3's full upstream test suite

Validation completed:

- `pre-commit run --files ...`: passed for all added specs and patches
- OBS project `home:cl_2:i3`: x86_64 and riscv64 builds are published/succeeded
- i3 `%check` runs upstream Meson `complete-run` with desktop file validation

## Related Issue

- N/A

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: ChatGPT:GPT-5

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
