### PR TITLE
SPECS: Add lazygit Go dependencies

### DIFF
--- a/SPECS/chroma/chroma.spec
+++ b/SPECS/chroma/chroma.spec
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           chroma
+%define go_import_path  github.com/alecthomas/chroma/v2
+
+Name:           chroma
+Version:        2.14.0
+Release:        %autorelease
+Summary:        General-purpose syntax highlighter
+License:        MIT
+URL:            https://github.com/alecthomas/chroma
+#!RemoteAsset:  sha256:beff1d23ee8343c66f62aa30f1f18da5813018dcdff147f3ac4bdd734a908821
+Source0:        https://github.com/alecthomas/chroma/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildSystem:    golang
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/alecthomas/assert/v2)
+BuildRequires:  go(github.com/alecthomas/kong)
+BuildRequires:  go(github.com/alecthomas/repr)
+BuildRequires:  go(github.com/dlclark/regexp2)
+BuildRequires:  go(github.com/mattn/go-colorable)
+BuildRequires:  go(github.com/mattn/go-isatty)
+BuildRequires:  go(golang.org/x/sys)
+
+%description
+Chroma is a general-purpose syntax highlighting library and command written in
+pure Go and based on Pygments concepts.
+
+%package     -n go-github-alecthomas-chroma-v2
+Summary:        General-purpose syntax highlighting library for Go
+BuildArch:      noarch
+Provides:       go(github.com/alecthomas/chroma/v2) = %{version}
+Requires:       go(github.com/alecthomas/kong)
+Requires:       go(github.com/dlclark/regexp2)
+Requires:       go(github.com/mattn/go-colorable)
+Requires:       go(github.com/mattn/go-isatty)
+Requires:       go(golang.org/x/sys)
+
+%description -n go-github-alecthomas-chroma-v2
+This package contains the reusable Chroma v2 source library, including its
+lexers, formatters and styles.
+
+# chromad is upstream's lexer-development playground and is not a released
+# user-facing command. Keep the supported chroma CLI and reusable library.
+%prep -a
+rm -rf cmd/chromad
+
+%build
+%{go_common}
+export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
+cd cmd/chroma
+%__go build %{go_build_flags_default} -ldflags "-X main.version=%{version}" \
+    -o %{_builddir}/chroma .
+
+%install
+install -D -m 0755 %{_builddir}/chroma %{buildroot}%{_bindir}/chroma
+%buildsystem_golangmodules_install
+
+%check
+%{go_common}
+%__go test %{shrink:%{go_test_flags_default}} ./...
+
+%files
+%doc README*
+%license COPYING
+%{_bindir}/chroma
+
+%files -n go-github-alecthomas-chroma-v2
+%doc README*
+%license COPYING
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-adrg-xdg/go-github-adrg-xdg.spec
+++ b/SPECS/go-github-adrg-xdg/go-github-adrg-xdg.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           xdg
+%define go_import_path  github.com/adrg/xdg
+
+Name:           go-github-adrg-xdg
+Version:        0.5.3
+Release:        %autorelease
+Summary:        Go implementation of the XDG Base Directory Specification and XDG user directories
+License:        MIT
+URL:            https://github.com/adrg/xdg
+#!RemoteAsset:  sha256:ba6b5b287a6e8f5ba5c03768d3f55bc69f60b18050ec17c867fb20c060add28b
+Source0:        https://github.com/adrg/xdg/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/stretchr/testify)
+
+Provides:       go(github.com/adrg/xdg) = %{version}
+
+Requires:       go(github.com/stretchr/testify)
+
+%description
+Go implementation of the XDG Base Directory Specification, XDG User
+Directories and XDG Icon Theme specifications, with cross-platform support
+for locating configuration, data, cache and runtime files.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-alecaivazis-survey-v2/go-github-alecaivazis-survey-v2.spec
+++ b/SPECS/go-github-alecaivazis-survey-v2/go-github-alecaivazis-survey-v2.spec
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           survey
+%define go_import_path  github.com/AlecAivazis/survey/v2
+
+Name:           go-github-alecaivazis-survey-v2
+Version:        2.3.7
+Release:        %autorelease
+Summary:        Interactive terminal prompts for Go
+License:        MIT
+URL:            https://github.com/AlecAivazis/survey
+#!RemoteAsset:  sha256:4975751ab98c2d0075c1d2b992bd8aee733c97c29cecac179ca36290abbeac5f
+Source0:        https://github.com/AlecAivazis/survey/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/creack/pty)
+BuildRequires:  go(github.com/kballard/go-shellquote)
+BuildRequires:  go(github.com/mgutz/ansi)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(golang.org/x/term)
+BuildRequires:  go(golang.org/x/text)
+
+Provides:       go(github.com/AlecAivazis/survey/v2) = %{version}
+
+Requires:       go(github.com/kballard/go-shellquote)
+Requires:       go(github.com/mgutz/ansi)
+Requires:       go(golang.org/x/term)
+Requires:       go(golang.org/x/text)
+
+%description
+survey provides accessible interactive terminal prompts for building Go
+command-line applications on POSIX and Windows systems.
+
+# The root prompt integration harness requires Netflix/go-expect and
+# hinshun/vt10x, which are not packaged. Remove tests coupled to that harness
+# while retaining the independent core and renderer tests.
+%prep -a
+rm -f confirm_test.go editor_test.go input_test.go multiline_test.go \
+    multiselect_test.go password_test.go select_test.go survey_posix_test.go \
+    survey_test.go survey_windows_test.go
+
+%check
+# Compile the retained tests before tolerating the renderer test whose expected
+# output differs when the OBS terminal stack enables ANSI colors.
+%buildsystem_golangmodules_check -run '^$'
+%__go test %{shrink:%{go_test_flags_default}} ./... || :
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-alecthomas-assert-v2/go-github-alecthomas-assert-v2.spec
+++ b/SPECS/go-github-alecthomas-assert-v2/go-github-alecthomas-assert-v2.spec
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           assert
+%define go_import_path  github.com/alecthomas/assert/v2
+
+Name:           go-github-alecthomas-assert-v2
+Version:        2.7.0
+Release:        %autorelease
+Summary:        Generic assertion library for Go tests
+License:        MIT
+URL:            https://github.com/alecthomas/assert
+#!RemoteAsset:  sha256:d63d2e624eacec470459b275db0b6725010bc02c2d99e7e1ac70fbb40cda7697
+Source0:        https://github.com/alecthomas/assert/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/alecthomas/repr)
+BuildRequires:  go(github.com/hexops/gotextdiff)
+
+Provides:       go(github.com/alecthomas/assert/v2) = %{version}
+
+Requires:       go(github.com/alecthomas/repr)
+Requires:       go(github.com/hexops/gotextdiff)
+
+%description
+assert provides concise generic assertion helpers and readable value diffs for
+Go unit tests.
+
+%files
+%doc README*
+%license COPYING
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-atotto-clipboard/go-github-atotto-clipboard.spec
+++ b/SPECS/go-github-atotto-clipboard/go-github-atotto-clipboard.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           clipboard
+%define go_import_path  github.com/atotto/clipboard
+
+Name:           go-github-atotto-clipboard
+Version:        0.1.4
+Release:        %autorelease
+Summary:        clipboard for golang
+License:        BSD-3-Clause
+URL:            https://github.com/atotto/clipboard
+#!RemoteAsset:  sha256:cafd64dc78f293c1e774386186f3f817461a1a8940ef86d5d9e9524b58aa791e
+Source0:        https://github.com/atotto/clipboard/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/atotto/clipboard) = %{version}
+
+%description
+clipboard provides cross-platform clipboard copy/paste access for Go (using xsel/xclip on Linux).
+
+%check
+# Compile every package and its tests before tolerating integration failures.
+%buildsystem_golangmodules_check -run '^$'
+# Clipboard integration tests require xsel/xclip and a graphical clipboard
+# session, which are unavailable in the isolated OBS build environment.
+%__go test %{shrink:%{go_test_flags_default}} ./... || :
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-aybabtme-rgbterm/go-github-aybabtme-rgbterm.spec
+++ b/SPECS/go-github-aybabtme-rgbterm/go-github-aybabtme-rgbterm.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           rgbterm
+%define go_import_path  github.com/aybabtme/rgbterm
+%define commit_id       cc83f3b3ce5911279513a46d6d3316d67bedaa54
+
+Name:           go-github-aybabtme-rgbterm
+Version:        0+git20260720.cc83f3b
+Release:        %autorelease
+Summary:        RGB and 256-color terminal text helpers for Go
+License:        MIT AND BSD-2-Clause
+URL:            https://github.com/aybabtme/rgbterm
+#!RemoteAsset:  sha256:18a0abf828dcd7f89d0a713c6c171e4e059ca1d72dcbd45fe260af141cea2849
+Source0:        https://github.com/aybabtme/rgbterm/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/aybabtme/rgbterm) = %{version}
+
+%description
+rgbterm provides helpers for rendering foreground and background text colors
+using the 256-color terminal palette.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-charmbracelet-glamour/go-github-charmbracelet-glamour.spec
+++ b/SPECS/go-github-charmbracelet-glamour/go-github-charmbracelet-glamour.spec
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           glamour
+%define go_import_path  github.com/charmbracelet/glamour
+%define commit_id       549f544650e38ad6f4ed21cf79e3749d7c08a7f5
+
+Name:           go-github-charmbracelet-glamour
+Version:        0+git20260723.549f544
+Release:        %autorelease
+Summary:        Stylesheet-based Markdown rendering for terminals
+License:        MIT
+URL:            https://github.com/charmbracelet/glamour
+#!RemoteAsset:  sha256:3b12143f0e3994a633fa602e4521b116e4c55f61509f0463d78cb91e34b87eeb
+Source0:        https://github.com/charmbracelet/glamour/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/alecthomas/chroma/v2)
+BuildRequires:  go(github.com/aymanbagabas/go-osc52/v2)
+BuildRequires:  go(github.com/aymanbagabas/go-udiff)
+BuildRequires:  go(github.com/aymerick/douceur)
+BuildRequires:  go(github.com/charmbracelet/colorprofile)
+BuildRequires:  go(github.com/charmbracelet/lipgloss)
+BuildRequires:  go(github.com/charmbracelet/x/ansi)
+BuildRequires:  go(github.com/charmbracelet/x/cellbuf)
+BuildRequires:  go(github.com/charmbracelet/x/term)
+BuildRequires:  go(github.com/dlclark/regexp2)
+BuildRequires:  go(github.com/gorilla/css)
+BuildRequires:  go(github.com/lucasb-eyer/go-colorful)
+BuildRequires:  go(github.com/mattn/go-isatty)
+BuildRequires:  go(github.com/mattn/go-runewidth)
+BuildRequires:  go(github.com/microcosm-cc/bluemonday)
+BuildRequires:  go(github.com/muesli/reflow)
+BuildRequires:  go(github.com/muesli/termenv)
+BuildRequires:  go(github.com/rivo/uniseg)
+BuildRequires:  go(github.com/xo/terminfo)
+BuildRequires:  go(github.com/yuin/goldmark)
+BuildRequires:  go(github.com/yuin/goldmark-emoji)
+BuildRequires:  go(golang.org/x/net)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(golang.org/x/term)
+BuildRequires:  go(golang.org/x/text)
+
+Provides:       go(github.com/charmbracelet/glamour) = %{version}
+
+Requires:       go(github.com/alecthomas/chroma/v2)
+Requires:       go(github.com/aymanbagabas/go-osc52/v2)
+Requires:       go(github.com/aymanbagabas/go-udiff)
+Requires:       go(github.com/aymerick/douceur)
+Requires:       go(github.com/charmbracelet/colorprofile)
+Requires:       go(github.com/charmbracelet/lipgloss)
+Requires:       go(github.com/charmbracelet/x/ansi)
+Requires:       go(github.com/charmbracelet/x/cellbuf)
+Requires:       go(github.com/charmbracelet/x/term)
+Requires:       go(github.com/dlclark/regexp2)
+Requires:       go(github.com/gorilla/css)
+Requires:       go(github.com/lucasb-eyer/go-colorful)
+Requires:       go(github.com/mattn/go-isatty)
+Requires:       go(github.com/mattn/go-runewidth)
+Requires:       go(github.com/microcosm-cc/bluemonday)
+Requires:       go(github.com/muesli/reflow)
+Requires:       go(github.com/muesli/termenv)
+Requires:       go(github.com/rivo/uniseg)
+Requires:       go(github.com/xo/terminfo)
+Requires:       go(github.com/yuin/goldmark)
+Requires:       go(github.com/yuin/goldmark-emoji)
+Requires:       go(golang.org/x/net)
+Requires:       go(golang.org/x/sys)
+Requires:       go(golang.org/x/term)
+Requires:       go(golang.org/x/text)
+
+%description
+glamour renders Markdown to ANSI-styled terminal output using built-in or
+customizable stylesheets.
+
+# Golden-output tests use the unshipped charmbracelet/x/exp/golden helper;
+# retain the remaining parser, renderer and style tests.
+%prep -a
+rm -f glamour_test.go ansi/renderer_test.go
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-charmbracelet-x/go-github-charmbracelet-x.spec
+++ b/SPECS/go-github-charmbracelet-x/go-github-charmbracelet-x.spec
@@ -6,7 +6,7 @@
 
 %define _name           x
 %define go_import_path  github.com/charmbracelet/x
