### PR TITLE
CI: Add check for _constraints.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,13 @@ repos:
        entry: |
          There should only be subdirectories under SPECS
        files: '^SPECS/[^/]+$'
+    -  id: dont-add-constraints-to-repo
+       name: "Don't add _constraints to spec directory"
+       language: fail
+       entry: |
+         _constraints should not be placed in the git repository
+         It should be configured in the obs repository.
+       files: ^SPECS/.*/_constraints$
     -  id: sourcewithRemoteAsset
        name: "check Source with #!RemoteAsset"
        language: python


### PR DESCRIPTION
## Summary

The _constraints file should add to obs project, not git repo.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
