### PR TITLE
SPECS: some go modules: Add tests dependent tzdata.

### DIFF
--- a/SPECS/go-github-gin-gonic-gin/go-github-gin-gonic-gin.spec
+++ b/SPECS/go-github-gin-gonic-gin/go-github-gin-gonic-gin.spec
@@ -13,7 +13,7 @@ Release:        %autorelease
 Summary:        Gin is a high-performance HTTP web framework written in Go. It provides a Martini-like API but with significantly better performance—up to 40 times faster—thanks to httprouter. Gin is designed for building REST APIs, web applications, and microservices.
 License:        MIT
 URL:            https://github.com/gin-gonic/gin
-#!RemoteAsset
+#!RemoteAsset:  sha256:9f6a9a6c2b96c323902d8ee1728152bafdf1894130554a93af5d3f1807c0403b
 Source0:        https://github.com/gin-gonic/gin/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
@@ -32,6 +32,8 @@ BuildRequires:  go(github.com/ugorji/go/codec)
 BuildRequires:  go(golang.org/x/net)
 BuildRequires:  go(gopkg.in/yaml.v2)
 BuildRequires:  go(google.golang.org/protobuf)
+# For tests.
+BuildRequires:  tzdata
 
 Provides:       go(github.com/gin-gonic/gin) = %{version}
 
@@ -58,4 +60,4 @@ developer productivity are essential.
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/go-github-go-playground-locales/go-github-go-playground-locales.spec
+++ b/SPECS/go-github-go-playground-locales/go-github-go-playground-locales.spec
@@ -13,7 +13,7 @@ Release:        %autorelease
 Summary:        a set of locales generated from the CLDR Project which can be used independently or within an i18n package
 License:        MIT
 URL:            https://github.com/go-playground/locales
-#!RemoteAsset
+#!RemoteAsset:  sha256:29b29f1ff125e04a4d81a1f584d929ac8444663255cfdfa076a78339e23b4624
 Source0:        https://github.com/go-playground/locales/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
@@ -23,6 +23,8 @@ BuildOption(prep):  -n %{_name}-%{version}
 BuildRequires:  go
 BuildRequires:  go-rpm-macros
 BuildRequires:  go(golang.org/x/text)
+# For tests.
+BuildRequires:  tzdata
 
 Provides:       go(github.com/go-playground/locales) = %{version}
 
@@ -53,4 +55,4 @@ Features
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/go-github-go-playground-validator-v10/go-github-go-playground-validator-v10.spec
+++ b/SPECS/go-github-go-playground-validator-v10/go-github-go-playground-validator-v10.spec
@@ -29,6 +29,8 @@ BuildRequires:  go(github.com/go-playground/universal-translator)
 BuildRequires:  go(github.com/leodido/go-urn)
 BuildRequires:  go(golang.org/x/crypto)
 BuildRequires:  go(golang.org/x/text)
+# For tests.
+BuildRequires:  tzdata
 
 Provides:       go(github.com/go-playground/validator/v10) = %{version}
 

--- a/SPECS/go-github-go-sql-driver-mysql/go-github-go-sql-driver-mysql.spec
+++ b/SPECS/go-github-go-sql-driver-mysql/go-github-go-sql-driver-mysql.spec
@@ -13,7 +13,7 @@ Release:        %autorelease
 Summary:        Go MySQL Driver is a MySQL driver for Go's (golang) database/sql package
 License:        MPL-2.0
 URL:            https://github.com/go-sql-driver/mysql
-#!RemoteAsset
+#!RemoteAsset:  sha256:c8aa24eb8b7e552b7c518215820dcc7865992e359358dd29f302d919106e95fc
 Source0:        https://github.com/go-sql-driver/mysql/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
@@ -21,6 +21,8 @@ BuildSystem:    golangmodules
 BuildRequires:  go
 BuildRequires:  go-rpm-macros
 BuildRequires:  go(filippo.io/edwards25519)
+# For tests.
+BuildRequires:  tzdata
 
 Provides:       go(github.com/go-sql-driver/mysql) = %{version}
 
@@ -48,4 +50,4 @@ MySQL-Driver for Go's database/sql package
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/go-github-hashicorp-cronexpr/go-github-hashicorp-cronexpr.spec
+++ b/SPECS/go-github-hashicorp-cronexpr/go-github-hashicorp-cronexpr.spec
@@ -13,7 +13,7 @@ Release:        %autorelease
 Summary:        Cron expression parser in Go language (golang)
 License:        Apache-2.0
 URL:            https://github.com/hashicorp/cronexpr