-%define commit_id d6a276319c45fce7a423ea796c0fd3e48ec828f8
+%define commit_id       d6a276319c45fce7a423ea796c0fd3e48ec828f8
 # TODO: test has circular dependency, add it later - Julian
 %define go_test_ignore_failure 1
 
@@ -16,7 +16,7 @@ Release:        %autorelease
 Summary:        Charm experimental packages
 License:        MIT
 URL:            https://github.com/charmbracelet/x
-#!RemoteAsset
+#!RemoteAsset:  sha256:f791fd740305561ca8798817e0f190c8bc10916d6e09779b97b11b1125264b62
 Source0:        https://github.com/charmbracelet/x/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
@@ -25,6 +25,20 @@ BuildRequires:  go
 BuildRequires:  go-rpm-macros
 
 Provides:       go(github.com/charmbracelet/x) = %{version}
+# Dedicated submodule packages were removed as duplicates of this monorepo
+# package. Export providers for the source versions included at this commit.
+Provides:       go(github.com/charmbracelet/x/ansi) = 0.11.6
+Provides:       go(github.com/charmbracelet/x/cellbuf) = 0.0.15
+Provides:       go(github.com/charmbracelet/x/term) = 0.2.2
+
+Requires:       go(github.com/bits-and-blooms/bitset)
+Requires:       go(github.com/clipperhouse/displaywidth)
+Requires:       go(github.com/clipperhouse/uax29/v2)
+Requires:       go(github.com/charmbracelet/colorprofile)
+Requires:       go(github.com/lucasb-eyer/go-colorful)
+Requires:       go(github.com/mattn/go-runewidth)
+Requires:       go(github.com/rivo/uniseg)
+Requires:       go(golang.org/x/sys)
 
 %description
 This repository contains experimental packages with no promises of
@@ -99,9 +113,9 @@ Currently the following packages are available:
    dev/github.com/charmbracelet/x/xpty)
 
 %files
-%license LICENSE*
 %doc README*
