### PR TITLE
SPECS: qt6-qttools: Adapt to llvm22.

### DIFF
--- a/SPECS/qt6-qttools/2000-adapt-to-llvm22.patch
+++ b/SPECS/qt6-qttools/2000-adapt-to-llvm22.patch
@@ -1,0 +1,42 @@
+diff --git a/src/qdoc/cmake/QDocConfiguration.cmake b/src/qdoc/cmake/QDocConfiguration.cmake
+index 72d27db9e..8a3cba463 100644
+--- a/src/qdoc/cmake/QDocConfiguration.cmake
++++ b/src/qdoc/cmake/QDocConfiguration.cmake
+@@ -5,6 +5,6 @@ set(QDOC_MINIMUM_CLANG_VERSION "17")
+
+ # List of explicitly supported Clang versions for QDoc
+ set(QDOC_SUPPORTED_CLANG_VERSIONS
+-    "21.1" "20.1" "19.1" "18.1" "17.0.6"
++    "22.1" "22.0" "21.1" "20.1" "19.1" "18.1" "17.0.6"
+ )
+
+diff --git a/src/qdoc/qdoc/CMakeLists.txt b/src/qdoc/qdoc/CMakeLists.txt
+index 90f1d7c23..84ebc3a28 100644
+--- a/src/qdoc/qdoc/CMakeLists.txt
++++ b/src/qdoc/qdoc/CMakeLists.txt
+@@ -97,6 +97,7 @@ qt_internal_add_tool(${target_name}
+     DEFINES
+         # To provide the ability to workaround version-specific Clang issues.
+         # A re-export of (LLVM|CLANG)_VERSION_MAJOR done in WrapLibClang.cmake
++        QT_NO_EMIT
+         LIBCLANG_VERSION_MAJOR=${QT_LIB_CLANG_VERSION_MAJOR}
+ )
+ qt_internal_return_unless_building_tools()
+diff --git a/src/qdoc/qdoc/src/qdoc/clangcodeparser.cpp b/src/qdoc/qdoc/src/qdoc/clangcodeparser.cpp
+index 66a750a3d..3f54ddff5 100644
+--- a/src/qdoc/qdoc/src/qdoc/clangcodeparser.cpp
++++ b/src/qdoc/qdoc/src/qdoc/clangcodeparser.cpp
+@@ -43,7 +43,12 @@
+ #include <clang/Lex/Lexer.h>
+ #include <llvm/Support/Casting.h>
+
+-#include "clang/AST/QualTypeNames.h"
++#if LIBCLANG_VERSION_MAJOR >= 22
++// LLVM 22 provides a compatible QualTypeNames implementation in libclang.
++#  include <clang/AST/QualTypeNames.h>
++#else
++#  include "clang/AST/QualTypeNames.h"
++#endif
+ #include "template_declaration.h"
+
+ #include <cstdio>

--- a/SPECS/qt6-qttools/qt6-qttools.spec
+++ b/SPECS/qt6-qttools/qt6-qttools.spec
@@ -28,6 +28,9 @@ BuildSystem:    cmake
 # some install dir is error.
 Patch0:         0001-fix-install-dir.patch
 
+# https://gitlab.archlinux.org/archlinux/packaging/packages/qt6-tools/-/blob/19e83dd083700044acfec5aa06d19c726ef0ab8d/llvm22.patch
+Patch2000:      2000-adapt-to-llvm22.patch
+
 BuildOption(conf):  -DQT_BUILD_EXAMPLES:BOOL=ON
 BuildOption(conf):  -DQT_INSTALL_EXAMPLES_SOURCES:BOOL=ON
 


### PR DESCRIPTION
## Summary
The patch is from ArchLinux. When the package is upgraded to 6.12 and above then can drop the patch.

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
