### PR TITLE
SPECS: go-github-golang-glog etc.: Fix Go vet warning. 

### DIFF
--- a/SPECS/go-github-golang-glog/2000-fix-stack-slice-format.patch
+++ b/SPECS/go-github-golang-glog/2000-fix-stack-slice-format.patch
@@ -1,0 +1,26 @@
+From 615faf9407beb2df61dca4b0346ea047ceffa579 Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Tue, 30 Jun 2026 19:48:21 +0800
+Subject: [PATCH] Fix vet warning for stack slice formatting
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ internal/stackdump/stackdump_test.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/internal/stackdump/stackdump_test.go b/internal/stackdump/stackdump_test.go
+index 7f782ca..195476d 100644
+--- a/internal/stackdump/stackdump_test.go
++++ b/internal/stackdump/stackdump_test.go
+@@ -116,7 +116,7 @@ func TestCallerPC(t *testing.T) {
+ 		stack := pcAt(calls, tc.depth)
+ 		if tc.wantEndOfStack {
+ 			if len(stack) != 0 {
+-				t.Errorf("for %v calls, stackdump.CallerPC(%v) =\n%q\nwant []", calls, tc.depth, stack)
++				t.Errorf("for %v calls, stackdump.CallerPC(%v) =\n%v\nwant []", calls, tc.depth, stack)
+ 			}
+ 			continue
+ 		}
+-- 
+2.43.0
+

--- a/SPECS/go-github-golang-glog/go-github-golang-glog.spec
+++ b/SPECS/go-github-golang-glog/go-github-golang-glog.spec
@@ -13,10 +13,13 @@ Release:        %autorelease
 Summary:        Leveled execution logs for Go
 License:        Apache-2.0
 URL:            https://github.com/golang/glog
-#!RemoteAsset
+#!RemoteAsset:  sha256:5f1479dfe446a12e4019014e52c3b8a045f00395113812aeaab6a0a754729bb5
 Source0:        https://github.com/golang/glog/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
+
+# Fix Go vet warning with current Go toolchain.
+Patch2000:      2000-fix-stack-slice-format.patch
 
 BuildOption(prep):  -n %{_name}-%{version}
 
@@ -45,4 +48,4 @@ over logging at the file level.
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/go-github-klauspost-compress/2000-fix-buffer-format.patch
+++ b/SPECS/go-github-klauspost-compress/2000-fix-buffer-format.patch
@@ -1,0 +1,35 @@
+From 3ac494feb9b3a7e836f26c26e9bd5a3170914d21 Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Tue, 30 Jun 2026 19:49:34 +0800
+Subject: [PATCH] Fix vet warning for buffer formatting
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ flate/inflate_test.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/flate/inflate_test.go b/flate/inflate_test.go
+index d018991..356a514 100644
+--- a/flate/inflate_test.go
++++ b/flate/inflate_test.go
+@@ -37,7 +37,7 @@ func TestReset(t *testing.T) {
+ 
+ 	for i, s := range ss {
+ 		if s != inflated[i].String() {
+-			t.Errorf("inflated[%d]:\ngot  %q\nwant %q", i, inflated[i], s)
++			t.Errorf("inflated[%d]:\ngot  %q\nwant %q", i, inflated[i].String(), s)
+ 		}
+ 	}
+ }
+@@ -94,7 +94,7 @@ func TestResetDict(t *testing.T) {
+ 
+ 	for i, s := range ss {
+ 		if s != inflated[i].String() {
+-			t.Errorf("inflated[%d]:\ngot  %q\nwant %q", i, inflated[i], s)
++			t.Errorf("inflated[%d]:\ngot  %q\nwant %q", i, inflated[i].String(), s)
+ 		}
+ 	}
+ }
+-- 
+2.43.0
+

--- a/SPECS/go-github-klauspost-compress/go-github-klauspost-compress.spec
+++ b/SPECS/go-github-klauspost-compress/go-github-klauspost-compress.spec
@@ -18,6 +18,9 @@ Source0:        https://github.com/klauspost/compress/archive/v%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
 
+# Fix Go vet warning with current Go toolchain.
+Patch2000:      2000-fix-buffer-format.patch
+
 BuildOption(prep):  -n %{_name}-%{version}
 BuildOption(check):  -short -timeout 1h
 

--- a/SPECS/go-github-prometheus-procfs/2001-report-raw-values-in-parse-errors.patch
+++ b/SPECS/go-github-prometheus-procfs/2001-report-raw-values-in-parse-errors.patch
@@ -1,0 +1,208 @@
+From aae20f999dae84b5991892e4c47fd761bbc37cb4 Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Fri, 10 Jul 2026 17:48:38 +0800
+Subject: [PATCH] fix(procfs): report raw values in parse errors
+
+Use the original string fields when reporting mountinfo and network socket parsing failures. The parsed integer destinations are zero-valued on errors and hide the malformed input.
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ mountinfo.go          |  4 ++--
+ mountinfo_test.go     | 32 ++++++++++++++++++++++++++++++++
+ net_ip_socket.go      | 18 +++++++++---------
+ net_ip_socket_test.go | 37 +++++++++++++++++++++++++++++++++++++
+ 4 files changed, 80 insertions(+), 11 deletions(-)
+
+diff --git a/mountinfo.go b/mountinfo.go
+index 8594ae7..c019656 100644
+--- a/mountinfo.go
++++ b/mountinfo.go
+@@ -98,11 +98,11 @@ func parseMountInfoString(mountString string) (*MountInfo, error) {
+ 
+ 	mount.MountID, err = strconv.Atoi(mountInfo[0])
+ 	if err != nil {
+-		return nil, fmt.Errorf("%w: mount ID: %q", ErrFileParse, mount.MountID)
++		return nil, fmt.Errorf("%w: mount ID: %q", ErrFileParse, mountInfo[0])
+ 	}
+ 	mount.ParentID, err = strconv.Atoi(mountInfo[1])
+ 	if err != nil {
+-		return nil, fmt.Errorf("%w: parent ID: %q", ErrFileParse, mount.ParentID)
++		return nil, fmt.Errorf("%w: parent ID: %q", ErrFileParse, mountInfo[1])
+ 	}
+ 	// Has optional fields, which is a space separated list of values.
+ 	// Example: shared:2 master:7
+diff --git a/mountinfo_test.go b/mountinfo_test.go
+index e40987b..832edac 100644
+--- a/mountinfo_test.go
++++ b/mountinfo_test.go
+@@ -13,11 +13,43 @@
+ package procfs
+ 
+ import (
++	"strings"
+ 	"testing"
+ 
+ 	"github.com/google/go-cmp/cmp"
+ )
+ 
++func TestParseMountInfoStringParseErrorsIncludeRawValue(t *testing.T) {
++	tests := []struct {
++		name  string
++		line  string
++		value string
++	}{
++		{
++			name:  "mount ID",
++			line:  "invalid-mount-id 21 0:16 / /sys rw shared:7 - sysfs sysfs rw",
++			value: "invalid-mount-id",
++		},
++		{
++			name:  "parent ID",
++			line:  "16 invalid-parent-id 0:16 / /sys rw shared:7 - sysfs sysfs rw",
++			value: "invalid-parent-id",
++		},
++	}
++
++	for _, test := range tests {
++		t.Run(test.name, func(t *testing.T) {
++			_, err := parseMountInfoString(test.line)
++			if err == nil {
++				t.Fatal("expected an error, but none occurred")
++			}
++			if !strings.Contains(err.Error(), test.value) {
++				t.Fatalf("error %q does not contain raw value %q", err, test.value)
++			}
++		})
++	}
++}
++
+ func TestMountInfo(t *testing.T) {
+ 	tests := []struct {
+ 		name    string
+diff --git a/net_ip_socket.go b/net_ip_socket.go
+index 9291f8c..b3b6ec3 100644
+--- a/net_ip_socket.go
++++ b/net_ip_socket.go
+@@ -178,7 +178,7 @@ func parseNetIPSocketLine(fields []string, isUDP bool) (*netIPSocketLine, error)
+ 	}
+ 
+ 	if line.Sl, err = strconv.ParseUint(s[0], 0, 64); err != nil {
+-		return nil, fmt.Errorf("%w: Unable to parse sl field in %q: %w", ErrFileParse, line.Sl, err)
++		return nil, fmt.Errorf("%w: Unable to parse sl field in %q: %w", ErrFileParse, s[0], err)
+ 	}
+ 	// local_address
+ 	l := strings.Split(fields[1], ":")
+@@ -189,7 +189,7 @@ func parseNetIPSocketLine(fields []string, isUDP bool) (*netIPSocketLine, error)
+ 		return nil, err
+ 	}
+ 	if line.LocalPort, err = strconv.ParseUint(l[1], 16, 64); err != nil {
+-		return nil, fmt.Errorf("%w: Unable to parse local_address port value line %q: %w", ErrFileParse, line.LocalPort, err)
++		return nil, fmt.Errorf("%w: Unable to parse local_address port value line %q: %w", ErrFileParse, l[1], err)
+ 	}
+ 
+ 	// remote_address
+@@ -201,12 +201,12 @@ func parseNetIPSocketLine(fields []string, isUDP bool) (*netIPSocketLine, error)
+ 		return nil, err
+ 	}
+ 	if line.RemPort, err = strconv.ParseUint(r[1], 16, 64); err != nil {
+-		return nil, fmt.Errorf("%w: Cannot parse rem_address port value in %q: %w", ErrFileParse, line.RemPort, err)
++		return nil, fmt.Errorf("%w: Cannot parse rem_address port value in %q: %w", ErrFileParse, r[1], err)
+ 	}
+ 
+ 	// st
+ 	if line.St, err = strconv.ParseUint(fields[3], 16, 64); err != nil {
+-		return nil, fmt.Errorf("%w: Cannot parse st value in %q: %w", ErrFileParse, line.St, err)
++		return nil, fmt.Errorf("%w: Cannot parse st value in %q: %w", ErrFileParse, fields[3], err)
+ 	}
+ 
+ 	// tx_queue and rx_queue
+@@ -219,27 +219,27 @@ func parseNetIPSocketLine(fields []string, isUDP bool) (*netIPSocketLine, error)
+ 		)
+ 	}
+ 	if line.TxQueue, err = strconv.ParseUint(q[0], 16, 64); err != nil {
+-		return nil, fmt.Errorf("%w: Cannot parse tx_queue value in %q: %w", ErrFileParse, line.TxQueue, err)
++		return nil, fmt.Errorf("%w: Cannot parse tx_queue value in %q: %w", ErrFileParse, q[0], err)
+ 	}
+ 	if line.RxQueue, err = strconv.ParseUint(q[1], 16, 64); err != nil {
+-		return nil, fmt.Errorf("%w: Cannot parse trx_queue value in %q: %w", ErrFileParse, line.RxQueue, err)
++		return nil, fmt.Errorf("%w: Cannot parse trx_queue value in %q: %w", ErrFileParse, q[1], err)
+ 	}
+ 
+ 	// uid
+ 	if line.UID, err = strconv.ParseUint(fields[7], 0, 64); err != nil {
+-		return nil, fmt.Errorf("%w: Cannot parse UID value in %q: %w", ErrFileParse, line.UID, err)
++		return nil, fmt.Errorf("%w: Cannot parse UID value in %q: %w", ErrFileParse, fields[7], err)
+ 	}
+ 
+ 	// inode
+ 	if line.Inode, err = strconv.ParseUint(fields[9], 0, 64); err != nil {
+-		return nil, fmt.Errorf("%w: Cannot parse inode value in %q: %w", ErrFileParse, line.Inode, err)
++		return nil, fmt.Errorf("%w: Cannot parse inode value in %q: %w", ErrFileParse, fields[9], err)
+ 	}
+ 
+ 	// drops
+ 	if isUDP {
+ 		drops, err := strconv.ParseUint(fields[12], 0, 64)
+ 		if err != nil {
+-			return nil, fmt.Errorf("%w: Cannot parse drops value in %q: %w", ErrFileParse, drops, err)
++			return nil, fmt.Errorf("%w: Cannot parse drops value in %q: %w", ErrFileParse, fields[12], err)
+ 		}
+ 		line.Drops = &drops
+ 	}
+diff --git a/net_ip_socket_test.go b/net_ip_socket_test.go
+index 4847d43..6e1c018 100644
+--- a/net_ip_socket_test.go
++++ b/net_ip_socket_test.go
+@@ -15,11 +15,48 @@ package procfs
+ 
+ import (
+ 	"net"
++	"strings"
+ 	"testing"
+ 
+ 	"github.com/google/go-cmp/cmp"
+ )
+ 
++func TestParseNetIPSocketLineParseErrorsIncludeRawValue(t *testing.T) {
++	baseFields := []string{"1:", "00000000:0000", "00000000:0000", "07", "00000000:00000001", "0:0", "0", "10", "0", "39309", "2", "000000009bd60d72", "5"}
++	tests := []struct {
++		name  string
++		value string
++		want  string
++		field int
++		isUDP bool
++	}{
++		{name: "sl", field: 0, value: "invalid-sl:", want: "invalid-sl"},
++		{name: "local port", field: 1, value: "00000000:invalid-local-port", want: "invalid-local-port"},
++		{name: "remote port", field: 2, value: "00000000:invalid-remote-port", want: "invalid-remote-port"},
++		{name: "state", field: 3, value: "invalid-state", want: "invalid-state"},
++		{name: "transmit queue", field: 4, value: "invalid-tx-queue:00000001", want: "invalid-tx-queue"},
++		{name: "receive queue", field: 4, value: "00000000:invalid-rx-queue", want: "invalid-rx-queue"},
++		{name: "UID", field: 7, value: "invalid-uid", want: "invalid-uid"},
++		{name: "inode", field: 9, value: "invalid-inode", want: "invalid-inode"},
++		{name: "drops", field: 12, value: "invalid-drops", want: "invalid-drops", isUDP: true},
++	}
++
++	for _, test := range tests {
++		t.Run(test.name, func(t *testing.T) {
++			fields := append([]string(nil), baseFields...)
++			fields[test.field] = test.value
++
++			_, err := parseNetIPSocketLine(fields, test.isUDP)
++			if err == nil {
++				t.Fatal("expected an error, but none occurred")
++			}
++			if !strings.Contains(err.Error(), test.want) {
++				t.Fatalf("error %q does not contain raw value %q", err, test.want)
++			}
++		})
++	}
++}
++
+ func Test_parseNetIPSocketLine(t *testing.T) {
+ 	tests := []struct {
+ 		fields  []string
+-- 
+2.43.0
+
+

--- a/SPECS/go-github-prometheus-procfs/go-github-prometheus-procfs.spec
+++ b/SPECS/go-github-prometheus-procfs/go-github-prometheus-procfs.spec
@@ -6,22 +6,23 @@
 
 %define _name           procfs
 %define go_import_path  github.com/prometheus/procfs
+%define commit_id       3c943fdba94a978d990553698da4add62bb11a30
 
 Name:           go-github-prometheus-procfs
-Version:        0.19.2
+Version:        0.19.2+git20260702.3c943fd
 Release:        %autorelease
 Summary:        procfs provides functions to retrieve system, kernel and process metrics from the pseudo-filesystem proc.
 License:        Apache-2.0
 URL:            https://github.com/prometheus/procfs
-#!RemoteAsset
-Source0:        https://github.com/prometheus/procfs/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+#!RemoteAsset:  sha256:e2046309491a50f1cf1757f4a37d21eea14eb3097e13eed2593efec464340b44
+Source0:        https://github.com/prometheus/procfs/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
 
 # https://sources.debian.org/src/golang-github-prometheus-procfs/0.19.2-1/debian/patches/0001-Fix-testdata-paths.patch
-Patch0:         2000-Fix-testdata-paths.patch
+Patch2000:      2000-Fix-testdata-paths.patch
 
-BuildOption(prep):  -n %{_name}-%{version}
+BuildOption(prep):  -n %{_name}-%{commit_id}
 
 BuildRequires:  go
 BuildRequires:  go-rpm-macros
@@ -56,4 +57,4 @@ cd %{_builddir}/go/src/%{go_import_path}
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/go-github-prometheus-procfs/go-github-prometheus-procfs.spec
+++ b/SPECS/go-github-prometheus-procfs/go-github-prometheus-procfs.spec
@@ -21,6 +21,8 @@ BuildSystem:    golangmodules
 
 # https://sources.debian.org/src/golang-github-prometheus-procfs/0.19.2-1/debian/patches/0001-Fix-testdata-paths.patch
 Patch2000:      2000-Fix-testdata-paths.patch
+# https://github.com/prometheus/procfs/pull/841
+Patch2001:      2001-report-raw-values-in-parse-errors.patch
 
 BuildOption(prep):  -n %{_name}-%{commit_id}
 

--- a/SPECS/go-github-spf13-cobra/2000-fix-directive-format.patch
+++ b/SPECS/go-github-spf13-cobra/2000-fix-directive-format.patch
@@ -1,0 +1,26 @@
+From 143acc85628652a059243e50964a83c35aa93e97 Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Tue, 30 Jun 2026 19:51:02 +0800
+Subject: [PATCH] Fix vet warning for directive formatting
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ completions_test.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/completions_test.go b/completions_test.go
+index ec7b907..07060ce 100644
+--- a/completions_test.go
++++ b/completions_test.go
+@@ -3727,7 +3727,7 @@ func TestGetFlagCompletion(t *testing.T) {
+ 					t.Errorf("Unexpected completions %q", comps)
+ 				}
+ 				if tc.directive != directive {
+-					t.Errorf("Unexpected directive %q", directive)
++					t.Errorf("Unexpected directive %v", directive)
+ 				}
+ 			}
+ 		})
+-- 
+2.43.0
+

--- a/SPECS/go-github-spf13-cobra/go-github-spf13-cobra.spec
+++ b/SPECS/go-github-spf13-cobra/go-github-spf13-cobra.spec
@@ -13,10 +13,13 @@ Release:        %autorelease
 Summary:        A Commander for modern Go CLI interactions
 License:        Apache-2.0
 URL:            https://github.com/spf13/cobra
-#!RemoteAsset
+#!RemoteAsset:  sha256:8ee67b82ddb730f6ed639724d19ddd874be36b65da45529ad5cacce53c310704
 Source0:        https://github.com/spf13/cobra/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
+
+# Fix Go vet warning with current Go toolchain.
+Patch2000:      2000-fix-directive-format.patch
 
 BuildOption(prep):  -n %{_name}-%{version}
 
@@ -51,4 +54,4 @@ of projects using Cobra.
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

For 2026.06 openruyi build fail fix.

The vet format check became strict after go 1.14, which causes many go packages build fail. And it is a commen issue for many go packages. 

All patchs in this PR were contributed to the upstream and waiting for further review.



## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: ChatGPT:GPT-5.5 High

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
