### PR TITLE
SPECS: aiohttp: update to 3.14.1 [security-fixes]

### DIFF
--- a/SPECS/python-aiohttp/python-aiohttp.spec
+++ b/SPECS/python-aiohttp/python-aiohttp.spec
@@ -1,18 +1,19 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
 # SPDX-FileContributor: yyjeqhc <jialin.oerv@isrc.iscas.ac.cn>
+# SPDX-FileContributor: Zitao Zhou <zitao.oerv@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %global srcname aiohttp
 
 Name:           python-%{srcname}
-Version:        3.13.3
+Version:        3.14.1
 Release:        %autorelease
 Summary:        Python HTTP client/server for asyncio
 License:        Apache-2.0
 URL:            https://github.com/aio-libs/aiohttp
-#!RemoteAsset:  sha256:a949eee43d3782f2daae4f4a2819b2cb9b0c5d3b7f7a927067cc84dafdbb9f88
+#!RemoteAsset:  sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035
 Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildSystem:    pyproject
 


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

Fixed advisories:
| CVE | GHSA | Severity | CVSS |
|------|------|----------|------|
| CVE-2026-54279 | GHSA-2fqr-mr3j-6wp8 | LOW | CVSS_V4: `CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:P/VC:N/VI:N/VA:N/SC:L/SI:N/SA:N/E:U` (low) |
| CVE-2026-34514 | GHSA-2vrm-gr82-f7m5 | LOW | CVSS_V4: `CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N/E:U` (low) |
| CVE-2026-34517 | GHSA-3wq7-rqq7-wx6j | LOW | CVSS_V4: `CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N/E:U` (medium) |
| CVE-2026-54273 | GHSA-4fvr-rgm6-gqmc | MODERATE | CVSS_V4: `CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N/E:U` (low) |
| CVE-2026-54275 | GHSA-4m7w-qmgq-4wj5 | LOW | CVSS_V4: `CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N/E:U` (low) |
| CVE-2026-34520 | GHSA-63hf-3vf5-4wqf | LOW | CVSS_V3: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:H`<br>CVSS_V4: `CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N/E:U` (low) |
| CVE-2026-54277 | GHSA-63hw-fmq6-xxg2 | MODERATE | CVSS_V4: `CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N/E:U` (medium) |
| CVE-2026-34518 | GHSA-966j-vmvw-g2g9 | LOW | CVSS_V3: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N`<br>CVSS_V4: `CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N/E:U` (low) |
| CVE-2026-54280 | GHSA-9x8q-7h8h-wcw9 | LOW | CVSS_V4: `CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N/E:U` (low) |
| CVE-2026-34525 | GHSA-c427-h43c-vf67 | MODERATE | CVSS_V4: `CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:N/VC:N/VI:L/VA:N/SC:L/SI:L/SA:N` (low) |
| CVE-2026-54278 | GHSA-g3cq-j2xw-wf74 | MODERATE | CVSS_V4: `CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N/E:U` (medium) |
| CVE-2026-34513 | GHSA-hcc4-c3v8-rx92 | LOW | CVSS_V4: `CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N/E:U` (low) |
| CVE-2026-47265 | GHSA-hg6j-4rv6-33pg | MODERATE | CVSS_V4: `CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N/E:U` (low) |
| CVE-2026-54276 | GHSA-hpj7-wq8m-9hgp | MODERATE | CVSS_V4: `CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N` (low) |
| CVE-2026-34993 | GHSA-jg22-mg44-37j8 | MODERATE | CVSS_V3: `CVSS:3.1/AV:L/AC:H/PR:H/UI:R/S:C/C:L/I:H/A:L` (medium, 6.4) |
| CVE-2026-34516 | GHSA-m5qp-6w8w-w647 | MODERATE | CVSS_V3: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H`<br>CVSS_V4: `CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N/E:U` (low) |
| CVE-2026-50269 | GHSA-m6qw-4cw2-hm4m | LOW | CVSS_V4: `CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N/E:U` (low) |
| CVE-2026-34519 | GHSA-mwh4-6h8g-pg8w | LOW | CVSS_V4: `CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N/E:U` (low) |
| CVE-2026-34515 | GHSA-p998-jp59-783m | MODERATE | CVSS_V4: `CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N/E:U` (low) |
| CVE-2026-22815 | GHSA-w2fm-2cpv-w7v5 | MODERATE | CVSS_V4: `CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N` (medium) |
| CVE-2026-54274 | GHSA-xcgm-r5h9-7989 | MODERATE | CVSS_V4: `CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N/E:U` (medium) |

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->
no issue.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
