### PR TITLE
SPECS: go-opentelemetry-collector-*: Fix files path

### DIFF
--- a/SPECS/go-opentelemetry-collector-component/go-opentelemetry-collector-component.spec
+++ b/SPECS/go-opentelemetry-collector-component/go-opentelemetry-collector-component.spec
@@ -50,6 +50,18 @@ Requires:       go(go.uber.org/zap)
 %description
 This package provides the component module used by OpenTelemetry Collector.
 
+%install
+# The upstream module tag archive contains the whole collector repository, so
+# build this package from its module subdirectory. - HNO3Miracle
+pushd component
+%buildsystem_golangmodules_install
+popd
+
+%check
+pushd component
+%buildsystem_golangmodules_check
+popd
+
 %files
 %doc README.md
 %license LICENSE

--- a/SPECS/go-opentelemetry-collector-confmap-xconfmap/go-opentelemetry-collector-confmap-xconfmap.spec
+++ b/SPECS/go-opentelemetry-collector-confmap-xconfmap/go-opentelemetry-collector-confmap-xconfmap.spec
@@ -49,6 +49,23 @@ Requires:       go(go.opentelemetry.io/collector/confmap)
 This package provides the xconfmap module for OpenTelemetry Collector.
 configuration validation helpers.
 
+%install
+# The upstream module tag archive contains the whole collector repository, so
+# build this package from its module subdirectory. - HNO3Miracle
+pushd confmap/xconfmap
+%buildsystem_golangmodules_install
+popd
+
+%check
+# xconfmap imports confmap/internal from the same upstream module tree, so copy
+# the parent module into GOPATH before testing this nested module. - HNO3Miracle
+export GO111MODULE=off
+export GOPATH=%{_builddir}/go:%{_datadir}/gocode
+rm -rf "%{_builddir}/go/src/go.opentelemetry.io/collector/confmap"
+mkdir -p "%{_builddir}/go/src/go.opentelemetry.io/collector"
+cp -a confmap "%{_builddir}/go/src/go.opentelemetry.io/collector/confmap"
+go test -v %{go_test_include}
+
 %files
 %doc README*
 %license LICENSE*

--- a/SPECS/go-opentelemetry-collector-confmap/go-opentelemetry-collector-confmap.spec
+++ b/SPECS/go-opentelemetry-collector-confmap/go-opentelemetry-collector-confmap.spec
@@ -57,9 +57,22 @@ Requires:       go(go.yaml.in/yaml/v3)
 %description
 This package provides the confmap module used by the OpenTelemetry Collector.
 
+%install
+# The upstream module tag archive contains the whole collector repository, so
+# build this package from its module subdirectory. - HNO3Miracle
+pushd confmap
+%buildsystem_golangmodules_install
+popd
+
+%check
+pushd confmap
+%buildsystem_golangmodules_check
+popd
+
 %files
 %doc README*
 %license LICENSE*
+%exclude %{go_sys_gopath}/%{go_import_path}/xconfmap
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog

--- a/SPECS/go-opentelemetry-collector-consumer-consumertest/go-opentelemetry-collector-consumer-consumertest.spec
+++ b/SPECS/go-opentelemetry-collector-consumer-consumertest/go-opentelemetry-collector-consumer-consumertest.spec
@@ -45,6 +45,23 @@ Requires:       go(go.opentelemetry.io/collector/pdata)
 %description
 This package provides the Go library go.opentelemetry.io/collector/consumer/consumertest.
 
+%install
+# The upstream module tag archive contains the whole collector repository, so
+# build this package from its module subdirectory. - HNO3Miracle
+pushd consumer/consumertest
+%buildsystem_golangmodules_install
+popd
+
+%check
+# consumertest imports the parent consumer module while tests run from a nested
+# module, so copy the parent module into GOPATH first. - HNO3Miracle
+export GO111MODULE=off
+export GOPATH=%{_builddir}/go:%{_datadir}/gocode
+rm -rf "%{_builddir}/go/src/go.opentelemetry.io/collector/consumer"
+mkdir -p "%{_builddir}/go/src/go.opentelemetry.io/collector"
+cp -a consumer "%{_builddir}/go/src/go.opentelemetry.io/collector/consumer"
+go test -v %{go_test_include}
+
 %files
 %doc README.md
 %license LICENSE

--- a/SPECS/go-opentelemetry-collector-consumer/go-opentelemetry-collector-consumer.spec
+++ b/SPECS/go-opentelemetry-collector-consumer/go-opentelemetry-collector-consumer.spec
@@ -43,9 +43,22 @@ Requires:       go(go.opentelemetry.io/collector/pdata)
 %description
 This package provides the consumer module used by OpenTelemetry Collector.
 
+%install
+# The upstream module tag archive contains the whole collector repository, so
+# build this package from its module subdirectory. - HNO3Miracle
+pushd consumer
+%buildsystem_golangmodules_install
+popd
+
+%check
+pushd consumer
+%buildsystem_golangmodules_check
+popd
+
 %files
 %doc README.md
 %license LICENSE
+%exclude %{go_sys_gopath}/%{go_import_path}/consumertest
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog

--- a/SPECS/go-opentelemetry-collector-featuregate/go-opentelemetry-collector-featuregate.spec
+++ b/SPECS/go-opentelemetry-collector-featuregate/go-opentelemetry-collector-featuregate.spec
@@ -42,6 +42,18 @@ Requires:       go(go.uber.org/multierr)
 %description
 This package provides the Go library go.opentelemetry.io/collector/featuregate.
 
