### PR TITLE
SPECS: libsoup: Upgrade to 3.7.1.

### DIFF
--- a/SPECS/libsoup/libsoup.spec
+++ b/SPECS/libsoup/libsoup.spec
@@ -6,14 +6,14 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 Name:           libsoup
-Version:        3.6.5
+Version:        3.7.1
 Release:        %autorelease
 Summary:        An HTTP library implementation in C
 License:        LGPL-2.0-or-later AND LGPL-2.1-or-later
 URL:            https://wiki.gnome.org/Projects/libsoup
 VCS:            git:https://gitlab.gnome.org/GNOME/libsoup
-#!RemoteAsset
-Source:         https://download.gnome.org/sources/libsoup/3.6/libsoup-%{version}.tar.xz
+#!RemoteAsset:  sha256:9c96e11bb91641fe21948013499ca716393c9e9336562f9ff849c41d4edab80e
+Source:         https://download.gnome.org/sources/libsoup/3.7/libsoup-%{version}.tar.xz
 BuildSystem:    meson
 
 BuildOption(conf):  -Ddocs=enabled
@@ -36,6 +36,7 @@ BuildRequires:  pkgconfig(libbrotlidec)
 BuildRequires:  pkgconfig(libnghttp2)
 BuildRequires:  pkgconfig(libpsl)
 BuildRequires:  pkgconfig(sqlite3)
+BuildRequires:  pkgconfig(libzstd)
 
 Recommends:     glib-networking >= 2.70.0
 
@@ -81,4 +82,4 @@ rm -rf %{buildroot}%{_datadir}/locale/*@*
 %{_docdir}/libsoup-3.0/
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
## Summary
This can also fix the current tests failure:
```
[  652s] stderr:
[  652s] **
[  652s] ERROR:../tests/tld-test.c:149:do_inet_tests: assertion failed (base_domain == tld_tests[i].result): ("c.bd" == NULL)
[  652s] **
[  652s] ERROR:../tests/tld-test.c:149:do_inet_tests: assertion failed (base_domain == tld_tests[i].result): ("c.bd" == "b.c.bd")
[  652s] **
[  652s] ERROR:../tests/tld-test.c:149:do_inet_tests: assertion failed (base_domain == tld_tests[i].result): ("c.bd" == "b.c.bd")
[  652s] 
[  652s] (test program exited with status code 1)
```

From the upstream [news](https://gitlab.gnome.org/GNOME/libsoup/-/blob/master/NEWS?ref_type=heads), it seems no obvious API breakage.
<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
