### PR TITLE
SPECS: python-ml-dtypes: Fix failure with newer setuptools.

### DIFF
--- a/SPECS/python-ml-dtypes/1000-Update-setuptools-requirement.patch
+++ b/SPECS/python-ml-dtypes/1000-Update-setuptools-requirement.patch
@@ -1,0 +1,35 @@
+From f1f6f7796ee58c44bf7ac669608525e80c9517a4 Mon Sep 17 00:00:00 2001
+From: "dependabot[bot]" <49699333+dependabot[bot]@users.noreply.github.com>
+Date: Tue, 10 Feb 2026 00:07:31 +0000
+Subject: [PATCH] Update setuptools requirement from ~=80.9.0 to >=80.9,<82.1
+
+Updates the requirements on [setuptools](https://github.com/pypa/setuptools) to permit the latest version.
+- [Release notes](https://github.com/pypa/setuptools/releases)
+- [Changelog](https://github.com/pypa/setuptools/blob/main/NEWS.rst)
+- [Commits](https://github.com/pypa/setuptools/compare/v80.9.0...v82.0.0)
+
+---
+updated-dependencies:
+- dependency-name: setuptools
+  dependency-version: 82.0.0
+  dependency-type: direct:development
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>
+---
+ pyproject.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 0de10bb1..b4453ca5 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -52,7 +52,7 @@ requires = [
+     # We build against the most recent supported NumPy 2.0 release;
+     # see https://github.com/numpy/numpy/issues/27265
+     "numpy~=2.0",
+-    "setuptools~=80.9.0",
++    "setuptools>=80.9,<82.1",
+ ]
+ build-backend = "setuptools.build_meta"
+ 

--- a/SPECS/python-ml-dtypes/python-ml-dtypes.spec
+++ b/SPECS/python-ml-dtypes/python-ml-dtypes.spec
@@ -4,19 +4,24 @@
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
-%global srcname ml_dtypes
+%global srcname ml-dtypes
+%global pypi_name ml_dtypes
 
-Name:           python-ml-dtypes
+Name:           python-%{srcname}
 Version:        0.5.4
 Release:        %autorelease
 Summary:        A stand-alone implementation of several NumPy dtype extensions
 License:        Apache-2.0
 URL:            https://github.com/jax-ml/ml_dtypes
 #!RemoteAsset:  sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453
-Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
+Source0:        https://files.pythonhosted.org/packages/source/m/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
 BuildSystem:    pyproject
 
-BuildOption(install):  -l %{srcname}
+# https://github.com/jax-ml/ml_dtypes/pull/358
+# Upstream not merge the PR, instead, changed the build backend.
+Patch1000:      1000-Update-setuptools-requirement.patch
+
+BuildOption(install):  -l %{pypi_name}
 
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(pip)


### PR DESCRIPTION
## Summary

https://github.com/jax-ml/ml_dtypes/pull/358

Upstream didn't merge the PR, instead, they changed the build backend: https://github.com/jax-ml/ml_dtypes/commit/26d9840b1b8aa209ec8f96cfa0b1ab81ac735d92

The PR fits for us and the new backend not.


## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
