### PR TITLE
SPECS: go-github-rogpeppe-go-internal: Fix tests.

### DIFF
--- a/SPECS/go-github-rogpeppe-go-internal/2002-Fix-FTBFS-with-golang-1.26.patch
+++ b/SPECS/go-github-rogpeppe-go-internal/2002-Fix-FTBFS-with-golang-1.26.patch
@@ -1,0 +1,23 @@
+From: "Dr. Tobias Quathamer" <toddy@debian.org>
+Date: Fri, 27 Feb 2026 21:23:54 +0100
+Subject: Fix FTBFS with golang 1.26
+
+The error is in cmd.go, line 546
+TestScript.Fatalf format %q has arg bgName of wrong type int
+---
+ testscript/cmd.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/testscript/cmd.go b/testscript/cmd.go
+index 55abd31..c2e04db 100644
+--- a/testscript/cmd.go
++++ b/testscript/cmd.go
+@@ -543,7 +543,7 @@ func (ts *TestScript) killBackground(signal os.Signal) {
+ 	for bgName, bg := range ts.background {
+ 		err := bg.cmd.Process.Signal(signal)
+ 		if err != nil {
+-			ts.Fatalf("unexpected error terminating background command %q: %v", bgName, err)
++			ts.Fatalf("unexpected error terminating background command %v: %v", bgName, err)
+ 		}
+ 	}
+ }

--- a/SPECS/go-github-rogpeppe-go-internal/go-github-rogpeppe-go-internal.spec
+++ b/SPECS/go-github-rogpeppe-go-internal/go-github-rogpeppe-go-internal.spec
@@ -13,12 +13,14 @@ Release:        %autorelease
 Summary:        Selected Go-internal packages factored out from the standard library
 License:        BSD-3-Clause
 URL:            https://github.com/rogpeppe/go-internal
-#!RemoteAsset
+#!RemoteAsset:  sha256:7e54f6d0f002a4904f150e29417515b286ff3b0bbde8e1a01082cbb5178132cb
 Source0:        https://github.com/rogpeppe/go-internal/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 # https://salsa.debian.org/go-team/packages/golang-github-rogpeppe-go-internal/-/blob/0f60076977a5f66c5f557820c009eb0b3d647b01/debian/0001-Allow-TestSimple-cover-to-PASS.patch
 Source1:        2000-Allow-TestSimple-cover-to-PASS.patch
 # Otherwise the TestScripts/env_var_with_go test will fail - 251
 Source2:        2001-Allow-empty-default-GOPROXY.patch
+# https://salsa.debian.org/go-team/packages/golang-github-rogpeppe-go-internal/-/blob/6a1ec9e79d68423095f64c13a428bac63148483c/debian/patches/0001-Fix-FTBFS-with-golang-1.26.patch
+Source3:        2002-Fix-FTBFS-with-golang-1.26.patch
 BuildArch:      noarch
 BuildSystem:    golangmodules
 
@@ -52,14 +54,15 @@ pushd %{_builddir}/go/src/%{go_import_path}
 # Apply patch here
 %__patch -N -p6 -i %{SOURCE1}
 %__patch -N -p1 -i %{SOURCE2}
+%__patch -N -p1 -i %{SOURCE3}
 # Then test
 go test -vet=off -v ./...
 popd
 
 %files
-%license LICENSE*
 %doc README*
+%license LICENSE*
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
## Summary

This fixes running the test suite with Go 1.26, including nested go test invocations such as TestTestwork.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
