### PR TITLE
SPECS: go-github-apache-thrift: Upgrade to 0.23.0.

### DIFF
--- a/SPECS/go-github-apache-thrift/1000-fix_go_print_format.patch
+++ b/SPECS/go-github-apache-thrift/1000-fix_go_print_format.patch
@@ -1,0 +1,88 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Laszlo Boszormenyi (GCS) <gcs@debian.org>
+Date: May, 01 2026 09:11:41 +0200
+Subject: print go int8 values as is
+
+Replace %q with %d in values formatting.
+
+Bug-Debian: https://bugs.debian.org/1129168
+Forwarded: no
+Author: Laszlo Boszormenyi (GCS) <gcs@debian.org>
+---
+
+--- thrift-0.22.0.orig/lib/go/thrift/protocol_test.go
++++ thrift-0.22.0/lib/go/thrift/protocol_test.go
+@@ -298,20 +298,20 @@ func ReadWriteByte(t testing.TB, p TProt
+ 	for k, v := range BYTE_VALUES {
+ 		err = p.WriteByte(context.Background(), v)
+ 		if err != nil {
+-			t.Errorf("%s: %T %T %q Error writing byte in list at index %d: %q", "ReadWriteByte", p, trans, err, k, v)
++			t.Errorf("%s: %T %T %q Error writing byte in list at index %d: %d", "ReadWriteByte", p, trans, err, k, v)
+ 		}
+ 	}
+ 	err = p.WriteListEnd(context.Background())
+ 	if err != nil {
+-		t.Errorf("%s: %T %T %q Error writing list end: %q", "ReadWriteByte", p, trans, err, BYTE_VALUES)
++		t.Errorf("%s: %T %T %q Error writing list end: %d", "ReadWriteByte", p, trans, err, BYTE_VALUES)
+ 	}
+ 	err = p.Flush(context.Background())
+ 	if err != nil {
+-		t.Errorf("%s: %T %T %q Error flushing list of bytes: %q", "ReadWriteByte", p, trans, err, BYTE_VALUES)
++		t.Errorf("%s: %T %T %q Error flushing list of bytes: %d", "ReadWriteByte", p, trans, err, BYTE_VALUES)
+ 	}
+ 	thetype2, thelen2, err := p.ReadListBegin(context.Background())
+ 	if err != nil {
+-		t.Errorf("%s: %T %T %q Error reading list: %q", "ReadWriteByte", p, trans, err, BYTE_VALUES)
++		t.Errorf("%s: %T %T %q Error reading list: %d", "ReadWriteByte", p, trans, err, BYTE_VALUES)
+ 	}
+ 	_, ok := p.(*TSimpleJSONProtocol)
+ 	if !ok {
+@@ -325,7 +325,7 @@ func ReadWriteByte(t testing.TB, p TProt
+ 	for k, v := range BYTE_VALUES {
+ 		value, err := p.ReadByte(context.Background())
+ 		if err != nil {
+-			t.Errorf("%s: %T %T %q Error reading byte at index %d: %q", "ReadWriteByte", p, trans, err, k, v)
++			t.Errorf("%s: %T %T %q Error reading byte at index %d: %d", "ReadWriteByte", p, trans, err, k, v)
+ 		}
+ 		if v != value {
+ 			t.Errorf("%s: %T %T %d != %d", "ReadWriteByte", p, trans, v, value)
+@@ -348,7 +348,7 @@ func ReadWriteI16(t testing.TB, p TProto
+ 	p.Flush(context.Background())
+ 	thetype2, thelen2, err := p.ReadListBegin(context.Background())
+ 	if err != nil {
+-		t.Errorf("%s: %T %T %q Error reading list: %q", "ReadWriteI16", p, trans, err, INT16_VALUES)
++		t.Errorf("%s: %T %T %q Error reading list: %d", "ReadWriteI16", p, trans, err, INT16_VALUES)
+ 	}
+ 	_, ok := p.(*TSimpleJSONProtocol)
+ 	if !ok {
+@@ -362,7 +362,7 @@ func ReadWriteI16(t testing.TB, p TProto
+ 	for k, v := range INT16_VALUES {
+ 		value, err := p.ReadI16(context.Background())
+ 		if err != nil {
+-			t.Errorf("%s: %T %T %q Error reading int16 at index %d: %q", "ReadWriteI16", p, trans, err, k, v)
++			t.Errorf("%s: %T %T %q Error reading int16 at index %d: %d", "ReadWriteI16", p, trans, err, k, v)
+ 		}
+ 		if v != value {
+ 			t.Errorf("%s: %T %T %d != %d", "ReadWriteI16", p, trans, v, value)
+@@ -421,7 +421,7 @@ func ReadWriteI64(t testing.TB, p TProto
+ 	p.Flush(context.Background())
+ 	thetype2, thelen2, err := p.ReadListBegin(context.Background())
+ 	if err != nil {
+-		t.Errorf("%s: %T %T %q Error reading list: %q", "ReadWriteI64", p, trans, err, INT64_VALUES)
++		t.Errorf("%s: %T %T %q Error reading list: %d", "ReadWriteI64", p, trans, err, INT64_VALUES)
+ 	}
+ 	_, ok := p.(*TSimpleJSONProtocol)
+ 	if !ok {
+@@ -435,10 +435,10 @@ func ReadWriteI64(t testing.TB, p TProto
+ 	for k, v := range INT64_VALUES {
+ 		value, err := p.ReadI64(context.Background())
+ 		if err != nil {
+-			t.Errorf("%s: %T %T %q Error reading int64 at index %d: %q", "ReadWriteI64", p, trans, err, k, v)
++			t.Errorf("%s: %T %T %q Error reading int64 at index %d: %d", "ReadWriteI64", p, trans, err, k, v)
+ 		}
+ 		if v != value {
+-			t.Errorf("%s: %T %T %q != %q", "ReadWriteI64", p, trans, v, value)
++			t.Errorf("%s: %T %T %d != %d", "ReadWriteI64", p, trans, v, value)
+ 		}
+ 	}
+ 	if err != nil {

--- a/SPECS/go-github-apache-thrift/go-github-apache-thrift.spec
+++ b/SPECS/go-github-apache-thrift/go-github-apache-thrift.spec
@@ -13,15 +13,18 @@
 }
 
 Name:           go-github-apache-thrift
-Version:        0.22.0
+Version:        0.23.0
 Release:        %autorelease
 Summary:        Apache Thrift
 License:        Apache-2.0
 URL:            https://github.com/apache/thrift
-#!RemoteAsset
+#!RemoteAsset:  sha256:087ba9517063c8252e9e7fb4e3891a9fd85e20af80e0309e2276eff16791d75c
 Source0:        https://github.com/apache/thrift/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
+
+# From Debian.
+Patch1000:      1000-fix_go_print_format.patch
 
 BuildOption(prep):  -n %{_name}-%{version}
 BuildOption(check):  -skip TestSocketIsntListeningAfterInterrupt
@@ -52,4 +55,4 @@ rm -rf lib/go/test
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Also fixed 'Errorf format %q has arg v of wrong type int8' errors.

