### PR TITLE
SPECS: labwc: Force the initial modeset commit to actually happen.

### DIFF
--- a/SPECS/labwc/0001-output-force-initial-modeset-commit-on-new-output.patch
+++ b/SPECS/labwc/0001-output-force-initial-modeset-commit-on-new-output.patch
@@ -1,0 +1,35 @@
+diff --git a/src/output.c b/src/output.c
+index 2eab8ec3d1..6b88e3c83d 100644
+--- a/src/output.c
++++ b/src/output.c
+@@ -529,6 +529,30 @@ configure_new_output(struct output *output)
+ 	add_output_to_layout(output);
+ 	server.pending_output_layout_change--;
+ 
++	/*
++	 * Force the initial modeset commit to actually happen.
++	 *
++	 * lab_wlr_scene_output_commit() skips the real commit whenever the
++	 * scene reports neither damage nor needs_frame. But on this very
++	 * first commit the output has not been modeset yet, so its resolution
++	 * is still 0x0: scene damage is clipped against that empty area and
++	 * can never accumulate, and needs_frame is never raised on its own.
++	 * As a result the enabled=true state set above would never be
++	 * committed and the output would stay black until some unrelated
++	 * event (VT switch, hotplug, display-manager restart) happens to
++	 * raise needs_frame.
++	 *
++	 * With hardware cursors this is masked, because uploading the cursor
++	 * image raises needs_frame as a side effect. With
++	 * WLR_NO_HARDWARE_CURSORS=1 (software cursors) that path is gone and
++	 * the missing initial commit becomes reliably reproducible, e.g.
++	 * under QEMU/virtio-gpu.
++	 *
++	 * Schedule a frame here so needs_frame is raised and this enable is
++	 * always committed, independent of the cursor mode.
++	 */
++	wlr_output_schedule_frame(wlr_output);
++
+ 	/*
+ 	 * Commit the output this way instead, HDR needs a buffer, and
+ 	 * this commit must be called after the output is added to the

--- a/SPECS/labwc/labwc.spec
+++ b/SPECS/labwc/labwc.spec
@@ -15,6 +15,10 @@ URL:            https://github.com/labwc/labwc
 Source0:        https://github.com/labwc/labwc/archive/refs/tags/%{version}.tar.gz
 BuildSystem:    meson
 
+# Backport of upstream PR labwc/labwc#3656
+# It can be removed in the next release, as it has been accepted upstream.
+Patch0:         0001-output-force-initial-modeset-commit-on-new-output.patch
+
 BuildOption(conf):  -Dxwayland=disabled
 
 BuildRequires:  meson >= 0.59.0


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

This is a backport patch that has already been accepted upstream but will not be included in a package until the next release; therefore, it is being added temporarily.

Description of the patch:

In a QEMU/virtio-gpu environment, the existing logic causes the "needs_frame" flag to fail to trigger when using WLR_NO_HARDWARE_CURSORS=1 (software cursors), resulting in a continuously black screen.

With hardware cursors, this is masked because uploading the cursor image raises needs_frame as a side effect.

This commit ensures that the enable operation is successfully committed regardless of the cursor mode.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #867

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