+%install
+# The upstream module tag archive contains the whole collector repository, so
+# build this package from its module subdirectory. - HNO3Miracle
+pushd featuregate
+%buildsystem_golangmodules_install
+popd
+
+%check
+pushd featuregate
+%buildsystem_golangmodules_check
+popd
+
 %files
 %doc README.md
 %license LICENSE

--- a/SPECS/go-opentelemetry-collector-internal-componentalias/go-opentelemetry-collector-internal-componentalias.spec
+++ b/SPECS/go-opentelemetry-collector-internal-componentalias/go-opentelemetry-collector-internal-componentalias.spec
@@ -48,6 +48,18 @@ Requires:       go(go.opentelemetry.io/collector/component)
 %description
 This package provides the Go library go.opentelemetry.io/collector/internal/componentalias.
 
+%install
+# The upstream module tag archive contains the whole collector repository, so
+# build this package from its module subdirectory. - HNO3Miracle
+pushd internal/componentalias
+%buildsystem_golangmodules_install
+popd
+
+%check
+pushd internal/componentalias
+%buildsystem_golangmodules_check
+popd
+
 %files
 %doc README.md
 %license LICENSE

--- a/SPECS/go-opentelemetry-collector-internal-testutil/go-opentelemetry-collector-internal-testutil.spec
+++ b/SPECS/go-opentelemetry-collector-internal-testutil/go-opentelemetry-collector-internal-testutil.spec
@@ -37,6 +37,18 @@ Requires:       go(github.com/stretchr/testify)
 %description
 This package provides the Go library go.opentelemetry.io/collector/internal/testutil.
 
+%install
+# The upstream module tag archive contains the whole collector repository, so
+# build this package from its module subdirectory. - HNO3Miracle
+pushd internal/testutil
+%buildsystem_golangmodules_install
+popd
+
+%check
+pushd internal/testutil
+%buildsystem_golangmodules_check
+popd
+
 %files
 %doc README.md
 %license LICENSE

--- a/SPECS/go-opentelemetry-collector-pdata/go-opentelemetry-collector-pdata.spec
+++ b/SPECS/go-opentelemetry-collector-pdata/go-opentelemetry-collector-pdata.spec
@@ -54,6 +54,18 @@ Requires:       go(google.golang.org/protobuf)
 %description
 This package provides the pdata module used by OpenTelemetry Collector.
 
+%install
+# The upstream module tag archive contains the whole collector repository, so
+# build this package from its module subdirectory. - HNO3Miracle
+pushd pdata
+%buildsystem_golangmodules_install
+popd
+
+%check
+pushd pdata
+%buildsystem_golangmodules_check
+popd
+
 %files
 %doc README.md
 %license LICENSE

--- a/SPECS/go-opentelemetry-collector-pipeline/go-opentelemetry-collector-pipeline.spec
+++ b/SPECS/go-opentelemetry-collector-pipeline/go-opentelemetry-collector-pipeline.spec
@@ -33,6 +33,18 @@ Provides:       go(go.opentelemetry.io/collector/pipeline) = %{version}
 %description
 This package provides the Go library go.opentelemetry.io/collector/pipeline.
 
+%install
+# The upstream module tag archive contains the whole collector repository, so
+# build this package from its module subdirectory. - HNO3Miracle
+pushd pipeline
+%buildsystem_golangmodules_install
+popd
+
+%check
+pushd pipeline
+%buildsystem_golangmodules_check
+popd
+
 %files
 %doc README.md
 %license LICENSE

--- a/SPECS/go-opentelemetry-collector-processor/go-opentelemetry-collector-processor.spec
+++ b/SPECS/go-opentelemetry-collector-processor/go-opentelemetry-collector-processor.spec
@@ -56,6 +56,24 @@ Requires:       go(go.opentelemetry.io/collector/pipeline)
 %description
 This package provides the processor module used by OpenTelemetry Collector.
 
+%install
+# The upstream module tag archive contains the whole collector repository, so
+# build this package from its module subdirectory. - HNO3Miracle
+pushd processor
+%buildsystem_golangmodules_install
+popd
+
+%check
+# processor imports collector/internal/componentalias from the same upstream
+# module tree, so copy the parent collector tree into GOPATH before testing
+# this module. - HNO3Miracle
+export GO111MODULE=off
+export GOPATH=%{_builddir}/go:%{_datadir}/gocode
+rm -rf "%{_builddir}/go/src/go.opentelemetry.io/collector"
+mkdir -p "%{_builddir}/go/src/go.opentelemetry.io"
+cp -a . "%{_builddir}/go/src/go.opentelemetry.io/collector"
+go test -v %{go_test_include}
+
 %files
 %doc README.md
 %license LICENSE


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

In `go-opentelemetry-collector-*` series source compress file, the directory structure would be like
```
 opentelemetry-collector-pdata-v1.58.0/
    pdata/
      go.mod
      pcommon/
      pmetric/
```

But the real import path is 
`go.opentelemetry.io/collector/pdata`

So the install of it should be in `pdata/` directory.

Attaching the obs log:
```
cannot find package "go.opentelemetry.io/collector/pdata/pcommon"
no Go files in /usr/share/gocode/src/go.opentelemetry.io/collector/component
```

## Checklist

- [x]  I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: ChatGPT:GPT-5.5 xhigh

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
