### PR TITLE
SPECS: python-hydra-core: Update to 1.3.3 to fix %build.

### DIFF
--- a/SPECS/python-hydra-core/python-hydra-core.spec
+++ b/SPECS/python-hydra-core/python-hydra-core.spec
@@ -5,15 +5,16 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %global srcname hydra-core
+%global pypi_name hydra_core
 
 Name:           python-%{srcname}
-Version:        1.3.2
+Version:        1.3.3
 Release:        %autorelease
 Summary:        A framework for elegantly configuring complex applications
 License:        MIT
 URL:            https://github.com/facebookresearch/hydra
-#!RemoteAsset:  sha256:8a878ed67216997c3e9d88a8e72e7b4767e81af37afb4ea3334b269a4390a824
-Source0:        https://files.pythonhosted.org/packages/source/h/%{srcname}/%{srcname}-%{version}.tar.gz
+#!RemoteAsset:  sha256:b7477ee21f08b62f71bf0126d44695c048dc7e9c0cc79e2d593b707cb1e44048
+Source0:        https://files.pythonhosted.org/packages/source/h/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
 


### PR DESCRIPTION
## Summary

Update `python-hydra-core` to 1.3.3, build failure due to `pkg_resources` problem, and upstream has fixed it.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
