### PR TITLE
SPECS: python-cffsubr: Fix no 'dry_run' argument error.

### DIFF
--- a/SPECS/python-cffsubr/0001-Remove-dry_run-argument-from-copy_file.patch
+++ b/SPECS/python-cffsubr/0001-Remove-dry_run-argument-from-copy_file.patch
@@ -1,0 +1,26 @@
+From 472aef1e8c6a8a3c45efac810d02a6b325bc5226 Mon Sep 17 00:00:00 2001
+From: Khaled Hosny <khaled@aliftype.com>
+Date: Thu, 26 Mar 2026 00:12:30 +0200
+Subject: [PATCH 2/2] Remove dry_run argument from copy_file
+
+It does not seem to be supported anymore. Fixes:
+
+  File "<string>", line 70, in build_extension
+TypeError: copy_file() got an unexpected keyword argument 'dry_run'
+---
+ setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 6d9851a..020ffe5 100755
+--- a/setup.py
++++ b/setup.py
+@@ -67,7 +67,7 @@ def build_extension(self, ext):
+         dest_path = self.get_ext_fullpath(ext.name)
+         mkpath(os.path.dirname(dest_path), verbose=self.verbose, dry_run=self.dry_run)
+ 
+-        copy_file(exe_fullpath, dest_path, verbose=self.verbose, dry_run=self.dry_run)
++        copy_file(exe_fullpath, dest_path, verbose=self.verbose)
+ 
+ 
+ cmdclass["build_ext"] = ExecutableBuildExt

--- a/SPECS/python-cffsubr/python-cffsubr.spec
+++ b/SPECS/python-cffsubr/python-cffsubr.spec
@@ -19,6 +19,8 @@ Source0:        https://files.pythonhosted.org/packages/source/c/%{srcname}/%{sr
 Source1:        https://www.antlr.org/download/antlr4-cpp-runtime-4.13.2-source.zip
 BuildSystem:    pyproject
 
+# Not merged yet. https://github.com/adobe-type-tools/cffsubr/pull/34
+Patch0:         0001-Remove-dry_run-argument-from-copy_file.patch
 # Use offline ANTLR archive and fix old CMake policy settings in bundled AFDKO.
 Patch2000:      2000-afdko-use-antlr4-archive-from-env.patch
 # Avoid pip downloading python-cmake/python-ninja from setup_requires.


### PR DESCRIPTION
Current build error:
```
[   38s]       self._build_extensions_serial()
[   38s]       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
[   38s]     File "/usr/lib/python3.13/site-packages/setuptools/_distutils/command/build_ext.py", line 509, in _build_extensions_serial
[   38s]       self.build_extension(ext)
[   38s]       ~~~~~~~~~~~~~~~~~~~~^^^^^
[   38s]     File "<string>", line 70, in build_extension
[   38s]   TypeError: copy_file() got an unexpected keyword argument 'dry_run'
```

Setuptools v81.0.0 has removed '--dry-run' parameter to setup.py.

This patch is from upstream undergoing PR:
  https://github.com/adobe-type-tools/cffsubr/pull/34
