### PR TITLE
SPECS: arrow: Update to 24.0.0.

### DIFF
--- a/SPECS/arrow/0001-use-system-mimalloc-shared-library.patch
+++ b/SPECS/arrow/0001-use-system-mimalloc-shared-library.patch
@@ -1,45 +1,38 @@
---- arrow-apache-arrow-23.0.1/cpp/cmake_modules/ThirdpartyToolchain.cmake.orig
-+++ arrow-apache-arrow-23.0.1/cpp/cmake_modules/ThirdpartyToolchain.cmake
-@@ -2321,72 +2321,21 @@
- if(ARROW_MIMALLOC)
-   if(NOT ARROW_ENABLE_THREADING)
+From abba42a759b9b80146f327155d605618f33d96ec Mon Sep 17 00:00:00 2001
+From: misaka00251 <liuxin@iscas.ac.cn>
+Date: Fri, 26 Jun 2026 17:22:58 +0800
+Subject: [PATCH] Using system mimalloc shared library
+
+---
+ cpp/cmake_modules/ThirdpartyToolchain.cmake | 68 ++++-----------------
+ 1 file changed, 12 insertions(+), 56 deletions(-)
+
+diff --git a/cpp/cmake_modules/ThirdpartyToolchain.cmake b/cpp/cmake_modules/ThirdpartyToolchain.cmake
+index 665d1b5..04bc728 100644
+--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
++++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
+@@ -2349,62 +2349,18 @@ if(ARROW_MIMALLOC)
      message(FATAL_ERROR "Can't use mimalloc with ARROW_ENABLE_THREADING=OFF")
--  endif()
--
+   endif()
+ 
 -  message(STATUS "Building (vendored) mimalloc from source")
 -  # We only use a vendored mimalloc as we want to control its build options.
 -
 -  set(MIMALLOC_LIB_BASE_NAME "mimalloc")
 -  if(${UPPERCASE_BUILD_TYPE} STREQUAL "DEBUG")
 -    set(MIMALLOC_LIB_BASE_NAME "${MIMALLOC_LIB_BASE_NAME}-${LOWERCASE_BUILD_TYPE}")
