### PR TITLE
SPECS: llvm-defaults: Fix conflicts with clang-resource-filesystem.

### DIFF
--- a/SPECS/llvm-defaults/llvm-defaults.spec
+++ b/SPECS/llvm-defaults/llvm-defaults.spec
@@ -347,12 +347,12 @@ test "${clang_major}" = "%{maj_ver}"
 test -n "${clang_minor}"
 test -n "${clang_patch}"
 
-install -p -m0644 -D %{SOURCE0} %{buildroot}%{_rpmmacrodir}/macros.clang
+install -p -m0644 -D %{SOURCE0} %{buildroot}%{_rpmmacrodir}/macros.clang%{maj_ver}
 sed -i -e "s|@@CLANG_MAJOR_VERSION@@|${clang_major}|" \
        -e "s|@@CLANG_MINOR_VERSION@@|${clang_minor}|" \
        -e "s|@@CLANG_PATCH_VERSION@@|${clang_patch}|" \
-       %{buildroot}%{_rpmmacrodir}/macros.clang
-echo "%%clang%{maj_ver}_resource_dir %%{_prefix}/lib/clang/%{maj_ver}" >> %{buildroot}%{_rpmmacrodir}/macros.clang
+       %{buildroot}%{_rpmmacrodir}/macros.clang%{maj_ver}
+echo "%%clang%{maj_ver}_resource_dir %%{_prefix}/lib/clang/%{maj_ver}" >> %{buildroot}%{_rpmmacrodir}/macros.clang%{maj_ver}
 
 %post -n lld
 update-alternatives --install %{_bindir}/ld ld %{_bindir}/ld.lld 1
@@ -439,7 +439,7 @@ fi
 %files -n clang-static
 
 %files -n clang-rpm-macros
-%{_rpmmacrodir}/macros.clang
+%{_rpmmacrodir}/macros.clang%{maj_ver}
 
 %files -n flang
 %{_bindir}/flang


### PR DESCRIPTION
## Summary

Currently, both packages provide `macros.clang`, which could lead to confusion:

```
[    7s] [9/178] installing clang-rpm-macros-22-9.1.or
[    7s] 	file /usr/lib/rpm/macros.d/macros.clang from install of clang-rpm-macros-22-9.1.or.noarch conflicts with file from package clang-resource-filesystem-21.1.7-19.3.or.x86_64
[    7s] exit ...
```

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
