### PR TITLE
SPECS: clevis: upgrade to v23 and fix tests

### DIFF
--- a/SPECS/clevis/clevis.spec
+++ b/SPECS/clevis/clevis.spec
@@ -1,22 +1,27 @@
 # SPDX-FileCopyrightText: (C) 2025 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2025 openRuyi Project Contributors
+# SPDX-FileContributor: Jingkun Zheng <zhengjingkun@iscas.ac.cn>
 # SPDX-FileContributor: yyjeqhc <jialin.oerv@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
 Name:           clevis
-Version:        21
+Version:        23
 Release:        %autorelease
 Summary:        Automated decryption framework
 License:        GPL-3.0-or-later
 URL:            https://github.com/latchset/clevis
-#!RemoteAsset
+#!RemoteAsset:  sha256:a8a09f148d54d91aa0d21c5fa508dd1446c2a200be7679fbf6e7d19196aec164
 Source0:        https://github.com/latchset/clevis/archive/refs/tags/v%{version}.tar.gz
 Source1:        clevis.sysusers
 BuildSystem:    meson
 
 BuildOption(conf):  -Duser=clevis
 BuildOption(conf):  -Dgroup=clevis
+BuildOption(conf):  -Dtpm1=disabled
+%ifarch riscv64
+BuildOption(check):  --timeout-multiplier 2
+%endif
 
 BuildRequires:  meson
 BuildRequires:  gcc
@@ -33,6 +38,7 @@ BuildRequires:  pkgconfig(openssl)
 BuildRequires:  pkgconfig(libcryptsetup)
 BuildRequires:  pkgconfig(luksmeta)
 BuildRequires:  cryptsetup
+BuildRequires:  curl
 
 Requires:       coreutils
 Requires:       jose >= 8
@@ -66,22 +72,21 @@ install -p -D -m 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/clevis.conf
 %{_bindir}/clevis*
 %{_sysusersdir}/clevis.conf
 %{_libexecdir}/clevis-luks-askpass
-%{_libexecdir}/clevis-luks-unlocker
 %{_unitdir}/clevis-luks-askpass.path
 %{_unitdir}/clevis-luks-askpass.service
-%dir %{_prefix}/lib/dracut/modules.d/60clevis*
-%{_prefix}/lib/dracut/modules.d/60clevis/clevis-hook.sh
+%dir %{_prefix}/lib/dracut/modules.d/50clevis*
+%{_prefix}/lib/dracut/modules.d/50clevis/*
 %{_sysconfdir}/xdg/autostart/clevis-luks-udisks2.desktop
 %attr(4755, root, root) %{_libexecdir}/%{name}-luks-udisks2
 %{_libexecdir}/clevis-luks-pkcs11-*
 %{_unitdir}/clevis-luks-pkcs11-askpass.service
 %{_unitdir}/clevis-luks-pkcs11-askpass.socket
-%{_prefix}/lib/dracut/modules.d/60clevis-pin-pkcs11/*
-%{_prefix}/lib/dracut/modules.d/60clevis-pin-null/module-setup.sh
-%{_prefix}/lib/dracut/modules.d/60clevis-pin-sss/module-setup.sh
-%{_prefix}/lib/dracut/modules.d/60clevis-pin-tang/module-setup.sh
-%{_prefix}/lib/dracut/modules.d/60clevis-pin-tpm2/module-setup.sh
-%{_prefix}/lib/dracut/modules.d/60clevis/module-setup.sh
+%{_prefix}/lib/dracut/modules.d/50clevis-pin-pkcs11/*
+%{_prefix}/lib/dracut/modules.d/50clevis-pin-null/module-setup.sh
+%{_prefix}/lib/dracut/modules.d/50clevis-pin-sss/module-setup.sh
+%{_prefix}/lib/dracut/modules.d/50clevis-pin-tang/module-setup.sh
+%{_prefix}/lib/dracut/modules.d/50clevis-pin-tpm2/module-setup.sh
+%{_prefix}/lib/dracut/modules.d/50clevis-pin-file/module-setup.sh
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

Upgrade `clevis` to v23 and fix build tests.

The tests requires `curl` which was missing from the SPEC file.

TPM 1.2 support `-Dtpm1` is currently set to `disabled`, otherwise the build will hit `ERROR: Program 'tpm_sealdata' not found or not executable` and then fails (openRuyi currently does not have the `tpm-tools` package).

During building I see the `pin-sss` test will timeout on some RVA20 hardware (takes roughly 36s while the timeout limit is 30s), so I doubled that.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- N/A

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
