### PR TITLE
SPECS: Add moby leaf Go dependencies (batch 1)

### DIFF
--- a/SPECS/go-github-cpuguy83-tar2go/go-github-cpuguy83-tar2go.spec
+++ b/SPECS/go-github-cpuguy83-tar2go/go-github-cpuguy83-tar2go.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           tar2go
+%define go_import_path  github.com/cpuguy83/tar2go
+
+Name:           go-github-cpuguy83-tar2go
+Version:        0.3.1
+Release:        %autorelease
+Summary:        Expose a tar archive as a Go io/fs filesystem
+License:        MIT
+URL:            https://github.com/cpuguy83/tar2go
+#!RemoteAsset:  sha256:9088bf2ab0459fb981086a1c5024764b7840277f1bbec7b7faf379abe70ca793
+Source0:        https://github.com/cpuguy83/tar2go/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/cpuguy83/tar2go) = %{version}
+
+%description
+tar2go exposes the contents of a tar archive through the Go io/fs.FS interface.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-docker-go-metrics/go-github-docker-go-metrics.spec
+++ b/SPECS/go-github-docker-go-metrics/go-github-docker-go-metrics.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-metrics
+%define go_import_path  github.com/docker/go-metrics
+
+Name:           go-github-docker-go-metrics
+Version:        0.0.1
+Release:        %autorelease
+Summary:        Package for metrics collection in Docker projects
+License:        Apache-2.0
+URL:            https://github.com/docker/go-metrics
+#!RemoteAsset:  sha256:a8a31fd2f59880f4d771c7de45b7dbcee309468ed94740d960e0c76488f9a60b
+Source0:        https://github.com/docker/go-metrics/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/prometheus/client_golang)
+
+Provides:       go(github.com/docker/go-metrics) = %{version}
+
+Requires:       go(github.com/prometheus/client_golang)
+
+%description
+go-metrics is a Prometheus-based metrics collection helper library used across Docker/Moby projects.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-moby-locker/go-github-moby-locker.spec
+++ b/SPECS/go-github-moby-locker/go-github-moby-locker.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           locker
+%define go_import_path  github.com/moby/locker
+
+Name:           go-github-moby-locker
+Version:        1.0.1
+Release:        %autorelease
+Summary:        This is a direct pull from https://github.com/moby/moby/tree/master/pkg/locker
+License:        Apache-2.0
+URL:            https://github.com/moby/locker
+#!RemoteAsset:  sha256:524f312615b4dc06f0199612125a9e0481869a087875666e39f09873a09e24fc
+Source0:        https://github.com/moby/locker/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/moby/locker) = %{version}
+
+%description
+locker provides a mechanism for creating per-key finer-grained locking in Go.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-moby-patternmatcher/go-github-moby-patternmatcher.spec
+++ b/SPECS/go-github-moby-patternmatcher/go-github-moby-patternmatcher.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           patternmatcher
+%define go_import_path  github.com/moby/patternmatcher
+
+Name:           go-github-moby-patternmatcher
+Version:        0.6.1
+Release:        %autorelease
+Summary:        Docker-style ignore-pattern matching for Go
+License:        Apache-2.0
+URL:            https://github.com/moby/patternmatcher
+#!RemoteAsset:  sha256:9c32428a3338eb7bd102ad68f9e3b7be21c75fd62400b0cadf2f125cc3e4243a
+Source0:        https://github.com/moby/patternmatcher/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/moby/patternmatcher) = %{version}
+
+%description
+patternmatcher implements Docker-style pattern matching (.dockerignore semantics) for Go.
+
+%files
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-moby-pubsub/go-github-moby-pubsub.spec
+++ b/SPECS/go-github-moby-pubsub/go-github-moby-pubsub.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           pubsub
+%define go_import_path  github.com/moby/pubsub
+
+Name:           go-github-moby-pubsub
+Version:        1.0.0
+Release:        %autorelease
+Summary:        Simple publish-subscribe package for Go
+License:        Apache-2.0
+URL:            https://github.com/moby/pubsub
+#!RemoteAsset:  sha256:f0076b6a2c498dbbc27311d8b0035955a626f773137f62e25c386c1adc543562
+Source0:        https://github.com/moby/pubsub/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/moby/pubsub) = %{version}
+
+%description
+pubsub is a simple, generic publish/subscribe package for Go.
+
+%files
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-opencontainers-runtime-spec/go-github-opencontainers-runtime-spec.spec
+++ b/SPECS/go-github-opencontainers-runtime-spec/go-github-opencontainers-runtime-spec.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           runtime-spec
+%define go_import_path  github.com/opencontainers/runtime-spec
+
+Name:           go-github-opencontainers-runtime-spec
+Version:        1.3.0
+Release:        %autorelease
+Summary:        OCI Runtime Specification
+License:        Apache-2.0
+URL:            https://github.com/opencontainers/runtime-spec
+#!RemoteAsset:  sha256:136b36bd1087c38bb3202bb3b0421c241bde06f4aa6325da4d5dc03a23e68d1d
+Source0:        https://github.com/opencontainers/runtime-spec/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/opencontainers/runtime-spec) = %{version}
+
+# schema/ provides JSON-schema validation pulling xeipuuv/gojsonschema; downstream uses specs-go only.
+%prep -a
+rm -rf schema
+
+%description
+This package provides the Go types for the Open Container Initiative (OCI) Runtime Specification.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-tonistiigi-go-archvariant/go-github-tonistiigi-go-archvariant.spec
+++ b/SPECS/go-github-tonistiigi-go-archvariant/go-github-tonistiigi-go-archvariant.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-archvariant
+%define go_import_path  github.com/tonistiigi/go-archvariant
+
+Name:           go-github-tonistiigi-go-archvariant
+Version:        1.0.0
+Release:        %autorelease
+Summary:        Detect the supported amd64 microarchitecture variant
+License:        MIT
+URL:            https://github.com/tonistiigi/go-archvariant
+#!RemoteAsset:  sha256:fb75a03315e6049b381437404597ee84987f7fe9fa1637878ce2af99cb888a66
+Source0:        https://github.com/tonistiigi/go-archvariant/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/tonistiigi/go-archvariant) = %{version}
+
+%description
+go-archvariant detects the highest amd64 microarchitecture level (v1-v4) supported by the running CPU.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-vbatts-tar-split/go-github-vbatts-tar-split.spec
+++ b/SPECS/go-github-vbatts-tar-split/go-github-vbatts-tar-split.spec
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           tar-split
+%define go_import_path  github.com/vbatts/tar-split
+
+Name:           go-github-vbatts-tar-split
+Version:        0.12.3
+Release:        %autorelease
+Summary:        Pristinely disassemble and reassemble tar archives
+License:        BSD-3-Clause
+URL:            https://github.com/vbatts/tar-split
+#!RemoteAsset:  sha256:d91f5f15618b96e763686cfc0328b93a38a7cb9510d699d23fe5809b316798d9
+Source0:        https://github.com/vbatts/tar-split/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Upstream test uses %q with int args that the current go vet rejects.
+BuildOption(check):  -vet=off
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/sirupsen/logrus)
+BuildRequires:  go(github.com/stretchr/testify)
+
+Provides:       go(github.com/vbatts/tar-split) = %{version}
+
+Requires:       go(github.com/sirupsen/logrus)
+Requires:       go(github.com/stretchr/testify)
+
+# cmd/ is the tar-split CLI pulling urfave/cli; downstream uses the library only.
+%prep -a
+rm -rf cmd
+
+%description
+tar-split can disassemble a tar archive into metadata and raw content and losslessly reassemble it byte-for-byte.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

