### PR TITLE
SPECS: spdk: enable isa-l_crypto support for risc-v 64

### DIFF
--- a/SPECS/spdk/2002-ISAL_CRYPTO.patch
+++ b/SPECS/spdk/2002-ISAL_CRYPTO.patch
@@ -1,0 +1,26 @@
+From 62b4b86f4b01c1dee1ea38a45c689bf9eabcb046 Mon Sep 17 00:00:00 2001
+From: Sun Yuechi <sunyuechi@iscas.ac.cn>
+Date: Tue, 3 Feb 2026 19:23:30 +0800
+Subject: [PATCH] ISAL_CRYPTO
+
+Signed-off-by: Sun Yuechi <sunyuechi@iscas.ac.cn>
+---
+ configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index 04fa11887..c2dc5230f 100755
+--- a/configure
++++ b/configure
+@@ -1229,7 +1229,7 @@ fi
+ if [[ "${CONFIG[ISAL_PKG_CONFIG]}" = "y" ]]; then
+ 	echo "Using system ISA-L"
+ 	CONFIG[ISAL]=y
+-	if [[ $arch == x86_64* ]] || [[ $arch == aarch64* ]]; then
++	if [[ $arch == x86_64* ]] || [[ $arch == aarch64* ]] || [[ $arch == riscv64* ]]; then
+ 		CONFIG[ISAL_CRYPTO]=y
+ 	else
+ 		# missing isal_aes_xts_*
+-- 
+2.52.0
+

--- a/SPECS/spdk/spdk.spec
+++ b/SPECS/spdk/spdk.spec
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: (C) 2025 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2025 openRuyi Project Contributors
 # SPDX-FileContributor: Jingkun Zheng <zhengjingkun@iscas.ac.cn>
+# SPDX-FileContributor: Julian Zhu <julian.oerv@isrc.iscas.ac.cn>
 # SPDX-FileContributor: sunyuechi <sunyuechi@iscas.ac.cn>
 # SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
 #
@@ -16,13 +17,6 @@ VCS:            git:https://github.com/spdk/spdk
 #!RemoteAsset:  sha256:f2abbd321a8140c908d6a197e2f6e263e6ae3a42beb6e4aee2b1c62def1afd25
 Source0:        https://github.com/spdk/spdk/archive/refs/tags/v%{version}.tar.gz
 BuildSystem:    autotools
-
-# Warning: This patch seems abandoned
-# https://github.com/spdk/spdk/issues/2736
-# https://review.spdk.io/c/spdk/spdk/+/14996
-# We're using the patch based on the Alpine one (which looks somehow similar), refreshed to v25.09
-# https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/spdk/isal.patch
-Patch0:         2001-with-system-isal.patch
 
 BuildOption(install):  libdir=%{_libdir}
 
@@ -58,6 +52,16 @@ Requires:       fuse3
 The Storage Performance Development Kit provides a set of tools
 and libraries for writing high performance, scalable, user-mode storage
 applications.
+
+%patchlist
+# Warning: This patch seems abandoned
+# https://github.com/spdk/spdk/issues/2736
+# https://review.spdk.io/c/spdk/spdk/+/14996
+# We're using the patch based on the Alpine one (which looks somehow similar), refreshed to v25.09
+# https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/spdk/isal.patch
+2001-with-system-isal.patch
+# Add support for ISA-L_crypto library on RISC-V 64
+2002-ISAL_CRYPTO.patch
 
 %package        devel
 Summary:        Storage Performance Development Kit development files


### PR DESCRIPTION
## Summary

Since #769 has added aes support for RISC-V 64 in isa-l_crypto, now we can enable isa-l_crypto support for risc-v 64 in spdk.

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

No

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
