### PR TITLE
CI: Add no-entries-directly-under-SPECS check.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,12 @@ repos:
          see https://peps.python.org/pep-0503/#normalized-names
          see https://openruyi.cn/docs/guide/packaging-guidelines/languages/Python
        files: python-(?!([a-z0-9]|[a-z0-9][a-z0-9._-]*[a-z0-9])).*\.spec$
+    -  id: no-entries-directly-under-SPECS
+       name: "SPECS may only containreal subdirectorys"
+       language: fail
+       entry: |
+         There should only be subdirectories under SPECS
+       files: '^SPECS/[^/]+$'
     -  id: sourcewithRemoteAsset
        name: "check Source with #!RemoteAsset"
        language: python


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: GPT5.5

use GPT 5.5 to write regular expression 

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
