### PR TITLE
SPECS: gsl, build with clang and delivery LLVM IR

### DIFF
--- a/SPECS/gsl/2000-Fix-undefined-behavior-in-gsl_pow_int.patch
+++ b/SPECS/gsl/2000-Fix-undefined-behavior-in-gsl_pow_int.patch
@@ -1,0 +1,29 @@
+From 26d5fad373881e6599ba9a9af0d3b24d078249dc Mon Sep 17 00:00:00 2001
+From: YunQiang Su <yunqiang@isrc.iscas.ac.cn>
+Date: Wed, 1 Jul 2026 12:55:15 +0800
+Subject: [PATCH] Fix undefined behavior in gsl_pow_int
+
+I find this problem when I build gsl with clang, and run unit tests:
+
+FAIL: gsl_pow_int(1.0000001,-2147483648) (1 observed vs
+5.44471031785229506e-94 expected) [100]
+---
+ sys/pow_int.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sys/pow_int.c b/sys/pow_int.c
+index 26c7fff7..0d25ce95 100644
+--- a/sys/pow_int.c
++++ b/sys/pow_int.c
+@@ -31,7 +31,7 @@ double gsl_pow_int(double x, int n)
+ 
+   if(n < 0) {
+     x = 1.0/x;
+-    un = -n;
++    un = -(unsigned int)n;
+   } else {
+     un = n;
+   }
+-- 
+2.47.3
+

--- a/SPECS/gsl/gsl.spec
+++ b/SPECS/gsl/gsl.spec
@@ -14,7 +14,7 @@ Summary:        The GNU Scientific Library for numerical analysis
 License:        GPL-3.0-or-later
 URL:            https://www.gnu.org/software/gsl/
 VCS:            git:https://git.savannah.gnu.org/git/gsl.git
-#!RemoteAsset
+#!RemoteAsset:  sha256:6a99eeed15632c6354895b1dd542ed5a855c0f15d9ad1326c6fe2b2c9e423190
 Source0:        https://ftpmirror.gnu.org/gnu/gsl/gsl-%{version}.tar.gz
 BuildSystem:    autotools
 
@@ -107,4 +107,4 @@ export PATH=/var/lib/clang-wrap:$PATH
 %{_includedir}/gsl/
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/gsl/gsl.spec
+++ b/SPECS/gsl/gsl.spec
@@ -5,6 +5,8 @@
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
+%define __install /var/lib/clang-wrap/install
+
 Name:           gsl
 Version:        2.8
 Release:        %autorelease
@@ -19,10 +21,16 @@ BuildSystem:    autotools
 BuildOption(conf):  --disable-silent-rules
 BuildOption(conf):  --disable-static
 BuildOption(conf):  CFLAGS="%{optflags} -ffp-contract=off"
+BuildOption(conf):  CC=clang CXX=clang++
 
-BuildRequires:  gcc
+# https://lists.gnu.org/archive/html/bug-gsl/2026-05/msg00004.html
+# Undefined behavior in gsl_pow_int
+Patch0:         2000-Fix-undefined-behavior-in-gsl_pow_int.patch
+
 BuildRequires:  pkgconfig
 BuildRequires:  make
+BuildRequires:  clang-wrap
+BuildRequires:  llvm
 
 %description
 The GNU Scientific Library (GSL) is a collection of routines for
@@ -37,16 +45,52 @@ Requires:       pkgconfig
 The gsl-devel package contains the header files necessary for
 developing programs using the GSL (GNU Scientific Library).
 
-%install -a
-rm -rf %{buildroot}%{_infodir}/dir
+%prep -a
+%autosetup -p1
+
+%conf -p
+%ifarch riscv64
+export EMIT_LLVMIR=-march=rva23u64
+%elifarch x86_64
+export EMIT_LLVMIR=-march=x86-64-v4
+%else
+export EMIT_LLVMIR=1
+%endif
+export PATH=/var/lib/clang-wrap:$PATH
+
+%build -p
+%ifarch riscv64
+export EMIT_LLVMIR=-march=rva23u64
+%elifarch x86_64
+export EMIT_LLVMIR=-march=x86-64-v4
+%else
+export EMIT_LLVMIR=1
+%endif
+export PATH=/var/lib/clang-wrap:$PATH
+
+%install -p
+%ifarch riscv64
+export EMIT_LLVMIR=-march=rva23u64
+%elifarch x86_64
+export EMIT_LLVMIR=-march=x86-64-v4
+%else
+export EMIT_LLVMIR=1
+%endif
+export PATH=/var/lib/clang-wrap:$PATH
 
 %files
 %license COPYING
 %doc AUTHORS ChangeLog NEWS README THANKS TODO
 %{_bindir}/gsl-histogram
+%{_bindir}/../lib/llvmir-bin/gsl-histogram
+%{_bindir}/../lib/llvmir-bin/gsl-histogram_cmd
 %{_bindir}/gsl-randist
+%{_bindir}/../lib/llvmir-bin/gsl-randist
+%{_bindir}/../lib/llvmir-bin/gsl-randist_cmd
 %{_libdir}/libgsl.so.28*
+%{_libdir}/llvmir/libgsl.so.28*
 %{_libdir}/libgslcblas.so.0*
+%{_libdir}/llvmir/libgslcblas.so.0*
 %{_mandir}/man1/gsl-histogram.1*
 %{_mandir}/man1/gsl-randist.1*
 

--- a/SPECS/gsl/gsl.spec
+++ b/SPECS/gsl/gsl.spec
@@ -31,6 +31,7 @@ BuildRequires:  pkgconfig
 BuildRequires:  make
 BuildRequires:  clang-wrap
 BuildRequires:  llvm
+BuildRequires:  clang
 
 %description
 The GNU Scientific Library (GSL) is a collection of routines for


### PR DESCRIPTION
With the test, gsl built with clang can archive better performance than gcc.

Signed-off-by: YunQiang Su <yunqiang@isrc.iscas.ac.cn>