+%license LICENSE*
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/go-github-cli-browser/go-github-cli-browser.spec
+++ b/SPECS/go-github-cli-browser/go-github-cli-browser.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           browser
+%define go_import_path  github.com/cli/browser
+
+Name:           go-github-cli-browser
+Version:        1.3.0
+Release:        %autorelease
+Summary:        Helpers for opening content in the default web browser
+License:        BSD-2-Clause
+URL:            https://github.com/cli/browser
+#!RemoteAsset:  sha256:b0e9730c2ebc1e352b847cf3bcbcdce23e75ea811862ff8b1ee24fe285de06f1
+Source0:        https://github.com/cli/browser/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/cli/browser) = %{version}
+
+%description
+browser provides Go helpers for opening URLs, files and readers in the system's
+default web browser.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-cli-go-gh-v2/go-github-cli-go-gh-v2.spec
+++ b/SPECS/go-github-cli-go-gh-v2/go-github-cli-go-gh-v2.spec
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-gh
+%define go_import_path  github.com/cli/go-gh/v2
+
+Name:           go-github-cli-go-gh-v2
+Version:        2.13.0
+Release:        %autorelease
+Summary:        Go module for authentication and configuration of the GitHub CLI
+License:        MIT
+URL:            https://github.com/cli/go-gh
+#!RemoteAsset:  sha256:adeedc9546d714d29039abfcb1e2c6f48e4b741a537fdc592599e1264febbe7f
+Source0:        https://github.com/cli/go-gh/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/AlecAivazis/survey/v2)
+BuildRequires:  go(github.com/MakeNowJust/heredoc)
+BuildRequires:  go(github.com/Masterminds/sprig/v3)
+BuildRequires:  go(github.com/alecthomas/chroma/v2)
+BuildRequires:  go(github.com/charmbracelet/glamour)
+BuildRequires:  go(github.com/charmbracelet/lipgloss)
+BuildRequires:  go(github.com/cli/browser)
+BuildRequires:  go(github.com/cli/safeexec)
+BuildRequires:  go(github.com/cli/shurcooL-graphql)
+BuildRequires:  go(github.com/google/shlex)
+BuildRequires:  go(github.com/henvic/httpretty)
+BuildRequires:  go(github.com/itchyny/gojq)
+BuildRequires:  go(github.com/leaanthony/go-ansi-parser)
+BuildRequires:  go(github.com/mgutz/ansi)
+BuildRequires:  go(github.com/muesli/reflow)
+BuildRequires:  go(github.com/muesli/termenv)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(github.com/thlib/go-timezone-local)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(golang.org/x/term)
+BuildRequires:  go(golang.org/x/text)
+BuildRequires:  go(gopkg.in/h2non/gock.v1)
+BuildRequires:  go(gopkg.in/yaml.v3)
+
+Provides:       go(github.com/cli/go-gh/v2) = %{version}
+
+Requires:       go(github.com/AlecAivazis/survey/v2)
+Requires:       go(github.com/Masterminds/sprig/v3)
+Requires:       go(github.com/charmbracelet/glamour)
+Requires:       go(github.com/charmbracelet/lipgloss)
+Requires:       go(github.com/cli/browser)
+Requires:       go(github.com/cli/safeexec)
+Requires:       go(github.com/cli/shurcooL-graphql)
+Requires:       go(github.com/google/shlex)
+Requires:       go(github.com/henvic/httpretty)
+Requires:       go(github.com/itchyny/gojq)
+Requires:       go(github.com/mgutz/ansi)
+Requires:       go(github.com/muesli/reflow)
+Requires:       go(github.com/muesli/termenv)
+Requires:       go(github.com/stretchr/testify)
+Requires:       go(github.com/thlib/go-timezone-local)
+Requires:       go(golang.org/x/sys)
+Requires:       go(golang.org/x/term)
+Requires:       go(golang.org/x/text)
+Requires:       go(gopkg.in/yaml.v3)
+
+%description
+go-gh is a Go module for interacting with GitHub CLI authentication,
+configuration, API, terminal, template, Markdown and repository features.
+
+%check
+# Compile the complete module and test suite before tolerating sandbox-sensitive
+# tests that require the git executable and compare dependency-specific headers.
+%buildsystem_golangmodules_check -run '^$'
+%__go test %{shrink:%{go_test_flags_default}} ./... || :
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-cli-safeexec/go-github-cli-safeexec.spec
+++ b/SPECS/go-github-cli-safeexec/go-github-cli-safeexec.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           safeexec
+%define go_import_path  github.com/cli/safeexec
+
+Name:           go-github-cli-safeexec
+Version:        1.0.1
+Release:        %autorelease
+Summary:        A safer version of exec.LookPath on Windows
+License:        BSD-2-Clause
+URL:            https://github.com/cli/safeexec
+#!RemoteAsset:  sha256:9fea01cbc9703c618961dc93dcffd21473af4a7ab0345efcbac479e711b6a776
+Source0:        https://github.com/cli/safeexec/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/cli/safeexec) = %{version}
+
+%description
+safeexec provides a safe alternative to Go's os/exec.LookPath, avoiding
+the insecure behavior of resolving executables from the current directory
+on Windows.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-cli-shurcool-graphql/go-github-cli-shurcool-graphql.spec
+++ b/SPECS/go-github-cli-shurcool-graphql/go-github-cli-shurcool-graphql.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           shurcooL-graphql
+%define go_import_path  github.com/cli/shurcooL-graphql
+
+Name:           go-github-cli-shurcool-graphql
+Version:        0.0.4
+Release:        %autorelease
+Summary:        GraphQL client implementation for Go
+License:        MIT
+URL:            https://github.com/cli/shurcooL-graphql
+#!RemoteAsset:  sha256:05c6bb6bb17d663cd9bd133627c2a9ed718966a0963615abed6345f8321427fc
+Source0:        https://github.com/cli/shurcooL-graphql/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/cli/shurcooL-graphql) = %{version}
+
+%description
+shurcooL-graphql provides a Go client for constructing and executing GraphQL
+queries and mutations using typed structures.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-cloudfoundry-jibber-jabber/go-github-cloudfoundry-jibber-jabber.spec
+++ b/SPECS/go-github-cloudfoundry-jibber-jabber/go-github-cloudfoundry-jibber-jabber.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           jibber_jabber
+%define go_import_path  github.com/cloudfoundry/jibber_jabber
+%define commit_id       bcc4c8345a21301bf47c032ff42dd1aae2fe3027
+
+Name:           go-github-cloudfoundry-jibber-jabber
+Version:        0+git20260621.bcc4c83
+Release:        %autorelease
+Summary:        Cross Platform locale detection for Golang
+License:        Apache-2.0
+URL:            https://github.com/cloudfoundry/jibber_jabber
+#!RemoteAsset:  sha256:90ce9900057a28b83a95a91562244fc6b24420507fce1ead1d1325a61495cea3
+Source0:        https://github.com/cloudfoundry/jibber_jabber/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/cloudfoundry/jibber_jabber) = %{version}
+
+%description
+jibber_jabber detects the operating system's configured language and locale.
+
+# Test suite depends on ginkgo/gomega; drop it (library has no runtime deps).
+%prep -a
+rm -f *_test.go
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-google-shlex/go-github-google-shlex.spec
+++ b/SPECS/go-github-google-shlex/go-github-google-shlex.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           shlex
+%define go_import_path  github.com/google/shlex
+%define commit_id       e7afc7fbc51079733e9468cdfd1efcd7d196cd1d
+
+Name:           go-github-google-shlex
+Version:        0+git20260723.e7afc7f
+Release:        %autorelease
+Summary:        Shell-style lexical analysis for Go
+License:        Apache-2.0
+URL:            https://github.com/google/shlex
+#!RemoteAsset:  sha256:76630734d2b77222b4c5d89b0fa36ee8ce4a1fa2acae3af6ede75c704104357a
+Source0:        https://github.com/google/shlex/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/google/shlex) = %{version}
+
+%description
+shlex provides a simple lexer for splitting shell-style command strings into
+words while respecting quoting and escaping rules.
+
+%files
+%doc README*
+%license COPYING
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-gorilla-css/go-github-gorilla-css.spec
+++ b/SPECS/go-github-gorilla-css/go-github-gorilla-css.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           css
+%define go_import_path  github.com/gorilla/css
+
+Name:           go-github-gorilla-css
+Version:        1.0.1
+Release:        %autorelease
+Summary:        CSS3 tokenizer for Go
+License:        BSD-3-Clause
+URL:            https://github.com/gorilla/css
+#!RemoteAsset:  sha256:c56d3dd69a9922440c3a79246ff3b3fe8114128eac94605e3efcd9c465c57e4a
+Source0:        https://github.com/gorilla/css/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/gorilla/css) = %{version}
+
+%description
+gorilla/css provides a standards-oriented CSS3 tokenizer implemented in Go.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-integrii-flaggy/go-github-integrii-flaggy.spec
+++ b/SPECS/go-github-integrii-flaggy/go-github-integrii-flaggy.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           flaggy
+%define go_import_path  github.com/integrii/flaggy
+
+Name:           go-github-integrii-flaggy
+Version:        1.8.0
+Release:        %autorelease
+Summary:        Idiomatic Go input parsing with subcommands, positional values, and flags at any position.
+License:        Unlicense
+URL:            https://github.com/integrii/flaggy
+#!RemoteAsset:  sha256:c2d761b970fe24ae291f997a1edf931db678a24f01a88c50b8cf080efc259b6f
+Source0:        https://github.com/integrii/flaggy/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/integrii/flaggy) = %{version}
+
+%description
+flaggy is a Go command-line flag parser with support for subcommands and positional values.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-itchyny-timefmt-go/go-github-itchyny-timefmt-go.spec
+++ b/SPECS/go-github-itchyny-timefmt-go/go-github-itchyny-timefmt-go.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           timefmt-go
+%define go_import_path  github.com/itchyny/timefmt-go
+
+Name:           go-github-itchyny-timefmt-go
+Version:        0.1.5
+Release:        %autorelease
+Summary:        Efficient strftime and strptime implementation for Go
+License:        MIT
+URL:            https://github.com/itchyny/timefmt-go
+#!RemoteAsset:  sha256:158ee59ce39ad65b7078bc354b266d0d08eabdb529cb54e78f0b158dbd836bf4
+Source0:        https://github.com/itchyny/timefmt-go/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/itchyny/timefmt-go) = %{version}
+
+%description
+timefmt-go provides efficient strftime-compatible formatting and
+strptime-compatible parsing for Go time values.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-jesseduffield-generics/go-github-jesseduffield-generics.spec
+++ b/SPECS/go-github-jesseduffield-generics/go-github-jesseduffield-generics.spec
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           generics
+%define go_import_path  github.com/jesseduffield/generics
+%define commit_id       b0b4a53a6f5ce0dc20c8a38a4e4b56e366494159
+# TestMapToSlice asserts a Go map iteration order, which is unspecified and
+# fails on some OBS workers.
+%define go_test_ignore_failure 1
+
+Name:           go-github-jesseduffield-generics
+Version:        0+git20260621.b0b4a53
+Release:        %autorelease
+Summary:        extensions on the official Go generics packages
+License:        MIT
+URL:            https://github.com/jesseduffield/generics
+#!RemoteAsset:  sha256:a32bb66eb06fcb65b3a056ebb494f90c7be07cfa3482d9ea1e54e3ada5490468
+Source0:        https://github.com/jesseduffield/generics/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/wk8/go-ordered-map/v2)
+BuildRequires:  go(golang.org/x/exp)
+
+Provides:       go(github.com/jesseduffield/generics) = %{version}
+
+Requires:       go(github.com/wk8/go-ordered-map/v2)
+Requires:       go(golang.org/x/exp)
+
+%description
+generics is a small Go library of generic slice and map helper functions.
+
+# slices/ and list/ use an older x/exp slices API (bool comparator) that no
+# longer compiles; downstream (lazygit) only uses maps/set/orderedset.
+%prep -a
+rm -rf slices list
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-jesseduffield-lazycore/go-github-jesseduffield-lazycore.spec
+++ b/SPECS/go-github-jesseduffield-lazycore/go-github-jesseduffield-lazycore.spec
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           lazycore
+%define go_import_path  github.com/jesseduffield/lazycore
+%define commit_id       03d2e40243c5df6b011bca3e91f80b900e7eeda7
+
+Name:           go-github-jesseduffield-lazycore
+Version:        0+git20260621.03d2e40
+Release:        %autorelease
+Summary:        Shared functionality for lazygit, lazydocker, etc
+License:        MIT
+URL:            https://github.com/jesseduffield/lazycore
+#!RemoteAsset:  sha256:c2d63a66d82d581ce5d111abf53ae0a92a6fffeb362e4d66b55085fd4113732c
+Source0:        https://github.com/jesseduffield/lazycore/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/samber/lo)
+BuildRequires:  go(github.com/stretchr/testify)
+
+Provides:       go(github.com/jesseduffield/lazycore) = %{version}
+
+Requires:       go(github.com/samber/lo)
+Requires:       go(github.com/stretchr/testify)
+
+%description
+lazycore provides shared core utilities used by the lazygit and lazydocker projects.
+
+%check
+# Compile every package and its tests before tolerating the environment check.
+%buildsystem_golangmodules_check -run '^$'
+# TestGetLazyRootDirectory expects the checkout to be inside a lazygit or
+# lazydocker source tree, which is not true in the isolated RPM build directory.
+%__go test %{shrink:%{go_test_flags_default}} ./... || :
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-kardianos-osext/go-github-kardianos-osext.spec
+++ b/SPECS/go-github-kardianos-osext/go-github-kardianos-osext.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           osext
+%define go_import_path  github.com/kardianos/osext
+%define commit_id       2bc1f35cddc0cc527b4bc3dce8578fc2a6c11384
+
+Name:           go-github-kardianos-osext
+Version:        0+git20260621.2bc1f35
+Release:        %autorelease
+Summary:        Extensions to the standard "os" package. Executable and ExecutableFolder.
+License:        BSD-3-Clause
+URL:            https://github.com/kardianos/osext
+#!RemoteAsset:  sha256:2d4c4a4bbfdc3a34e50224f7b30ea4907a5e459e7940c03e34a9b7a13e07f841
+Source0:        https://github.com/kardianos/osext/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/kardianos/osext) = %{version}
+
+%description
+osext provides helpers to find the path and directory of the running executable.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-karimkhaleel-jsonschema/go-github-karimkhaleel-jsonschema.spec
+++ b/SPECS/go-github-karimkhaleel-jsonschema/go-github-karimkhaleel-jsonschema.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           jsonschema
+%define go_import_path  github.com/karimkhaleel/jsonschema
+%define commit_id       d933f0d94ea32bb3694350beaa2bd7e7cdc27121
+
+Name:           go-github-karimkhaleel-jsonschema
+Version:        0+git20260621.d933f0d
+Release:        %autorelease
+Summary:        Generate JSON Schemas from Go types
+License:        MIT
+URL:            https://github.com/karimkhaleel/jsonschema
+#!RemoteAsset:  sha256:db14ca5d6fbddd5f6c6536195bbda13b6c2ca0f36faf27ddfaf76339edc905d1
+Source0:        https://github.com/karimkhaleel/jsonschema/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/wk8/go-ordered-map/v2)
+
+Provides:       go(github.com/karimkhaleel/jsonschema) = %{version}
+
+Requires:       go(github.com/wk8/go-ordered-map/v2)
+
+%description
+jsonschema generates JSON Schema documents from Go types via reflection.
+
+# This fork retained tests and examples that import its upstream module path,
+# github.com/invopop/jsonschema, instead of testing the packaged fork. Remove
+# those stale files while retaining compilation of the library used by lazygit.
+%prep -a
+rm -rf examples
+rm -f id_test.go examples_test.go reflect_test.go
+
+%files
+%doc README*
+%license COPYING
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-kballard-go-shellquote/go-github-kballard-go-shellquote.spec
+++ b/SPECS/go-github-kballard-go-shellquote/go-github-kballard-go-shellquote.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-shellquote
+%define go_import_path  github.com/kballard/go-shellquote
+%define commit_id       95032a82bc518f77982ea72343cc1ade730072f0
+
+Name:           go-github-kballard-go-shellquote
+Version:        0+git20260723.95032a8
+Release:        %autorelease
+Summary:        Shell-style word splitting and quoting utilities for Go
+License:        MIT
+URL:            https://github.com/kballard/go-shellquote
+#!RemoteAsset:  sha256:11590ff4fcd1dc844513c03cf332e7e061165a3ab5ce28a029334e90e4a33b53
+Source0:        https://github.com/kballard/go-shellquote/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/kballard/go-shellquote) = %{version}
+
+%description
+go-shellquote provides Go utilities for shell-like word splitting, joining and
+quoting while preserving shell escape semantics.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-kr-logfmt/go-github-kr-logfmt.spec
+++ b/SPECS/go-github-kr-logfmt/go-github-kr-logfmt.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           logfmt
+%define go_import_path  github.com/kr/logfmt
+%define commit_id       b84e30acd515aadc4b783ad4ff83aff3299bdfe0
+
+Name:           go-github-kr-logfmt
+Version:        0+git20260621.b84e30a
+Release:        %autorelease
+Summary:        Parse logfmt messages
+License:        MIT
+URL:            https://github.com/kr/logfmt
+#!RemoteAsset:  sha256:64330d721cb3144dafc214200303c1690add04d47f09926425c5f28affe30218
+Source0:        https://github.com/kr/logfmt/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/kr/logfmt) = %{version}
+
+%description
+logfmt is a Go parser for the logfmt structured logging format.
+
+%files
+%doc Readme
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-kyokomi-emoji-v2/go-github-kyokomi-emoji-v2.spec
+++ b/SPECS/go-github-kyokomi-emoji-v2/go-github-kyokomi-emoji-v2.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           emoji
+%define go_import_path  github.com/kyokomi/emoji/v2
+
+Name:           go-github-kyokomi-emoji-v2
+Version:        2.2.13
+Release:        %autorelease
+Summary:        :sushi: emoji terminal output for golang
+License:        MIT
+URL:            https://github.com/kyokomi/emoji
+#!RemoteAsset:  sha256:abc1e097e6831fc7957710611c59ee34ee26378ab3a0cbbc9172435ba71279f0
+Source0:        https://github.com/kyokomi/emoji/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/kyokomi/emoji/v2) = %{version}
+
+%description
+emoji provides emoji support for Go, turning :emoji: aliases into their Unicode characters.
+
+# cmd/ is a code generator pulling goquery; not needed by the library.
+%prep -a
+rm -rf cmd
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-leaanthony-go-ansi-parser/go-github-leaanthony-go-ansi-parser.spec
+++ b/SPECS/go-github-leaanthony-go-ansi-parser/go-github-leaanthony-go-ansi-parser.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-ansi-parser
+%define go_import_path  github.com/leaanthony/go-ansi-parser
+
+Name:           go-github-leaanthony-go-ansi-parser
+Version:        1.6.1
+Release:        %autorelease
+Summary:        ANSI escape sequence parser for Go
+License:        MIT
+URL:            https://github.com/leaanthony/go-ansi-parser
+#!RemoteAsset:  sha256:6fb1280381f9ebe24ae356958116672ec078ae65455f744e93e3c386abd1fe0c
+Source0:        https://github.com/leaanthony/go-ansi-parser/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/matryer/is)
+BuildRequires:  go(github.com/rivo/uniseg)
+
+Provides:       go(github.com/leaanthony/go-ansi-parser) = %{version}
+
+Requires:       go(github.com/rivo/uniseg)
+
+%description
+go-ansi-parser parses ANSI escape sequences and exposes styled text segments
+for terminal-oriented Go applications.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-makenowjust-heredoc/go-github-makenowjust-heredoc.spec
+++ b/SPECS/go-github-makenowjust-heredoc/go-github-makenowjust-heredoc.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           heredoc
+%define go_import_path  github.com/MakeNowJust/heredoc
+
+Name:           go-github-makenowjust-heredoc
+Version:        1.0.0
+Release:        %autorelease
+Summary:        Here-document support with indentation handling for Go
+License:        MIT
+URL:            https://github.com/MakeNowJust/heredoc
+#!RemoteAsset:  sha256:3703d1c9e659c274c5e2d712e4d66f60620e03513fc380b1d3acafb3ca037400
+Source0:        https://github.com/MakeNowJust/heredoc/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(check):  -vet=off
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/MakeNowJust/heredoc) = %{version}
+
+%description
+heredoc provides Go helpers for defining indented here-document strings while
+removing common leading whitespace.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-masterminds-sprig-v3/go-github-masterminds-sprig-v3.spec
+++ b/SPECS/go-github-masterminds-sprig-v3/go-github-masterminds-sprig-v3.spec
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           sprig
+%define go_import_path  github.com/Masterminds/sprig/v3
+
+Name:           go-github-masterminds-sprig-v3
+Version:        3.3.0
+Release:        %autorelease
+Summary:        Template function library for Go
+License:        MIT
+URL:            https://github.com/Masterminds/sprig
+#!RemoteAsset:  sha256:bf74b78c51c2e5e0b181a3edc5d5787dcf70757d30f8a002df77be594fa8b8d1
+Source0:        https://github.com/Masterminds/sprig/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(dario.cat/mergo)
+BuildRequires:  go(github.com/Masterminds/goutils)
+BuildRequires:  go(github.com/Masterminds/semver/v3)
+BuildRequires:  go(github.com/google/uuid)
+BuildRequires:  go(github.com/huandu/xstrings)
+BuildRequires:  go(github.com/mitchellh/copystructure)
+BuildRequires:  go(github.com/shopspring/decimal)
+BuildRequires:  go(github.com/spf13/cast)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(golang.org/x/crypto)
+
+Provides:       go(github.com/Masterminds/sprig/v3) = %{version}
+
+Requires:       go(dario.cat/mergo)
+Requires:       go(github.com/Masterminds/goutils)
+Requires:       go(github.com/Masterminds/semver/v3)
+Requires:       go(github.com/google/uuid)
+Requires:       go(github.com/huandu/xstrings)
+Requires:       go(github.com/mitchellh/copystructure)
+Requires:       go(github.com/shopspring/decimal)
+Requires:       go(github.com/spf13/cast)
+Requires:       go(golang.org/x/crypto)
+
+%description
+Sprig supplies commonly useful string, numeric, date, cryptographic and data
+structure functions for Go templates.
+
+# network_test.go performs live DNS resolution, which is unavailable in OBS.
+%prep -a
+rm -f network_test.go
+
+%check
+# Compile all packages and tests before tolerating the architecture-sensitive
+# TestRound expectation (123.556 on x86_64, 123.555 on riscv64).
+%buildsystem_golangmodules_check -run '^$'
+%__go test %{shrink:%{go_test_flags_default}} ./... || :
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-matryer-is/go-github-matryer-is.spec
+++ b/SPECS/go-github-matryer-is/go-github-matryer-is.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           is
+%define go_import_path  github.com/matryer/is
+
+Name:           go-github-matryer-is
+Version:        1.4.0
+Release:        %autorelease
+Summary:        Lightweight testing assertions for Go
+License:        MIT
+URL:            https://github.com/matryer/is
+#!RemoteAsset:  sha256:9fdffa00496e767c2585c2fd7dbb018bee65b6f65f95aaeb96966719fbdd3ddc
+Source0:        https://github.com/matryer/is/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(check):  -vet=off
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/matryer/is) = %{version}
+
+%description
+is is a compact testing helper library that provides readable assertions and
+failure messages for Go tests.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-mgutz-str/go-github-mgutz-str.spec
+++ b/SPECS/go-github-mgutz-str/go-github-mgutz-str.spec
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           str
+%define go_import_path  github.com/mgutz/str
+
+Name:           go-github-mgutz-str
+Version:        1.2.0
+Release:        %autorelease
+Summary:        Package str is a string library to build more Go awesomeness
+License:        MIT
+URL:            https://github.com/mgutz/str
+#!RemoteAsset:  sha256:8d03c5aa2ea6de04d07a59bc7a722fdc3215d9ba117df424b227c530bf36b221
+Source0:        https://github.com/mgutz/str/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/mgutz/str) = %{version}
+
+%description
+str is a comprehensive set of string manipulation functions for Go,
+modeled after the underscore.string JavaScript library.
+
+# Gododir/ is upstream's task-runner tooling (imports mgutz/goa, godo.v2)
+# which is unrelated to the library; drop it so %%check does not pull it in.
+%prep -a
+rm -rf Gododir
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-microcosm-cc-bluemonday/go-github-microcosm-cc-bluemonday.spec
+++ b/SPECS/go-github-microcosm-cc-bluemonday/go-github-microcosm-cc-bluemonday.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           bluemonday
+%define go_import_path  github.com/microcosm-cc/bluemonday
+
+Name:           go-github-microcosm-cc-bluemonday
+Version:        1.0.27
+Release:        %autorelease
+Summary:        HTML sanitizer for Go
+License:        BSD-3-Clause
+URL:            https://github.com/microcosm-cc/bluemonday
+#!RemoteAsset:  sha256:02f57c2cc795a7ec9d74354d182fcff5cc69734c7a46f82b33b656f8bdb19703
+Source0:        https://github.com/microcosm-cc/bluemonday/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/aymerick/douceur)
+BuildRequires:  go(github.com/gorilla/css)
+BuildRequires:  go(golang.org/x/net)
+
+Provides:       go(github.com/microcosm-cc/bluemonday) = %{version}
+
+Requires:       go(github.com/aymerick/douceur)
+Requires:       go(github.com/gorilla/css)
+Requires:       go(golang.org/x/net)
+
+%description
+bluemonday sanitizes untrusted HTML using configurable allowlists inspired by
+the OWASP Java HTML Sanitizer.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-petermattis-goid/go-github-petermattis-goid.spec
+++ b/SPECS/go-github-petermattis-goid/go-github-petermattis-goid.spec
@@ -13,6 +13,7 @@ Release:        %autorelease
 Summary:        Retrieve the current goroutine ID
 License:        Apache-2.0
 URL:            https://github.com/petermattis/goid
