### PR TITLE
SPECS: gcc{15,16}: add a patch fixing autovec fmin/fmax NaN handling

### DIFF
--- a/SPECS/arrow/arrow.spec
+++ b/SPECS/arrow/arrow.spec
@@ -108,12 +108,6 @@ rm -f  %{buildroot}%{_libdir}/pkgconfig/arrow-testing.pc
 export PARQUET_TEST_DATA=%{_builddir}/parquet-testing/data
 export ARROW_TEST_DATA=%{_builddir}/arrow-testing/data
 
-%ifarch riscv64
-# RISC-V FMIN/FMAX choose the non-NaN operand when only one operand is NaN,
-# while these tests expect NaN propagation for floating min/max.
-export GTEST_FILTER='-TestFloatingMinMaxKernel/0.Floats:TestFloatingMinMaxKernel/1.Floats'
-%endif
-
 %files
 %doc %{_datadir}/doc/arrow/NOTICE.txt
 %doc %{_datadir}/doc/arrow/README.md

--- a/SPECS/gcc15/1000-UPSTREAM-RISC-V-Change-initial-value-for-fmin-fmax-autovec-re.patch
+++ b/SPECS/gcc15/1000-UPSTREAM-RISC-V-Change-initial-value-for-fmin-fmax-autovec-re.patch
@@ -1,0 +1,92 @@
+From 61afbbe1b2e4a6592fa56cbe1695a07601c012f1 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
+Date: Tue, 30 Jun 2026 16:23:20 +0800
+Subject: [PATCH] RISC-V: Change initial value for fmin/fmax autovec reduce
+ [PR126049]
+
+Currently the auto-vectorization of C fmin()/fmax() uses
+infinity/-infinity as the initial value for reduction, which introduces
+bogus infinity values when iterating over an array with only NaNs.
+
+As all C fmin()/fmax(), RV F/D fmin/fmax, RVV vfmin/vfmax and RVV
+vfredmin/vfredmax are implementing the IEEE754 minimumNumber or
+maximumNumber behavior, an initial value of NaN is more suitable than
+infinity when reducing the vector (if the input vector is all NaN, the
+result will still be NaN and if the input vector contains non-NaN
+elements they will cover the initial NaN).
+
+Change the initial value during reduction from corresponding inf to a
+quiet NaN.
+
+        PR target/126049
+
+gcc/ChangeLog:
+        * config/riscv/autovec.md: Change fmin/fmax reduction initial
+        value from inf/-inf to NaN for proper semantics of corresponding
+        C funtion.
+
+gcc/testsuite/ChangeLog:
+        * gcc.target/riscv/rvv/autovec/pr126049.c: New.
+---
+ gcc/config/riscv/autovec.md                   |  4 +--
+ .../gcc.target/riscv/rvv/autovec/pr126049.c   | 26 +++++++++++++++++++
+ 2 files changed, 28 insertions(+), 2 deletions(-)
+ create mode 100644 gcc/testsuite/gcc.target/riscv/rvv/autovec/pr126049.c
+
+diff --git a/gcc/config/riscv/autovec.md b/gcc/config/riscv/autovec.md
+index fc5a31c9396..7eed31391e5 100644
+--- a/gcc/config/riscv/autovec.md
++++ b/gcc/config/riscv/autovec.md
+@@ -2423,7 +2423,7 @@
+   "TARGET_VECTOR && !HONOR_SNANS (<MODE>mode)"
+ {
+   REAL_VALUE_TYPE rv;
+-  real_inf (&rv, true);
++  real_nan (&rv, "", 1, VOIDmode);
+   rtx f = const_double_from_real_value (rv, <VEL>mode);
+   riscv_vector::expand_reduction (UNSPEC_REDUC_MAX,
+ 				  UNSPEC_REDUC_MAX_VL0_SAFE,
+@@ -2438,7 +2438,7 @@
+   "TARGET_VECTOR && !HONOR_SNANS (<MODE>mode)"
+ {
+   REAL_VALUE_TYPE rv;
+-  real_inf (&rv, false);
++  real_nan (&rv, "", 1, VOIDmode);
+   rtx f = const_double_from_real_value (rv, <VEL>mode);
+   riscv_vector::expand_reduction (UNSPEC_REDUC_MIN,
+ 				  UNSPEC_REDUC_MIN_VL0_SAFE,
+diff --git a/gcc/testsuite/gcc.target/riscv/rvv/autovec/pr126049.c b/gcc/testsuite/gcc.target/riscv/rvv/autovec/pr126049.c
+new file mode 100644
+index 00000000000..1fab4466525
+--- /dev/null
++++ b/gcc/testsuite/gcc.target/riscv/rvv/autovec/pr126049.c
+@@ -0,0 +1,26 @@
++/* { dg-do run } */
++/* { dg-require-effective-target riscv_v_ok } */
++/* { dg-options "-march=rv64gcv -mabi=lp64d -O2 -ftree-vectorize" } */
++
++#define NAN (__builtin_nan(""))
++
++__attribute__ ((noipa)) float
++maxx (float *arr, unsigned int sz)
++{
++  float val = NAN;
++  unsigned int i;
++
++  for (i = 0; i < sz; i++)
++    val = __builtin_fmaxf (val, arr[i]);
++
++  return val;
++}
++
++int
++main ()
++{
++  float arr[] = { NAN, NAN, NAN, NAN };
++  float res = maxx (arr, 4);
++  if (!__builtin_isnan (res))
++    __builtin_abort ();
++}
+-- 
+2.52.0
+

--- a/SPECS/gcc15/gcc15.spec
+++ b/SPECS/gcc15/gcc15.spec
@@ -190,6 +190,8 @@ Patch1033:      0033-RISC-V-Support-Ssu64xl-extension.patch
 Patch1034:      0034-RISC-V-Update-Profiles-string-in-RV23.patch
 Patch1035:      0035-RISC-V-Add-Profiles-RVA-B23S64-support.patch
 Patch1036:      0036-RISC-V-check-if-we-can-vec_extract.patch
+# Fix tree vectorization breaking NaN handling of fmin/fmax
+Patch1000:      1000-UPSTREAM-RISC-V-Change-initial-value-for-fmin-fmax-autovec-re.patch
 
 %description
 Core package for the GNU Compiler Collection, including the C language

--- a/SPECS/gcc16/1000-UPSTREAM-RISC-V-Change-initial-value-for-fmin-fmax-autovec-re.patch
+++ b/SPECS/gcc16/1000-UPSTREAM-RISC-V-Change-initial-value-for-fmin-fmax-autovec-re.patch
@@ -1,0 +1,92 @@
+From 61afbbe1b2e4a6592fa56cbe1695a07601c012f1 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <zhengxingda@iscas.ac.cn>
+Date: Tue, 30 Jun 2026 16:23:20 +0800
+Subject: [PATCH] RISC-V: Change initial value for fmin/fmax autovec reduce
+ [PR126049]
+
+Currently the auto-vectorization of C fmin()/fmax() uses
+infinity/-infinity as the initial value for reduction, which introduces
+bogus infinity values when iterating over an array with only NaNs.
+
+As all C fmin()/fmax(), RV F/D fmin/fmax, RVV vfmin/vfmax and RVV
+vfredmin/vfredmax are implementing the IEEE754 minimumNumber or
+maximumNumber behavior, an initial value of NaN is more suitable than
+infinity when reducing the vector (if the input vector is all NaN, the
+result will still be NaN and if the input vector contains non-NaN
+elements they will cover the initial NaN).
+
+Change the initial value during reduction from corresponding inf to a
+quiet NaN.
+
+        PR target/126049
+
+gcc/ChangeLog:
+        * config/riscv/autovec.md: Change fmin/fmax reduction initial
+        value from inf/-inf to NaN for proper semantics of corresponding
+        C funtion.
+
+gcc/testsuite/ChangeLog:
+        * gcc.target/riscv/rvv/autovec/pr126049.c: New.
+---
+ gcc/config/riscv/autovec.md                   |  4 +--
+ .../gcc.target/riscv/rvv/autovec/pr126049.c   | 26 +++++++++++++++++++
+ 2 files changed, 28 insertions(+), 2 deletions(-)
+ create mode 100644 gcc/testsuite/gcc.target/riscv/rvv/autovec/pr126049.c
+
+diff --git a/gcc/config/riscv/autovec.md b/gcc/config/riscv/autovec.md
+index fc5a31c9396..7eed31391e5 100644
+--- a/gcc/config/riscv/autovec.md
++++ b/gcc/config/riscv/autovec.md
+@@ -2423,7 +2423,7 @@
+   "TARGET_VECTOR && !HONOR_SNANS (<MODE>mode)"
+ {
+   REAL_VALUE_TYPE rv;
+-  real_inf (&rv, true);
++  real_nan (&rv, "", 1, VOIDmode);
+   rtx f = const_double_from_real_value (rv, <VEL>mode);
+   riscv_vector::expand_reduction (UNSPEC_REDUC_MAX,
+ 				  UNSPEC_REDUC_MAX_VL0_SAFE,
+@@ -2438,7 +2438,7 @@
+   "TARGET_VECTOR && !HONOR_SNANS (<MODE>mode)"
+ {
+   REAL_VALUE_TYPE rv;
+-  real_inf (&rv, false);
++  real_nan (&rv, "", 1, VOIDmode);
+   rtx f = const_double_from_real_value (rv, <VEL>mode);
+   riscv_vector::expand_reduction (UNSPEC_REDUC_MIN,
+ 				  UNSPEC_REDUC_MIN_VL0_SAFE,
+diff --git a/gcc/testsuite/gcc.target/riscv/rvv/autovec/pr126049.c b/gcc/testsuite/gcc.target/riscv/rvv/autovec/pr126049.c
+new file mode 100644
+index 00000000000..1fab4466525
+--- /dev/null
++++ b/gcc/testsuite/gcc.target/riscv/rvv/autovec/pr126049.c
+@@ -0,0 +1,26 @@
++/* { dg-do run } */
++/* { dg-require-effective-target riscv_v_ok } */
++/* { dg-options "-march=rv64gcv -mabi=lp64d -O2 -ftree-vectorize" } */
++
++#define NAN (__builtin_nan(""))
++
++__attribute__ ((noipa)) float
++maxx (float *arr, unsigned int sz)
++{
++  float val = NAN;
++  unsigned int i;
++
++  for (i = 0; i < sz; i++)
++    val = __builtin_fmaxf (val, arr[i]);
++
++  return val;
++}
++
++int
++main ()
++{
++  float arr[] = { NAN, NAN, NAN, NAN };
++  float res = maxx (arr, 4);
++  if (!__builtin_isnan (res))
++    __builtin_abort ();
++}
+-- 
+2.52.0
+

--- a/SPECS/gcc16/gcc16.spec
+++ b/SPECS/gcc16/gcc16.spec
@@ -149,6 +149,8 @@ Requires:       libvtv >= %{version}-%{release}
 %endif
 Suggests:       gcc%{vermajor}-doc
 
+# Fix tree vectorization breaking NaN handling of fmin/fmax
+Patch1000:      1000-UPSTREAM-RISC-V-Change-initial-value-for-fmin-fmax-autovec-re.patch
 Patch2000:      2000-textdomain.patch
 Patch2001:      2001-rename-info-files.patch
 


### PR DESCRIPTION
## Summary

Fixing wrong NaN handling during GCC's auto-vectorization of fmin()/fmax() (which is found by a failed testcase of package `arrow`).

The failed testcase of `arrow` is also re-enabled.

## Related Issue

- Resolves #830

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.