### PR TITLE
SPECS: Add ranger

### DIFF
--- a/SPECS/ranger/ranger.spec
+++ b/SPECS/ranger/ranger.spec
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           ranger
+Version:        1.9.4
+Release:        %autorelease
+Summary:        Vim-like console file manager
+License:        GPL-3.0-only
+URL:            https://ranger.github.io
+#!RemoteAsset:  sha256:7ad75e0d1b29087335fbb1691b05a800f777f4ec9cba84faa19355075d7f0f89
+Source0:        https://github.com/ranger/ranger/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{name} +auto
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+# ranger.gui.color calls curses.setupterm() at import time, so the import
+# check needs a terminfo database and a known terminal.
+BuildRequires:  ncurses
+
+%description
+ranger is a console file manager with VI key bindings. It provides a
+minimalistic and nice curses interface with a view on the directory
+hierarchy. It ships with rifle, a file launcher that is good at
+automatically finding out which program to use for which file type.
+
+%check -p
+# ranger.gui.color runs curses.setupterm() on import; give it a known terminal.
+export TERM=xterm
+
+%files -f %{pyproject_files}
+%license LICENSE
+# ranger ships example/config plugin scripts under %%_docdir; their byte-compiled
+# __pycache__ artifacts are not needed and would otherwise be unpackaged.
+%exclude %{_datadir}/doc/ranger/config/__pycache__
+%exclude %{_datadir}/doc/ranger/config/colorschemes/__pycache__
+%exclude %{_datadir}/doc/ranger/examples/__pycache__
+%exclude %{_datadir}/doc/ranger/tools/__pycache__
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

Add a new package: **ranger**, a Vim-like console file manager written in
Python. It provides a minimalistic curses interface with a view on the
directory hierarchy and ships `rifle`, its file launcher. Built as a
`pyproject` package; the bundled example/config plugins and man pages are
installed, and `ncurses` is pulled in at build time because
`ranger.gui.color` calls `curses.setupterm()` on import (the import check
runs with `TERM` set).

Upstream: https://github.com/ranger/ranger (v1.9.4)

Validated on OBS for both `x86_64` and `riscv64` (succeeded).

## Related Issue

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: Claude Code:Opus 4.8

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
