### PR TITLE
SPECS: qt6-qtwebengine: Fix build error with gcc16, glibc 2.43, rvv.

### DIFF
--- a/SPECS/qt6-qtwebengine/0007-adapt-chromium-to-gcc16-glibc2.43-and-rvv.patch
+++ b/SPECS/qt6-qtwebengine/0007-adapt-chromium-to-gcc16-glibc2.43-and-rvv.patch
@@ -1,0 +1,67 @@
+--- a/src/3rdparty/chromium/base/strings/to_string.h
++++ b/src/3rdparty/chromium/base/strings/to_string.h
+@@ -6,6 +6,7 @@
+ #define BASE_STRINGS_TO_STRING_H_
+ 
+ #include <concepts>
++#include <cstdint>
+ #include <iomanip>
+ #include <ios>
+ #include <memory>
+--- a/src/3rdparty/chromium/sandbox/linux/system_headers/linux_seccomp.h
++++ a/src/3rdparty/chromium/sandbox/linux/system_headers/linux_seccomp.h
+@@ -214,8 +214,11 @@ struct seccomp_notif_addfd {
+ #define SECCOMP_RET_INVALID 0x00010000U  // Illegal return value
+ #endif
+ 
++// check glibc version < 2.42
++#if (__GLIBC__ < 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 42)
+ #ifndef SYS_SECCOMP
+ #define SYS_SECCOMP                   1
+ #endif
++#endif
+ 
+ #endif  // SANDBOX_LINUX_SYSTEM_HEADERS_LINUX_SECCOMP_H_
+--- a/src/3rdparty/chromium/v8/src/json/json-stringifier.cc     2025-11-14 07:55:10.000000000 +0000
++++ b/src/3rdparty/chromium/v8/src/json/json-stringifier.cc     2026-06-18 05:56:31.648272572 +0000
+@@ -2902,9 +2902,11 @@
+
+   for (; block + (stride - 1) < end; block += stride) {
+     const auto input = hw::LoadU(tag, block);
+-    const auto has_lower_than_0x20 = input < mask_0x20;
+-    const auto has_0x22 = input == mask_0x22;
+-    const auto has_0x5c = input == mask_0x5c;
++    // TODO(floitsch): use operators for the comparisons when they are available
++    // on RISC-V.
++    const auto has_lower_than_0x20 = hw::Lt(input, mask_0x20);
++    const auto has_0x22 = hw::Eq(input, mask_0x22);
++    const auto has_0x5c = hw::Eq(input, mask_0x5c);
+     const auto result = hw::Or(hw::Or(has_lower_than_0x20, has_0x22), has_0x5c);
+
+     // No character that needs escaping found in block.
+--- a/src/3rdparty/chromium/third_party/libyuv/source/row_rvv.cc  2025-11-14 07:55:10.000000000 +0000
++++ b/src/3rdparty/chromium/third_party/libyuv/source/row_rvv.cc   2026-06-20 10:09:23.592876393 +0000
+@@ -17,9 +17,7 @@
+
+ #include "libyuv/row.h"
+
+-// This module is for clang rvv. GCC hasn't supported segment load & store.
+-#if !defined(LIBYUV_DISABLE_RVV) && defined(__riscv_vector) && \
+-    defined(__clang__)
++#if !defined(LIBYUV_DISABLE_RVV) && defined(__riscv_vector)
+ #include <assert.h>
+ #include <riscv_vector.h>
+
+--- a/src/3rdparty/chromium/third_party/libyuv/source/scale_rvv.cc   2025-11-14 07:55:10.000000000 +0000
++++ b/src/3rdparty/chromium/third_party/libyuv/source/scale_rvv.cc   2026-06-20 10:11:59.024821956 +0000
+@@ -18,9 +18,7 @@
+ #include "libyuv/row.h"
+ #include "libyuv/scale_row.h"
+
+-// This module is for clang rvv. GCC hasn't supported segment load & store.
+-#if !defined(LIBYUV_DISABLE_RVV) && defined(__riscv_vector) && \
+-    defined(__clang__)
++#if !defined(LIBYUV_DISABLE_RVV) && defined(__riscv_vector)
+ #include <assert.h>
+ #include <riscv_vector.h>
+ #ifdef __cplusplus

--- a/SPECS/qt6-qtwebengine/qt6-qtwebengine.spec
+++ b/SPECS/qt6-qtwebengine/qt6-qtwebengine.spec
@@ -33,6 +33,8 @@ Patch3:         0004-riscv-sandbox.patch
 Patch4:         0005-riscv-v8.patch
 Patch5:         0006-riscv-enable-v8-webasm.patch
 %endif
+# Based on various upstream commits.
+Patch6:         0007-adapt-chromium-to-gcc16-glibc2.43-and-rvv.patch
 
 BuildOption(conf):  -DCMAKE_TOOLCHAIN_FILE="%{_libdir}/cmake/Qt6/qt.toolchain.cmake"
 BuildOption(conf):  -DFEATURE_webengine_build_gn=ON
@@ -236,7 +238,6 @@ sed -i -e "s|%{version} \${_Qt6WebEngine|%{real_version} \${_Qt6WebEngine|" \
 %{_qt6_translationsdir}/qtwebengine_locales/
 %{_qt6_archdatadir}/sbom/%{qt_module}-%{real_version}.spdx
 %{_qt6_archdatadir}/sbom/qtpdf-%{real_version}.spdx
-%{_qt6_datadir}/resources/qtwebengine_devtools_resources.pak
 %{_qt6_libdir}/libQt6Pdf.so.*
 %{_qt6_libdir}/libQt6PdfQuick.so.*
 %{_qt6_libdir}/libQt6PdfWidgets.so.*


### PR DESCRIPTION
The patch is based on various upstream commits, such as:

https://chromium-review.googlesource.com/c/v8/v8/+/6979448

https://chromium.googlesource.com/libyuv/libyuv/+/022efdb0b771f7353741dbe360b8bef4e0a874eb%5E%21/#F0

Fix: https://github.com/openRuyi-Project/openRuyi/issues/724