### PR TITLE
SPECS: shim: force rv64gc for RVA23 builds

### DIFF
--- a/SPECS/shim/shim.spec
+++ b/SPECS/shim/shim.spec
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: (C) 2025 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2025 openRuyi Project Contributors
+# SPDX-FileContributor: Jingkun Zheng <zhengjingkun@iscas.ac.cn>
 # SPDX-FileContributor: Zheng Junjie <zhengjunjie@iscas.ac.cn>
 # SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
 # SPDX-FileContributor: Xiang W <wangxiang@iscas.ac.cn>
@@ -79,6 +80,16 @@ The source code of UEFI shim loader
 %prep -a
 # We use our own gnu-efi
 tar --strip-components=1 -xvf %{SOURCE1} -C gnu-efi
+
+# Force RV64GC since Zifencei is not part of RVA23U64, but RVA23S64;
+# And Zifencei is part of RV64G (RV64IMAFD_Zicsr_Zifencei)
+# FIXME: Forcing RV64GC is only a temporary solution.
+# According to UEFI spec, we should only use `-march=rv64imac_zicsr_zifencei`, but right now this is causing FTBFS.
+# See https://github.com/openRuyi-Project/openRuyi/issues/762 for more info.
+
+%ifarch riscv64
+  echo 'override CC := $(CC) -march=rv64gc' >> Make.defaults
+%endif
 
 %conf
 # No Configure


### PR DESCRIPTION
## Summary

RVA23U64 does not include Zifencei / fence.i, while the patch for shim requires fence.i explicitly.

shim being a UEFI program should not use RVA23U64 anyway.

This is a dirty hack to force `-march=rv64gc`.

According to UEFI specs, we should actually only use `-march=rv64imac_zicsr_zifencei`, but that's causing FTBFS, so we're back to `rv64gc` for now.

See the related issue for more info.

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #762 

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
