### PR TITLE
SPECS: KDE Frameworks: Update to 6.27

### DIFF
--- a/SPECS/kf6-attica/kf6-attica.spec
+++ b/SPECS/kf6-attica/kf6-attica.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname attica
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-attica
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Open Collaboration Service client library
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/attica.git
-#!RemoteAsset:  sha256:eb2d3d2d8b12c2ab4d192c4ae6f07b0188a40aa002b3056db6369b47b2f9df96
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:8f3d3d61ec8a7456db8a75caa801a2e5f5e046728bd240a003e71b8813093ae4
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-baloo/kf6-baloo.spec
+++ b/SPECS/kf6-baloo/kf6-baloo.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname baloo
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-baloo
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Framework for searching and managing metadata
 License:        GPL-2.0-or-later AND LGPL-2.1-or-later AND LGPL-3.0-only
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/baloo.git
-#!RemoteAsset:  sha256:702f5b868aaef48153c6c3828111b3b335403079491a8f37043ebd89c6995b30
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:6b226118bde28e81217f8cd6129f6e24c5d422bd7a322fe682e592b028b72db7
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF
@@ -78,7 +78,6 @@ package contains aditional command line utilities.
 Summary:        Development package for baloo6
 Requires:       %{name}%{?_isa} = %{version}-%{release}
 Requires:       lmdb-devel
-Requires:       cmake(KF6Config) >= %{_kf6_version}
 Requires:       cmake(KF6CoreAddons) >= %{_kf6_version}
 Requires:       cmake(KF6FileMetaData) >= %{_kf6_version}
 Requires:       cmake(Qt6Core) >= %{qt6_version}

--- a/SPECS/kf6-breeze-icons/kf6-breeze-icons.spec
+++ b/SPECS/kf6-breeze-icons/kf6-breeze-icons.spec
@@ -7,20 +7,20 @@
 %define qt6_version 6.8.0
 
 %define rname breeze-icons
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 %define _lto_cflags %{nil}
 
 Name:           kf6-breeze-icons
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Breeze icon theme
 License:        LGPL-3.0-only
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/breeze-icons
-#!RemoteAsset:  sha256:4e123fac511dfab2b7c505857849a5cecfac2ce6194e3230c51ceec31676b06e
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:bc8c2337802837ff1809269a8e4c4311b93e7e90c78ab4fe2a86cf5300ffd414
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-extra-cmake-modules/kf6-extra-cmake-modules.spec
+++ b/SPECS/kf6-extra-cmake-modules/kf6-extra-cmake-modules.spec
@@ -7,13 +7,13 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 Name:           kf6-extra-cmake-modules
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        CMake modules
 License:        BSD-3-Clause
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/extra-cmake-modules
-#!RemoteAsset:  sha256:2374a29b68298a6e70299a1f7321eb67ce293d1bbe3bdd5a1b9154eb16c04abb
+#!RemoteAsset:  sha256:0c748a066f87e07408482cf5f9a5115047c18c92ae7c7f22e59ded3b3ac6c0ad
 Source0:        https://invent.kde.org/frameworks/extra-cmake-modules/-/archive/v%{version}/extra-cmake-modules-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    cmake

--- a/SPECS/kf6-frameworkintegration/kf6-frameworkintegration.spec
+++ b/SPECS/kf6-frameworkintegration/kf6-frameworkintegration.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname frameworkintegration
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-frameworkintegration
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Plugins responsible for better integration of Qt applications in KDE Workspace
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/frameworkintegration.git
-#!RemoteAsset:  sha256:84ebbad39b559e271bcec4817eba9124903ca660ad4f5c3f73f21a5f4a32062d
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:55eefe8ebc67a040e64c75482276c29a69d0c5877b7b3674f4c7a40238c6d44c
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-karchive/kf6-karchive.spec
+++ b/SPECS/kf6-karchive/kf6-karchive.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname karchive
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-karchive
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Qt 6 addon providing access to numerous types of archives
 License:        LGPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/karchive
