### PR TITLE
SPECS: libpng: Update package & pngfix should belong to libpng-devel.

### DIFF
--- a/SPECS/libpng/libpng.spec
+++ b/SPECS/libpng/libpng.spec
@@ -7,13 +7,13 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 Name:           libpng
-Version:        1.6.55
+Version:        1.6.58
 Release:        %autorelease
 Summary:        A library of functions for manipulating PNG image format files
 License:        zlib
 URL:            http://www.libpng.org/pub/png/
 VCS:            git:https://github.com/glennrp/libpng
-#!RemoteAsset
+#!RemoteAsset:  sha256:a9d4df463d36a6e5f9c29bd6f4967312d17e996c1854f3511f833924eb1993cf
 Source0:        https://github.com/glennrp/%{name}/archive/v%{version}/%{name}-%{version}.tar.gz
 BuildSystem:    cmake
 
@@ -46,7 +46,6 @@ the libpng package.
 
 %files
 %license LICENSE
-%{_bindir}/pngfix
 %{_libdir}/libpng*.so.*
 %{_mandir}/man5/*
 
@@ -62,4 +61,4 @@ the libpng package.
 %{_mandir}/man3/*
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
## Summary

While using `osc` to do a local build on my machine, this error happened:

```
[  519s] installing libpng-1.6.55-8.2.or20
[  519s]        file /usr/bin/pngfix from install of libpng-1.6.55-8.2.or20.riscv64 conflicts with file from package libpng-devel-1.6.55-8.1.or20.riscv64
[  519s] exit ...
[  519s]
```

`pngfix` should belong to the `devel` subpackage. Also, update `libpng` to the latest version.

## Related Issue

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
