### PR TITLE
SPECS: llvm-defaults: don't hardcode clang version in macros.clang

### DIFF
--- a/SPECS/llvm-defaults/llvm-defaults.spec
+++ b/SPECS/llvm-defaults/llvm-defaults.spec
@@ -347,12 +347,7 @@ test "${clang_major}" = "%{maj_ver}"
 test -n "${clang_minor}"
 test -n "${clang_patch}"
 
-install -p -m0644 -D %{SOURCE0} %{buildroot}%{_rpmmacrodir}/macros.clang%{maj_ver}
-sed -i -e "s|@@CLANG_MAJOR_VERSION@@|${clang_major}|" \
-       -e "s|@@CLANG_MINOR_VERSION@@|${clang_minor}|" \
-       -e "s|@@CLANG_PATCH_VERSION@@|${clang_patch}|" \
-       %{buildroot}%{_rpmmacrodir}/macros.clang%{maj_ver}
-echo "%%clang%{maj_ver}_resource_dir %%{_prefix}/lib/clang/%{maj_ver}" >> %{buildroot}%{_rpmmacrodir}/macros.clang%{maj_ver}
+install -p -m0644 -D %{SOURCE0} %{buildroot}%{_rpmmacrodir}/macros.clang
 
 %post -n lld
 update-alternatives --install %{_bindir}/ld ld %{_bindir}/ld.lld 1
@@ -439,7 +434,7 @@ fi
 %files -n clang-static
 
 %files -n clang-rpm-macros
-%{_rpmmacrodir}/macros.clang%{maj_ver}
+%{_rpmmacrodir}/macros.clang
 
 %files -n flang
 %{_bindir}/flang

--- a/SPECS/llvm-defaults/macros.clang
+++ b/SPECS/llvm-defaults/macros.clang
@@ -6,4 +6,4 @@
 # headers and libraries.  This path should be used by packages that need to
 # install files into this directory.  This macro's value changes every time
 # clang's version changes.
-%clang_resource_dir %{_libdir}/llvm22/lib/clang/%{clang_major_version}
+%clang_resource_dir %{_libdir}/llvm%{clang_major_version}/lib/clang/%{clang_major_version}

--- a/SPECS/llvm-defaults/macros.clang
+++ b/SPECS/llvm-defaults/macros.clang
@@ -6,4 +6,4 @@
 # headers and libraries.  This path should be used by packages that need to
 # install files into this directory.  This macro's value changes every time
 # clang's version changes.
-%clang_resource_dir %{_prefix}/lib/clang/%{clang_major_version}
+%clang_resource_dir %{_libdir}/llvm22/lib/clang/%{clang_major_version}

--- a/SPECS/llvm-defaults/macros.clang
+++ b/SPECS/llvm-defaults/macros.clang
@@ -1,7 +1,7 @@
-%clang_major_version @@CLANG_MAJOR_VERSION@@
-%clang_minor_version @@CLANG_MINOR_VERSION@@
-%clang_patch_version @@CLANG_PATCH_VERSION@@
-%clang_version %{clang_major_version}.%{clang_minor_version}.%{clang_patch_version}
+%clang_version   %(clang -dumpversion)
+%clang_major_version %(echo %{clang_version} | awk -F. '{print $1}')
+%clang_minor_version %(echo %{clang_version} | awk -F. '{print $2}')
+%clang_patch_version %(echo %{clang_version} | awk -F. '{print $3}')
 # This is the path to the clang resource directory that has clang's internal
 # headers and libraries.  This path should be used by packages that need to
 # install files into this directory.  This macro's value changes every time


### PR DESCRIPTION
The macros.clang can get the version of defualt clang by
  clang -dumpversion

Signed-off-by: YunQiang Su <yunqiang@isrc.iscas.ac.cn>