-#!RemoteAsset:  sha256:a7fdf6d0b8db88d60aa52bcc87d8e00d95391a1ad39a4b2a8e9f3027b8ff4035
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:434edf78df8f4c9f25000d107ad1520d7ac14db580a202047bf19cbf77376522
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kauth/kf6-kauth.spec
+++ b/SPECS/kf6-kauth/kf6-kauth.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname   kauth
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kauth
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Framework which lets applications perform actions as a privileged user
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kauth
-#!RemoteAsset:  sha256:e6b6562114c2cb71db6ca48fdf0ebed2df70e164c48295b35433a80b03385847
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:741934765f0c9f1c535598203fbad3f1b97231cc683a218a7f39fab948c13eab
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kbookmarks/kf6-kbookmarks.spec
+++ b/SPECS/kf6-kbookmarks/kf6-kbookmarks.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kbookmarks
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kbookmarks
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Framework for manipulating bookmarks in XBEL format
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kbookmarks
-#!RemoteAsset:  sha256:82e8794281870686da9e7e7b5ddc0839f50b15d919357490d508faccb2635030
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:75a43775ef03cb0c577c70d9605203789b3c75b786efa17a2e8c286d0c55fb93
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kcmutils/kf6-kcmutils.spec
+++ b/SPECS/kf6-kcmutils/kf6-kcmutils.spec
@@ -10,18 +10,18 @@
 # Internal QML import
 %global __requires_exclude qt6qmlimport\\(org\\.kde\\.kcmutils\\.private.*\\)
 
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kcmutils
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Classes to work with KCModules
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kcmutils
-#!RemoteAsset:  sha256:6d0810649b71528124cdf9dbdeb8b3c6c6d31d787325ca3e4a20c536ecbdf2d9
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:beb0a50a22230fdd94164a5d6e53ea7f4cbc97b86cbab3ff2a592ea8663efa41
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kcodecs/kf6-kcodecs.spec
+++ b/SPECS/kf6-kcodecs/kf6-kcodecs.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname   kcodecs
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kcodecs
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Method collection to manipulate strings using various encodings
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kcodecs
-#!RemoteAsset:  sha256:ee1fe3bd8bcd93a84d44186a5fc50395b6bf43dd2bf8972338a7aad72aa0bcb4
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:77f51f7586e8b457534d95dd241280e8b7475915c656e661dc37b1e8a773c595
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kcolorscheme/kf6-kcolorscheme.spec
+++ b/SPECS/kf6-kcolorscheme/kf6-kcolorscheme.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kcolorscheme
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kcolorscheme
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Classes to read and interact with KColorScheme
 License:        LGPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kcolorscheme
-#!RemoteAsset:  sha256:74149a0379bd8bf6590d3c1f7f8c503665e0f3adafc2adbd44fc6bb764c969f1
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:574e12350ea1adf248c5263cf18d145476d368664a302514d1065aa2563e1efd
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kcompletion/kf6-kcompletion.spec
+++ b/SPECS/kf6-kcompletion/kf6-kcompletion.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kcompletion
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kcompletion
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Widgets with advanced completion support
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kcompletion
-#!RemoteAsset:  sha256:95f71eb807e4de40ecdfe7234c9c3d844423171ac52588aecca642f78d904e48
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:006864dcba5d5fc87b4ca5dcc1239538657a5d052057bae5d3bc3e71eaba0551
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kconfig/kf6-kconfig.spec
+++ b/SPECS/kf6-kconfig/kf6-kconfig.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kconfig
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kconfig
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Advanced configuration system
 License:        LGPL-2.1-or-later AND GPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            https://invent.kde.org/frameworks/kconfig
-#!RemoteAsset:  sha256:8bb5aa918d8e60ec140a33db3c329414d2319dc97a1644b368da5576125c92b5
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:e19728b80e6cc017502fcb50fe6d7e9b5ba9727871ac3a4e9811875e01cb5fe9
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF
@@ -88,6 +88,8 @@ their changes to their respective configuration files. Development files.
 %{_kf6_libdir}/libKF6ConfigCore.so.*
 %{_kf6_libdir}/libKF6ConfigGui.so.*
 %{_kf6_libdir}/libKF6ConfigQml.so.*
+%{_kf6_libdir}/qt6/metatypes/qt6kf6configcore_metatypes.json
+%{_kf6_libdir}/qt6/metatypes/qt6kf6configgui_metatypes.json
 %{_datadir}/locale/*/LC_MESSAGES/kconfig6_qt.qm
 %{_kf6_libexecdir}/kconf_update
 %{_kf6_qmldir}/org/kde/config/

--- a/SPECS/kf6-kconfigwidgets/kf6-kconfigwidgets.spec
+++ b/SPECS/kf6-kconfigwidgets/kf6-kconfigwidgets.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kconfigwidgets
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kconfigwidgets
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Widgets for configuration dialogs
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kconfigwidgets
-#!RemoteAsset:  sha256:3babcef22aea293fad0db65fcdbf76eb4ac9077bc758ee8daec108090242ea3c
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:404ed0606dfb13cc44c36deaf5f880eeec75018ae878125dabf83f32efeb0a7f
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kcoreaddons/kf6-kcoreaddons.spec
+++ b/SPECS/kf6-kcoreaddons/kf6-kcoreaddons.spec
@@ -12,14 +12,14 @@
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kcoreaddons
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Utilities for core application functionality and accessing the OS
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            https://invent.kde.org/frameworks/kcoreaddons
-#!RemoteAsset:  sha256:92fdbfab68e52d9eacf44a992f01cb364d6395c24441e2fd47dd48a23b3281f6
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:ad0d0147968dabdcf011425cf7764e71a0d0cfdc30e9e34b561ea5ba9a768001
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF
@@ -84,6 +84,7 @@ The package contains the PySide6 bindings library for %{name}.
 %{_kf6_debugdir}/kcoreaddons.categories
 %{_kf6_debugdir}/kcoreaddons.renamecategories
 %{_kf6_libdir}/libKF6CoreAddons.so.*
+%{_kf6_libdir}/qt6/metatypes/qt6kf6coreaddons_metatypes.json
 %{_datadir}/locale/*/LC_MESSAGES/kcoreaddons6_qt.qm
 %{_kf6_qmldir}/org/kde/coreaddons/
 

