### PR TITLE
SPECS: openssl: Fix AES-XTS code comments(Backport)

### DIFF
--- a/SPECS/openssl/0009-Backport-riscv-AES-XTS-Code-Comment-Correction.patch
+++ b/SPECS/openssl/0009-Backport-riscv-AES-XTS-Code-Comment-Correction.patch
@@ -1,0 +1,44 @@
+From 3c2a99bef3204515031db7933398497fe6942c8d Mon Sep 17 00:00:00 2001
+From: Lu Zhou <zhou.lu1@zte.com.cn>
+Date: Wed, 8 Jul 2026 10:37:22 +0800
+Subject: [PATCH] Backport (riscv): AES-XTS Code Comment Correction
+
+Reference:https://github.com/openssl/openssl/commit/9d46f7f415349f3c445bca6b58fb10444bc79fd1
+Reviewed-by: Eugene Syromiatnikov <esyr@openssl.org>
+Reviewed-by: Paul Dale <paul.dale@oracle.com>
+MergeDate: Wed Mar  4 09:59:09 2026
+(Merged from https://github.com/openssl/openssl/pull/30194)
+
+The comments in the tail handling part of the AES-XTS decryption code were incorrect, which hindered understanding, and have now been fixed.
+
+Signed-off-by: Lu Zhou <zhou.lu1@zte.com.cn>
+Signed-off-by: Shangcheng Huang <huang.shangcheng@zte.com.cn>
+---
+ crypto/aes/asm/aes-riscv64-zvbb-zvkg-zvkned.pl | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/crypto/aes/asm/aes-riscv64-zvbb-zvkg-zvkned.pl b/crypto/aes/asm/aes-riscv64-zvbb-zvkg-zvkned.pl
+index 5fb2cc3..a78b4d2 100644
+--- a/crypto/aes/asm/aes-riscv64-zvbb-zvkg-zvkned.pl
++++ b/crypto/aes/asm/aes-riscv64-zvbb-zvkg-zvkned.pl
+@@ -633,7 +633,7 @@ aes_xts_dec_128:
+     @{[aes_128_dec]}
+     @{[vxor_vv $V24, $V24, $V28]}
+ 
+-    # store second to last block plaintext
++    # store last block plaintext
+     @{[vse32_v $V24, $OUTPUT]}
+ 
+     ret
+@@ -697,7 +697,7 @@ aes_xts_dec_256:
+     @{[aes_256_dec]}
+     @{[vxor_vv $V24, $V24, $V28]}
+ 
+-    # store second to last block plaintext
++    # store last block plaintext
+     @{[vse32_v $V24, $OUTPUT]}
+ 
+     ret
+-- 
+2.27.0
+

--- a/SPECS/openssl/openssl.spec
+++ b/SPECS/openssl/openssl.spec
@@ -56,6 +56,8 @@ Requires:       %{name}%{?_isa} = %{version}-%{release}
 0007-RISC-V-GHASH-Zvkg-multi-block-aggregation.patch
 # https://github.com/openssl/openssl/pull/28673
 0008-Backport-Instruction-rearrangement-optimization-for-SHA256-on-RISCV.patch
+# https://github.com/openssl/openssl/pull/30194
+0009-Backport-riscv-AES-XTS-Code-Comment-Correction.patch
 
 %description    devel
 This package contains the header files, pkgconfig/cmake files, development


### PR DESCRIPTION
SPECS: openssl: Fix AES-XTS code comments(Backport)

## Summary 

This PR backports an upstream fix for OpenSSL on the RISC-V architecture.
It corrects the comments in the tail handling part of the AES-XTS decryption code (specifically in `aes-riscv64-zvbb-zvkg-zvkned.pl`). The previous comments were incorrect and hindered understanding, and have now been properly updated.

**Upstream Reference:**
- Commit: https://github.com/openssl/openssl/commit/9d46f7f415349f3c445bca6b58fb10444bc79fd1
- PR: https://github.com/openssl/openssl/pull/30194
 
## Related Issue 
 
<!-- 
Link related issues if applicable. 
Example: Resolves #123 
--> 
 
- Resolves # 
 
## Checklist 
 
- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it. 
 
<!-- 
If this PR includes non-trivial AI-assisted content, check the box below and add attribution 
using the `AGENT_NAME:MODEL_VERSION` format. 
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking 
--> 
 
- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content. 
 
Assisted-by: Trae:Gemini-3.1-Pro-Preview
 
[openRuyi Code of Conduct]:  
https://openruyi.cn/governance/legal/code-of-conduct  
  
[AI-Assisted Contribution Policy]: 
https://openruyi.cn/governance/policy/ai-contribution-policy