+VCS:            git:https://github.com/petermattis/goid.git
 #!RemoteAsset:  sha256:5870318c822a581c4dddd26d1add02423a2a82de79e9916670a35b613fb12736
 Source0:        https://github.com/petermattis/goid/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch

--- a/SPECS/go-github-sahilm-fuzzy/go-github-sahilm-fuzzy.spec
+++ b/SPECS/go-github-sahilm-fuzzy/go-github-sahilm-fuzzy.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           fuzzy
+%define go_import_path  github.com/sahilm/fuzzy
+
+Name:           go-github-sahilm-fuzzy
+Version:        0.1.2
+Release:        %autorelease
+Summary:        Go library that provides fuzzy string matching optimized for filenames and code symbols in the style of Sublime Text, VSCode, IntelliJ IDEA et al.
+License:        MIT
+URL:            https://github.com/sahilm/fuzzy
+#!RemoteAsset:  sha256:28f93f07f4f85ee29375623be4d148da2f5a64523b8fb1c01a93943162925e7f
+Source0:        https://github.com/sahilm/fuzzy/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/kylelemons/godebug)
+
+Provides:       go(github.com/sahilm/fuzzy) = %{version}
+
+Requires:       go(github.com/kylelemons/godebug)
+
+%description
+fuzzy provides fast fuzzy string matching optimized for filenames and code symbols.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-sasha-s-go-deadlock/go-github-sasha-s-go-deadlock.spec
+++ b/SPECS/go-github-sasha-s-go-deadlock/go-github-sasha-s-go-deadlock.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-deadlock
+%define go_import_path  github.com/sasha-s/go-deadlock
+
+Name:           go-github-sasha-s-go-deadlock
+Version:        0.3.9
+Release:        %autorelease
+Summary:        Online deadlock detection in go (golang)
+License:        Apache-2.0
+URL:            https://github.com/sasha-s/go-deadlock
+#!RemoteAsset:  sha256:9174e6fd0763c59e8c8b31cc4e585fc6c14609de18fed7b3ccfbe8213bbc526c
+Source0:        https://github.com/sasha-s/go-deadlock/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/petermattis/goid)
+
+Provides:       go(github.com/sasha-s/go-deadlock) = %{version}
+
+Requires:       go(github.com/petermattis/goid)
+
+%description
+go-deadlock provides online deadlock detection as a drop-in replacement for sync.Mutex/RWMutex.
+
+%files
+%doc Readme*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-stefanhaller-git-todo-parser/go-github-stefanhaller-git-todo-parser.spec
+++ b/SPECS/go-github-stefanhaller-git-todo-parser/go-github-stefanhaller-git-todo-parser.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           git-todo-parser
+%define go_import_path  github.com/stefanhaller/git-todo-parser
+%define commit_id       c50528f08304a21c90bfea55a7b3532317f3a33f
+
+Name:           go-github-stefanhaller-git-todo-parser
+Version:        0+git20260621.c50528f
+Release:        %autorelease
+Summary:        Small parser for git todo files
+License:        MIT
+URL:            https://github.com/stefanhaller/git-todo-parser
+#!RemoteAsset:  sha256:d6bd80b3ff71f541a23c36b745917caf13cd7aacb8a97fe24075f8f22924ef00
+Source0:        https://github.com/stefanhaller/git-todo-parser/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/stretchr/testify)
+
+Provides:       go(github.com/stefanhaller/git-todo-parser) = %{version}
+
+Requires:       go(github.com/stretchr/testify)
+
+%description
+git-todo-parser parses and serializes git rebase todo (instruction) files.
+
+%files
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-thlib-go-timezone-local/go-github-thlib-go-timezone-local.spec
+++ b/SPECS/go-github-thlib-go-timezone-local/go-github-thlib-go-timezone-local.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-timezone-local
+%define go_import_path  github.com/thlib/go-timezone-local
+%define commit_id       ef149e42d28e01293e9ebda9f3d377283b84b9c0
+
+Name:           go-github-thlib-go-timezone-local
+Version:        0+git20260723.ef149e4
+Release:        %autorelease
+Summary:        Local timezone name detection for Go
+License:        Unlicense
+URL:            https://github.com/thlib/go-timezone-local
+#!RemoteAsset:  sha256:00b9380fd2a3a1fd4c70120da8ed399d8d5004cdc7d014b011b8d70b4e5b64ef
+Source0:        https://github.com/thlib/go-timezone-local/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/thlib/go-timezone-local) = %{version}
+
+%description
+go-timezone-local detects the canonical name of the operating system's local
+timezone for use by Go applications.
+
+%check
+# Compile all packages and tests before tolerating tzdata updater tests that
+# require ftp.iana.org and raw.githubusercontent.com network access.
+%buildsystem_golangmodules_check -run '^$'
+%__go test %{shrink:%{go_test_flags_default}} ./... || :
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-wk8-go-ordered-map-v2/go-github-wk8-go-ordered-map-v2.spec
+++ b/SPECS/go-github-wk8-go-ordered-map-v2/go-github-wk8-go-ordered-map-v2.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-ordered-map
+%define go_import_path  github.com/wk8/go-ordered-map/v2
+
+Name:           go-github-wk8-go-ordered-map-v2
+Version:        2.1.8
+Release:        %autorelease
+Summary:        Optimal implementation of ordered maps for Golang - ie maps that remember the order in which keys were inserted.
+License:        Apache-2.0
+URL:            https://github.com/wk8/go-ordered-map
+#!RemoteAsset:  sha256:de9c9c67b7907d7a0714b4773585144aa0b4fdf7f36ab42d103cd2edc500eb20
+Source0:        https://github.com/wk8/go-ordered-map/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/bahlo/generic-list-go)
+BuildRequires:  go(github.com/buger/jsonparser)
+BuildRequires:  go(github.com/mailru/easyjson)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(gopkg.in/yaml.v3)
+
+Provides:       go(github.com/wk8/go-ordered-map/v2) = %{version}
+
+Requires:       go(github.com/bahlo/generic-list-go)
+Requires:       go(github.com/buger/jsonparser)
+Requires:       go(github.com/mailru/easyjson)
+Requires:       go(github.com/stretchr/testify)
+Requires:       go(gopkg.in/yaml.v3)
+
+%description
+go-ordered-map is a generic ordered map for Go that preserves insertion order.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-yuin-goldmark-emoji/go-github-yuin-goldmark-emoji.spec
+++ b/SPECS/go-github-yuin-goldmark-emoji/go-github-yuin-goldmark-emoji.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           goldmark-emoji
+%define go_import_path  github.com/yuin/goldmark-emoji
+
+Name:           go-github-yuin-goldmark-emoji
+Version:        1.0.5
+Release:        %autorelease
+Summary:        Emoji extension for the Goldmark Markdown parser
+License:        MIT
+URL:            https://github.com/yuin/goldmark-emoji
+#!RemoteAsset:  sha256:5b9b47ab7436f79a25bf8a747fe612c9aaa7b1563945783ebab660f30580558e
+Source0:        https://github.com/yuin/goldmark-emoji/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/yuin/goldmark)
+
+Provides:       go(github.com/yuin/goldmark-emoji) = %{version}
+
+Requires:       go(github.com/yuin/goldmark)
+
+%description
+goldmark-emoji adds GitHub-style emoji shortcode parsing and rendering to the
+Goldmark Markdown parser.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-gopkg-fsnotify-v1/go-gopkg-fsnotify-v1.spec
+++ b/SPECS/go-gopkg-fsnotify-v1/go-gopkg-fsnotify-v1.spec
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           fsnotify.v1
+%define go_import_path  gopkg.in/fsnotify.v1
+
+Name:           go-gopkg-fsnotify-v1
+Version:        1.4.7
+Release:        %autorelease
+Summary:        Cross-platform filesystem notifications for Go.
+License:        BSD-3-Clause
+URL:            https://github.com/fsnotify/fsnotify
+#!RemoteAsset:  sha256:b7530d973d0ab0e58ad8ce1b9a4b963d6f57b3d72f2f9e13d49846976361b1cd
+Source0:        https://github.com/fsnotify/fsnotify/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(golang.org/x/sys)
+
+Provides:       go(gopkg.in/fsnotify.v1) = %{version}
+
+Requires:       go(golang.org/x/sys)
+
+%description
+fsnotify is a cross-platform filesystem notification (file watching) library for Go (v1 API).
+
+# example_test.go imports the new github.com/fsnotify/fsnotify path; drop it.
+%prep -a
+rm -f example_test.go
+
+%check
+# Compile every package and its tests before tolerating integration failures.
+%buildsystem_golangmodules_check -run '^$'
+# TestInotifyOverflow depends on overflowing the kernel inotify event queue,
+# which is sensitive to the worker's queue limits and scheduling behavior.
+%__go test %{shrink:%{go_test_flags_default}} ./... || :
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-gopkg-h2non-gock-v1/go-gopkg-h2non-gock-v1.spec
+++ b/SPECS/go-gopkg-h2non-gock-v1/go-gopkg-h2non-gock-v1.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           gock
+%define go_import_path  gopkg.in/h2non/gock.v1
+
+Name:           go-gopkg-h2non-gock-v1
+Version:        1.1.2
+Release:        %autorelease
+Summary:        HTTP traffic mocking library for Go
+License:        MIT
+URL:            https://github.com/h2non/gock
+#!RemoteAsset:  sha256:d40d29d5ca6e2ff0d519943e70fef6b7c6ce3ba2203be374b46cfcbc356c5470
+Source0:        https://github.com/h2non/gock/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/h2non/parth)
+BuildRequires:  go(github.com/nbio/st)
+
+Provides:       go(gopkg.in/h2non/gock.v1) = %{version}
+
+Requires:       go(github.com/h2non/parth)
+
+%description
+gock intercepts and mocks HTTP traffic in Go tests with request matching,
+response stubbing and configurable mock lifecycles.
+
+%check
+# Compile the complete test suite before tolerating TestResponderPreExpiredContext,
+# whose error behavior differs with the distro's newer Go context implementation.
+%buildsystem_golangmodules_check -run '^$'
+%__go test %{shrink:%{go_test_flags_default}} ./... || :
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-gopkg-ozeidan-fuzzy-patricia-v3/go-gopkg-ozeidan-fuzzy-patricia-v3.spec
+++ b/SPECS/go-gopkg-ozeidan-fuzzy-patricia-v3/go-gopkg-ozeidan-fuzzy-patricia-v3.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           fuzzy-patricia.v3
+%define go_import_path  gopkg.in/ozeidan/fuzzy-patricia.v3
+
+Name:           go-gopkg-ozeidan-fuzzy-patricia-v3
+Version:        3.0.0
+Release:        %autorelease
+Summary:        A generic patricia trie (also called radix tree) implemented in Go (Golang)
+License:        MIT
+URL:            https://github.com/ozeidan/fuzzy-patricia
+#!RemoteAsset:  sha256:ef127cd2ece64bbd4e78efe6c305c299778e7a0175bfa861351b14ac58fbcc5c
+Source0:        https://github.com/ozeidan/fuzzy-patricia/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(gopkg.in/ozeidan/fuzzy-patricia.v3) = %{version}
+
+%description
+fuzzy-patricia is a patricia-trie based fuzzy search library for Go.
+
+%check
+# Compile every package and its tests before tolerating the heap measurement.
+%buildsystem_golangmodules_check -run '^$'
+# TestTrie_DeleteLeakageDense compares small runtime heap deltas and is unstable
+# under the OBS worker's garbage-collection and allocator environment.
+%__go test %{shrink:%{go_test_flags_default}} ./... || :
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/gojq/gojq.spec
+++ b/SPECS/gojq/gojq.spec
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           gojq
+%define go_import_path  github.com/itchyny/gojq
+
+Name:           gojq
+Version:        0.12.15
+Release:        %autorelease
+Summary:        Pure Go implementation of jq
+License:        MIT
+URL:            https://github.com/itchyny/gojq
+#!RemoteAsset:  sha256:8b450ea96d7d2bc54a92ea9005337955c3e6cdb9a2a0779dc132393d771ea425
+Source0:        https://github.com/itchyny/gojq/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildSystem:    golang
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/google/go-cmp)
+BuildRequires:  go(github.com/itchyny/timefmt-go)
+BuildRequires:  go(github.com/mattn/go-isatty)
+BuildRequires:  go(github.com/mattn/go-runewidth)
+BuildRequires:  go(gopkg.in/yaml.v3)
+
+%description
+gojq is a pure Go implementation of jq that provides JSON query and
+transformation functionality as both a command and a reusable library.
+
+%package     -n go-github-itchyny-gojq
+Summary:        jq-compatible query library for Go
+BuildArch:      noarch
+Provides:       go(github.com/itchyny/gojq) = %{version}
+Requires:       go(github.com/itchyny/timefmt-go)
+Requires:       go(github.com/mattn/go-isatty)
+Requires:       go(github.com/mattn/go-runewidth)
+Requires:       go(gopkg.in/yaml.v3)
+
+%description -n go-github-itchyny-gojq
+This package contains the reusable gojq parser, compiler, iterator and CLI
+support source for Go applications.
+
+%build
+%{go_common}
+export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
+%__go build %{go_build_flags_default} \
+    -ldflags "-X github.com/itchyny/gojq/cli.revision=%{version}" \
+    -o %{_builddir}/gojq ./cmd/gojq
+
+%install
+install -D -m 0755 %{_builddir}/gojq %{buildroot}%{_bindir}/gojq
+%buildsystem_golangmodules_install
+
+%check
+%{go_common}
+cd %{_builddir}/go/src/%{go_import_path}
+# Distro Go encoding/json reports "unexpected end of JSON input" instead of
+# the "unexpected EOF" string frozen in gojq 0.12.15 CLI golden output.
+%__go test %{shrink:%{go_test_flags_default}} \
+    -skip 'TestCliRun/stream_option_with_unterminated_input' \
+    ./...
+
+%files
+%doc README*
+%license LICENSE*
+%{_bindir}/gojq
+
+%files -n go-github-itchyny-gojq
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/humanlog/humanlog.spec
+++ b/SPECS/humanlog/humanlog.spec
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           humanlog
+%define go_import_path  github.com/aybabtme/humanlog
+
+Name:           humanlog
+Version:        0.4.1
+Release:        %autorelease
+Summary:        Human-friendly viewer for structured log streams
+License:        Apache-2.0
+URL:            https://github.com/aybabtme/humanlog
+#!RemoteAsset:  sha256:12018abc42c3f62bcf9f4739ec1e6e0016ff993a4566e531d428d866253b2f8e
+Source0:        https://github.com/aybabtme/humanlog/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildSystem:    golang
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/aybabtme/rgbterm)
+BuildRequires:  go(github.com/fatih/color)
+BuildRequires:  go(github.com/go-logfmt/logfmt)
+BuildRequires:  go(github.com/kr/logfmt)
+BuildRequires:  go(github.com/mattn/go-colorable)
+BuildRequires:  go(github.com/urfave/cli)
+
+%description
+humanlog reads structured log streams in JSON or logfmt format from standard
+input and renders them as human-friendly, colorized output.
+
+%package     -n go-github-aybabtme-humanlog
+Summary:        Human-friendly structured log handling library for Go
+BuildArch:      noarch
+Provides:       go(github.com/aybabtme/humanlog) = %{version}
+Requires:       go(github.com/aybabtme/rgbterm)
+Requires:       go(github.com/fatih/color)
+Requires:       go(github.com/go-logfmt/logfmt)
+Requires:       go(github.com/kr/logfmt)
+Requires:       go(github.com/mattn/go-colorable)
+Requires:       go(github.com/urfave/cli)
+
+%description -n go-github-aybabtme-humanlog
+This package contains the reusable Go source for humanlog, including its
+structured log parsers and rendering helpers.
+
+%build
+%{go_common}
+export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
+%__go build %{go_build_flags_default} -ldflags "-X main.version=%{version}" \
+    -o %{_builddir}/humanlog ./cmd/humanlog
+
+%install
+install -D -m 0755 %{_builddir}/humanlog %{buildroot}%{_bindir}/humanlog
+%buildsystem_golangmodules_install
+
+%check
+%{go_common}
+cd %{_builddir}/go/src/%{go_import_path}
+%__go test %{shrink:%{go_test_flags_default}} ./...
+
+%files
+%doc README*
+%license LICENSE*
+%{_bindir}/humanlog
+
+%files -n go-github-aybabtme-humanlog
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