--- a/SPECS/kf6-kcrash/kf6-kcrash.spec
+++ b/SPECS/kf6-kcrash/kf6-kcrash.spec
@@ -11,14 +11,14 @@
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kcrash
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        An application crash handler
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kcrash
-#!RemoteAsset:  sha256:d05d93863a745ce0d4ab8ccff684a84a813ee4cbcc68c9c7a5175107b107e931
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:f8e1083863dac2c07068b10614ca7d4b52c6920df0228854cfc37e0d6578d902
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kdbusaddons/kf6-kdbusaddons.spec
+++ b/SPECS/kf6-kdbusaddons/kf6-kdbusaddons.spec
@@ -11,14 +11,14 @@
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kdbusaddons
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Convenience classes for QtDBus
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            https://invent.kde.org/frameworks/kdbusaddons
-#!RemoteAsset:  sha256:894bb2e032c6f6d9b4a58b8b24678692a9f4e70e953ff4dabda2ed4e9b5431e2
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:9ea3792b2f1c43d5551437260803fdd676c903e2768f4aac4186054e5b22d4ca
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kdeclarative/kf6-kdeclarative.spec
+++ b/SPECS/kf6-kdeclarative/kf6-kdeclarative.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kdeclarative
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kdeclarative
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Integration of QML and KDE workspaces
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kdeclarative.git
-#!RemoteAsset:  sha256:9a464e560e436cd3a626ca6aab894f414c6212d2de8b9c5a8eda33be213e00d8
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:b14e81143aed25ee62413f9c2b3742c558f5b6a1da6c5b92ca9a95bb6341e964
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kded/kf6-kded.spec
+++ b/SPECS/kf6-kded/kf6-kded.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kded
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kded
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Central daemon of KDE workspaces
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kded
-#!RemoteAsset:  sha256:4265d1162cbd7febf16d103bf1bd9fab858fa3f54f52797ed0938436bee347af
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:4f24067915b05a1d0cc87e2c37f37eb0e8c441e8fccdf06ca27ee7b923058243
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kdesu/kf6-kdesu.spec
+++ b/SPECS/kf6-kdesu/kf6-kdesu.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kdesu
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kdesu
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        User interface for running shell commands with root privileges
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kdesu.git
-#!RemoteAsset:  sha256:37df33a1236850b6bebd773a1aeab56ca597e347432924ca5855369337d4be24
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:a8a0c5103cb43dc62952aab76bb7e576e8643dbb31672e2ac2988279ab571700
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kdnssd/kf6-kdnssd.spec
+++ b/SPECS/kf6-kdnssd/kf6-kdnssd.spec
@@ -11,14 +11,14 @@
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kdnssd
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Network service discovery using Zeroconf
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kdnssd.git
-#!RemoteAsset:  sha256:8439daed9c4b942a74393daf23c8d97fdaabd81b93dc347f91bbb45a2bf85248
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:a60746aca1ce6cfd2fbd20144bc4869d2b00d04b597aedab3dd37a345fb03bb4
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kdoctools/kf6-kdoctools.spec
+++ b/SPECS/kf6-kdoctools/kf6-kdoctools.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kdoctools
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kdoctools
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Tools to create documentation from DocBook
 License:        LGPL-2.1-or-later AND MIT
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kdoctools
-#!RemoteAsset:  sha256:3fbea5de215076130007f3c18e16b870774ffa4fc85ddace201ac020d0245fb6
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:69026ef8607cb6257e4d1f0e46e451130ef7ba67994a83e4f9a6c46eefd5a3f3
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kfilemetadata/kf6-kfilemetadata.spec
+++ b/SPECS/kf6-kfilemetadata/kf6-kfilemetadata.spec
@@ -7,20 +7,20 @@
 %define qt6_version 6.8.0
 
 %define rname kfilemetadata
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 %bcond ffmpeg 1
 
 Name:           kf6-kfilemetadata
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Library for extracting Metadata
 License:        GPL-2.0-or-later AND LGPL-2.1-or-later AND LGPL-3.0-only
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kfilemetadata.git
-#!RemoteAsset:  sha256:f75942b9a3d1be0b0910cd50a22c3c432ededdc506858c8d5511ddf5498051f2
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:27f68558259394ad84d357aa316821672ee66481fa851ddf2a6109f668a6c6a3
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kglobalaccel/kf6-kglobalaccel.spec
+++ b/SPECS/kf6-kglobalaccel/kf6-kglobalaccel.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kglobalaccel
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kglobalaccel
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Global desktop keyboard shortcuts
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kglobalaccel
-#!RemoteAsset:  sha256:3f19d22d143577e5ddcc883170fe19a56f8f65766e41c4f9c011c4dfbde17a61
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:e7ba1601a159ea79f424a4d53647415393f90dbeda1e3216d023eeb5420837d3
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kguiaddons/kf6-kguiaddons.spec
+++ b/SPECS/kf6-kguiaddons/kf6-kguiaddons.spec
@@ -8,19 +8,19 @@
 
 %define rname kguiaddons
 
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 # %%{!?_kf6_version: %%global _kf6_version %%{version}}
-%global _kf6_version 6.26.0
+%global _kf6_version 6.27.0
 
 Name:           kf6-kguiaddons
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Utilities for graphical user interfaces
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kguiaddons
-#!RemoteAsset:  sha256:8375342f852104f36fd72a6870eb9795183af4516592cd6fa73445ea6b813172
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:29b043480c45d3e51c57cac74fd83589cc7729c907a6585b72880cbf07feaf82
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF
@@ -77,6 +77,7 @@ of colors, fonts, text, images, keyboard input. Development files.
 %{_kf6_bindir}/kde-geo-uri-handler
 %{_kf6_debugdir}/kguiaddons.categories
 %{_kf6_libdir}/libKF6GuiAddons.so.*
