### PR TITLE
SPECS: python-pymilvus: Update to 2.6.16.

### DIFF
--- a/SPECS/python-pymilvus/2000-Relax-hatchling-version.patch
+++ b/SPECS/python-pymilvus/2000-Relax-hatchling-version.patch
@@ -1,0 +1,24 @@
+From 3c0903bb5498bbda4f78c95087dc412a94717d88 Mon Sep 17 00:00:00 2001
+From: misaka00251 <liuxin@iscas.ac.cn>
+Date: Fri, 26 Jun 2026 16:43:33 +0800
+Subject: [PATCH] Relax hatchling version
+
+---
+ pyproject.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index ac8288c0..b819bda5 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,6 +1,6 @@
+ [build-system]
+ requires = [
+-  "hatchling>=1.27,<1.28",
++  "hatchling>=1.27",
+   "setuptools_scm[toml]>=8",
+ ]
+ build-backend = "hatchling.build"
+-- 
+2.54.0
+

--- a/SPECS/python-pymilvus/python-pymilvus.spec
+++ b/SPECS/python-pymilvus/python-pymilvus.spec
@@ -7,15 +7,18 @@
 %global srcname pymilvus
 
 Name:           python-%{srcname}
-Version:        2.6.9
+Version:        2.6.16
 Release:        %autorelease
 Summary:        Python Sdk for Milvus
 License:        Apache-2.0
 URL:            https://github.com/milvus-io/pymilvus
-#!RemoteAsset:  sha256:c53a3d84ff15814e251be13edda70a98a1c8a6090d7597a908387cbb94a9504a
+#!RemoteAsset:  sha256:0ad2518252224ec4ec663b1d17a89bb9c404d089c15e70888aabd021cd258ccf
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
+
+# Our hatchling maybe newer than upstream
+Patch2000:      2000-Relax-hatchling-version.patch
 
 BuildOption(install):  -l %{srcname}
 # Skip bulk_writer, don't need it for now
@@ -27,6 +30,9 @@ BuildRequires:  python3dist(parso)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm)
+BuildRequires:  python3dist(setuptools-scm[toml])
+BuildRequires:  python3dist(gitpython)
 BuildRequires:  python3dist(wheel)
 
 Provides:       python3-%{srcname} = %{version}-%{release}
@@ -36,7 +42,14 @@ Provides:       python3-%{srcname} = %{version}-%{release}
 Python SDK for Milvus.
 
 %generate_buildrequires
+export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PYMILVUS=%{version}
 %pyproject_buildrequires
+
+%build -p
+export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PYMILVUS=%{version}
+
+%install -p
+export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PYMILVUS=%{version}
 
 %files -f %{pyproject_files}
 %doc README.md


### PR DESCRIPTION
## Summary

pymilvus 2.6.9 relies on a private API from `setuptools_scm`, but our version of `setuptools_scm` no longer provides this private API.

Also fixes hatchling version problem.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
