### PR TITLE
set %_rpmformat to 4 on CI

### DIFF
--- a/.github/build/_config
+++ b/.github/build/_config
@@ -39,6 +39,7 @@ Prefer: libquadmath
 Prefer: libgfortran
 
 Macros:
+%_rpmformat 4
 %dist .or
 %_vendor openruyi
 %ext_info .gz


### PR DESCRIPTION
## Summary
should fix https://github.com/openRuyi-Project/openRuyi/pull/884 CI
<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy

<!-- Message of single commit: -->

.github: build: Set _rpmformat to 4

Signed-off-by: Zheng Junjie <zhengjunjie@iscas.ac.cn>