-#!RemoteAsset
+#!RemoteAsset:  sha256:1d546a0497dd21a16f75745bd5645af96d63f506249f4582855f2a9fdc07f29a
 Source0:        https://github.com/hashicorp/cronexpr/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
@@ -21,6 +21,8 @@ BuildSystem:    golangmodules
 BuildRequires:  go
 BuildRequires:  go-rpm-macros
 BuildRequires:  go(github.com/stretchr/testify)
+# For tests
+BuildRequires:  tzdata
 
 Provides:       go(github.com/hashicorp/cronexpr) = %{version}
 
@@ -36,4 +38,4 @@ stamp which satisfies the cron expression.
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/go-github-jinzhu-now/go-github-jinzhu-now.spec
+++ b/SPECS/go-github-jinzhu-now/go-github-jinzhu-now.spec
@@ -13,13 +13,15 @@ Release:        %autorelease
 Summary:        Now is a time toolkit for golang
 License:        MIT
 URL:            https://github.com/jinzhu/now
-#!RemoteAsset
+#!RemoteAsset:  sha256:6660b00538ebb0e0ade120371f2a891c692650e9126bd45a805b8f4d65293127
 Source0:        https://github.com/jinzhu/now/archive/refs/tags/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
 
 BuildRequires:  go
 BuildRequires:  go-rpm-macros
+# For tests.
+BuildRequires:  tzdata
 
 Provides:       go(github.com/jinzhu/now) = %{version}
 
@@ -32,4 +34,4 @@ Now is a time toolkit for golang
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/go-github-spf13-cast/go-github-spf13-cast.spec
+++ b/SPECS/go-github-spf13-cast/go-github-spf13-cast.spec
@@ -14,7 +14,7 @@ Release:        %autorelease
 Summary:        safe and easy casting from one type to another in Go
 License:        MIT
 URL:            https://github.com/spf13/cast
-#!RemoteAsset
+#!RemoteAsset:  sha256:d62a9b81da805574153b14c9defb1d817f71fb9ebb5b6d20e8859b3029170a38
 Source0:        https://github.com/spf13/cast/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
@@ -27,6 +27,8 @@ BuildOption(prep):  -n %{_name}-%{version}
 BuildRequires:  go
 BuildRequires:  go-rpm-macros
 BuildRequires:  go(github.com/frankban/quicktest)
+# For tests.
+BuildRequires:  tzdata
 
 Provides:       go(github.com/spf13/cast) = %{version}
 
@@ -50,4 +52,4 @@ TOML or JSON for meta data.
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/go-uber-atomic/go-uber-atomic.spec
+++ b/SPECS/go-uber-atomic/go-uber-atomic.spec
@@ -13,7 +13,7 @@ Release:        %autorelease
 Summary:        Wrapper types for sync/atomic which enforce atomic access
 License:        MIT
 URL:            https://github.com/uber-go/atomic
-#!RemoteAsset
+#!RemoteAsset:  sha256:cfe258c20d71ac4dbf0f716a23ed00c332b7f281180651e2a67ad40a8b0772cc
 Source0:        https://github.com/uber-go/atomic/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
@@ -23,6 +23,8 @@ BuildOption(prep):  -n %{_name}-%{version}
 BuildRequires:  go
 BuildRequires:  go-rpm-macros
 BuildRequires:  go(github.com/stretchr/testify)
+# For tests.
+BuildRequires:  tzdata
 
 Provides:       go(go.uber.org/atomic) = %{version}
 
@@ -35,4 +37,4 @@ Simple wrappers for primitive types to enforce atomic access.
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Currently, these packages test failure with timezone, such as:
```
[  276s] === RUN   TestMappingTime
[  276s]     form_mapping_test.go:168: 
[  276s]         	Error Trace:	/home/abuild/rpmbuild/BUILD/go-github-gin-gonic-gin-1.8.1-build/go/src/github.com/gin-gonic/gin/binding/form_mapping_test.go:168
[  276s]         	Error:      	Received unexpected error:
[  276s]         	            	unknown time zone Europe/Berlin
[  276s]         	Test:       	TestMappingTime
[  276s] --- FAIL: TestMappingTime (0.00s)
```