-   endif()
- 
+-  endif()
+-
 -  set(MIMALLOC_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/mimalloc_ep/src/mimalloc_ep")
 -  set(MIMALLOC_INCLUDE_DIR "${MIMALLOC_PREFIX}/include")
 -  set(MIMALLOC_STATIC_LIB
 -      "${MIMALLOC_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}${MIMALLOC_LIB_BASE_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX}"
 -  )
-+  message(STATUS "Using system mimalloc shared library")
-+  find_package(mimalloc REQUIRED)
- 
+-
 -  set(MIMALLOC_C_FLAGS ${EP_C_FLAGS})
 -  if(MINGW)
 -    # Workaround https://github.com/microsoft/mimalloc/issues/910 on RTools40
 -    set(MIMALLOC_C_FLAGS "${MIMALLOC_C_FLAGS} -DERROR_COMMITMENT_MINIMUM=635")
-+  if(NOT TARGET mimalloc::mimalloc)
-+    add_library(mimalloc::mimalloc SHARED IMPORTED)
-+    find_library(MIMALLOC_LIB mimalloc)
-+    find_path(MIMALLOC_INCLUDE_DIR mimalloc.h)
-+    set_target_properties(mimalloc::mimalloc PROPERTIES
-+      IMPORTED_LOCATION "${MIMALLOC_LIB}")
-+    target_include_directories(mimalloc::mimalloc INTERFACE "${MIMALLOC_INCLUDE_DIR}")
-   endif()
- 
--  set(MIMALLOC_PATCH_COMMAND "")
--  if(${UPPERCASE_BUILD_TYPE} STREQUAL "DEBUG")
--    find_program(PATCH patch REQUIRED)
--    set(MIMALLOC_PATCH_COMMAND ${PATCH} -p1 -i
--                               ${CMAKE_CURRENT_LIST_DIR}/mimalloc-1138.patch)
 -  endif()
 -
 -  set(MIMALLOC_CMAKE_ARGS
@@ -59,7 +52,6 @@
 -                      ${EP_COMMON_OPTIONS}
 -                      URL ${MIMALLOC_SOURCE_URL}
 -                      URL_HASH "SHA256=${ARROW_MIMALLOC_BUILD_SHA256_CHECKSUM}"
--                      PATCH_COMMAND ${MIMALLOC_PATCH_COMMAND}
 -                      CMAKE_ARGS ${MIMALLOC_CMAKE_ARGS}
 -                      BUILD_BYPRODUCTS "${MIMALLOC_STATIC_LIB}")
 -
@@ -79,7 +71,21 @@
 -  list(APPEND ARROW_BUNDLED_STATIC_LIBS mimalloc::mimalloc)
 -
 -  set(mimalloc_VENDORED TRUE)
++  message(STATUS "Using system mimalloc shared library")
++  find_package(mimalloc REQUIRED)
++
++  if(NOT TARGET mimalloc::mimalloc)
++    add_library(mimalloc::mimalloc SHARED IMPORTED)
++    find_library(MIMALLOC_LIB mimalloc)
++    find_path(MIMALLOC_INCLUDE_DIR mimalloc.h)
++    set_target_properties(mimalloc::mimalloc PROPERTIES
++      IMPORTED_LOCATION "${MIMALLOC_LIB}")
++    target_include_directories(mimalloc::mimalloc INTERFACE "${MIMALLOC_INCLUDE_DIR}")
++  endif()
 +  set(mimalloc_VENDORED FALSE)
  endif()
  
  # ----------------------------------------------------------------------
+-- 
+2.54.0
+

--- a/SPECS/arrow/arrow.spec
+++ b/SPECS/arrow/arrow.spec
@@ -4,23 +4,23 @@
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
-%global parquet_test_commit a3d96a65e11e2bbca7d22a894e8313ede90a33a3
-%global arrow_test_commit df428ddaa22d94dfb525af4c0951f3dafb463795
+%global parquet_test_commit e74785d85a4ecee829e1e405444d6a1b24b8bc9c
+%global arrow_test_commit 249079a810caedda6898464003c7ef8a47efeeae
 
 Name:           arrow
-Version:        23.0.1
+Version:        24.0.0
 Release:        %autorelease
 Summary:        Apache Arrow is a universal columnar format and multi-language toolbox
 License:        Apache-2.0
 URL:            https://arrow.apache.org
 VCS:            git:https://github.com/apache/arrow
-#!RemoteAsset
+#!RemoteAsset:  sha256:94e18d188f26324c4da6bb3a723fec1536ae88b8308bada28d53c0b8d5206b28
 Source0:        https://github.com/apache/arrow/archive/apache-arrow-%{version}/%{name}-%{version}.tar.gz
 # parquet-testing data submodule, pinned to the commit used by arrow %%{version}
-#!RemoteAsset
+#!RemoteAsset:  sha256:6b3d9c1d9b9f059cf3b84b10af2b8a861db167f7809ecef555e610d26fd16433
 Source1:        https://github.com/apache/parquet-testing/archive/%{parquet_test_commit}/parquet-testing.tar.gz
 # arrow-testing data submodule, pinned to the commit used by arrow %%{version}
-#!RemoteAsset
+#!RemoteAsset:  sha256:0ad28c64bcea7a0d201043b7782b4545af822f976946bc7fc233b583cebca92e
 Source2:        https://github.com/apache/arrow-testing/archive/%{arrow_test_commit}/arrow-testing.tar.gz
 BuildSystem:    cmake
 
@@ -108,10 +108,16 @@ rm -f  %{buildroot}%{_libdir}/pkgconfig/arrow-testing.pc
 export PARQUET_TEST_DATA=%{_builddir}/parquet-testing/data
 export ARROW_TEST_DATA=%{_builddir}/arrow-testing/data
 
+%ifarch riscv64
+# RISC-V FMIN/FMAX choose the non-NaN operand when only one operand is NaN,
+# while these tests expect NaN propagation for floating min/max.
+export GTEST_FILTER='-TestFloatingMinMaxKernel/0.Floats:TestFloatingMinMaxKernel/1.Floats'
+%endif
+
 %files
-%license %{_datadir}/doc/arrow/LICENSE.txt
 %doc %{_datadir}/doc/arrow/NOTICE.txt
 %doc %{_datadir}/doc/arrow/README.md
+%license %{_datadir}/doc/arrow/LICENSE.txt
 %{_libdir}/libarrow.so.*
 %{_libdir}/libarrow_acero.so.*
 %{_libdir}/libarrow_compute.so.*
@@ -143,4 +149,4 @@ export ARROW_TEST_DATA=%{_builddir}/arrow-testing/data
 %{_libdir}/pkgconfig/parquet.pc
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
## Summary

Update arrow and skip `arrow-compute-aggregate-test` on riscv64. On the RVA23 machine, this test will not pass:

```
Value of: std::isnan(checked_cast<const ScalarType&>(*val).value)
  Actual: false
Expected: true
```

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
