### PR TITLE
enable build qemu-user static

### DIFF
--- a/SPECS/glib/glib.spec
+++ b/SPECS/glib/glib.spec
@@ -13,7 +13,7 @@
 %bcond bootstrap 0
 %endif
 
-%bcond  static        0
+%bcond  static        1
 # For -tests subpackage.
 %bcond  tests         0
 %bcond  doc           0
@@ -94,6 +94,10 @@ This package contains the essential runtime libraries and tools.
 %package        devel
 Summary:        Development files for the GLib library
 Requires:       %{name}%{?_isa} = %{version}-%{release}
+%if %{with static}
+Provides:       %{name}-static = %{version}-%{release}
+Provides:       %{name}-static%{?_isa} = %{version}-%{release}
+%endif
 
 %description    devel
 This package contains the header files, libraries, and developer tools
@@ -180,6 +184,9 @@ glib-compile-schemas %{_datadir}/glib-2.0/schemas &> /dev/null || :
 %{_datadir}/bash-completion/completions/gsettings
 
 %files devel
+%if %{with static}
+%{_libdir}/lib*.a
+%endif
 %{_libdir}/lib*.so
 %dir %{_libdir}/glib-2.0
 %dir %{_libdir}/glib-2.0/include

--- a/SPECS/qemu/qemu.spec
+++ b/SPECS/qemu/qemu.spec
@@ -43,8 +43,8 @@
 # By default build dynamic user-mode emulation
 %bcond user_dynamic 1
 
-# By default do not build static user-mode emulation
-%bcond user_static 0
+# By default build static user-mode emulation
+%bcond user_static 1
 
 # Disable compiler Werror by default
 %bcond enable_werror 0
@@ -404,7 +404,7 @@ BuildRequires:  igvm-devel
 %if %{with user_static}
 BuildRequires:  glib-static
 BuildRequires:  glibc-static
-BuildRequires:  zlib-devel-static
+BuildRequires:  zlib-ng-compat-static
 #BuildRequires:  libatomic-static
 %endif
 # Requires for the openRuyi 'qemu' metapackage
@@ -1541,6 +1541,7 @@ popd
 %{_bindir}/qemu-sparc32plus-static
 %{_bindir}/qemu-sparc64-static
 %{_bindir}/qemu-x86_64-static
+%{_bindir}/qemu-i386-static
 %if %{with have_systemtap}
 %{_datadir}/systemtap/tapset/qemu-aarch64-log-static.stp
 %{_datadir}/systemtap/tapset/qemu-aarch64-simpletrace-static.stp
@@ -1607,6 +1608,7 @@ popd
 %endif
 %ifnarch x86_64
 %{_exec_prefix}/lib/binfmt.d/qemu-x86_64-static.conf
+%{_exec_prefix}/lib/binfmt.d/qemu-i386-static.conf
 %{_exec_prefix}/lib/binfmt.d/qemu-i486-static.conf
 %endif
 %{_exec_prefix}/lib/binfmt.d/qemu-s390x-static.conf


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [ ] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy

<!-- Message of single commit: -->

SPECS: glib: Enable static build.

Build qemu-user-static require glib static library.

Signed-off-by: Zheng Junjie <zhengjunjie@iscas.ac.cn>