### PR TITLE
SPECS: snappy: Provide pkgconfig(snappy)

### DIFF
--- a/SPECS/snappy/2001-readd-pkgconfig-support.patch
+++ b/SPECS/snappy/2001-readd-pkgconfig-support.patch
@@ -1,0 +1,55 @@
+From f7f916d3abb6147b0fa62145b5d4e4e34684dceb Mon Sep 17 00:00:00 2001
+From: Sun Yuechi <sunyuechi@iscas.ac.cn>
+Date: Thu, 2 Jul 2026 20:12:08 -0700
+Subject: [PATCH] re-add pkg-config support
+
+Generate and install snappy.pc from a template under
+${CMAKE_INSTALL_LIBDIR}/pkgconfig with an absolute libdir.
+
+Based on Debian's patch:
+https://sources.debian.org/src/snappy/1.2.2-2/debian/patches/readd_pkgconfig_support.patch
+---
+ CMakeLists.txt     |  9 +++++++++
+ cmake/snappy.pc.in | 10 ++++++++++
+ 2 files changed, 19 insertions(+)
+ create mode 100644 cmake/snappy.pc.in
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cd71a47..d90a1ee 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -418,6 +418,15 @@ if(SNAPPY_INSTALL)
+     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+   )
+ 
++  configure_file(
++    "${PROJECT_SOURCE_DIR}/cmake/snappy.pc.in"
++    "${PROJECT_BINARY_DIR}/snappy.pc"
++    @ONLY
++  )
++  install(
++    FILES "${PROJECT_BINARY_DIR}/snappy.pc"
++    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
++  )
+   include(CMakePackageConfigHelpers)
+   configure_package_config_file(
+     "cmake/${PROJECT_NAME}Config.cmake.in"
+diff --git a/cmake/snappy.pc.in b/cmake/snappy.pc.in
+new file mode 100644
+index 0000000..3a03106
+--- /dev/null
++++ b/cmake/snappy.pc.in
+@@ -0,0 +1,10 @@
++prefix=@CMAKE_INSTALL_PREFIX@
++exec_prefix=${prefix}
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
++includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
++
++Name: @PROJECT_NAME@
++Description: A fast compressor/decompressor library
++Version: @PROJECT_VERSION@
++Libs: -L${libdir} -lsnappy
++Cflags: -I${includedir}
+-- 
+2.55.0
+

--- a/SPECS/snappy/snappy.spec
+++ b/SPECS/snappy/snappy.spec
@@ -18,6 +18,8 @@ BuildSystem:    cmake
 
 # https://sources.debian.org/patches/snappy/1.2.2-1/add_option_to_enable_rtti.patch/
 Patch2000:      2000-honor-SNAPPY_ENABLE_RTTI.patch
+# Re-add pkg-config support
+Patch2001:      2001-readd-pkgconfig-support.patch
 
 BuildOption(conf):  -DBUILD_SHARED_LIBS:BOOL=ON
 BuildOption(conf):  -DSNAPPY_ENABLE_RTTI:BOOL=ON
@@ -55,6 +57,7 @@ developing applications that use the Snappy library.
 %dir %{_libdir}/cmake
 %dir %{_libdir}/cmake/Snappy
 %{_libdir}/cmake/Snappy/*
+%{_libdir}/pkgconfig/snappy.pc
 
 %changelog
 %autochangelog


### PR DESCRIPTION
## Summary

The Ceph upstream template requires pkgconfig(snappy)

https://github.com/ceph/ceph/blob/5bc195949ab4a82c5de4ac1416f6270df90f9a31/ceph.spec.in#L315

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
