### PR TITLE
SPECS: Add HashiCorp Consul service-discovery dependencies

### DIFF
--- a/SPECS/go-github-hashicorp-consul-api/go-github-hashicorp-consul-api.spec
+++ b/SPECS/go-github-hashicorp-consul-api/go-github-hashicorp-consul-api.spec
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           consul
+%define go_import_path  github.com/hashicorp/consul/api
+%define archive_dir     consul-api-v%{version}
+
+# Some api tests start a local Consul agent / probe the network, which the
+# isolated build sandbox restricts; run the tests but tolerate the failures.
+%global go_test_ignore_failure 1
+
+Name:           go-github-hashicorp-consul-api
+Version:        1.32.1
+Release:        %autorelease
+Summary:        Go client library for the HashiCorp Consul HTTP API
+License:        MPL-2.0
+URL:            https://github.com/hashicorp/consul
+#!RemoteAsset:  sha256:ed118767ca37e3caf003b0a2e7e1b0b3b335590950d8f278833bf1cde6b9dc08
+Source0:        https://github.com/hashicorp/consul/archive/refs/tags/api/v%{version}.tar.gz#/%{_name}-api-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{archive_dir}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/google/go-cmp)
+BuildRequires:  go(github.com/hashicorp/consul/sdk)
+BuildRequires:  go(github.com/hashicorp/go-cleanhttp)
+BuildRequires:  go(github.com/hashicorp/go-hclog)
+BuildRequires:  go(github.com/hashicorp/go-multierror)
+BuildRequires:  go(github.com/hashicorp/go-rootcerts)
+BuildRequires:  go(github.com/hashicorp/go-uuid)
+BuildRequires:  go(github.com/hashicorp/serf)
+BuildRequires:  go(github.com/mitchellh/mapstructure)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(golang.org/x/exp)
+
+Provides:       go(github.com/hashicorp/consul/api) = %{version}
+
+Requires:       go(github.com/google/go-cmp)
+Requires:       go(github.com/hashicorp/consul/sdk)
+Requires:       go(github.com/hashicorp/go-cleanhttp)
+Requires:       go(github.com/hashicorp/go-hclog)
+Requires:       go(github.com/hashicorp/go-multierror)
+Requires:       go(github.com/hashicorp/go-rootcerts)
+Requires:       go(github.com/hashicorp/go-uuid)
+Requires:       go(github.com/hashicorp/serf)
+Requires:       go(github.com/mitchellh/mapstructure)
+
+# The upstream archive is the whole consul repository; keep only the api
+# submodule so the build targets github.com/hashicorp/consul/api alone.
+%prep -a
+find . -maxdepth 1 -mindepth 1 -not -name api -exec rm -rf {} +
+shopt -s dotglob
+mv api/* .
+rmdir api
+# Drop the local replace directive so the packaged consul/sdk is used.
+sed -i '\#replace github.com/hashicorp/consul/sdk#d' go.mod
+
+%description
+This package provides the Go client library (github.com/hashicorp/consul/api)
+for interacting with the HashiCorp Consul HTTP API, used by Prometheus' Consul
+service discovery.
+
+%files
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-hashicorp-consul-sdk/go-github-hashicorp-consul-sdk.spec
+++ b/SPECS/go-github-hashicorp-consul-sdk/go-github-hashicorp-consul-sdk.spec
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           consul
+%define go_import_path  github.com/hashicorp/consul/sdk
+%define archive_dir     consul-sdk-v%{version}
+
+# Some sdk helpers (testutil/retry) start local servers and probe the network,
+# which the isolated build sandbox restricts; run the tests but tolerate them.
+%global go_test_ignore_failure 1
+
+Name:           go-github-hashicorp-consul-sdk
+Version:        0.18.1
+Release:        %autorelease
+Summary:        Shared SDK helpers for HashiCorp Consul
+License:        MPL-2.0
+URL:            https://github.com/hashicorp/consul
+#!RemoteAsset:  sha256:a3827a453ca0e255482cb31076c6c293e9a286a08ab893d651c4966bdca1b67f
+Source0:        https://github.com/hashicorp/consul/archive/refs/tags/sdk/v%{version}.tar.gz#/%{_name}-sdk-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{archive_dir}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/hashicorp/go-cleanhttp)
+BuildRequires:  go(github.com/hashicorp/go-hclog)
+BuildRequires:  go(github.com/hashicorp/go-uuid)
+BuildRequires:  go(github.com/hashicorp/go-version)
+BuildRequires:  go(github.com/pkg/errors)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(golang.org/x/sys)
+
+Provides:       go(github.com/hashicorp/consul/sdk) = %{version}
+
+Requires:       go(github.com/hashicorp/go-cleanhttp)
+Requires:       go(github.com/hashicorp/go-hclog)
+Requires:       go(github.com/hashicorp/go-uuid)
+Requires:       go(github.com/hashicorp/go-version)
+Requires:       go(github.com/pkg/errors)
+
+# The upstream archive is the whole consul repository; keep only the sdk
+# submodule so the build targets github.com/hashicorp/consul/sdk alone.
+%prep -a
+find . -maxdepth 1 -mindepth 1 -not -name sdk -exec rm -rf {} +
+shopt -s dotglob
+mv sdk/* .
+rmdir sdk
+
+%description
+This package provides the shared SDK helpers (github.com/hashicorp/consul/sdk)
+used by the HashiCorp Consul API client and tests.
+
+%files
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-hashicorp-logutils/go-github-hashicorp-logutils.spec
+++ b/SPECS/go-github-hashicorp-logutils/go-github-hashicorp-logutils.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           logutils
+%define go_import_path  github.com/hashicorp/logutils
+
+Name:           go-github-hashicorp-logutils
+Version:        1.0.0
+Release:        %autorelease
+Summary:        Utilities for slightly better logging in Go
+License:        MPL-2.0
+URL:            https://github.com/hashicorp/logutils
+#!RemoteAsset:  sha256:9e3c7cee3552acacd2ad1d212f87c682d227179e34b306afdce945b41799e4b6
+Source0:        https://github.com/hashicorp/logutils/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/hashicorp/logutils) = %{version}
+
+%description
+logutils augments the Go standard library "log" package with level-based
+filtering, without fragmenting the ecosystem with a new logging package. It is
+used by the hashicorp/serf agent CLI.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-hashicorp-mdns/go-github-hashicorp-mdns.spec
+++ b/SPECS/go-github-hashicorp-mdns/go-github-hashicorp-mdns.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           mdns
+%define go_import_path  github.com/hashicorp/mdns
+
+# The server/client tests need real multicast networking, which the isolated
+# build sandbox restricts; run them but tolerate the failures.
+%define go_test_ignore_failure 1
+
+Name:           go-github-hashicorp-mdns
+Version:        1.0.4
+Release:        %autorelease
+Summary:        Simple mDNS client/server library in Go
+License:        MIT
+URL:            https://github.com/hashicorp/mdns
+#!RemoteAsset:  sha256:e30f485b22f98971a65243f4f31545ca6b9756686e4df998c947c4801badea8c
+Source0:        https://github.com/hashicorp/mdns/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/miekg/dns)
+BuildRequires:  go(golang.org/x/net)
+
+Provides:       go(github.com/hashicorp/mdns) = %{version}
+
+Requires:       go(github.com/miekg/dns)
+Requires:       go(golang.org/x/net)
+
+%description
+mdns is a simple multicast DNS (mDNS) client and server library, used for
+zero-configuration service discovery. It is an optional backend of the
+hashicorp/serf agent CLI.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-hashicorp-memberlist/go-github-hashicorp-memberlist.spec
+++ b/SPECS/go-github-hashicorp-memberlist/go-github-hashicorp-memberlist.spec
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           memberlist
+%define go_import_path  github.com/hashicorp/memberlist
+
+# Some tests bind real UDP/TCP sockets and probe network interfaces, which the
+# isolated build sandbox restricts; run them but tolerate the failures.
+%global go_test_ignore_failure 1
+
+Name:           go-github-hashicorp-memberlist
+Version:        0.5.0
+Release:        %autorelease
+Summary:        Go library for gossip based membership and failure detection
+License:        MPL-2.0
+URL:            https://github.com/hashicorp/memberlist
+#!RemoteAsset:  sha256:c543f70d8f08fd71e816085549ef4d33e794f3b75308de88706eb63985e9e3a7
+Source0:        https://github.com/hashicorp/memberlist/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/armon/go-metrics)
+BuildRequires:  go(github.com/google/btree)
+BuildRequires:  go(github.com/hashicorp/go-msgpack)
+BuildRequires:  go(github.com/hashicorp/go-multierror)
+BuildRequires:  go(github.com/hashicorp/go-sockaddr)
+BuildRequires:  go(github.com/miekg/dns)
+BuildRequires:  go(github.com/sean-/seed)
+BuildRequires:  go(github.com/stretchr/testify)
+
+Provides:       go(github.com/hashicorp/memberlist) = %{version}
+
+Requires:       go(github.com/armon/go-metrics)
+Requires:       go(github.com/google/btree)
+Requires:       go(github.com/hashicorp/go-msgpack)
+Requires:       go(github.com/hashicorp/go-multierror)
+Requires:       go(github.com/hashicorp/go-sockaddr)
+Requires:       go(github.com/miekg/dns)
+Requires:       go(github.com/sean-/seed)
+
+%description
+memberlist is a Go library that manages cluster membership and member
+failure detection using a gossip based protocol, used by Serf and Consul.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-mitchellh-cli/go-github-mitchellh-cli.spec
+++ b/SPECS/go-github-mitchellh-cli/go-github-mitchellh-cli.spec
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           cli
+%define go_import_path  github.com/mitchellh/cli
+
+# Some tests exercise interactive/terminal behaviour and timing, which the
+# isolated build sandbox restricts; run them but tolerate the failures.
+%define go_test_ignore_failure 1
+
+Name:           go-github-mitchellh-cli
+Version:        1.1.0
+Release:        %autorelease
+Summary:        A Go library for implementing command-line interfaces
+License:        MPL-2.0
+URL:            https://github.com/mitchellh/cli
+#!RemoteAsset:  sha256:f6350f72a358d6d829684e95e2a1e3ea7b7793959c676b53f5ef19e5e7b90abf
+Source0:        https://github.com/mitchellh/cli/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/armon/go-radix)
+BuildRequires:  go(github.com/bgentry/speakeasy)
+BuildRequires:  go(github.com/fatih/color)
+BuildRequires:  go(github.com/hashicorp/errwrap)
+BuildRequires:  go(github.com/hashicorp/go-multierror)
+BuildRequires:  go(github.com/mattn/go-isatty)
+BuildRequires:  go(github.com/posener/complete)
+
+Provides:       go(github.com/mitchellh/cli) = %{version}
+
+Requires:       go(github.com/armon/go-radix)
+Requires:       go(github.com/bgentry/speakeasy)
+Requires:       go(github.com/fatih/color)
+Requires:       go(github.com/hashicorp/go-multierror)
+Requires:       go(github.com/mattn/go-isatty)
+Requires:       go(github.com/posener/complete)
+
+%description
+cli is a library for implementing command-line interfaces in Go: subcommands,
+flag parsing, help output and shell autocompletion. It is the CLI framework
+used by the hashicorp/serf agent command.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-posener-complete/go-github-posener-complete.spec
+++ b/SPECS/go-github-posener-complete/go-github-posener-complete.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           complete
+%define go_import_path  github.com/posener/complete
+
+# Some tests exercise shell completion against the real environment, which the
+# isolated build sandbox restricts; run them but tolerate the failures.
+%define go_test_ignore_failure 1
+
+Name:           go-github-posener-complete
+Version:        1.2.3
+Release:        %autorelease
+Summary:        Bash completion written in and for Go programs
+License:        MIT
+URL:            https://github.com/posener/complete
+#!RemoteAsset:  sha256:2ea9ccea70aae01118c8ffeb608aa57a894c2917cbdd3332a89edeba47241018
+Source0:        https://github.com/posener/complete/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/hashicorp/go-multierror)
+BuildRequires:  go(github.com/stretchr/testify)
+
+Provides:       go(github.com/posener/complete) = %{version}
+
+Requires:       go(github.com/hashicorp/go-multierror)
+
+%description
+complete provides shell command-line completion for Go programs, allowing a
+program to act as its own bash/zsh completion handler. It is used by
+mitchellh/cli (and thus the hashicorp/serf agent CLI).
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-ryanuber-columnize/go-github-ryanuber-columnize.spec
+++ b/SPECS/go-github-ryanuber-columnize/go-github-ryanuber-columnize.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           columnize
+%define go_import_path  github.com/ryanuber/columnize
+%define commit_id       9b3edd62028f107d7cabb19353292afd29311a4e
+
+Name:           go-github-ryanuber-columnize
+Version:        0+git20260624.9b3edd6
+Release:        %autorelease
+Summary:        Easy column-formatted output for Go
+License:        MIT
+URL:            https://github.com/ryanuber/columnize
+#!RemoteAsset:  sha256:eed20c1d22138359ef2fe0908fc47b19a15108b66b36b6f30365dfd22bee1dec
+Source0:        https://github.com/ryanuber/columnize/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# The upstream version serf pins predates any release tag, so build from the
+# pinned commit.
+BuildOption(prep):  -n %{_name}-%{commit_id}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/ryanuber/columnize) = %{version}
+
+%description
+columnize formats lists of data into aligned columns of text. It is used by
+the hashicorp/serf agent CLI for tabular output.
+
+%files
+%doc README*
+%license COPYING
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/serf/serf.spec
+++ b/SPECS/serf/serf.spec
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           serf
+%define go_import_path  github.com/hashicorp/serf
+
+Name:           serf
+Version:        0.10.1
+Release:        %autorelease
+Summary:        Service orchestration and membership using a gossip protocol
+License:        MPL-2.0
+URL:            https://github.com/hashicorp/serf
+#!RemoteAsset:  sha256:cd98087010275887e90d0761a3c63c6c1be7fb00f5a827ae57ac4c82e8a55ec5
+Source0:        https://github.com/hashicorp/serf/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildSystem:    golang
+
+BuildOption(prep):  -n %{_name}-%{version}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/armon/circbuf)
+BuildRequires:  go(github.com/armon/go-metrics)
+BuildRequires:  go(github.com/hashicorp/go-msgpack)
+BuildRequires:  go(github.com/hashicorp/go-syslog)
+BuildRequires:  go(github.com/hashicorp/logutils)
+BuildRequires:  go(github.com/hashicorp/mdns)
+BuildRequires:  go(github.com/hashicorp/memberlist)
+BuildRequires:  go(github.com/mitchellh/cli)
+BuildRequires:  go(github.com/mitchellh/mapstructure)
+BuildRequires:  go(github.com/ryanuber/columnize)
+
+%description
+Serf is a decentralized solution for service discovery and orchestration that
+is lightweight, highly available and fault tolerant, using an efficient gossip
+protocol. This package provides the serf agent command-line tool.
+
+%package     -n go-github-hashicorp-serf
+Summary:        Service orchestration and membership using a gossip protocol (source)
+BuildArch:      noarch
+Provides:       go(github.com/hashicorp/serf) = %{version}
+Requires:       go(github.com/armon/circbuf)
+Requires:       go(github.com/armon/go-metrics)
+Requires:       go(github.com/hashicorp/go-msgpack)
+Requires:       go(github.com/hashicorp/memberlist)
+
+%description -n go-github-hashicorp-serf
+This package contains the source for the github.com/hashicorp/serf Go library
+(the serf, coordinate and client packages), used by consul/api and nomad/api.
+
+%build
+%{go_common}
+export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
+# Output outside the source tree: the module has a serf/ directory, so the
+# binary cannot be named "serf" in the current directory.
+%__go build %{go_build_flags_default} -o %{_builddir}/serf-agent ./cmd/serf
+
+%install
+install -D -m 0755 %{_builddir}/serf-agent %{buildroot}%{_bindir}/%{_name}
+%buildsystem_golangmodules_install
+
+# The serf agent and some library tests start local servers / probe the
+# network, which the isolated build sandbox restricts. The golang buildsystem's
+# check does not honour go_test_ignore_failure, so run the tests but tolerate
+# the failures explicitly.
+%check
+%{go_common}
+cd %{_builddir}/go/src/%{go_import_path}
+%__go test %{shrink:%{go_test_flags_default}} ./... || :
+
+%files
+%doc README*
+%license LICENSE*
+%{_bindir}/%{_name}
+
+%files -n go-github-hashicorp-serf
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

Add the HashiCorp Consul service-discovery dependency chain (used by
Prometheus' Consul SD), unblocked by the go-msgpack root v0.5.x split (#761).
One package per commit; all build on OBS for `x86_64` and `riscv64`.

Core chain:

- `go-github-hashicorp-memberlist` (v0.5.0) — gossip-based cluster membership
- `serf` (v0.10.1) — service orchestration on memberlist. Packaged as both the
  **`serf` agent program** (`/usr/bin/serf`) and the **`go-github-hashicorp-serf`
  library** subpackage (`go(github.com/hashicorp/serf)`, used by consul/api).
  Per review feedback the upstream `cmd/serf` agent is now built rather than
  trimmed away.
- `go-github-hashicorp-consul-sdk` (v0.18.1) — Consul shared SDK helpers
  (submodule: archive trimmed to `sdk/`)
- `go-github-hashicorp-consul-api` (v1.32.1) — Consul HTTP API client
  (submodule: archive trimmed to `api/`, local `replace` of consul/sdk dropped
  so the packaged consul/sdk is used)

Dependencies of the serf agent CLI (newly required now that the program is
built):

- `go-github-hashicorp-logutils` (v1.0.0)
- `go-github-ryanuber-columnize` (commit `9b3edd6`, no release tag)
- `go-github-posener-complete` (v1.2.3)
- `go-github-hashicorp-mdns` (v1.0.4)
- `go-github-mitchellh-cli` (v1.1.0)

memberlist/serf and consul/api import `github.com/hashicorp/go-msgpack` at the
root path (v0.5.x) from #761 (merged). Network/agent-dependent tests are
tolerated with rationale comments (`go_test_ignore_failure` for golangmodules
packages; an explicit tolerant `%check` for the `golang`-buildsystem serf
program, whose check does not honour that macro).

## Related Issue

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: Claude Code:Opus 4.8

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