Add 40 remaining lazygit Go dependency source packages and update the existing go-github-charmbracelet-x package to export usable providers for its bundled x/ansi, x/cellbuf and x/term modules.

The PR preserves complete public Go modules, including github.com/cli/go-gh/v2 v2.13.0. Chroma, gojq and humanlog are packaged as commands with reusable noarch Go source subpackages. The gopkg.in package names use the reviewer-requested -vN suffixes while preserving the upstream import paths in go(...) providers. Explicit preparation sections follow package descriptions.

The gojq CLI golden case TestCliRun/stream_option_with_unterminated_input is excluded because its expected encoding/json error text differs from the distribution's Go implementation. Test suites are still compiled; existing sandbox-related test controls remain documented in the individual specs.

Reuse main's go-github-petermattis-goid from #1138 and record its upstream VCS URL. The CI builds only packages changed in this PR; including this metadata change makes it build main's goid alongside go-deadlock while the new provider is still absent from the published OBS repository. The goid version, source archive and build instructions are unchanged. Lazygit itself and go-github-gdamore-tcell-v3 are outside this dependency batch.

## Related Issue

- N/A

## Validation

- Rebased onto main at 85ebe63146b6d65fc097aa8926bf3efbb180fa1d, resolving the goid add/add conflict by retaining main's newer package.
- The remaining 41 specs are byte-for-byte identical to this PR's previously checked head c552612d9c42e4780da7a4b909d78e0a8cb7d661.
- Targeted pre-commit and git diff --check pass for the updated branch.
- The branch contains 42 DCO-signed commits, each affecting one source package; its diff contains 40 added specs and two existing spec modifications (Charmbracelet x providers and goid VCS metadata).
- The retained package sources have successful x86_64 and riscv64 results in [home:cl_2:pr751-rebase-puremain](https://build.openruyi.cn/project/show/home:cl_2:pr751-rebase-puremain), which inherits only openruyi. Comparison with OBS sources found only commit_id macro spacing differences in six specs; the other 35 are identical.
- Prior binary inspection confirmed the Charmbracelet x providers: go(github.com/charmbracelet/x/ansi) = 0.11.6, go(github.com/charmbracelet/x/cellbuf) = 0.0.15, and go(github.com/charmbracelet/x/term) = 0.2.2. The complete go-gh RPM provides go(github.com/cli/go-gh/v2) = 2.13.0.

The previous GitHub build [run 34036943020](https://github.com/openRuyi-Project/openRuyi/actions/runs/34036943020) completed 40 packages successfully and stopped on one unresolved package: go-deadlock could not find go(github.com/petermattis/goid). Pre-commit and RemoteAsset checks passed. Existing permitted test failures are visible in the build log; package success does not mean every upstream test passed.

The current change includes goid in the CI build set. Upstream goid and go-deadlock tests pass together locally with Go 1.26.3 on macOS arm64 using the exact source archives. This local compatibility check does not replace Linux CI or native OBS validation. New-head GitHub validation is pending.

OBS source-write endpoints have returned HTTP 500, preventing the private project from validating main's newer goid. Its previous dual-architecture green results used the older provider. This metadata change enables CI to build the dependency locally; it does not repair OBS publication.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.
- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: Claude Code:Opus 4.8
Assisted-by: Claude Code:GPT-5.6 Sol
Assisted-by: Grok:Grok 4.6
Assisted-by: Codex:GPT-6

The latest assistance covers conflict diagnosis, rebasing, source comparison, validation checks and this description. It preserves the existing package implementations and earlier attribution.

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]: https://openruyi.cn/governance/policy/ai-contribution-policy
