### PR TITLE
rpm-config-openruyi: Set _pkgverify_level for rpm6

### DIFF
--- a/SPECS/rpm-config-openruyi/macros
+++ b/SPECS/rpm-config-openruyi/macros
@@ -1,3 +1,8 @@
+
+# XXX: Under rpm6, signatures are required by default. In the future,
+# we should add signatures.
+%_pkgverify_level digest
+
 # directories
 %_infodir               %{_prefix}/share/info
 %_mandir                %{_prefix}/share/man


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy

<!-- Message of single commit: -->

rpm-config-openruyi: Set _pkgverify_level for rpm6

This circumvents the rpm6 signature issue. But we should support signatures.