### PR TITLE
fix pbuild preinstallerror

### DIFF
--- a/.github/build/pbuild.patch
+++ b/.github/build/pbuild.patch
@@ -1,0 +1,17 @@
+--- a/usr/lib/build/build-pkg-rpm
++++ b/usr/lib/build/build-pkg-rpm
+@@ -236,12 +236,12 @@
+         esac
+     fi
+     if test "$PAYLOADDECOMPRESS" = "cat" ; then
+-        rpm2cpio "$BUILD_INIT_CACHE/rpms/$PKG.rpm" | $CPIO || cleanup_and_exit 1
++        rpm2archive -n "$BUILD_INIT_CACHE/rpms/$PKG.rpm" | $TAR -x || cleanup_and_exit 1
+     else
+ 	test "$PAYLOADDECOMPRESS" = "lzma -d" && check_rpm_decompressor lzma
+ 	test "$PAYLOADDECOMPRESS" = "xz -d"   && check_rpm_decompressor xz
+ 	test "$PAYLOADDECOMPRESS" = "zstd -d" && check_rpm_decompressor zstd
+-        rpm2cpio "$BUILD_INIT_CACHE/rpms/$PKG.rpm" | $PAYLOADDECOMPRESS | $CPIO || cleanup_and_exit 1
++        rpm2archive "$BUILD_INIT_CACHE/rpms/$PKG.rpm" | $PAYLOADDECOMPRESS | $TAR -x || cleanup_and_exit 1
+     fi
+     test -L "$BUILD_INIT_CACHE/scripts" && cleanup_and_exit 1
+     rm -rf "$BUILD_INIT_CACHE/scripts/$PKG.pre" "$BUILD_INIT_CACHE/scripts/$PKG.preprog" "$BUILD_INIT_CACHE/scripts/$PKG.post" "$BUILD_INIT_CACHE/scripts/$PKG.postprog"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ permissions:
 
 on:
   pull_request:
-    branches: [main, ci-test]
+    branches: [main, ci-test, fix-pbuild]
     paths:
      - 'SPECS/**'
 
@@ -49,6 +49,9 @@ jobs:
         echo "deb http://download.opensuse.org/repositories/openSUSE:/Tools/xUbuntu_24.04/ /" | sudo tee /etc/apt/sources.list.d/obs.list
         wget -qO - http://download.opensuse.org/repositories/openSUSE:/Tools/xUbuntu_24.04/Release.key | sudo apt-key add -
         sudo apt update && sudo apt install osc obs-build libwww-perl libxml-parser-perl -y
+    - name: apply pbuild patch
+      run: |
+        sudo patch --directory=/ --strip=1 -i $(pwd)/.github/build/pbuild.patch
     - name: Limit the number of compilations
       if: steps.changed-files.outputs.specs_any_changed == 'true'
       run: |


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy

<!-- Message of single commit: -->

CI: Fix pbuild using with rpm6+ubuntu24

Only when rpm6 + ubuntu24, the following error will occur.

```
...
[    4s] files over 4GB not supported by cpio, use rpm2archive instead
[    4s] [110/126] preinstalling rpm-config-openruyi...
[    4s] [111/126] preinstalling systemd-pam...
[    4s] [112/126] preinstalling openruyi-authselect-profiles...
[    4s] [113/126] preinstalling rpm...
[    4s] [114/126] preinstalling systemd...
[    4s] [115/126] preinstalling dbus-common...
[    4s] [116/126] preinstalling pam...
[    4s] [117/126] preinstalling kbd...
[    4s] [118/126] preinstalling libpwquality...
[    4s] [119/126] preinstalling dbus...
[    4s] [120/126] preinstalling dbus-tools...
[    4s] [121/126] preinstalling systemd-udev...
[    4s] [122/126] preinstalling util-linux...
[    4s] [123/126] preinstalling device-mapper...
[    4s] [124/126] preinstalling rpm-build...
[    4s] [125/126] preinstalling device-mapper-libs...
[    4s] [126/126] preinstalling cryptsetup-libs...
[    4s] initializing rpm db...
[    4s] chroot: failed to run command '/usr/bin/rpmdb': No such file or directory
...
```