+%{_kf6_libdir}/qt6/metatypes/qt6kf6guiaddons_metatypes.json
 %{_kf6_qmldir}/org/kde/guiaddons/
 
 %files devel

--- a/SPECS/kf6-kholidays/kf6-kholidays.spec
+++ b/SPECS/kf6-kholidays/kf6-kholidays.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kholidays
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kholidays
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Holiday calculation library
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kholidays.git
-#!RemoteAsset:  sha256:fc4f46cb5bb8e4766f550fe1a8b401731d797fcf6afa7cb53679048c215a60be
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:84ce2acd5565a9510d74945ea2311f8c099cb031393255d1c8d399665d57b914
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-ki18n/kf6-ki18n.spec
+++ b/SPECS/kf6-ki18n/kf6-ki18n.spec
@@ -11,14 +11,14 @@
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-ki18n
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        KDE Gettext-based UI text internationalization
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            https://invent.kde.org/frameworks/ki18n
-#!RemoteAsset:  sha256:484aad486bfafef6c86d8d5b26529258e67c74c96250c1ac212ddf568448c7c0
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:cd812ae95b0e95b40e46a50b9dea6d188eec001be96b1e1a5d962730e5f9bc58
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kiconthemes/kf6-kiconthemes.spec
+++ b/SPECS/kf6-kiconthemes/kf6-kiconthemes.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kiconthemes
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kiconthemes
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Icon GUI utilities
 License:        LGPL-2.1-or-later AND GPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kiconthemes
-#!RemoteAsset:  sha256:ed6c0c0bfed517dd5b6462d9b1c84ebe7bc99c7a75214921b5978f086df8653d
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:6fe86f0c0ff41044f44d1f37f9ae001b8d2c1a5a8bc06c41c43ed574138af5be
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kidletime/kf6-kidletime.spec
+++ b/SPECS/kf6-kidletime/kf6-kidletime.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kidletime
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kidletime
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        User and system idle time reporting singleton
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kidletime.git
-#!RemoteAsset:  sha256:f0efd67ee0e5b5eb9200e924e9478c1ecb179b4a38e0cf125b377e7fa373ef07
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:2cb0196ee3bb1b60be9bad14b4d04dfaf53b3d0017cd459083035c715910551b
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF
@@ -57,7 +57,6 @@ notified upon idle time events, such as custom timeouts, or user activity.
 %package        devel
 Summary:        Build environment for kidletime, an idle time singleton
 Requires:       %{name}%{?_isa} = %{version}-%{release}
-Requires:       cmake(Qt6Core) >= %{qt6_version}
 
 %description    devel
 Development files for KIdleTime, which is a singleton reporting

--- a/SPECS/kf6-kimageformats/kf6-kimageformats.spec
+++ b/SPECS/kf6-kimageformats/kf6-kimageformats.spec
@@ -14,18 +14,18 @@
 %bcond jxl 1
 %bcond jp2 1
 
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kimageformats
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Image format plugins for Qt
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kimageformats.git
-#!RemoteAsset:  sha256:c192552ee1831fd5e09af4e3633bb24726dfb4031170c4285024683bedaf9972
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:6a9f40936ba946279063cbdaea473b9eb735b53047b0124c88aca7db17ccabac
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF
@@ -75,7 +75,7 @@ image formats.
 
 %package        eps
 Summary:        EPS image format plugin for Qt
-Requires:       ghostscript
+Recommends:     ghostscript
 
 %description    eps
 This plugin provides support for the EPS document format for QtGui. As
@@ -101,6 +101,7 @@ to provide additional image format plugins for QtGui.
 %if %{with exr}
 %{_kf6_plugindir}/imageformats/kimg_exr.so
 %endif
+%{_kf6_plugindir}/imageformats/kimg_ff.so
 %{_kf6_plugindir}/imageformats/kimg_hdr.so
 %if %{with heif}
 %{_kf6_plugindir}/imageformats/kimg_heif.so