Add a first batch of small, standalone Go library dependencies of
`github.com/moby/moby`. These are leaf/near-leaf modules that build cleanly;
each was generated with `go2spec` and hand-tuned (official GitHub sources,
correct licenses/sha256, trimmed descriptions, `%doc` before `%license`),
one package per commit. All build on OBS for `x86_64` and `riscv64`.

- `go-github-moby-locker` (v1.0.1) — per-key locking
- `go-github-moby-patternmatcher` (v0.6.1) — .dockerignore-style matching
- `go-github-moby-pubsub` (v1.0.0) — simple publish/subscribe
- `go-github-docker-go-metrics` (v0.0.1) — Prometheus metrics helpers
- `go-github-opencontainers-runtime-spec` (v1.3.0) — OCI runtime spec types
  (`schema/` trimmed: it pulls xeipuuv/gojsonschema and is unused downstream)
- `go-github-tonistiigi-go-archvariant` (v1.0.0) — amd64 microarch detection
- `go-github-vbatts-tar-split` (v0.12.3) — lossless tar disassembly/reassembly
  (`cmd/` trimmed: it pulls urfave/cli; vet disabled for an upstream test)
- `go-github-cpuguy83-tar2go` (v0.3.1) — expose a tar as an io/fs.FS

Note: this does not make `go-github-moby-moby` itself resolvable — the moby
root still requires large subtrees (buildkit, swarmkit, containerd/v2, cfssl,
hcsshim, ...). These packages are useful container-ecosystem libraries on
their own.

## Related Issue

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: Claude Code:Opus 4.8

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
