### PR TITLE
SPECS: python-pyqt6: Set c++17 to fix build error.

### DIFF
--- a/SPECS/python-pyqt6-sip/python-pyqt6-sip.spec
+++ b/SPECS/python-pyqt6-sip/python-pyqt6-sip.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kai Zhang <zhangkai@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname PyQt6-sip
+%global pypi_name pyqt6_sip
+
+Name:           python-pyqt6-sip
+Version:        13.11.1
+Release:        %autorelease
+Summary:        The sip module support for PyQt6
+License:        GPL-2.0-only OR GPL-3.0-only
+URL:            https://www.riverbankcomputing.com/software/sip/
+#!RemoteAsset:  sha256:869c5b48afe38e55b1ee0dd72182b0886e968cc509b98023ff50010b013ce1be
+Source0:        https://files.pythonhosted.org/packages/source/p/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l PyQt6
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+
+Provides:       python3-pyqt6-sip = %{version}-%{release}
+Provides:       python3-pyqt6-sip%{?_isa} = %{version}-%{release}
+%python_provide python3-pyqt6-sip
+
+%description
+The sip extension module provides support for the PyQt6 package.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README
+
+%changelog
+%autochangelog

--- a/SPECS/python-pyqt6/python-pyqt6.spec
+++ b/SPECS/python-pyqt6/python-pyqt6.spec
@@ -69,7 +69,7 @@ RPM macros for PyQt6.
 
 %package        devel
 Summary:        Development files for python3-PyQt6
-Requires:       python3-PyQt6%{?_isa} = %{version}-%{release}
+Requires:       python3-pyqt6%{?_isa} = %{version}-%{release}
 Requires:       pkgconfig(Qt6Core)
 Provides:       python3-PyQt6-devel
 %python_provide python3-PyQt6-devel
@@ -91,7 +91,7 @@ sip-build \
   --dbus=%{_includedir}/dbus-1.0/ \
   --pep484-pyi \
   --qmake-setting 'QMAKE_CFLAGS_RELEASE="%{build_cflags}"' \
-  --qmake-setting 'QMAKE_CXXFLAGS_RELEASE="%{build_cxxflags} `pkg-config --cflags dbus-python` -DQT_NO_INT128"' \
+  --qmake-setting 'QMAKE_CXXFLAGS_RELEASE="%{build_cxxflags} `pkg-config --cflags dbus-python` -DQT_NO_INT128 -std=c++17"' \
   --qmake-setting 'QMAKE_LFLAGS_RELEASE="%{build_ldflags}"'
 
 %install -a


### PR DESCRIPTION
Gcc16 default to c++20 standard, this leads to the error:
```
[  880s] /home/abuild/rpmbuild/BUILD/python-pyqt6-6.10.1-build/python-pyqt6-6.10.1/build/QtCore/sipQtCorecmodule.cpp:8393:32: error: no matching function for call to ‘operator!=(QLocale::Language&, const QLocale&)’
[  880s]  8393 |             sipRes = operator!=(sipCpp, *a0);
[  880s]       |                      ~~~~~~~~~~^~~~~~~~~~~~~
[  880s]   • there are 2 candidates
[  880s] In file included from /usr/include/qt6/QtCore/qcborvalue.h:9:
[  880s]     • candidate 1: ‘bool operator!=(QCborTag, QCborKnownTags)’
[  880s]       /usr/include/qt6/QtCore/qcborcommon.h:65:13:
[  880s]          65 | inline bool operator!=(QCborTag t, QCborKnownTags kt)   { return quint64(t) != quint64(kt); }
[  880s]             |             ^~~~~~~~
[  880s]       • no known conversion for argument 1 from ‘QLocale::Language’ to ‘QCborTag’
[  880s]         /usr/include/qt6/QtCore/qcborcommon.h:65:33:
[  880s]            65 | inline bool operator!=(QCborTag t, QCborKnownTags kt)   { return quint64(t) != quint64(kt); }
[  880s]               |                        ~~~~~~~~~^
[  880s]     • candidate 2: ‘bool operator!=(QCborKnownTags, QCborTag)’
[  880s]       /usr/include/qt6/QtCore/qcborcommon.h:66:13:
[  880s]          66 | inline bool operator!=(QCborKnownTags kt, QCborTag t)   { return quint64(t) != quint64(kt); }
[  880s]             |             ^~~~~~~~
[  880s]       • no known conversion for argument 1 from ‘QLocale::Language’ to ‘QCborKnownTags’
[  880s]         /usr/include/qt6/QtCore/qcborcommon.h:66:39:
[  880s]            66 | inline bool operator!=(QCborKnownTags kt, QCborTag t)   { return quint64(t) != quint64(kt); }
[  880s]               |                        ~~~~~~~~~~~~~~~^~
```

Fix: https://github.com/openRuyi-Project/openRuyi/issues/782