### PR TITLE
SPECS: python-torch: Add missing buildrequires.

### DIFF
--- a/SPECS/python-torch/python-torch.spec
+++ b/SPECS/python-torch/python-torch.spec
@@ -122,6 +122,8 @@ BuildRequires:  pkgconfig(nlohmann_json)
 BuildRequires:  pkgconfig(numa)
 BuildRequires:  pkgconfig(openblas64)
 BuildRequires:  pkgconfig(protobuf)
+# Protobuf requires zlib, zlib RelWithDebInfo mode requires libz.a
+BuildRequires:  zlib-ng-compat-static
 BuildRequires:  pkgconfig(valgrind)
 BuildRequires:  pocketfft-devel
 BuildRequires:  pthreadpool-devel


### PR DESCRIPTION
Current build error:
```
[   21s]   CMake Error at /lib64/cmake/ZLIB/ZLIB-targets.cmake:84 (message):
[   21s]     The imported target "ZLIB::ZLIBSTATIC" references the file
[   21s] 
[   21s]        "/usr/lib64/libz.a"
[   21s] 
[   21s]     but this file does not exist.  Possible reasons include:
[   21s] 
[   21s]     * The file was deleted, renamed, or moved to another location.
[   21s] 
[   21s]     * An install or uninstall procedure did not complete successfully.
[   21s] 
[   21s]     * The installation package was faulty and contained
[   21s] 
[   21s]        "/lib64/cmake/ZLIB/ZLIB-targets.cmake"
[   21s] 
[   21s]     but not all the files it references.
[   21s] 
[   21s]   Call Stack (most recent call first):
[   21s]     /lib64/cmake/ZLIB/zlib-config.cmake:44 (include)
[   21s]     /lib64/cmake/protobuf/protobuf-config.cmake:6 (find_package)
[   21s]     cmake/public/protobuf.cmake:4 (find_package)
[   21s]     cmake/ProtoBuf.cmake:89 (include)
[   21s]     cmake/Dependencies.cmake:107 (include)
[   21s]     CMakeLists.txt:932 (include)
```
This package buildrequires protobuf, protobuf requires zlib. In cmake RelWithDebInfo build mode, /lib64/cmake/ZLIB/ZLIB-targets-relwithdebinfo.cmake has:. 
```
# Import target "ZLIB::ZLIBSTATIC" for configuration "RelWithDebInfo"
set_property(TARGET ZLIB::ZLIBSTATIC APPEND PROPERTY IMPORTED_CONFIGURATIONS RELWITHDEBINFO)
set_target_properties(ZLIB::ZLIBSTATIC PROPERTIES
  IMPORTED_LINK_INTERFACE_LANGUAGES_RELWITHDEBINFO "C"
  IMPORTED_LOCATION_RELWITHDEBINFO "/usr/lib64/libz.a"
  )
```
libz.a been needed which lives in zlib-ng-compat-static. It needs to be explicitly buildrequired