### PR TITLE
use clang to build gsl and delivery LLVM IR 

### DIFF
--- a/SPECS/clang-wrap/Cargo.toml
+++ b/SPECS/clang-wrap/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "clang-wrap"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+pathdiff = "0.2"
+
+[[bin]]
+name = "clang"
+path = "src/main.rs"
+
+[[bin]]
+name = "ar"
+path = "src/bin/ar-wrap.rs"
+
+[[bin]]
+name = "install"
+path = "src/bin/install-wrap.rs"
+
+[[bin]]
+name = "ln"
+path = "src/bin/ln-wrap.rs"
+
+[[bin]]
+name = "mv"
+path = "src/bin/mv-wrap.rs"
+
+[[bin]]
+name = "cp"
+path = "src/bin/cp-wrap.rs"
+
+[[bin]]
+name = "strip"
+path = "src/bin/strip-wrap.rs"

--- a/SPECS/clang-wrap/clang-wrap.spec
+++ b/SPECS/clang-wrap/clang-wrap.spec
@@ -15,6 +15,7 @@ Summary:        clang-wrap to collect LLVM IR
 URL:            https://github.com/openRuyi-Project/clang-wrap
 #!RemoteAsset:  sha256:f6eeb35daec88135c047fe1d9c3e1960d69dfebb1d0041a336805f338807e76d
 Source0:        https://github.com/openRuyi-Project/clang-wrap/archive/%{git_commit}.tar.gz
+Source1:        macros.clang-wrap
 BuildSystem:    rust
 
 BuildRequires:  cargo
@@ -28,7 +29,10 @@ BuildRequires:  crate(pathdiff-0.2/default)
 This package contains wrap of clang, clang++, ar, cp, install, strip.
 These wrappers work on normal object and the IR files at the same time.
 
+%{load:%{SOURCE1}}
+
 %install
+install -p -m0644 -D %{SOURCE1} %{buildroot}%{_rpmmacrodir}/macros.clang-wrap
 cargo install --path=. --root=%{buildroot}/%{_libdir}/clang-wrap
 ln -sf clang %{buildroot}/%{_libdir}/clang-wrap/bin/clang++
 
@@ -36,12 +40,12 @@ ln -sf clang %{buildroot}/%{_libdir}/clang-wrap/bin/clang++
 # there's no check
 
 %filetriggerin -p /bin/sh -- %{_bindir}
-mkdir -p %{_var}/lib/clang-wrap
+mkdir -p %{clang_wrap_varlibdir}
 while read file; do
     name=$(basename $file)
     case $name in
         clang-[0-9]* | clang++-[0-9]* | clang | clang++)
-           ln -sf %{_libdir}/clang-wrap/bin/clang %{_var}/lib/clang-wrap/$name
+           ln -sf %{_libdir}/clang-wrap/bin/clang %{clang_wrap_varlibdir}/$name
            ;;
     esac
 done
@@ -54,28 +58,29 @@ while read file; do
     name=$(basename $file)
     case $name in
         clang-[0-9]* | clang++-[0-9]* | clang | clang++)
-            rm -f %{_var}/lib/clang-wrap/$name
+            rm -f %{clang_wrap_varlibdir}/$name
             ;;
     esac
 done
 
 %post
-rm -rf %{_var}/lib/clang-wrap
-mkdir -p %{_var}/lib/clang-wrap
+rm -rf %{clang_wrap_varlibdir}
+mkdir -p %{clang_wrap_varlibdir}
 for file in `find %{_libdir}/clang-wrap/bin -type f,l | grep -v bin/clang`;do
-    ln -sf $file %{_var}/lib/clang-wrap
+    ln -sf $file %{clang_wrap_varlibdir}
 done
 for file in `ls %{_bindir}/clang* 2>/dev/null`;do
     name=$(basename $file)
     case $name in
         clang-[0-9]* | clang++-[0-9]* | clang | clang++)
-           ln -sf clang %{_var}/lib/clang-wrap/$name
+           ln -sf clang %{clang_wrap_varlibdir}/$name
            ;;
     esac
 done
 
 %files
 %{_libdir}/clang-wrap
+%{_rpmmacrodir}/macros.clang-wrap
 
 %changelog
 %autochangelog

--- a/SPECS/clang-wrap/macros.clang-wrap
+++ b/SPECS/clang-wrap/macros.clang-wrap
@@ -1,0 +1,3 @@
+%clang_wrap_llvmir_bin_dir %{_prefix}/lib/llvmir-bin
+%clang_wrap_llvmir_dir %{_libdir}/llvmir
+%clang_wrap_varlibdir %{_var}/lib/clang-wrap

