### PR TITLE
SPECS: dracut: Add patch to fix dbus.service deps

### DIFF
--- a/SPECS/dracut/2000-fix-dbus-restrict-After-Requires-removal-patterns.patch
+++ b/SPECS/dracut/2000-fix-dbus-restrict-After-Requires-removal-patterns.patch
@@ -1,0 +1,57 @@
+From b9418ad1aab99bd91200a2c30bb42140d300103d Mon Sep 17 00:00:00 2001
+From: Vivian Wang <wangruikang@iscas.ac.cn>
+Date: Wed, 1 Jul 2026 11:12:19 +0800
+Subject: [PATCH] fix(dbus): restrict After/Requires removal patterns
+
+While the intention for removing all After= and Requires= lines on
+dbus.service and dbus.socket is to remove the dependency on
+sysinit.target, this unintentionally removes the Requires=dbus.socket
+dependency for dbus.service as well, which is present in both upstream
+dbus and dbus-broker.
+
+Restrict the pattern to only lines mentioning sysinit.target, to better
+match what Ubuntu has added downstream.
+---
+ modules.d/16dbus-broker/module-setup.sh | 3 ++-
+ modules.d/16dbus-daemon/module-setup.sh | 6 ++++--
+ 2 files changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/modules.d/16dbus-broker/module-setup.sh b/modules.d/16dbus-broker/module-setup.sh
+index 2bc39249..cac53d96 100755
+--- a/modules.d/16dbus-broker/module-setup.sh
++++ b/modules.d/16dbus-broker/module-setup.sh
+@@ -55,7 +55,8 @@ install() {
+ 
+     # Remove After/Requires=sysinit.target for initramfs in the dbus socket unit.
+     sed -i -e \
+-        '/^\(After\|DefaultDependencies\|Requires\)=/d
++        '/^\(After\|Requires\)=.*sysinit\.target/d
++        /^DefaultDependencies=/d
+         /^\[Unit\]/aDefaultDependencies=no\nConflicts=shutdown.target\nBefore=shutdown.target sockets.target
+         /^\[Socket\]/aRemoveOnStop=yes' \
+         "$initdir$systemdsystemunitdir/dbus.socket"
+diff --git a/modules.d/16dbus-daemon/module-setup.sh b/modules.d/16dbus-daemon/module-setup.sh
+index 6758c52e..598154da 100755
+--- a/modules.d/16dbus-daemon/module-setup.sh
++++ b/modules.d/16dbus-daemon/module-setup.sh
+@@ -52,13 +52,15 @@ install() {
+ 
+     # Remove After/Requires=sysinit.target and After=basic.target for initramfs in the dbus service unit.
+     sed -i -e \
+-        '/^\(After\|DefaultDependencies\|Requires\)=/d
++        '/^\(After\|Requires\)=.*sysinit\.target/d
++        /^DefaultDependencies=/d
+         /^\[Unit\]/aDefaultDependencies=no\nConflicts=shutdown.target\nBefore=shutdown.target' \
+         "$initdir$systemdsystemunitdir/dbus.service"
+ 
+     # Remove After/Requires=sysinit.target for initramfs in the dbus socket unit.
+     sed -i -e \
+-        '/^\(After\|DefaultDependencies\|Requires\)=/d
++        '/^\(After\|Requires\)=.*sysinit\.target/d
++        /^DefaultDependencies=/d
+         /^\[Unit\]/aDefaultDependencies=no\nConflicts=shutdown.target\nBefore=shutdown.target sockets.target
+         /^\[Socket\]/aRemoveOnStop=yes' \
+         "$initdir$systemdsystemunitdir/dbus.socket"
+-- 
+2.54.0
+

--- a/SPECS/dracut/dracut.spec
+++ b/SPECS/dracut/dracut.spec
@@ -15,6 +15,9 @@ URL:            https://github.com/dracut-ng/dracut-ng
 Source:         %{url}/archive/refs/tags/%{version}.tar.gz
 BuildSystem:    autotools
 
+# https://github.com/dracut-ng/dracut/pull/2482
+Patch2000:      2000-fix-dbus-restrict-After-Requires-removal-patterns.patch
+
 BuildOption(conf):  --systemdsystemunitdir=%{_unitdir}
 BuildOption(conf):  --bashcompletiondir=$(pkg-config --variable=completionsdir bash-completion)
 BuildOption(conf):  --libdir=%{_prefix}/lib


### PR DESCRIPTION
Add a patch to preserve Requires=dbus.socket for dbus.service. This seems to fix the problem of NetworkManager.service not starting, although I don't know why.

## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Related to #841, but I don't know why this seems to fix that

## Checklist

- [X] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
