### PR TITLE
SPECS: python-outlines-core: Add cmake to fix build.

### DIFF
--- a/SPECS/python-outlines-core/python-outlines-core.spec
+++ b/SPECS/python-outlines-core/python-outlines-core.spec
@@ -23,11 +23,14 @@ BuildOption(install):  -l %{pypi_name}
 BuildOption(check):  -e outlines_core.kernels.mlx
 # No module named 'numba'
 BuildOption(check):  -e outlines_core.kernels.numpy
+# ImportError: libomp.so: cannot open shared object file: No such file or directory
+BuildOption(check):  -e outlines_core.kernels.torch
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(torch)
 BuildRequires:  rust
+BuildRequires:  cmake
 BuildRequires:  rust-rpm-macros
 BuildRequires:  python3dist(maturin)
 BuildRequires:  python3dist(pip)


### PR DESCRIPTION
## Summary

Fix the build of python-outlines-core in rva23.

## Checklist

- [X] I have read the [openRuyi Code of Conduct] and agree to abide by it.

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.