--- a/SPECS/gsl/2000-Fix-undefined-behavior-in-gsl_pow_int.patch
+++ b/SPECS/gsl/2000-Fix-undefined-behavior-in-gsl_pow_int.patch
@@ -1,0 +1,29 @@
+From 26d5fad373881e6599ba9a9af0d3b24d078249dc Mon Sep 17 00:00:00 2001
+From: YunQiang Su <yunqiang@isrc.iscas.ac.cn>
+Date: Wed, 1 Jul 2026 12:55:15 +0800
+Subject: [PATCH] Fix undefined behavior in gsl_pow_int
+
+I find this problem when I build gsl with clang, and run unit tests:
+
+FAIL: gsl_pow_int(1.0000001,-2147483648) (1 observed vs
+5.44471031785229506e-94 expected) [100]
+---
+ sys/pow_int.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sys/pow_int.c b/sys/pow_int.c
+index 26c7fff7..0d25ce95 100644
+--- a/sys/pow_int.c
++++ b/sys/pow_int.c
+@@ -31,7 +31,7 @@ double gsl_pow_int(double x, int n)
+ 
+   if(n < 0) {
+     x = 1.0/x;
+-    un = -n;
++    un = -(unsigned int)n;
+   } else {
+     un = n;
+   }
+-- 
+2.47.3
+

--- a/SPECS/gsl/gsl.spec
+++ b/SPECS/gsl/gsl.spec
@@ -5,11 +5,26 @@
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
-%bcond bootstrap 0
+# XXX: This feature should be moved to a more appropriate location.
+%bcond llvmir 1
 
-%if %{with bootstrap}
-%global toolchain gcc
-%else
+%if %{with llvmir}
+  %define __install /var/lib/clang-wrap/install
+
+  %ifarch x86_64
+     %global emit_llvmir_flags -march=x86-64-v4
+  %elifarch riscv64
+     %global emit_llvmir_flags -march=rva23u64
+  %else
+     %global emit_llvmir_flags 1
+  %endif
+
+%global ___build_pre \
+        set -x \
+        export EMIT_LLVMIR=%{emit_llvmir_flags} \
+        export PATH=%{clang_wrap_varlibdir}:$PATH \
+        set +x \
+        %{?___build_pre}
 %global toolchain clang
 %endif
 
@@ -32,9 +47,10 @@ BuildOption(conf):  --disable-silent-rules
 BuildOption(conf):  --disable-static
 BuildOption(conf):  CFLAGS="%{optflags} -ffp-contract=off"
 
-%if %{without bootstrap}
+%if %{with llvmir}
 BuildRequires:  clang
 BuildRequires:  llvm
+BuildRequires:  clang-wrap
 %endif
 BuildRequires:  autoconf
 BuildRequires:  automake
@@ -70,6 +86,12 @@ rm -rf %{buildroot}%{_infodir}/dir
 %{_libdir}/libgslcblas.so.0*
 %{_mandir}/man1/gsl-histogram.1*
 %{_mandir}/man1/gsl-randist.1*
+%if %{with llvmir}
+%{clang_wrap_llvmir_bin_dir}/gsl-histogram{,_cmd}
+%{clang_wrap_llvmir_bin_dir}/gsl-randist{,_cmd}
+%{clang_wrap_llvmir_dir}/libgsl.so.*
+%{clang_wrap_llvmir_dir}/libgslcblas.so.*
+%endif
 
 %files devel
 %{_bindir}/gsl-config

--- a/SPECS/gsl/gsl.spec
+++ b/SPECS/gsl/gsl.spec
@@ -5,6 +5,14 @@
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
+%bcond bootstrap 0
+
+%if %{with bootstrap}
+%global toolchain gcc
+%else
+%global toolchain clang
+%endif
+
 Name:           gsl
 Version:        2.8
 Release:        %autorelease
@@ -12,15 +20,25 @@ Summary:        The GNU Scientific Library for numerical analysis
 License:        GPL-3.0-or-later
 URL:            https://www.gnu.org/software/gsl/
 VCS:            git:https://git.savannah.gnu.org/git/gsl.git
-#!RemoteAsset
+#!RemoteAsset:  sha256:6a99eeed15632c6354895b1dd542ed5a855c0f15d9ad1326c6fe2b2c9e423190
 Source0:        https://ftpmirror.gnu.org/gnu/gsl/gsl-%{version}.tar.gz
 BuildSystem:    autotools
+
+# https://lists.gnu.org/archive/html/bug-gsl/2026-05/msg00004.html
+# Undefined behavior in gsl_pow_int
+Patch2000:      2000-Fix-undefined-behavior-in-gsl_pow_int.patch
 
 BuildOption(conf):  --disable-silent-rules
 BuildOption(conf):  --disable-static
 BuildOption(conf):  CFLAGS="%{optflags} -ffp-contract=off"
 
-BuildRequires:  gcc
+%if %{without bootstrap}
+BuildRequires:  clang
+BuildRequires:  llvm
+%endif
+BuildRequires:  autoconf
+BuildRequires:  automake
+BuildRequires:  libtool
 BuildRequires:  pkgconfig
 BuildRequires:  make
 
@@ -36,6 +54,9 @@ Requires:       pkgconfig
 %description    devel
 The gsl-devel package contains the header files necessary for
 developing programs using the GSL (GNU Scientific Library).
+
+%conf -p
+autoreconf -fiv
 
 %install -a
 rm -rf %{buildroot}%{_infodir}/dir
@@ -62,4 +83,4 @@ rm -rf %{buildroot}%{_infodir}/dir
 %{_includedir}/gsl/
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
## Summary
replace #840, but no include clang-wrap for now.
<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy

<!-- Message of single commit: -->

SPECS: gsl: Build with clang