--- a/SPECS/kf6-kio/kf6-kio.spec
+++ b/SPECS/kf6-kio/kf6-kio.spec
@@ -11,14 +11,14 @@
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kio
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Network transparent access to files and data
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kio
-#!RemoteAsset:  sha256:567f64db9766986b5535d884a5db30203685c33e67f56892bceff30e1bd5cc8a
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:fc201b02c277a35ce81414b1de7e6f851e46b0b5d43beb784936a4a6dc6167d0
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kirigami/kf6-kirigami.spec
+++ b/SPECS/kf6-kirigami/kf6-kirigami.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kirigami
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kirigami
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Set of QtQuick components
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kirigami
-#!RemoteAsset:  sha256:b268785b271198acec7fe4b6177eafdee890e180245c7168916da3ccff1425ff
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:d7daa74e9fe81b674e54e6e979feb85d3d2f4216bf6d9c02bfaa2c021fe1ac2d
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF
@@ -82,6 +82,7 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/locale/*@*
 %{_kf6_libdir}/libKirigamiLayouts.so.*
 %{_kf6_libdir}/libKirigamiLayoutsPrivate.so.*
 %{_kf6_libdir}/libKirigamiPlatform.so.*
+%{_kf6_libdir}/qt6/metatypes/qt6kirigamiplatform_metatypes.json
 %{_kf6_libdir}/libKirigamiPrimitives.so.*
 %{_kf6_libdir}/libKirigamiPolyfill.so.*
 %{_kf6_libdir}/libKirigamiTemplates.so.*

--- a/SPECS/kf6-kitemmodels/kf6-kitemmodels.spec
+++ b/SPECS/kf6-kitemmodels/kf6-kitemmodels.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kitemmodels
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kitemmodels
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Set of item models extending the Qt model-view framework
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kitemmodels.git
-#!RemoteAsset:  sha256:a996201062ff7d21f9db972debc2d9615762ddb0fd9da069a42b7fd7bba1e61d
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:f5aec7198b161562616c139ed037e562e7ae6822b839f67c8c2e2f97678fc58e
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kitemviews/kf6-kitemviews.spec
+++ b/SPECS/kf6-kitemviews/kf6-kitemviews.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kitemviews
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kitemviews
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Set of item views extending the Qt model-view framework
 License:        LGPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kitemviews
-#!RemoteAsset:  sha256:e76cc9d7561d0aae22b07a77552fbcddf61c8066bac5cfac9958ac065b617e74
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:7a286f147144714aa9e8f567dd5a0638a8fb81df97a34a0112f725b72aa36979
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kjobwidgets/kf6-kjobwidgets.spec
+++ b/SPECS/kf6-kjobwidgets/kf6-kjobwidgets.spec
@@ -8,18 +8,18 @@
 
 %define rname kjobwidgets
 
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kjobwidgets
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Widgets for showing progress of asynchronous jobs
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kjobwidgets
-#!RemoteAsset:  sha256:8057b7bd132cc2b469ac406f95ba22bc3cfc240c1031485f19fa072ab942f71e
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:3149cd07d82204c6bfa8d86c590bf0c92905e1b5b075c7b543540916a61d7a03
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-knewstuff/kf6-knewstuff.spec
+++ b/SPECS/kf6-knewstuff/kf6-knewstuff.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname knewstuff
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-knewstuff
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Framework for downloading and sharing additional application data
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://github.com/KDE/knewstuff.git
-#!RemoteAsset:  sha256:94ef39077ba53a72f4e555b6f94a2762cba79730619cb80a31c5435642ebe1aa
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:8c19df7ba5940c36ff15051703acd3a16c664b4a570817b6770fafc7ab59d6de
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-knotifications/kf6-knotifications.spec
+++ b/SPECS/kf6-knotifications/kf6-knotifications.spec
@@ -12,14 +12,14 @@
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-knotifications
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        KDE Desktop notifications
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/knotifications
-#!RemoteAsset:  sha256:2033a798856a9d2776e6e4cef6f3eb3bc24b938c0d00b06b2f6e71be44e1446a
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:eeb067fab001dd24735ad56e8ec4808fca76e5ecdf003cf614246c9abe1c3e19
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-knotifyconfig/kf6-knotifyconfig.spec
+++ b/SPECS/kf6-knotifyconfig/kf6-knotifyconfig.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname knotifyconfig
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-knotifyconfig
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Configuration dialog for desktop notifications
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/knotifyconfig.git
-#!RemoteAsset:  sha256:062e22f48a1da485d42ef56b37db1fc502f5f9305871483627d218f357560a28
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:81861316d615e7e5ff07143c1d58d9b52cadc5e02ab38c8f2677c01f71e51f26
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kpackage/kf6-kpackage.spec
+++ b/SPECS/kf6-kpackage/kf6-kpackage.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kpackage
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kpackage
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Non-binary asset user-installable package managing framework
 License:        GPL-2.0-or-later AND LGPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kpackage
-#!RemoteAsset:  sha256:313cda4a335ecdb67bb8e2fcc15bdeb5970db17d5597282ca655bf97a98abab5
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:5fa4b07f729c3ff6b7f362d318374810fa55b13a922d2b240462eb8efc1045e8
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kparts/kf6-kparts.spec
+++ b/SPECS/kf6-kparts/kf6-kparts.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kparts
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kparts
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Plugin framework for user interface components
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kparts
-#!RemoteAsset:  sha256:049c2cf048b4cbbffe0bea9357bd9ab53b8be672ba509b2bb058f764d21b3f5b
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:0c2ce39f110e12ff0882c725bee7455b9085489c12d31eb4b3164b150fb8de24
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kpty/kf6-kpty.spec
+++ b/SPECS/kf6-kpty/kf6-kpty.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kpty
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kpty
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Primitives to interface with pseudo terminal devices
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kpty.git
-#!RemoteAsset:  sha256:7613c26cfaa7465a2fe28a22762ceb38266414e7f4a94a127c09dc0628625553
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:ad06bfda8df019bb2b33567ce3df539bcc107e0dfe004281e5ff9ae4617c6ecc
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kquickcharts/kf6-kquickcharts.spec
+++ b/SPECS/kf6-kquickcharts/kf6-kquickcharts.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kquickcharts
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kquickcharts
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Set of charts for QtQuick applications
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kquickcharts.git
-#!RemoteAsset:  sha256:ae3e0784a2a2d1396cb751cc61f43a567e066d6434971246b1a18365481a1b52
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:d2a533bbf3d7f257e9306009bc32bdea41346cbd8e82d06c188879d5f0460380
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-krunner/kf6-krunner.spec
+++ b/SPECS/kf6-krunner/kf6-krunner.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname krunner
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-krunner
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        KDE Framework for providing different actions given a string query
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/krunner.git
-#!RemoteAsset:  sha256:3519c7fe170be1359a4c38dd5269de64c0208ccfeb950661002ddfa4e92f2bf0
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:46d06321bbccadb8f3fbb948ffaac5eff18dad9552fde677761ddddb9470202f
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF
@@ -53,6 +53,7 @@ Files needed for developing custom runners or frontends.
 %doc README.md
 %license LICENSES/*
 %{_kf6_libdir}/libKF6Runner.so.*
+%{_kf6_libdir}/qt6/metatypes/qt6kf6runner_metatypes.json
 %{_kf6_debugdir}/krunner.categories
 %{_kf6_debugdir}/krunner.renamecategories
 

--- a/SPECS/kf6-kservice/kf6-kservice.spec
+++ b/SPECS/kf6-kservice/kf6-kservice.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kservice
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kservice
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Plugin framework for desktop services
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kservice
-#!RemoteAsset:  sha256:f8528524ccafb6a495962dd3260c442377920169f1c444f11657ea42558a53b6
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:3736c6d6cd389efc89adbcb64fe7ba25ffc9d62eb8eaf6393f42bb85f655a8c7
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kstatusnotifieritem/kf6-kstatusnotifieritem.spec
+++ b/SPECS/kf6-kstatusnotifieritem/kf6-kstatusnotifieritem.spec
@@ -8,18 +8,18 @@
 
 %define rname kstatusnotifieritem
 
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kstatusnotifieritem
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Implementation of Status Notifier Items
 License:        LGPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kstatusnotifieritem.git
-#!RemoteAsset:  sha256:898914c94820f99889d879f33cabbb5fbe7b9f4e24a6a1d9a9b4439489bc3266
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:a2eec2a981ed9da6cffc955cc21a50dcbc77141cbb840d915f92d1897442d239
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-ksvg/kf6-ksvg.spec
+++ b/SPECS/kf6-ksvg/kf6-ksvg.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname ksvg
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-ksvg
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Components for handling SVGs
 License:        GPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/ksvg
-#!RemoteAsset:  sha256:f3a7412e227d13b1cafec91c1b58dd3f86980abefc08b2535b46bef362b4c07e
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:68d43f014639ae6097012cdd67bdbbefd5425b17d2322d94f55be2b138613e0a
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 Patch0:         0001-Revert-Support-for-fractional-scaling.patch

--- a/SPECS/kf6-ktexteditor/kf6-ktexteditor.spec
+++ b/SPECS/kf6-ktexteditor/kf6-ktexteditor.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname ktexteditor
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-ktexteditor
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Embeddable text editor component
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/ktexteditor.git
-#!RemoteAsset:  sha256:ec7bc094f93d514b5f675ae95c274dd24acc47769d971606d8708cc88f811341
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:2b737a61737e73650cd0b40d9e246a182dcccc6c8ae8121cfcb9415433ee41ae
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DENABLE_KAUTH:BOOL=FALSE

--- a/SPECS/kf6-ktextwidgets/kf6-ktextwidgets.spec
+++ b/SPECS/kf6-ktextwidgets/kf6-ktextwidgets.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname ktextwidgets
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-ktextwidgets
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        KDE Text editing widgets
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/ktextwidgets
-#!RemoteAsset:  sha256:6511f9909f90fac951e2873a44dd451b8ac71d38085a62c65a6fb5028e62d84d
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:03c35d8899559efc17b4f74e86eefd8358dafd7aa9311c89b9c09f7b35700756
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kunitconversion/kf6-kunitconversion.spec
+++ b/SPECS/kf6-kunitconversion/kf6-kunitconversion.spec
@@ -8,18 +8,18 @@
 
 %define rname kunitconversion
 
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kunitconversion
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Tool for converting physical units
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kunitconversion.git
-#!RemoteAsset:  sha256:94404453011eec373f858ef4a58091d24fbadbb90f96bbbf470c098646d9675e
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:404e064114c95eca0ef759b96ca4e0ba5f9b8bc563138574358270963f3f5554
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kuserfeedback/kf6-kuserfeedback.spec
+++ b/SPECS/kf6-kuserfeedback/kf6-kuserfeedback.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kuserfeedback
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kuserfeedback
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Framework for collecting feedback from application users
 License:        MIT
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kuserfeedback.git
-#!RemoteAsset:  sha256:6cc18dca65a24af2ac262cb9c8761991701c8081a7133487b4ec936003f3f864
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:5ad0228aa4872f6238b93827e99d263aebcc7e0bfc4f28ba3cf39c0fd2add7a9
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DQT_MAJOR_VERSION:STRING=6
@@ -50,7 +50,7 @@ KDE Telemetry Policy, which forbids the usage of unique identification.
 
 %package        server
 Summary:        Server component of kf6-kuserfeedback
-Requires:       (php-sqlite or php-mysql or php-pgsql)
+Recommends:     (php-sqlite or php-mysql or php-pgsql)
 Requires:       kf6-kuserfeedback >= %{version}
 Requires:       php
 

--- a/SPECS/kf6-kwallet/kf6-kwallet.spec
+++ b/SPECS/kf6-kwallet/kf6-kwallet.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname kwallet
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kwallet
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Safe desktop-wide storage for passwords
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kwallet
-#!RemoteAsset:  sha256:2321f8591f1f225d3d7253fae9ee61d0789db231b3eeae6a5f8a14c013531389
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:daa03acc40eec873bb450fd8116ae7c788b86a7ceebc9fa555b4a166feeb7983
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kwidgetsaddons/kf6-kwidgetsaddons.spec
+++ b/SPECS/kf6-kwidgetsaddons/kf6-kwidgetsaddons.spec
@@ -8,18 +8,18 @@
 
 %define rname kwidgetsaddons
 
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kwidgetsaddons
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Large set of desktop widgets
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/kwidgetsaddons
-#!RemoteAsset:  sha256:65044882e30b305fe9fb20331a354cd811ca9d80b5c7f9fa722639f3334fe630
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:4cba86999331960b3fddac8ed02cccb31fc49406422360217135f6bf3fbca8d9
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-kwindowsystem/kf6-kwindowsystem.spec
+++ b/SPECS/kf6-kwindowsystem/kf6-kwindowsystem.spec
@@ -8,14 +8,14 @@
 %define qt6_version 6.8.0
 
 Name:           kf6-kwindowsystem
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        KDE Access to window manager
 License:        LGPL-2.1-or-later
 URL:            https://kde.org
 VCS:            git:https://invent.kde.org/frameworks/kwindowsystem
-#!RemoteAsset:  sha256:5f7962b7c986e77c5d25fa4f7d09cd89144b8781e57ebc37fd45eaec1961bb02
-Source0:        https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:401e5700ab36530a605410464268bf726c898da42c6f7d7bf05a9db00ccfe172
+Source0:        https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF
@@ -28,7 +28,7 @@ BuildRequires:  doxygen
 BuildRequires:  graphviz
 BuildRequires:  xmlto
 BuildRequires:  pkgconfig
-BuildRequires:  kf6-extra-cmake-modules >= 6.26.0
+BuildRequires:  kf6-extra-cmake-modules >= 6.27.0
 BuildRequires:  qt6-qtbase-private-devel >= 6.8.0
 BuildRequires:  cmake(Qt6GuiPrivate)
 BuildRequires:  cmake(Qt6LinguistTools)

--- a/SPECS/kf6-kxmlgui/kf6-kxmlgui.spec
+++ b/SPECS/kf6-kxmlgui/kf6-kxmlgui.spec
@@ -8,18 +8,18 @@
 
 %define rname kxmlgui
 
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-kxmlgui
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Framework for managing menu and toolbar actions
 License:        LGPL-2.1-or-later AND GPL-2.0-or-later
 URL:            https://www.kde.org
-VCS:            git:https://invent.kde.org/frameworks/kxmlgui
-#!RemoteAsset:  sha256:4383855cea5a7f9a269c72dda15490b8d70c1d23d17950963937332fc5d6b7a0
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+VCS:            git:https://invent.kde.org/frameworks/kxmlgui.git
+#!RemoteAsset:  sha256:36d5c9cf8a851a63c1064d6a9987e961c0860ebd1396cda99119e570847df721
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-modemmanager-qt/kf6-modemmanager-qt.spec
+++ b/SPECS/kf6-modemmanager-qt/kf6-modemmanager-qt.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname modemmanager-qt
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-modemmanager-qt
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Qt wrapper for ModemManager DBus API
 License:        LGPL-2.1-only OR LGPL-3.0-only
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/modemmanager-qtt.git
-#!RemoteAsset:  sha256:bef456ac0a5983bcc14a1580cb0d32a001241f380d901cb503613855380af3a5
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:a893a169dd40c430c51d39326b1af0aab2a9d6c20adc34f2b8e6332c152f6234
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-networkmanager-qt/kf6-networkmanager-qt.spec
+++ b/SPECS/kf6-networkmanager-qt/kf6-networkmanager-qt.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname networkmanager-qt
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-networkmanager-qt
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        A Qt wrapper for NetworkManager DBus API
 License:        LGPL-2.1-only OR LGPL-3.0-only
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/networkmanager-qt.git
-#!RemoteAsset:  sha256:a5cfed06af6156161f7fee56efe1521a6e9e26119327069f1799986f90b432e5
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:a8193895b420d576fac228388ba8fd1b24d6f229c43b7963e2ed581ef82cad9a
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-prison/kf6-prison.spec
+++ b/SPECS/kf6-prison/kf6-prison.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname prison
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-prison
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Barcode abstraction layer library
 License:        MIT
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/prison.git
-#!RemoteAsset:  sha256:0414ddc310bca5eecfc1a6f9d4463b8a6d81894db4128ac43b4f8c1e14b73b5b
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:760903e9ae401f8bcdb9efc9ad6548982642e7411a223c8ceb41e5491a6b1135
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-purpose/kf6-purpose.spec
+++ b/SPECS/kf6-purpose/kf6-purpose.spec
@@ -10,18 +10,18 @@
 %define qt6_version 6.8.0
 
 %define rname purpose
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-purpose
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Framework to integrate services and actions in applications
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/purpose.git
-#!RemoteAsset:  sha256:cc7b7599d1ac7ce7ed07351a35d742fac1b7e554b208a7b1c92e859b3b4add30
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:c4e348fa5ac990a77b3926105c62bc4f2dddaf8d7554c43ee4f18de3d16a3699
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-qqc2-desktop-style/kf6-qqc2-desktop-style.spec
+++ b/SPECS/kf6-qqc2-desktop-style/kf6-qqc2-desktop-style.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname qqc2-desktop-style
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-qqc2-desktop-style
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        A Qt Quick Controls 2 Style for Desktop UIs
 License:        GPL-2.0-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/qqc2-desktop-style.git
-#!RemoteAsset:  sha256:1805fa31355ff86c02158fd2b8d396fd88835d01db97d8700314c48ee3360986
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:6c005f06c5f8c4ac349238abf14999bb917215a8f7b8c51364e2fdd12e9e6355
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-solid/kf6-solid.spec
+++ b/SPECS/kf6-solid/kf6-solid.spec
@@ -9,14 +9,14 @@
 %define rname solid
 
 Name:           kf6-solid
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        KDE Desktop hardware abstraction
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/solid
-#!RemoteAsset:  sha256:85cfab9b0787f59478661140997c485fadab62cec535ffcef2953d312f736c4a
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:70a9ee69b4357ebf83cc87aa61db6fdff8c96a59e24f9572e51716f1d3c579fe
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-sonnet/kf6-sonnet.spec
+++ b/SPECS/kf6-sonnet/kf6-sonnet.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname sonnet
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-sonnet
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        KDE spell checking library
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/sonnet
-#!RemoteAsset:  sha256:3ac4e165c0b3c79eda416b754bb837292f354188a1220f2065f57f686489af25
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:f8dcbba58d3479dfa4922146270f6ecb7ce0d987d82edc59b0c7c27ff965f65a
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-syndication/kf6-syndication.spec
+++ b/SPECS/kf6-syndication/kf6-syndication.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname syndication
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-syndication
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        RSS/Atom parsing library
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/syndication.git
-#!RemoteAsset:  sha256:6130b8bc976cb078eda34b833ecd558a156b4e6bc4cb55e57ac362cb2998ba47
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:e28036eba9bf94f62466eaff66f49305fff9dd576a317df2474d6bfe5bfbc759
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-syntax-highlighting/kf6-syntax-highlighting.spec
+++ b/SPECS/kf6-syntax-highlighting/kf6-syntax-highlighting.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname syntax-highlighting
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-syntax-highlighting
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        Syntax highlighting engine and library
 License:        LGPL-2.1-or-later AND GPL-2.0-only AND GPL-2.0-or-later AND GPL-3.0-only AND MIT AND BSD-3-Clause AND Artistic-1.0
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/syntax-highlighting.git
-#!RemoteAsset:  sha256:a4e86d167cd5f3c4318584119451f891551c24cd4a0ff1f7ef95e2476a39c5ac
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:cbff001b9f00d032feb254313ecfee9a6e0a0b3c5a8c82a7e0806c5f1915a545
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF

--- a/SPECS/kf6-threadweaver/kf6-threadweaver.spec
+++ b/SPECS/kf6-threadweaver/kf6-threadweaver.spec
@@ -7,18 +7,18 @@
 %define qt6_version 6.8.0
 
 %define rname threadweaver
-# Full KF6 version (e.g. 6.26.0)
+# Full KF6 version (e.g. 6.27.0)
 %{!?_kf6_version: %global _kf6_version %{version}}
 
 Name:           kf6-threadweaver
-Version:        6.26.0
+Version:        6.27.0
 Release:        %autorelease
 Summary:        KDE Helper for multithreaded programming
 License:        LGPL-2.1-or-later
 URL:            https://www.kde.org
 VCS:            git:https://invent.kde.org/frameworks/threadweaver.git
-#!RemoteAsset:  sha256:ad32daeafac62077590885f3abc4bcac1abbc6faeb34c20b32f6040648f7de1b
-Source:         https://download.kde.org/stable/frameworks/6.26/%{rname}-%{version}.tar.xz
+#!RemoteAsset:  sha256:6be89d43b4d7cfd4ce519ed24b8bcf8400c93bcfc6f42d9931cd0f852269bdcb
+Source:         https://download.kde.org/stable/frameworks/6.27/%{rname}-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildOption(conf):  -DBUILD_TESTING=OFF


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

This commit includes an update to KDE Frameworks 6.27 as part of the integration with the July release of openruyi.

https://kde.org/announcements/frameworks/6/6.27.0/

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->
no
- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
