### PR TITLE
SPECS: openssl: add RISC-V crypto backport patchset (AES/SM4/SM2)

### DIFF
--- a/SPECS/openssl/0009-Backport-riscv-AES-XTS-Code-Comment-Correction.patch
+++ b/SPECS/openssl/0009-Backport-riscv-AES-XTS-Code-Comment-Correction.patch
@@ -1,0 +1,44 @@
+From 3c2a99bef3204515031db7933398497fe6942c8d Mon Sep 17 00:00:00 2001
+From: Lu Zhou <zhou.lu1@zte.com.cn>
+Date: Wed, 8 Jul 2026 10:37:22 +0800
+Subject: [PATCH] Backport (riscv): AES-XTS Code Comment Correction
+
+Reference:https://github.com/openssl/openssl/commit/9d46f7f415349f3c445bca6b58fb10444bc79fd1
+Reviewed-by: Eugene Syromiatnikov <esyr@openssl.org>
+Reviewed-by: Paul Dale <paul.dale@oracle.com>
+MergeDate: Wed Mar  4 09:59:09 2026
+(Merged from https://github.com/openssl/openssl/pull/30194)
+
+The comments in the tail handling part of the AES-XTS decryption code were incorrect, which hindered understanding, and have now been fixed.
+
+Signed-off-by: Lu Zhou <zhou.lu1@zte.com.cn>
+Signed-off-by: Shangcheng Huang <huang.shangcheng@zte.com.cn>
+---
+ crypto/aes/asm/aes-riscv64-zvbb-zvkg-zvkned.pl | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/crypto/aes/asm/aes-riscv64-zvbb-zvkg-zvkned.pl b/crypto/aes/asm/aes-riscv64-zvbb-zvkg-zvkned.pl
+index 5fb2cc3..a78b4d2 100644
+--- a/crypto/aes/asm/aes-riscv64-zvbb-zvkg-zvkned.pl
++++ b/crypto/aes/asm/aes-riscv64-zvbb-zvkg-zvkned.pl
+@@ -633,7 +633,7 @@ aes_xts_dec_128:
+     @{[aes_128_dec]}
+     @{[vxor_vv $V24, $V24, $V28]}
+ 
+-    # store second to last block plaintext
++    # store last block plaintext
+     @{[vse32_v $V24, $OUTPUT]}
+ 
+     ret
+@@ -697,7 +697,7 @@ aes_xts_dec_256:
+     @{[aes_256_dec]}
+     @{[vxor_vv $V24, $V24, $V28]}
+ 
+-    # store second to last block plaintext
++    # store last block plaintext
+     @{[vse32_v $V24, $OUTPUT]}
+ 
+     ret
+-- 
+2.27.0
+

--- a/SPECS/openssl/0010-Backport-riscv-Performance-Optimization-of-SM4-CBC-on-RISC-V-Architecture.patch
+++ b/SPECS/openssl/0010-Backport-riscv-Performance-Optimization-of-SM4-CBC-on-RISC-V-Architecture.patch
@@ -1,0 +1,883 @@
+From d4b84b7fb2705f8661e2bc34c71f529ce9b75458 Mon Sep 17 00:00:00 2001
+From: Lu Zhou <zhou.lu1@zte.com.cn>
+Date: Wed, 8 Jul 2026 10:07:48 +0800
+Subject: [PATCH] Backport (riscv):Performance Optimization of SM4-CBC Encryption and Decryption with Assembly on RISC-V Architecture
+
+Reference:https://github.com/openssl/openssl/commit/c90b7dddf25f44c3ed27a69ae6bc67cfdb4894cd
+Performance Optimization of SM4-CBC Encryption and Decryption with Assembly on RISC-V Architecture
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+Reviewed-by: Paul Dale <paul.dale@oracle.com>
+(Merged from https://github.com/openssl/openssl/pull/29137)
+Added assembly implementation for SM4-CBC encryption and decryption. The code adopts a block processing approach, dynamically selecting different blocks for batch processing based on data length. The encryption function supports 4-block and single-block modes, while the decryption function supports 8-block, 4-block, and single-block modes. After optimization, the performance of both encryption and decryption has been enhanced.
+
+Reference:https://github.com/openssl/openssl/commit/7b3810847ed5427c5a1b8223bb5ed688fdf75eeb
+sm4-riscv64-zvksed.pl: Code comment corrections
+Reviewed-by: Eugene Syromiatnikov <esyr@openssl.org>
+Reviewed-by: Paul Dale <paul.dale@oracle.com>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/29134)
+
+Reference:https://github.com/openssl/openssl/commit/2d75c5e383194ec2d0e2306232bdb38c3b343c50
+SM4-CBC performance improvement on RISC-V
+Modify the IV update method to further improve the performance of SM4-CBC encryption on the RISC-V architecture.
+Reviewed-by: Paul Dale <paul.dale@oracle.com>
+Reviewed-by: Neil Horman <nhorman@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/29451)
+The original method of updating the IV involved loading ciphertext from memory, which impacted encryption performance. It has now been modified to implement IV updates using indexing and the vrgather.vv instruction, resulting in some improvement in encryption performance.
+
+Reference:https://github.com/openssl/openssl/commit/f1482a709d5e7c407948f50b155c8c9b086e6566
+Instruction reordering to further improve SM4-CBC decryption performance on the RISC-V architecture
+Reviewed-by: Neil Horman <nhorman@openssl.org>
+Reviewed-by: Paul Dale <paul.dale@oracle.com>
+(Merged from https://github.com/openssl/openssl/pull/29544)
+Instructions with RAW (Read After Write) data dependencies were separated to avoid pipeline stalls caused by immediate storage of unready data. The original approach of interleaved storage of plaintext after decryption was adjusted to store multiple blocks of plaintext uniformly after all block XOR operations are completed.
+
+Performance Improvement
+
+Encrypt Test	Baseline	Optimized	Improvement ratio
+64 bytes	21202.40k	29065.79k	41%
+256 bytes	24267.41k	35295.70k	46%
+1024 bytes	25058.35k	37176.58k	47%
+8192 bytes	25338.51k	37956.19k	50%
+16384 bytes	25471.66k	38098.26k	49%
+Decrypt Test	Baseline	Optimized	Improvement ratio
+64 bytes	20265.13k	24045.42k	9%
+256 bytes	22869.98k	30145.99k	24%
+1024 bytes	23741.09k	32372.05k	30%
+8192 bytes	24144.55k	32686.89k	31%
+16384 bytes	23840.61k	33030.14k	33%
+
+Signed-off-by: Lu Zhou <zhou.lu1@zte.com.cn>
+Signed-off-by: Shangcheng Huang <huang.shangcheng@zte.com.cn>
+---
+ crypto/perlasm/riscv.pm                       |   9 +
+ crypto/sm4/asm/sm4-riscv64-zvksed.pl          | 659 ++++++++++++++++--
+ include/crypto/sm4_platform.h                 |   6 +
+ .../ciphers/cipher_sm4_hw_rv64i.inc           |   8 +
+ test/recipes/30-test_evp_data/evpciph_sm4.txt |   6 +
+ 5 files changed, 612 insertions(+), 76 deletions(-)
+
+diff --git a/crypto/perlasm/riscv.pm b/crypto/perlasm/riscv.pm
+index bac41fb..3abc327 100644
+--- a/crypto/perlasm/riscv.pm
++++ b/crypto/perlasm/riscv.pm
+@@ -457,6 +457,15 @@ sub minu {
+ }
+ 
+ # Vector instructions
++sub vrgather_vv {
++    # vrgather.vv vd, vs2, vs1, vm
++    my $template = 0b001100_0_00000_00000_000_00000_1010111;
++    my $vd = read_vreg shift;
++    my $vs2 = read_vreg shift;
++    my $vs1 = read_vreg shift;
++    my $vm = read_mask_vreg shift;
++    return ".word ".($template | ($vm << 25) | ($vs2 << 20) | ($vs1 << 15) | ($vd << 7));
++}
+ 
+ sub vadd_vv {
+     # vadd.vv vd, vs2, vs1, vm
+diff --git a/crypto/sm4/asm/sm4-riscv64-zvksed.pl b/crypto/sm4/asm/sm4-riscv64-zvksed.pl
+index 0734e5f..7fa3ff5 100644
+--- a/crypto/sm4/asm/sm4-riscv64-zvksed.pl
++++ b/crypto/sm4/asm/sm4-riscv64-zvksed.pl
+@@ -2,7 +2,7 @@
+ # This file is dual-licensed, meaning that you can use it under your
+ # choice of either of the following two licenses:
+ #
+-# Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
++# Copyright 2023-2026 The OpenSSL Project Authors. All Rights Reserved.
+ #
+ # Licensed under the Apache License 2.0 (the "License"). You can obtain
+ # a copy in the file LICENSE in the source distribution or at
+@@ -59,6 +59,559 @@ my $code=<<___;
+ .text
+ ___
+ 
++my $BLOCK_SIZE = 16;
++my $STRIDE = -4;  # Used for reversing word order
++my $FOUR_BLOCKS = 64;
++my $EIGHT_BLOCKS = 128;
++my ($vk0,$vk1,$vk2,$vk3,$vk4,$vk5,$vk6,$vk7)=("v16","v17","v18","v19","v20","v21","v22","v23");
++my ($tmp_stride,$tmp_base)=("t1","t2");
++# Loading with word order reversed
++sub reverse_order_L {
++    my $vreg = shift;
++    my $base_reg = shift;
++
++    return <<___;
++        addi $tmp_base, $base_reg, 12
++        @{[vlse32_v $vreg, $tmp_base, $tmp_stride]}
++___
++}
++
++# Storing with word order reversed
++sub reverse_order_S {
++    my $vreg = shift;
++    my $base_reg = shift;
++
++    return <<___;
++        addi $tmp_base, $base_reg, 12
++        @{[vsse32_v $vreg, $tmp_base, $tmp_stride]}
++___
++}
++
++# Load 32 round keys
++sub enc_load_key {
++    my $keys = shift;
++
++    my $code=<<___;
++    # Order of elements was adjusted in set_encrypt_key()
++    @{[vle32_v $vk0, $keys]} # rk[0:3]
++    addi $keys, $keys, $BLOCK_SIZE
++    @{[vle32_v $vk1, $keys]} # rk[4:7]
++    addi $keys, $keys, $BLOCK_SIZE
++    @{[vle32_v $vk2, $keys]} # rk[8:11]
++    addi $keys, $keys, $BLOCK_SIZE
++    @{[vle32_v $vk3, $keys]} # rk[12:15]
++    addi $keys, $keys, $BLOCK_SIZE
++    @{[vle32_v $vk4, $keys]} # rk[16:19]
++    addi $keys, $keys, $BLOCK_SIZE
++    @{[vle32_v $vk5, $keys]} # rk[20:23]
++    addi $keys, $keys, $BLOCK_SIZE
++    @{[vle32_v $vk6, $keys]} # rk[24:27]
++    addi $keys, $keys, $BLOCK_SIZE
++    @{[vle32_v $vk7, $keys]} # rk[28:31]
++___
++
++    return $code;
++}
++
++sub dec_load_key {
++    my $keys = shift;
++
++    my $code=<<___;
++    # Order of elements was adjusted in set_decrypt_key()
++    @{[vle32_v $vk7, $keys]} # rk[31:28]
++    addi $keys, $keys, $BLOCK_SIZE
++    @{[vle32_v $vk6, $keys]} # rk[27:24]
++    addi $keys, $keys, $BLOCK_SIZE
++    @{[vle32_v $vk5, $keys]} # rk[23:20]
++    addi $keys, $keys, $BLOCK_SIZE
++    @{[vle32_v $vk4, $keys]} # rk[19:16]
++    addi $keys, $keys, $BLOCK_SIZE
++    @{[vle32_v $vk3, $keys]} # rk[15:12]
++    addi $keys, $keys, $BLOCK_SIZE
++    @{[vle32_v $vk2, $keys]} # rk[11:8]
++    addi $keys, $keys, $BLOCK_SIZE
++    @{[vle32_v $vk1, $keys]} # rk[7:4]
++    addi $keys, $keys, $BLOCK_SIZE
++    @{[vle32_v $vk0, $keys]} # rk[3:0]
++___
++
++    return $code;
++}
++
++# Encrypt with all keys
++sub enc_blk {
++    my $data = shift;
++
++    my $code=<<___;
++    @{[vsm4r_vs $data, $vk0]}
++    @{[vsm4r_vs $data, $vk1]}
++    @{[vsm4r_vs $data, $vk2]}
++    @{[vsm4r_vs $data, $vk3]}
++    @{[vsm4r_vs $data, $vk4]}
++    @{[vsm4r_vs $data, $vk5]}
++    @{[vsm4r_vs $data, $vk6]}
++    @{[vsm4r_vs $data, $vk7]}
++___
++
++    return $code;
++}
++
++# Decrypt with all keys
++sub dec_blk {
++    my $data = shift;
++
++    my $code=<<___;
++    @{[vsm4r_vs $data, $vk7]}
++    @{[vsm4r_vs $data, $vk6]}
++    @{[vsm4r_vs $data, $vk5]}
++    @{[vsm4r_vs $data, $vk4]}
++    @{[vsm4r_vs $data, $vk3]}
++    @{[vsm4r_vs $data, $vk2]}
++    @{[vsm4r_vs $data, $vk1]}
++    @{[vsm4r_vs $data, $vk0]}
++___
++
++    return $code;
++}
++
++# Decrypt 4 blocks with all keys
++sub dec_4blks {
++    my $data0 = shift;
++    my $data1 = shift;
++    my $data2 = shift;
++    my $data3 = shift;
++
++    my $code=<<___;
++    @{[vsm4r_vs $data0, $vk7]}
++    @{[vsm4r_vs $data1, $vk7]}
++    @{[vsm4r_vs $data2, $vk7]}
++    @{[vsm4r_vs $data3, $vk7]}
++
++    @{[vsm4r_vs $data0, $vk6]}
++    @{[vsm4r_vs $data1, $vk6]}
++    @{[vsm4r_vs $data2, $vk6]}
++    @{[vsm4r_vs $data3, $vk6]}
++
++    @{[vsm4r_vs $data0, $vk5]}
++    @{[vsm4r_vs $data1, $vk5]}
++    @{[vsm4r_vs $data2, $vk5]}
++    @{[vsm4r_vs $data3, $vk5]}
++
++    @{[vsm4r_vs $data0, $vk4]}
++    @{[vsm4r_vs $data1, $vk4]}
++    @{[vsm4r_vs $data2, $vk4]}
++    @{[vsm4r_vs $data3, $vk4]}
++
++    @{[vsm4r_vs $data0, $vk3]}
++    @{[vsm4r_vs $data1, $vk3]}
++    @{[vsm4r_vs $data2, $vk3]}
++    @{[vsm4r_vs $data3, $vk3]}
++
++    @{[vsm4r_vs $data0, $vk2]}
++    @{[vsm4r_vs $data1, $vk2]}
++    @{[vsm4r_vs $data2, $vk2]}
++    @{[vsm4r_vs $data3, $vk2]}
++
++    @{[vsm4r_vs $data0, $vk1]}
++    @{[vsm4r_vs $data1, $vk1]}
++    @{[vsm4r_vs $data2, $vk1]}
++    @{[vsm4r_vs $data3, $vk1]}
++
++    @{[vsm4r_vs $data0, $vk0]}
++    @{[vsm4r_vs $data1, $vk0]}
++    @{[vsm4r_vs $data2, $vk0]}
++    @{[vsm4r_vs $data3, $vk0]}
++___
++
++    return $code;
++}
++
++####
++# void rv64i_zvksed_sm4_cbc_encrypt(const unsigned char *in, unsigned char *out,
++#                                   size_t len, const SM4_KEY *key,
++#                                   unsigned char *iv, int enc);
++#
++{
++my ($in,$out,$len,$keys,$ivp)=("a0","a1","a2","a3","a4");
++my ($tmp,$base)=("t0","t2");
++my ($vdata0,$vdata1,$vdata2,$vdata3,$vdata4,$vdata5,$vdata6,$vdata7)=("v1","v2","v3","v4","v5","v6","v7","v24");
++my ($vivec)=("v8");
++my ($vindex)=("v0");
++
++$code .= <<___;
++.section .rodata
++.align 4
++.Lreverse_index:
++    .word 3, 2, 1, 0
++.text
++.p2align 3
++.globl rv64i_zvksed_sm4_cbc_encrypt
++.type rv64i_zvksed_sm4_cbc_encrypt,\@function
++rv64i_zvksed_sm4_cbc_encrypt:
++    # check whether the length is a multiple of 16 and >= 16
++    li $tmp, $BLOCK_SIZE
++    bltu $len, $tmp, .Lcbc_enc_end
++    andi $tmp, $len, 15
++    bnez $tmp, .Lcbc_enc_end
++
++    @{[vsetivli "zero", 4, "e32", "m1", "ta", "ma"]}
++    # Load 32 round keys
++    @{[enc_load_key $keys]}
++
++    # Load IV
++    @{[vle32_v $vivec, $ivp]}
++
++    # Load the reverse index (for IV updates)
++    la $tmp, .Lreverse_index
++    @{[vle32_v $vindex, $tmp]}
++# =====================================================
++# If data length ≥ 64 bytes, process 4 blocks in batch:
++# 4-block CBC encryption pipeline:
++#   1. Load 4 plaintext blocks
++#   2. Reverse bytes for SM4 endianness
++#   3. Perform XOR operation with IV or previous ciphertext block (CBC chain)
++#   4. Encrypt each data block using the enc_blk function
++#   5. Adjust the byte order and store the ciphertext block
++#   6. Update the initialization vector (IV)
++# If data length < 64 bytes, process it block by block using the Lcbc_enc_single function
++# =====================================================
++.Lcbc_enc_loop:
++    li $tmp, $FOUR_BLOCKS
++    bltu $len, $tmp, .Lcbc_enc_single
++    # Load input data0-data3
++    @{[vle32_v $vdata0, $in]}
++    addi $in, $in, $BLOCK_SIZE
++    @{[vle32_v $vdata1, $in]}
++    addi $in, $in, $BLOCK_SIZE
++    @{[vle32_v $vdata2, $in]}
++    addi $in, $in, $BLOCK_SIZE
++    @{[vle32_v $vdata3, $in]}
++    addi $in, $in, $BLOCK_SIZE
++    #XOR with IV
++    @{[vxor_vv $vdata0, $vdata0, $vivec]}
++
++    @{[vrev8_v $vdata0, $vdata0]}
++    # Encrypt with all keys
++    @{[enc_blk $vdata0]}
++    @{[vrev8_v $vdata0, $vdata0]}
++
++    #Update IV to ciphertext block 0
++    @{[vrgather_vv $vivec, $vdata0, $vindex]}
++
++    @{[vxor_vv $vdata1, $vdata1, $vivec]}
++
++    @{[vrev8_v $vdata1, $vdata1]}
++    @{[enc_blk $vdata1]}
++    @{[vrev8_v $vdata1, $vdata1]}
++
++    #Update IV to ciphertext block 1
++    @{[vrgather_vv $vivec, $vdata1, $vindex]}
++
++    @{[vxor_vv $vdata2, $vdata2, $vivec]}
++
++    @{[vrev8_v $vdata2, $vdata2]}
++    @{[enc_blk $vdata2]}
++    @{[vrev8_v $vdata2, $vdata2]}
++
++    #Update IV to ciphertext block 2
++    @{[vrgather_vv $vivec, $vdata2, $vindex]}
++
++    @{[vxor_vv $vdata3, $vdata3, $vivec]}
++
++    @{[vrev8_v $vdata3, $vdata3]}
++    @{[enc_blk $vdata3]}
++    @{[vrev8_v $vdata3, $vdata3]}
++
++    #Update IV to ciphertext block 3
++    @{[vrgather_vv $vivec, $vdata3, $vindex]}
++
++    # Save the ciphertext (in reverse element order)
++    li $tmp_stride, $STRIDE
++    @{[reverse_order_S $vdata0, $out]}
++    addi $out, $out, $BLOCK_SIZE
++    @{[reverse_order_S $vdata1, $out]}
++    addi $out, $out, $BLOCK_SIZE
++    @{[reverse_order_S $vdata2, $out]}
++    addi $out, $out, $BLOCK_SIZE
++    @{[reverse_order_S $vdata3, $out]}
++    addi $out, $out, $BLOCK_SIZE
++
++    addi $len, $len, -$FOUR_BLOCKS
++    bnez $len, .Lcbc_enc_loop
++    #Save the final IV
++    @{[vse32_v $vivec, $ivp]}
++    ret
++
++.Lcbc_enc_single:
++    # Load input data0
++    @{[vle32_v $vdata0, $in]}
++    addi $in, $in, $BLOCK_SIZE
++    #XOR with IV
++    @{[vxor_vv $vdata0, $vdata0, $vivec]}
++
++    @{[vrev8_v $vdata0, $vdata0]}
++    # Encrypt with all keys
++    @{[enc_blk $vdata0]}
++    @{[vrev8_v $vdata0, $vdata0]}
++
++    # Update IV to ciphertext block 0
++    @{[vrgather_vv $vivec, $vdata0, $vindex]}
++
++    # Save the ciphertext (in reverse element order)
++    li $tmp_stride, $STRIDE
++    @{[reverse_order_S $vdata0, $out]}
++    addi $out, $out, $BLOCK_SIZE
++    addi $len, $len, -$BLOCK_SIZE
++
++    li $tmp, $BLOCK_SIZE
++    bgeu $len, $tmp, .Lcbc_enc_single
++    # Save the final IV
++    @{[vse32_v $vivec, $ivp]}
++.Lcbc_enc_end:
++    ret
++.size rv64i_zvksed_sm4_cbc_encrypt,.-rv64i_zvksed_sm4_cbc_encrypt
++___
++
++####
++# void rv64i_zvksed_sm4_cbc_decrypt(const unsigned char *in, unsigned char *out,
++#                                   size_t len, const SM4_KEY *key,
++#                                   unsigned char *iv, int enc);
++#
++$code .= <<___;
++.p2align 3
++.globl rv64i_zvksed_sm4_cbc_decrypt
++.type rv64i_zvksed_sm4_cbc_decrypt,\@function
++rv64i_zvksed_sm4_cbc_decrypt:
++    # check whether the length is a multiple of 16 and >= 16
++    li $tmp, $BLOCK_SIZE
++    bltu $len, $tmp, .Lcbc_dec_end
++    andi $tmp, $len, 15
++    bnez $tmp, .Lcbc_dec_end
++
++    @{[vsetivli "zero", 4, "e32", "m1", "ta", "ma"]}
++    # Load IV (in reverse element order)
++    li $tmp_stride, $STRIDE
++    @{[reverse_order_L $vivec, $ivp]}
++
++    # Load 32 round keys
++    @{[dec_load_key $keys]}
++# =====================================================
++# If data length ≥ 128 bytes, process 8 blocks in batch:
++# 8-block CBC decryption pipeline:
++#   1. Load 8 ciphertext blocks
++#   2. Reverse bytes for SM4 endianness
++#   3. Use two calls to dec_4blks for decrypting each data block
++#   4. XOR with previous ciphertext block (CBC chain)
++#   5. Update IV and store plaintext with byte reversal
++# =====================================================
++.Lcbc_dec_loop:
++    li $tmp, $EIGHT_BLOCKS
++    bltu $len, $tmp, .Lcbc_check_64
++    # Load input data0-data7
++    @{[vle32_v $vdata0, $in]}
++    addi $in, $in, $BLOCK_SIZE
++    @{[vle32_v $vdata1, $in]}
++    addi $in, $in, $BLOCK_SIZE
++    @{[vle32_v $vdata2, $in]}
++    addi $in, $in, $BLOCK_SIZE
++    @{[vle32_v $vdata3, $in]}
++    addi $in, $in, $BLOCK_SIZE
++    @{[vle32_v $vdata4, $in]}
++    addi $in, $in, $BLOCK_SIZE
++    @{[vle32_v $vdata5, $in]}
++    addi $in, $in, $BLOCK_SIZE
++    @{[vle32_v $vdata6, $in]}
++    addi $in, $in, $BLOCK_SIZE
++    @{[vle32_v $vdata7, $in]}
++    addi $in, $in, $BLOCK_SIZE
++
++    @{[vrev8_v $vdata0, $vdata0]}
++    @{[vrev8_v $vdata1, $vdata1]}
++    @{[vrev8_v $vdata2, $vdata2]}
++    @{[vrev8_v $vdata3, $vdata3]}
++    @{[vrev8_v $vdata4, $vdata4]}
++    @{[vrev8_v $vdata5, $vdata5]}
++    @{[vrev8_v $vdata6, $vdata6]}
++    @{[vrev8_v $vdata7, $vdata7]}
++    # Decrypt 8 data blocks
++    @{[dec_4blks $vdata0,$vdata1,$vdata2,$vdata3]}
++    @{[dec_4blks $vdata4,$vdata5,$vdata6,$vdata7]}
++    @{[vrev8_v $vdata0, $vdata0]}
++    @{[vrev8_v $vdata1, $vdata1]}
++    @{[vrev8_v $vdata2, $vdata2]}
++    @{[vrev8_v $vdata3, $vdata3]}
++    @{[vrev8_v $vdata4, $vdata4]}
++    @{[vrev8_v $vdata5, $vdata5]}
++    @{[vrev8_v $vdata6, $vdata6]}
++    @{[vrev8_v $vdata7, $vdata7]}
++
++    @{[vxor_vv $vdata0, $vdata0, $vivec]}
++
++    # Update ciphertext to IV (in reverse element order)
++    addi $base, $in, -128
++    @{[reverse_order_L $vivec, $base]}
++
++    @{[vxor_vv $vdata1, $vdata1, $vivec]}
++
++    addi $base, $in, -112
++    @{[reverse_order_L $vivec, $base]}
++
++    @{[vxor_vv $vdata2, $vdata2, $vivec]}
++
++    addi $base, $in, -96
++    @{[reverse_order_L $vivec, $base]}
++
++    @{[vxor_vv $vdata3, $vdata3, $vivec]}
++
++    addi $base, $in, -80
++    @{[reverse_order_L $vivec, $base]}
++
++    @{[vxor_vv $vdata4, $vdata4, $vivec]}
++
++    addi $base, $in, -64
++    @{[reverse_order_L $vivec, $base]}
++
++    @{[vxor_vv $vdata5, $vdata5, $vivec]}
++
++    addi $base, $in, -48
++    @{[reverse_order_L $vivec, $base]}
++
++    @{[vxor_vv $vdata6, $vdata6, $vivec]}
++
++    addi $base, $in, -32
++    @{[reverse_order_L $vivec, $base]}
++
++    @{[vxor_vv $vdata7, $vdata7, $vivec]}
++
++    addi $base, $in, -16
++    @{[reverse_order_L $vivec, $base]}
++
++    # Save the plaintext (in reverse element order)
++    @{[reverse_order_S $vdata0, $out]}
++    addi $out, $out, $BLOCK_SIZE
++    @{[reverse_order_S $vdata1, $out]}
++    addi $out, $out, $BLOCK_SIZE
++    @{[reverse_order_S $vdata2, $out]}
++    addi $out, $out, $BLOCK_SIZE
++    @{[reverse_order_S $vdata3, $out]}
++    addi $out, $out, $BLOCK_SIZE
++    @{[reverse_order_S $vdata4, $out]}
++    addi $out, $out, $BLOCK_SIZE
++    @{[reverse_order_S $vdata5, $out]}
++    addi $out, $out, $BLOCK_SIZE
++    @{[reverse_order_S $vdata6, $out]}
++    addi $out, $out, $BLOCK_SIZE
++    @{[reverse_order_S $vdata7, $out]}
++    addi $out, $out, $BLOCK_SIZE
++
++    addi $len, $len, -$EIGHT_BLOCKS
++    bnez $len, .Lcbc_dec_loop
++    #Save the final IV (in reverse element order)
++    @{[reverse_order_S $vivec, $ivp]}
++    ret
++# =====================================================
++# If data length ≥ 64 bytes, process in batches of 4 blocks:
++# 4-block CBC decryption process:
++#   1. Load 4 ciphertext blocks
++#   2. Reverse byte order to fit SM4 byte order
++#   3. Decrypt each data block using the dec_4blks function
++#   4. XOR with previous ciphertext block (CBC chain)
++#   5. Update IV and store plaintext with byte reversal
++# If the data length is less than 64 bytes, process it block by block using the Lcbc_dec_single function
++# =====================================================
++.Lcbc_check_64:
++    li $tmp, $FOUR_BLOCKS
++    bltu $len, $tmp, .Lcbc_dec_single
++    # Load input data0-data3
++    @{[vle32_v $vdata0, $in]}
++    addi $in, $in, $BLOCK_SIZE
++    @{[vle32_v $vdata1, $in]}
++    addi $in, $in, $BLOCK_SIZE
++    @{[vle32_v $vdata2, $in]}
++    addi $in, $in, $BLOCK_SIZE
++    @{[vle32_v $vdata3, $in]}
++    addi $in, $in, $BLOCK_SIZE
++
++    @{[vrev8_v $vdata0, $vdata0]}
++    @{[vrev8_v $vdata1, $vdata1]}
++    @{[vrev8_v $vdata2, $vdata2]}
++    @{[vrev8_v $vdata3, $vdata3]}
++    # Decrypt 4 data blocks
++    @{[dec_4blks $vdata0,$vdata1,$vdata2,$vdata3]}
++    @{[vrev8_v $vdata0, $vdata0]}
++    @{[vrev8_v $vdata1, $vdata1]}
++    @{[vrev8_v $vdata2, $vdata2]}
++    @{[vrev8_v $vdata3, $vdata3]}
++
++    @{[vxor_vv $vdata0, $vdata0, $vivec]}
++
++    # Update ciphertext to IV (in reverse element order)
++    addi $base, $in, -64
++    @{[reverse_order_L $vivec, $base]}
++
++    @{[vxor_vv $vdata1, $vdata1, $vivec]}
++
++    addi $base, $in, -48
++    @{[reverse_order_L $vivec, $base]}
++
++    @{[vxor_vv $vdata2, $vdata2, $vivec]}
++
++    addi $base, $in, -32
++    @{[reverse_order_L $vivec, $base]}
++
++    @{[vxor_vv $vdata3, $vdata3, $vivec]}
++
++    addi $base, $in, -16
++    @{[reverse_order_L $vivec, $base]}
++
++    # Save the plaintext (in reverse element order)
++    @{[reverse_order_S $vdata0, $out]}
++    addi $out, $out, $BLOCK_SIZE
++    @{[reverse_order_S $vdata1, $out]}
++    addi $out, $out, $BLOCK_SIZE
++    @{[reverse_order_S $vdata2, $out]}
++    addi $out, $out, $BLOCK_SIZE
++    @{[reverse_order_S $vdata3, $out]}
++    addi $out, $out, $BLOCK_SIZE
++
++    addi $len, $len, -$FOUR_BLOCKS
++    bnez $len, .Lcbc_check_64
++    #Save the final IV (in reverse element order)
++    @{[reverse_order_S $vivec, $ivp]}
++    ret
++
++.Lcbc_dec_single:
++    # Load input data0
++    @{[vle32_v $vdata0, $in]}
++    addi $in, $in, $BLOCK_SIZE
++
++    @{[vrev8_v $vdata0, $vdata0]}
++    # Decrypt with all keys
++    @{[dec_blk $vdata0]}
++    @{[vrev8_v $vdata0, $vdata0]}
++
++    #XOR with IV
++    @{[vxor_vv $vdata0, $vdata0, $vivec]}
++
++    # Update ciphertext to IV (in reverse element order)
++    li $tmp_stride, $STRIDE
++    addi $base, $in, -$BLOCK_SIZE
++    @{[reverse_order_L $vivec, $base]}
++    # Save the plaintext (in reverse element order)
++    @{[reverse_order_S $vdata0, $out]}
++    addi $out, $out, $BLOCK_SIZE
++    addi $len, $len, -$BLOCK_SIZE
++
++    li $tmp, $BLOCK_SIZE
++    bgeu $len, $tmp, .Lcbc_dec_single
++    #Save the final IV (in reverse element order)
++    @{[reverse_order_S $vivec, $ivp]}
++.Lcbc_dec_end:
++    ret
++.size rv64i_zvksed_sm4_cbc_decrypt,.-rv64i_zvksed_sm4_cbc_decrypt
++___
++}
++
+ ####
+ # int rv64i_zvksed_sm4_set_encrypt_key(const unsigned char *userKey,
+ #                                      SM4_KEY *key);
+@@ -94,19 +647,19 @@ rv64i_zvksed_sm4_set_encrypt_key:
+ 
+     # Store round keys
+     @{[vse32_v $vk0, $keys]} # rk[0:3]
+-    addi $keys, $keys, 16
++    addi $keys, $keys, $BLOCK_SIZE
+     @{[vse32_v $vk1, $keys]} # rk[4:7]
+-    addi $keys, $keys, 16
++    addi $keys, $keys, $BLOCK_SIZE
+     @{[vse32_v $vk2, $keys]} # rk[8:11]
+-    addi $keys, $keys, 16
++    addi $keys, $keys, $BLOCK_SIZE
+     @{[vse32_v $vk3, $keys]} # rk[12:15]
+-    addi $keys, $keys, 16
++    addi $keys, $keys, $BLOCK_SIZE
+     @{[vse32_v $vk4, $keys]} # rk[16:19]
+-    addi $keys, $keys, 16
++    addi $keys, $keys, $BLOCK_SIZE
+     @{[vse32_v $vk5, $keys]} # rk[20:23]
+-    addi $keys, $keys, 16
++    addi $keys, $keys, $BLOCK_SIZE
+     @{[vse32_v $vk6, $keys]} # rk[24:27]
+-    addi $keys, $keys, 16
++    addi $keys, $keys, $BLOCK_SIZE
+     @{[vse32_v $vk7, $keys]} # rk[28:31]
+ 
+     li a0, 1
+@@ -150,21 +703,21 @@ rv64i_zvksed_sm4_set_decrypt_key:
+ 
+     # Store round keys in reverse order
+     addi $keys, $keys, 12
+-    li $stride, -4
++    li $stride, $STRIDE
+     @{[vsse32_v $vk7, $keys, $stride]} # rk[31:28]
+-    addi $keys, $keys, 16
++    addi $keys, $keys, $BLOCK_SIZE
+     @{[vsse32_v $vk6, $keys, $stride]} # rk[27:24]
+-    addi $keys, $keys, 16
++    addi $keys, $keys, $BLOCK_SIZE
+     @{[vsse32_v $vk5, $keys, $stride]} # rk[23:20]
+-    addi $keys, $keys, 16
++    addi $keys, $keys, $BLOCK_SIZE
+     @{[vsse32_v $vk4, $keys, $stride]} # rk[19:16]
+-    addi $keys, $keys, 16
++    addi $keys, $keys, $BLOCK_SIZE
+     @{[vsse32_v $vk3, $keys, $stride]} # rk[15:12]
+-    addi $keys, $keys, 16
++    addi $keys, $keys, $BLOCK_SIZE
+     @{[vsse32_v $vk2, $keys, $stride]} # rk[11:8]
+-    addi $keys, $keys, 16
++    addi $keys, $keys, $BLOCK_SIZE
+     @{[vsse32_v $vk1, $keys, $stride]} # rk[7:4]
+-    addi $keys, $keys, 16
++    addi $keys, $keys, $BLOCK_SIZE
+     @{[vsse32_v $vk0, $keys, $stride]} # rk[3:0]
+ 
+     li a0, 1
+@@ -178,8 +731,8 @@ ___
+ #                               const SM4_KEY *key);
+ #
+ {
+-my ($in,$out,$keys,$stride)=("a0","a1","a2","t0");
+-my ($vdata,$vk0,$vk1,$vk2,$vk3,$vk4,$vk5,$vk6,$vk7,$vgen)=("v1","v2","v3","v4","v5","v6","v7","v8","v9","v10");
++my ($in,$out,$keys)=("a0","a1","a2");
++my ($vdata)=("v1");
+ $code .= <<___;
+ .p2align 3
+ .globl rv64i_zvksed_sm4_encrypt
+@@ -187,42 +740,19 @@ $code .= <<___;
+ rv64i_zvksed_sm4_encrypt:
+     @{[vsetivli__x0_4_e32_m1_tu_mu]}
+ 
+-    # Order of elements was adjusted in set_encrypt_key()
+-    @{[vle32_v $vk0, $keys]} # rk[0:3]
+-    addi $keys, $keys, 16
+-    @{[vle32_v $vk1, $keys]} # rk[4:7]
+-    addi $keys, $keys, 16
+-    @{[vle32_v $vk2, $keys]} # rk[8:11]
+-    addi $keys, $keys, 16
+-    @{[vle32_v $vk3, $keys]} # rk[12:15]
+-    addi $keys, $keys, 16
+-    @{[vle32_v $vk4, $keys]} # rk[16:19]
+-    addi $keys, $keys, 16
+-    @{[vle32_v $vk5, $keys]} # rk[20:23]
+-    addi $keys, $keys, 16
+-    @{[vle32_v $vk6, $keys]} # rk[24:27]
+-    addi $keys, $keys, 16
+-    @{[vle32_v $vk7, $keys]} # rk[28:31]
++    @{[enc_load_key $keys]}
+ 
+     # Load input data
+     @{[vle32_v $vdata, $in]}
+     @{[vrev8_v $vdata, $vdata]}
+ 
+     # Encrypt with all keys
+-    @{[vsm4r_vs $vdata, $vk0]}
+-    @{[vsm4r_vs $vdata, $vk1]}
+-    @{[vsm4r_vs $vdata, $vk2]}
+-    @{[vsm4r_vs $vdata, $vk3]}
+-    @{[vsm4r_vs $vdata, $vk4]}
+-    @{[vsm4r_vs $vdata, $vk5]}
+-    @{[vsm4r_vs $vdata, $vk6]}
+-    @{[vsm4r_vs $vdata, $vk7]}
++    @{[enc_blk $vdata]}
+ 
+     # Save the ciphertext (in reverse element order)
+     @{[vrev8_v $vdata, $vdata]}
+-    li $stride, -4
+-    addi $out, $out, 12
+-    @{[vsse32_v $vdata, $out, $stride]}
++    li $tmp_stride, $STRIDE
++    @{[reverse_order_S $vdata, $out]}
+ 
+     ret
+ .size rv64i_zvksed_sm4_encrypt,.-rv64i_zvksed_sm4_encrypt
+@@ -234,8 +764,8 @@ ___
+ #                               const SM4_KEY *key);
+ #
+ {
+-my ($in,$out,$keys,$stride)=("a0","a1","a2","t0");
+-my ($vdata,$vk0,$vk1,$vk2,$vk3,$vk4,$vk5,$vk6,$vk7,$vgen)=("v1","v2","v3","v4","v5","v6","v7","v8","v9","v10");
++my ($in,$out,$keys)=("a0","a1","a2");
++my ($vdata)=("v1");
+ $code .= <<___;
+ .p2align 3
+ .globl rv64i_zvksed_sm4_decrypt
+@@ -243,42 +773,19 @@ $code .= <<___;
+ rv64i_zvksed_sm4_decrypt:
+     @{[vsetivli__x0_4_e32_m1_tu_mu]}
+ 
+-    # Order of elements was adjusted in set_decrypt_key()
+-    @{[vle32_v $vk7, $keys]} # rk[31:28]
+-    addi $keys, $keys, 16
+-    @{[vle32_v $vk6, $keys]} # rk[27:24]
+-    addi $keys, $keys, 16
+-    @{[vle32_v $vk5, $keys]} # rk[23:20]
+-    addi $keys, $keys, 16
+-    @{[vle32_v $vk4, $keys]} # rk[19:16]
+-    addi $keys, $keys, 16
+-    @{[vle32_v $vk3, $keys]} # rk[15:11]
+-    addi $keys, $keys, 16
+-    @{[vle32_v $vk2, $keys]} # rk[11:8]
+-    addi $keys, $keys, 16
+-    @{[vle32_v $vk1, $keys]} # rk[7:4]
+-    addi $keys, $keys, 16
+-    @{[vle32_v $vk0, $keys]} # rk[3:0]
++    @{[dec_load_key $keys]}
+ 
+     # Load input data
+     @{[vle32_v $vdata, $in]}
+     @{[vrev8_v $vdata, $vdata]}
+ 
+-    # Encrypt with all keys
+-    @{[vsm4r_vs $vdata, $vk7]}
+-    @{[vsm4r_vs $vdata, $vk6]}
+-    @{[vsm4r_vs $vdata, $vk5]}
+-    @{[vsm4r_vs $vdata, $vk4]}
+-    @{[vsm4r_vs $vdata, $vk3]}
+-    @{[vsm4r_vs $vdata, $vk2]}
+-    @{[vsm4r_vs $vdata, $vk1]}
+-    @{[vsm4r_vs $vdata, $vk0]}
++    # Decrypt with all keys
++    @{[dec_blk $vdata]}
+ 
+-    # Save the ciphertext (in reverse element order)
++    # Save the plaintext (in reverse element order)
+     @{[vrev8_v $vdata, $vdata]}
+-    li $stride, -4
+-    addi $out, $out, 12
+-    @{[vsse32_v $vdata, $out, $stride]}
++    li $tmp_stride, $STRIDE
++    @{[reverse_order_S $vdata, $out]}
+ 
+     ret
+ .size rv64i_zvksed_sm4_decrypt,.-rv64i_zvksed_sm4_decrypt
+diff --git a/include/crypto/sm4_platform.h b/include/crypto/sm4_platform.h
+index 82396a2..c7dd198 100644
+--- a/include/crypto/sm4_platform.h
++++ b/include/crypto/sm4_platform.h
+@@ -47,6 +47,12 @@ void rv64i_zvksed_sm4_encrypt(const unsigned char *in, unsigned char *out,
+     const SM4_KEY *key);
+ void rv64i_zvksed_sm4_decrypt(const unsigned char *in, unsigned char *out,
+     const SM4_KEY *key);
++void rv64i_zvksed_sm4_cbc_encrypt(const unsigned char *in, unsigned char *out,
++                                  size_t len, const SM4_KEY *key,
++                                  unsigned char *iv, int enc);
++void rv64i_zvksed_sm4_cbc_decrypt(const unsigned char *in, unsigned char *out,
++                                  size_t len, const SM4_KEY *key,
++                                  unsigned char *iv, int enc);       
+ #elif (defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || defined(_M_X64))
+ /* Intel x86_64 support */
+ #include "internal/cryptlib.h"
+diff --git a/providers/implementations/ciphers/cipher_sm4_hw_rv64i.inc b/providers/implementations/ciphers/cipher_sm4_hw_rv64i.inc
+index 763d9d0..db5614d 100644
+--- a/providers/implementations/ciphers/cipher_sm4_hw_rv64i.inc
++++ b/providers/implementations/ciphers/cipher_sm4_hw_rv64i.inc
+@@ -38,6 +38,14 @@ static int cipher_hw_rv64i_zvksed_sm4_initkey(PROV_CIPHER_CTX *ctx,
+         ctx->stream.cbc = NULL;
+     }
+ 
++    if (ctx->mode == EVP_CIPH_CBC_MODE) {
++        if (ctx->enc) {
++            ctx->stream.cbc = (cbc128_f) rv64i_zvksed_sm4_cbc_encrypt;
++        } else {
++            ctx->stream.cbc = (cbc128_f) rv64i_zvksed_sm4_cbc_decrypt;
++        }
++    }
++
+     return 1;
+ }
+ 
+diff --git a/test/recipes/30-test_evp_data/evpciph_sm4.txt b/test/recipes/30-test_evp_data/evpciph_sm4.txt
+index 993cf7b..f23129c 100644
+--- a/test/recipes/30-test_evp_data/evpciph_sm4.txt
++++ b/test/recipes/30-test_evp_data/evpciph_sm4.txt
+@@ -13,6 +13,12 @@ Key = 0123456789ABCDEFFEDCBA9876543210
+ Plaintext  = 0123456789ABCDEFFEDCBA9876543210
+ Ciphertext = 681EDF34D206965E86B3E94F536E4246
+ 
++Cipher = SM4-CBC
++Key = 0123456789ABCDEFFEDCBA9876543210
++IV  = 0123456789ABCDEFFEDCBA9876543210
++Plaintext = 0123456789ABCDEFFEDCBA9876543210
++Ciphertext = 2677F46B09C122CC975533105BD4A22A
++
+ Cipher = SM4-CBC
+ Key = 0123456789ABCDEFFEDCBA9876543210
+ IV  = 0123456789ABCDEFFEDCBA9876543210
+-- 
+2.27.0
+

--- a/SPECS/openssl/0011-Backport-riscv-Further-improve-the-decryption-performance-of-AES-128-CBC-on-RISC-V.patch
+++ b/SPECS/openssl/0011-Backport-riscv-Further-improve-the-decryption-performance-of-AES-128-CBC-on-RISC-V.patch
@@ -1,0 +1,456 @@
+From 541a05c2419ed3f2402682817f02a3e0da8e1a0f Mon Sep 17 00:00:00 2001
+From: Lu Zhou <zhou.lu1@zte.com.cn>
+Date: Wed, 8 Jul 2026 10:52:45 +0800
+Subject: [PATCH] Backport (riscv): Further improve the decryption performance of AES-128-CBC on the RISC-V architecture
+
+Reference:https://github.com/openssl/openssl/commit/a81b4d920b28b4958d7fdc45648b5d778cc60df0
+
+Further improve the decryption performance of AES-128-CBC on the RISC-V architecture
+The decryption performance of AES-128-CBC is improved by 6% to 15%, with the main optimizations as follows:
+1.The block processing mode is adjusted to single-block loop + 4-block loop + 8-block loop.
+2.The backup of ciphertext using vmv_v_v for XOR operations is replaced with reloading using vle32_v.
+3.Key loading and decryption computation are interleaved in a loop.
+
+Hardware simulation environment verification data:
+| Decrypt Test |  Baseline   | Optimized  | Improvement ratio |
+| ------------ | --------------- | ------------- | ----------------- |
+| 16 bytes     | 14357.22k       | 15271.90k     | 6%                |
+| 64 bytes     | 29176.38k       | 33592.29k     | 15%               |
+| 256 bytes    | 38664.19k       | 42968.09k     | 11%               |
+| 1024 bytes   | 40308.09k       | 43875.04k     | 9%                |
+| 8192 bytes   | 42811.39k       | 46032.08k     | 8%                |
+| 16384 bytes  | 42809.28k       | 46110.04k     | 8%                |
+
+Reviewed-by: Neil Horman <nhorman@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.foundation>
+MergeDate: Thu Jun 18 12:22:19 2026
+(Merged from https://github.com/openssl/openssl/pull/31116)
+
+Signed-off-by: Lu Zhou <zhou.lu1@zte.com.cn>
+Signed-off-by: Shangcheng Huang <huang.shangcheng@zte.com.cn>
+---
+ crypto/aes/asm/aes-riscv64-zvkned.pl | 362 +++++++++++++++++----------
+ 1 file changed, 233 insertions(+), 129 deletions(-)
+
+diff --git a/crypto/aes/asm/aes-riscv64-zvkned.pl b/crypto/aes/asm/aes-riscv64-zvkned.pl
+index 80c7a71..45c2efd 100644
+--- a/crypto/aes/asm/aes-riscv64-zvkned.pl
++++ b/crypto/aes/asm/aes-riscv64-zvkned.pl
+@@ -2,7 +2,7 @@
+ # This file is dual-licensed, meaning that you can use it under your
+ # choice of either of the following two licenses:
+ #
+-# Copyright 2023-2026 The OpenSSL Project Authors. All Rights Reserved.
++# Copyright 2023-2025 The OpenSSL Project Authors. All Rights Reserved.
+ #
+ # Licensed under the Apache License 2.0 (the "License"). You can obtain
+ # a copy in the file LICENSE in the source distribution or at
+@@ -210,88 +210,6 @@ ___
+     return $code;
+ }
+ 
+-# aes-128 decryption with round keys v1-v11
+-sub aes_128_decrypt_6 {
+-    my $code=<<___;
+-    @{[vaesz_vs $V24, $V11]}   # with round key w[40,43]
+-    @{[vaesz_vs $V25, $V11]}   # with round key w[40,43]
+-    @{[vaesz_vs $V26, $V11]}   # with round key w[40,43]
+-    @{[vaesz_vs $V27, $V11]}   # with round key w[40,43]
+-    @{[vaesz_vs $V28, $V11]}   # with round key w[40,43]
+-    @{[vaesz_vs $V29, $V11]}   # with round key w[40,43]
+-    @{[vaesdm_vs $V24, $V10]}  # with round key w[36,39]
+-    @{[vaesdm_vs $V25, $V10]}  # with round key w[36,39]
+-    @{[vaesdm_vs $V26, $V10]}  # with round key w[36,39]
+-    @{[vaesdm_vs $V27, $V10]}  # with round key w[36,39]
+-    @{[vaesdm_vs $V28, $V10]}  # with round key w[36,39]
+-    @{[vaesdm_vs $V29, $V10]}  # with round key w[36,39]
+-    @{[vaesdm_vs $V24, $V9]}   # with round key w[32,35]
+-    @{[vaesdm_vs $V25, $V9]}   # with round key w[32,35]
+-    @{[vaesdm_vs $V26, $V9]}   # with round key w[32,35]
+-    @{[vaesdm_vs $V27, $V9]}   # with round key w[32,35]
+-    @{[vaesdm_vs $V28, $V9]}   # with round key w[32,35]
+-    @{[vaesdm_vs $V29, $V9]}   # with round key w[32,35]
+-
+-    @{[vaesdm_vs $V24, $V8]}   # with round key w[28,31]
+-    @{[vaesdm_vs $V25, $V8]}   # with round key w[28,31]
+-    @{[vaesdm_vs $V26, $V8]}   # with round key w[28,31]
+-    @{[vaesdm_vs $V27, $V8]}   # with round key w[28,31]
+-    @{[vaesdm_vs $V28, $V8]}   # with round key w[28,31]
+-    @{[vaesdm_vs $V29, $V8]}   # with round key w[28,31]
+-
+-    @{[vaesdm_vs $V24, $V7]}   # with round key w[24,27]
+-    @{[vaesdm_vs $V25, $V7]}   # with round key w[24,27]
+-    @{[vaesdm_vs $V26, $V7]}   # with round key w[24,27]
+-    @{[vaesdm_vs $V27, $V7]}   # with round key w[24,27]
+-    @{[vaesdm_vs $V28, $V7]}   # with round key w[24,27]
+-    @{[vaesdm_vs $V29, $V7]}   # with round key w[24,27]
+-
+-    @{[vaesdm_vs $V24, $V6]}   # with round key w[20,23]
+-    @{[vaesdm_vs $V25, $V6]}   # with round key w[20,23]
+-    @{[vaesdm_vs $V26, $V6]}   # with round key w[20,23]
+-    @{[vaesdm_vs $V27, $V6]}   # with round key w[20,23]
+-    @{[vaesdm_vs $V28, $V6]}   # with round key w[20,23]
+-    @{[vaesdm_vs $V29, $V6]}   # with round key w[20,23]
+-    
+-    @{[vaesdm_vs $V24, $V5]}   # with round key w[16,19]
+-    @{[vaesdm_vs $V25, $V5]}   # with round key w[16,19]
+-    @{[vaesdm_vs $V26, $V5]}   # with round key w[16,19]
+-    @{[vaesdm_vs $V27, $V5]}   # with round key w[16,19]
+-    @{[vaesdm_vs $V28, $V5]}   # with round key w[16,19]
+-    @{[vaesdm_vs $V29, $V5]}   # with round key w[16,19]
+-
+-    @{[vaesdm_vs $V24, $V4]}   # with round key w[12,15]
+-    @{[vaesdm_vs $V25, $V4]}   # with round key w[12,15]
+-    @{[vaesdm_vs $V26, $V4]}   # with round key w[12,15]
+-    @{[vaesdm_vs $V27, $V4]}   # with round key w[12,15]
+-    @{[vaesdm_vs $V28, $V4]}   # with round key w[12,15]
+-    @{[vaesdm_vs $V29, $V4]}   # with round key w[12,15]
+-
+-    @{[vaesdm_vs $V24, $V3]}   # with round key w[ 8,11]
+-    @{[vaesdm_vs $V25, $V3]}   # with round key w[ 8,11]
+-    @{[vaesdm_vs $V26, $V3]}   # with round key w[ 8,11]
+-    @{[vaesdm_vs $V27, $V3]}   # with round key w[ 8,11]
+-    @{[vaesdm_vs $V28, $V3]}   # with round key w[ 8,11]
+-    @{[vaesdm_vs $V29, $V3]}   # with round key w[ 8,11]
+-
+-    @{[vaesdm_vs $V24, $V2]}   # with round key w[ 4, 7]
+-    @{[vaesdm_vs $V25, $V2]}   # with round key w[ 4, 7]
+-    @{[vaesdm_vs $V26, $V2]}   # with round key w[ 4, 7]
+-    @{[vaesdm_vs $V27, $V2]}   # with round key w[ 4, 7]
+-    @{[vaesdm_vs $V28, $V2]}   # with round key w[ 4, 7]
+-    @{[vaesdm_vs $V29, $V2]}   # with round key w[ 4, 7]
+-
+-    @{[vaesdf_vs $V24, $V1]}   # with round key w[ 0, 3]
+-    @{[vaesdf_vs $V25, $V1]}   # with round key w[ 0, 3]
+-    @{[vaesdf_vs $V26, $V1]}   # with round key w[ 0, 3]
+-    @{[vaesdf_vs $V27, $V1]}   # with round key w[ 0, 3]
+-    @{[vaesdf_vs $V28, $V1]}   # with round key w[ 0, 3]
+-    @{[vaesdf_vs $V29, $V1]}   # with round key w[ 0, 3]
+-___
+-
+-    return $code;
+-}
+-
+ # aes-192 encryption with round keys v1-v13
+ sub aes_192_encrypt {
+     my $code=<<___;
+@@ -557,16 +475,161 @@ ___
+ $code .= <<___;
+ .p2align 3
+ L_cbc_dec_128:
+-    # Load all 11 round keys to v1-v11 registers.
+-    @{[aes_128_load_key $KEYP]}
+-
++    @{[vsetivli "zero", 4, "e32", "m1", "ta", "ma"]}
+     # Load IV.
+     @{[vle32_v $V16, $IVP]}
+ 
+-    li $T1, 96
++.Lcbc_dec_loop:
++    li $T0, 10
++    addi $KEYP, $KEYP, 160
++    @{[vle32_v $V11, $KEYP]}
++    addi $KEYP, $KEYP, -16
++    @{[vle32_v $V10, $KEYP]}
++    li $T1, 64
++    bgeu $LEN, $T1, .Lcbc_check_64
++
++    @{[vle32_v $V24, $INP]}
++    @{[vmv_v_v $V17, $V24]}
++    j 2f
++
++1:
++    li $T0, 10
++    addi $KEYP, $KEYP, 160
++    @{[vle32_v $V11, $KEYP]}
++    addi $KEYP, $KEYP, -16
++    @{[vle32_v $V10, $KEYP]}
++    @{[vle32_v $V24, $INP]}
++    @{[vmv_v_v $V17, $V24]}
++    addi $OUTP, $OUTP, 16
++
++2:
++    # AES body
++    @{[vaesz_vs $V24, $V11]}   # with round key w[40,43]
++    addi $T0, $T0, -2
+ 3:
+-    blt $LEN, $T1, L_small 
++    addi $KEYP, $KEYP, -16
++    @{[vle32_v $V11, $KEYP]}
++    @{[vaesdm_vs $V24, $V10]}  # with round key w[36,39]
++    addi $KEYP, $KEYP, -16
++    @{[vle32_v $V10, $KEYP]}
++    @{[vaesdm_vs $V24, $V11]}   # with round key w[32,35]
++    addi $T0, $T0, -2
++    bnez $T0, 3b
++    addi $KEYP, $KEYP, -16
++    @{[vle32_v $V11, $KEYP]}
++    @{[vaesdm_vs $V24, $V10]}   # with round key w[ 4, 7]
++    @{[vaesdf_vs $V24, $V11]}   # with round key w[ 0, 3]
++
++    @{[vxor_vv $V24, $V24, $V16]}
++    @{[vse32_v $V24, $OUTP]}
++    @{[vmv_v_v $V16, $V17]}
++
++    addi $LEN, $LEN, -16
++    addi $INP, $INP, 16
++
++    bnez $LEN, 1b
++
++    @{[vse32_v $V16, $IVP]}
++
++    ret
++
++# =====================================================
++# If data 128bytes > length ≥ 64 bytes, process in batches of 4 blocks:
++# 4-block CBC decryption process:
++#   1. Load 4 ciphertext blocks
++#   2. Back up the ciphertext blocks
++#   3. Decrypt each data block
++#   4. Reload ciphertext blocks into registers v17-v20 for XOR
++#   5. XOR with previous ciphertext block (CBC chain)
++#   6. Update IV and store plaintext
++# If the data length is less than 64 bytes, process it block by block using the Lcbc_dec_loop function
++# =====================================================
++.Lcbc_check_64:
++    li $T1, 128
++    bgeu $LEN, $T1, .Lcbc_check_128
+ 
++    @{[vle32_v $V24, $INP]}
++    addi $INP, $INP, 16
++    @{[vle32_v $V25, $INP]}
++    addi $INP, $INP, 16
++    @{[vle32_v $V26, $INP]}
++    addi $INP, $INP, 16
++    @{[vle32_v $V27, $INP]}
++    @{[vle32_v $V20, $INP]}
++    addi $INP, $INP, -16
++    @{[vle32_v $V19, $INP]}
++
++    @{[vaesz_vs $V24, $V11]}   # with round key w[40,43]
++    @{[vaesz_vs $V25, $V11]}   # with round key w[40,43]
++    @{[vaesz_vs $V26, $V11]}   # with round key w[40,43]
++    @{[vaesz_vs $V27, $V11]}   # with round key w[40,43]
++    addi $T0, $T0, -2
++4:
++    addi $KEYP, $KEYP, -16
++    @{[vle32_v $V11, $KEYP]}
++    @{[vaesdm_vs $V24, $V10]}  # with round key w[36,39]
++    @{[vaesdm_vs $V25, $V10]}  # with round key w[36,39]
++    @{[vaesdm_vs $V26, $V10]}  # with round key w[36,39]
++    @{[vaesdm_vs $V27, $V10]}  # with round key w[36,39]
++    addi $KEYP, $KEYP, -16
++    @{[vle32_v $V10, $KEYP]}
++    @{[vaesdm_vs $V24, $V11]}   # with round key w[32,35]
++    @{[vaesdm_vs $V25, $V11]}   # with round key w[32,35]
++    @{[vaesdm_vs $V26, $V11]}   # with round key w[32,35]
++    @{[vaesdm_vs $V27, $V11]}   # with round key w[32,35]
++    addi $T0, $T0, -2
++    bnez $T0, 4b
++    addi $KEYP, $KEYP, -16
++    @{[vle32_v $V11, $KEYP]}
++    addi $INP, $INP, -16
++    @{[vle32_v $V18, $INP]}
++    addi $INP, $INP, -16
++    @{[vle32_v $V17, $INP]}
++
++    @{[vaesdm_vs $V24, $V10]}   # with round key w[ 4, 7]
++    @{[vaesdm_vs $V25, $V10]}   # with round key w[ 4, 7]
++    @{[vaesdm_vs $V26, $V10]}   # with round key w[ 4, 7]
++    @{[vaesdm_vs $V27, $V10]}   # with round key w[ 4, 7]
++
++    @{[vaesdf_vs $V24, $V11]}   # with round key w[ 0, 3]
++    @{[vaesdf_vs $V25, $V11]}   # with round key w[ 0, 3]
++    @{[vaesdf_vs $V26, $V11]}   # with round key w[ 0, 3]
++    @{[vaesdf_vs $V27, $V11]}   # with round key w[ 0, 3]
++
++    @{[vxor_vv $V24, $V24, $V16]}
++    @{[vxor_vv $V25, $V25, $V17]}
++    @{[vxor_vv $V26, $V26, $V18]}
++    @{[vxor_vv $V27, $V27, $V19]}
++
++    @{[vse32_v $V24, $OUTP]}
++    addi $OUTP, $OUTP, 16
++    @{[vse32_v $V25, $OUTP]}
++    addi $OUTP, $OUTP, 16
++    @{[vse32_v $V26, $OUTP]}
++    addi $OUTP, $OUTP, 16
++    @{[vse32_v $V27, $OUTP]}
++    addi $OUTP, $OUTP, 16
++
++    @{[vmv_v_v $V16, $V20]}
++
++    addi $LEN, $LEN, -64
++    addi $INP, $INP, 64
++    bnez $LEN, .Lcbc_dec_loop
++    @{[vse32_v $V16, $IVP]}
++
++    ret
++
++# =====================================================
++# If data length ≥ 128 bytes, process 8 blocks in batch:
++# 8-block CBC decryption pipeline:
++#   1. Load 8 ciphertext blocks
++#   2. Back up the ciphertext blocks
++#   3. Decrypt each data block
++#   4. Reload ciphertext blocks into registers v17-v23 and v15 for XOR
++#   5. XOR with previous ciphertext block (CBC chain)
++#   6. Update IV and store plaintext
++# =====================================================
++.Lcbc_check_128:
+     @{[vle32_v $V24, $INP]}
+     addi $INP, $INP, 16
+     @{[vle32_v $V25, $INP]}
+@@ -579,67 +642,108 @@ L_cbc_dec_128:
+     addi $INP, $INP, 16
+     @{[vle32_v $V29, $INP]}
+     addi $INP, $INP, 16
+-    @{[vmv_v_v $V17, $V24]}  
+-    @{[vmv_v_v $V18, $V25]}
+-    @{[vmv_v_v $V19, $V26]} 
+-    @{[vmv_v_v $V20, $V27]} 
+-    @{[vmv_v_v $V21, $V28]} 
+-    @{[vmv_v_v $V22, $V29]}  
++    @{[vle32_v $V30, $INP]}
++    addi $INP, $INP, 16
++    @{[vle32_v $V31, $INP]}
++    @{[vle32_v $V15, $INP]}
++    addi $INP, $INP, -16
++    @{[vle32_v $V23, $INP]}
+ 
+-    @{[aes_128_decrypt_6]} 
++    @{[vaesz_vs $V24, $V11]}   # with round key w[40,43]
++    @{[vaesz_vs $V25, $V11]}   # with round key w[40,43]
++    @{[vaesz_vs $V26, $V11]}   # with round key w[40,43]
++    @{[vaesz_vs $V27, $V11]}   # with round key w[40,43]
++    @{[vaesz_vs $V28, $V11]}   # with round key w[40,43]
++    @{[vaesz_vs $V29, $V11]}   # with round key w[40,43]
++    @{[vaesz_vs $V30, $V11]}   # with round key w[40,43]
++    @{[vaesz_vs $V31, $V11]}   # with round key w[40,43]
++    addi $INP, $INP, -16
++    @{[vle32_v $V22, $INP]}
++    addi $INP, $INP, -16
++    @{[vle32_v $V21, $INP]}
++    addi $T0, $T0, -2
++4:
++    addi $KEYP, $KEYP, -16
++    @{[vle32_v $V11, $KEYP]}
++    @{[vaesdm_vs $V24, $V10]}  # with round key w[36,39]
++    @{[vaesdm_vs $V25, $V10]}  # with round key w[36,39]
++    @{[vaesdm_vs $V26, $V10]}  # with round key w[36,39]
++    @{[vaesdm_vs $V27, $V10]}  # with round key w[36,39]
++    @{[vaesdm_vs $V28, $V10]}  # with round key w[36,39]
++    @{[vaesdm_vs $V29, $V10]}  # with round key w[36,39]
++    @{[vaesdm_vs $V30, $V10]}  # with round key w[36,39]
++    @{[vaesdm_vs $V31, $V10]}  # with round key w[36,39]
++    addi $KEYP, $KEYP, -16
++    @{[vle32_v $V10, $KEYP]}
++    @{[vaesdm_vs $V24, $V11]}   # with round key w[32,35]
++    @{[vaesdm_vs $V25, $V11]}   # with round key w[32,35]
++    @{[vaesdm_vs $V26, $V11]}   # with round key w[32,35]
++    @{[vaesdm_vs $V27, $V11]}   # with round key w[32,35]
++    @{[vaesdm_vs $V28, $V11]}   # with round key w[32,35]
++    @{[vaesdm_vs $V29, $V11]}   # with round key w[32,35]
++    @{[vaesdm_vs $V30, $V11]}   # with round key w[32,35]
++    @{[vaesdm_vs $V31, $V11]}   # with round key w[32,35]
++    addi $T0, $T0, -2
++    bnez $T0, 4b
++    addi $KEYP, $KEYP, -16
++    @{[vle32_v $V11, $KEYP]}
++    addi $INP, $INP, -16
++    @{[vle32_v $V20, $INP]}
++    addi $INP, $INP, -16
++    @{[vle32_v $V19, $INP]}
++    addi $INP, $INP, -16
++    @{[vle32_v $V18, $INP]}
++    addi $INP, $INP, -16
++    @{[vle32_v $V17, $INP]}
++    @{[vaesdm_vs $V24, $V10]}   # with round key w[ 4, 7]
++    @{[vaesdm_vs $V25, $V10]}   # with round key w[ 4, 7]
++    @{[vaesdm_vs $V26, $V10]}   # with round key w[ 4, 7]
++    @{[vaesdm_vs $V27, $V10]}   # with round key w[ 4, 7]
++    @{[vaesdm_vs $V28, $V10]}   # with round key w[ 4, 7]
++    @{[vaesdm_vs $V29, $V10]}   # with round key w[ 4, 7]
++    @{[vaesdm_vs $V30, $V10]}   # with round key w[ 4, 7]
++    @{[vaesdm_vs $V31, $V10]}   # with round key w[ 4, 7]
++
++    @{[vaesdf_vs $V24, $V11]}   # with round key w[ 0, 3]
++    @{[vaesdf_vs $V25, $V11]}   # with round key w[ 0, 3]
++    @{[vaesdf_vs $V26, $V11]}   # with round key w[ 0, 3]
++    @{[vaesdf_vs $V27, $V11]}   # with round key w[ 0, 3]
++    @{[vaesdf_vs $V28, $V11]}   # with round key w[ 0, 3]
++    @{[vaesdf_vs $V29, $V11]}   # with round key w[ 0, 3]
++    @{[vaesdf_vs $V30, $V11]}   # with round key w[ 0, 3]
++    @{[vaesdf_vs $V31, $V11]}   # with round key w[ 0, 3]
+ 
+-    @{[vxor_vv $V24, $V24, $V16]}  
++    @{[vxor_vv $V24, $V24, $V16]}
+     @{[vxor_vv $V25, $V25, $V17]}
+     @{[vxor_vv $V26, $V26, $V18]}
+     @{[vxor_vv $V27, $V27, $V19]}
+     @{[vxor_vv $V28, $V28, $V20]}
+     @{[vxor_vv $V29, $V29, $V21]}
++    @{[vxor_vv $V30, $V30, $V22]}
++    @{[vxor_vv $V31, $V31, $V23]}
+ 
+     @{[vse32_v $V24, $OUTP]}
+-    addi $OUTP, $OUTP, 16 
++    addi $OUTP, $OUTP, 16
+     @{[vse32_v $V25, $OUTP]}
+-    addi $OUTP, $OUTP, 16      
++    addi $OUTP, $OUTP, 16
+     @{[vse32_v $V26, $OUTP]}
+     addi $OUTP, $OUTP, 16
+     @{[vse32_v $V27, $OUTP]}
+-    addi $OUTP, $OUTP, 16   
++    addi $OUTP, $OUTP, 16
+     @{[vse32_v $V28, $OUTP]}
+     addi $OUTP, $OUTP, 16
+     @{[vse32_v $V29, $OUTP]}
+     addi $OUTP, $OUTP, 16
+-
+-    @{[vmv_v_v $V16, $V22]}  
+-
+-    addi $LEN, $LEN, -96       
+-    
+-    bnez $LEN, 3b 
+-    @{[vse32_v $V16, $IVP]} 
+-
+-    ret
+-
+-L_small:
+-    @{[vle32_v $V24, $INP]}
+-    @{[vmv_v_v $V17, $V24]}
+-    j 2f
+-
+-1:
+-    @{[vle32_v $V24, $INP]}
+-    @{[vmv_v_v $V17, $V24]}
++    @{[vse32_v $V30, $OUTP]}
++    addi $OUTP, $OUTP, 16
++    @{[vse32_v $V31, $OUTP]}
+     addi $OUTP, $OUTP, 16
+ 
+-2:
+-    # AES body
+-    @{[aes_128_decrypt]}
+-
+-    @{[vxor_vv $V24, $V24, $V16]}
+-    @{[vse32_v $V24, $OUTP]}
+-    @{[vmv_v_v $V16, $V17]}
+-
+-    addi $LEN, $LEN, -16
+-    addi $INP, $INP, 16
+-
+-    bnez $LEN, 1b
++    @{[vmv_v_v $V16, $V15]}
+ 
++    addi $LEN, $LEN, -128
++    addi $INP, $INP, 128
++    bnez $LEN, .Lcbc_dec_loop
+     @{[vse32_v $V16, $IVP]}
+ 
+     ret
+-- 
+2.27.0
+

--- a/SPECS/openssl/0012-Add-SM2-implementation-in-generic-riscv64-asm.patch
+++ b/SPECS/openssl/0012-Add-SM2-implementation-in-generic-riscv64-asm.patch
@@ -1,0 +1,1360 @@
+From 76383789b3dad3be8a30db4b138ec7020dae2862 Mon Sep 17 00:00:00 2001
+From: geliya <ge.liya@zte.com.cn>
+Date: Mon, 6 Jul 2026 23:42:00 -0400
+Subject: [PATCH] Backport: Add SM2 implementation in generic riscv64 asm
+
+Reference: https://github.com/openssl/openssl/pull/25918/commits/6995febbf804c1d9a02d9b274fe305736e9bac9b
+
+Add SM2 implementation in generic riscv64 asm
+
+Signed-off-by: Shangcheng Huang <huang.shangcheng@zte.com.cn>
+
+---
+ crypto/ec/asm/ecp_sm2p256-riscv64.pl | 1306 ++++++++++++++++++++++++++
+ crypto/ec/build.info                 |   13 +
+ 2 files changed, 1319 insertions(+)
+ create mode 100644 crypto/ec/asm/ecp_sm2p256-riscv64.pl
+
+diff --git a/crypto/ec/asm/ecp_sm2p256-riscv64.pl b/crypto/ec/asm/ecp_sm2p256-riscv64.pl
+new file mode 100644
+index 0000000..2a17e12
+--- /dev/null
++++ b/crypto/ec/asm/ecp_sm2p256-riscv64.pl
+@@ -0,0 +1,1306 @@
++#! /usr/bin/env perl
++# Copyright 2025 The OpenSSL Project Authors. All Rights Reserved.
++#
++# Licensed under the Apache License 2.0 (the "License").  You may not use
++# this file except in compliance with the License.  You can obtain a copy
++# in the file LICENSE in the source distribution or at
++# https://www.openssl.org/source/license.html
++
++# $output is the last argument if it looks like a file (it has an extension)
++# $flavour is the first argument if it doesn't look like a file
++use strict;
++use warnings;
++
++use FindBin qw($Bin);
++use lib "$Bin";
++use lib "$Bin/../../perlasm";
++use riscv;
++
++my $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
++my $flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
++
++$output and open STDOUT,">$output";
++
++################################################################################
++# Utility functions to help with keeping track of which registers to stack/
++# unstack when entering / exiting routines.
++################################################################################
++{
++    # Callee-saved registers
++    my @callee_saved = map("x$_",(2,8,9,18..27));
++    # Caller-saved registers
++    my @caller_saved = map("x$_",(1,5..7,10..17,28..31));
++    my @must_save;
++    sub use_reg {
++        my $reg = shift;
++        if (grep(/^$reg$/, @callee_saved)) {
++            push(@must_save, $reg);
++        } elsif (!grep(/^$reg$/, @caller_saved)) {
++            # Register is not usable!
++            die("Unusable register ".$reg);
++        }
++        return $reg;
++    }
++    sub use_regs {
++        return map(use_reg("x$_"), @_);
++    }
++    sub save_regs {
++        my $ret = '';
++        my $stack_reservation = ($#must_save + 1) * 8;
++        my $stack_offset = $stack_reservation;
++        if ($stack_reservation % 16) {
++            $stack_reservation += 8;
++        }
++        $ret.="    addi    sp,sp,-$stack_reservation\n";
++        foreach (@must_save) {
++            $stack_offset -= 8;
++            $ret.="    sd      $_,$stack_offset(sp)\n";
++        }
++        return $ret;
++    }
++    sub load_regs {
++        my $ret = '';
++        my $stack_reservation = ($#must_save + 1) * 8;
++        my $stack_offset = $stack_reservation;
++        if ($stack_reservation % 16) {
++            $stack_reservation += 8;
++        }
++        foreach (@must_save) {
++            $stack_offset -= 8;
++            $ret.="    ld      $_,$stack_offset(sp)\n";
++        }
++        $ret.="    addi    sp,sp,$stack_reservation\n";
++        return $ret;
++    }
++    sub clear_regs {
++        @must_save = ();
++    }
++}
++
++my $code=<<___;
++.text
++___
++
++# Function arguments
++# Input block pointer, output block pointer, key pointer
++my ($i0, $i1, $i2) = use_regs(10 .. 12);
++my ($t0, $t1, $t2, $t3, $t4, $t5, $t6, $t7, $c0, $c1, $c2, $c3) = use_regs(5 .. 7, 13 ... 17, 28 .. 31);
++my ($s0, $s1, $s2, $s3, $s4, $s5, $s6, $s7, $s8, $s9, $s10) = use_regs(9, 18 .. 27);
++
++sub bn_mod_add() {
++# returns r = ( a + b ) mod p, where p is a predefined polynomial modulus
++# Input: $i1 = address of operand a, $i2 = address of operand b
++# Output: $i0 = address for result storage
++# Dependencies: $mod = address of modulus p (passed via parameter)
++# Register usage: $t0-$t7: data storage registers, $c0-$c3: carry/borrow flags
++    my $mod = shift;
++$code.=<<___;
++	// Load inputs
++	ld $t0, 0($i1)
++	ld $t1, 8($i1)
++	ld $t2, 16($i1)
++	ld $t3, 24($i1)
++
++	ld $t4, 0($i2)
++	ld $t5, 8($i2)
++	ld $t6, 16($i2)
++	ld $t7, 24($i2)
++
++	// Addition
++	add $t0, $t0, $t4
++	sltu $c0, $t0, $t4  //carry
++
++	add $t1, $t1, $t5
++	sltu $c1, $t1, $t5
++	add $t1, $t1, $c0
++	sltu $c0, $t1, $c0
++	add $c0, $c0, $c1
++
++	add $t2, $t2, $t6
++	sltu $c1, $t2, $t6
++	add $t2, $t2, $c0
++	sltu $c0, $t2, $c0
++	add $c0, $c0, $c1
++
++	add $t3, $t3, $t7
++	sltu $c1, $t3, $t7
++	add $t3, $t3, $c0
++	sltu $c0, $t3, $c0
++	add $c0, $c0, $c1
++
++	// Load polynomial
++	la $i2, $mod
++	ld $t4, 0($i2)
++	ld $t5, 8($i2)
++	ld $t6, 16($i2)
++	ld $t7, 24($i2)
++
++	// Sub polynomial
++	sltu $c3, $t0, $t4  //borrow
++	sub $t4, $t0, $t4
++	sltu $c1, $t1, $t5
++	sub $t5, $t1, $t5
++	sltu $c2, $t5, $c3
++	sub $t5, $t5, $c3
++	add $c1, $c1, $c2  //borrow
++	sltu $c3, $t2, $t6
++	sub $t6, $t2, $t6
++	sltu $c2, $t6, $c1
++	sub $t6, $t6, $c1
++	add $c3, $c3, $c2  //borrow
++	sltu $c1, $t3, $t7
++	sub $t7, $t3, $t7
++	sltu $c2, $t7, $c3
++	sub $t7, $t7, $c3
++	add $c3, $c1, $c2  //borrow
++
++	// Select based on carry
++	slt $c0, $c0, $c3
++	negw $c1, $c0
++	addw $c0, $c0, -1
++
++	and $t0, $t0, $c1
++	and $t1, $t1, $c1
++	and $t2, $t2, $c1
++	and $t3, $t3, $c1
++	and $t4, $t4, $c0
++	and $t5, $t5, $c0
++	and $t6, $t6, $c0
++	and $t7, $t7, $c0
++	or $t0, $t0, $t4
++	or $t1, $t1, $t5
++	or $t2, $t2, $t6
++	or $t3, $t3, $t7
++
++
++	// Store results
++	sd $t0, 0($i0)
++	sd $t1, 8($i0)
++	sd $t2, 16($i0)
++	sd $t3, 24($i0)
++___
++}
++
++sub bn_mod_sub() {
++# returns r = ( a - b ) mod p, where p is a predefined polynomial modulus
++# Input: $i1 = address of operand a, $i2 = address of operand b
++# Output: $i0 = address for result storage
++# Dependencies: $mod = address of modulus p (passed via parameter)
++# Register usage: $t0-$t7: data storage registers, $c0-$c3: carry/borrow flags
++    my $mod = shift;
++$code.=<<___;
++	// Load inputs
++	ld $t0, 0($i1)
++	ld $t1, 8($i1)
++	ld $t2, 16($i1)
++	ld $t3, 24($i1)
++
++	ld $t4, 0($i2)
++	ld $t5, 8($i2)
++	ld $t6, 16($i2)
++	ld $t7, 24($i2)
++
++	// Subtraction
++	sltu $c3, $t0, $t4  //borrow
++	sub $t0, $t0, $t4
++
++	sltu $c1, $t1, $t5
++	sub $t1, $t1, $t5
++	sltu $c2, $t1, $c3
++	sub $t1, $t1, $c3
++	add $c3, $c2, $c1
++
++	sltu $c1, $t2, $t6
++	sub $t2, $t2, $t6
++	sltu $c2, $t2, $c3
++	sub $t2, $t2, $c3
++	add $c3, $c2, $c1
++
++	sltu $c1, $t3, $t7
++	sub $t3, $t3, $t7
++	sltu $c2, $t3, $c3
++	sub $t3, $t3, $c3
++	add $c3, $c2, $c1
++
++	// Load polynomial
++	la $i2, $mod
++	ld $t4, 0($i2)
++	ld $t5, 8($i2)
++	ld $t6, 16($i2)
++	ld $t7, 24($i2)
++
++	// Add polynomial
++	add $t4, $t0, $t4
++	sltu $c0, $t4, $t0
++
++	add $t5, $t1, $t5
++	sltu $c1, $t5, $t1
++	add $t5, $t5, $c0
++	sltu $c0, $t5, $c0
++	add $c0, $c0, $c1
++
++	add $t6, $t2, $t6
++	sltu $c1, $t6, $t2
++	add $t6, $t6, $c0
++	sltu $c0, $t6, $c0
++	add $c0, $c0, $c1
++
++	add $t7, $t3, $t7
++	add $t7, $t7, $c0
++
++	negw $c1, $c3
++	addw $c3, $c3, -1
++
++	and $t0, $t0, $c3
++	and $t1, $t1, $c3
++	and $t2, $t2, $c3
++	and $t3, $t3, $c3
++	and $t4, $t4, $c1
++	and $t5, $t5, $c1
++	and $t6, $t6, $c1
++	and $t7, $t7, $c1
++	or $t0, $t0, $t4
++	or $t1, $t1, $t5
++	or $t2, $t2, $t6
++	or $t3, $t3, $t7
++
++	sd $t0, 0($i0)
++	sd $t1, 8($i0)
++	sd $t2, 16($i0)
++	sd $t3, 24($i0)
++___
++}
++
++sub bn_mod_div_by_2() {
++# returns r = ( a / 2 ) mod p, (if a_is_odd ? a + p : a) >> 1， where p is a predefined polynomial modulus
++# Input: $i1 = address of operand a
++# Output: $i0 = address for result storage
++# Dependencies: $mod = address of modulus k = (p + 1) / 2 (passed via parameter)
++# Register usage: $t0-$t7: data storage registers, $c0-$c3: carry/borrow flags
++# Principle:
++#     if a is even: 0 <= a / 2 < p, ( a / 2 ) mod p = a / 2
++#     if a is odd: ( a / 2 ) mod p = ( a + p ) >> 1, k = (p + 1) / 2, ( a / 2 ) mod p = a >> 1 + k
++    my $mod = shift;
++$code.=<<___;
++	// Load inputs
++	ld $t0, 0($i1)
++	ld $t1, 8($i1)
++	ld $t2, 16($i1)
++	ld $t3, 24($i1)
++
++	// Save the least significant bit, is odd?
++	andi $c0, $t0, 0x1
++
++	// Right shift 1
++	slli $t4, $t1, 63
++	srli $t0, $t0, 1
++	or $t0, $t0, $t4
++	slli $t5, $t2, 63
++	srli $t1, $t1, 1
++	or $t1, $t1, $t5
++	slli $t6, $t3, 63
++	srli $t2, $t2, 1
++	or $t2, $t2, $t6
++	srli $t3, $t3, 1
++
++	// Load mod
++	la $i2, $mod
++	ld $t4, 0($i2)
++	ld $t5, 8($i2)
++	ld $t6, 16($i2)
++	ld $t7, 24($i2)
++
++	sub $c1, zero, $c0  //if even， p clear to 0
++
++	and $t4, $t4, $c1
++	and $t5, $t5, $c1
++	and $t6, $t6, $c1
++	and $t7, $t7, $c1
++
++	add $t0, $t0, $t4
++	sltu $c0, $t0, $t4
++
++	add $t1, $t1, $t5
++	sltu $c1, $t1, $t5
++	add $t1, $t1, $c0
++	sltu $c0, $t1, $c0
++	add $c0, $c0, $c1
++
++	add $t2, $t2, $t6
++	sltu $c1, $t2, $t6
++	add $t2, $t2, $c0
++	sltu $c0, $t2, $c0
++	add $c0, $c0, $c1
++
++	add $t3, $t3, $t7
++	add $t3, $t3, $c0
++
++	sd $t0, 0($i0)
++	sd $t1, 8($i0)
++	sd $t2, 16($i0)
++	sd $t3, 24($i0)
++___
++}
++
++{
++$code.=<<___;
++
++.section .rodata
++.p2align 5
++// The polynomial p
++.type .Lpoly,\@object
++.Lpoly:
++.dword	0xffffffffffffffff,0xffffffff00000000,0xffffffffffffffff,0xfffffffeffffffff
++
++// The order of polynomial n
++.type .Lord,\@object
++.Lord:
++.dword	0x53bbf40939d54123,0x7203df6b21c6052b,0xffffffffffffffff,0xfffffffeffffffff
++
++// (p + 1) / 2
++.type .Lpoly_div_2,\@object
++.Lpoly_div_2:
++.dword	0x8000000000000000,0xffffffff80000000,0xffffffffffffffff,0x7fffffff7fffffff
++
++// (n + 1) / 2
++.type .Lord_div_2,\@object
++.Lord_div_2:
++.dword	0xa9ddfa049ceaa092,0xb901efb590e30295,0xffffffffffffffff,0x7fffffff7fffffff
++
++
++// void bn_rshift1(BN_ULONG *a);
++.globl	bn_rshift1
++.type	bn_rshift1,%function
++.p2align 5
++bn_rshift1:
++	// Load inputs
++	ld $t0, 0($i0)
++	ld $t1, 8($i0)
++	ld $t2, 16($i0)
++	ld $t3, 24($i0)
++
++	// Right shift 1
++	slli $t4, $t1, 63
++	srli $t0, $t0, 1
++	or $t0, $t0, $t4
++	slli $t5, $t2, 63
++	srli $t1, $t1, 1
++	or $t1, $t1, $t5
++	slli $t6, $t3, 63
++	srli $t2, $t2, 1
++	or $t2, $t2, $t6
++	srli $t7, $t3, 1
++
++	// Store results
++	sd $t0, 0($i0)
++	sd $t1, 8($i0)
++	sd $t2, 16($i0)
++	sd $t7, 24($i0)
++
++	ret
++.size bn_rshift1,.-bn_rshift1
++
++// void bn_sub(BN_ULONG *r, const BN_ULONG *a, const BN_ULONG *b);
++.globl	bn_sub
++.type	bn_sub,%function
++.p2align 5
++bn_sub:
++	// Load inputs
++	ld $t0, 0($i1)
++	ld $t1, 8($i1)
++	ld $t2, 16($i1)
++	ld $t3, 24($i1)
++
++	ld $t4, 0($i2)
++	ld $t5, 8($i2)
++	ld $t6, 16($i2)
++	ld $t7, 24($i2)
++
++	// Subtraction
++	sltu $c3, $t0, $t4  //borrow
++	sub $t0, $t0, $t4
++
++	sltu $c1, $t1, $t5
++	sub $t1, $t1, $t5
++	sltu $c0, $t1, $c3
++	sub $t1, $t1, $c3
++	add $c3, $c1, $c0
++
++	sltu $c2, $t2, $t6
++	sub $t2, $t2, $t6
++	sltu $c1, $t2, $c3
++	sub $t2, $t2, $c3
++	add $c2, $c2, $c1
++
++	sub $t3, $t3, $t7
++	sub $t3, $t3, $c2
++
++	// Store results
++	sd $t0, 0($i0)
++	sd $t1, 8($i0)
++	sd $t2, 16($i0)
++	sd $t3, 24($i0)
++
++	ret
++.size bn_sub,.-bn_sub
++
++// void ecp_sm2p256_mul_by_3(BN_ULONG *r,const BN_ULONG *a);
++.globl	ecp_sm2p256_mul_by_3
++.type	ecp_sm2p256_mul_by_3,%function
++.p2align 5
++ecp_sm2p256_mul_by_3:
++// returns r = ( a * 3 ) mod p, where p is a predefined polynomial modulus .Lpoly
++// Input: $i1 = address of operand a
++// Output: $i0 = address for result storage
++// Register usage: $t0-$t7,$s0-$s7: data storage registers, $c0-$c3: carry/borrow flags
++___
++$code.= save_regs();
++$code.=<<___;
++	// Load inputs
++	ld $t0, 0($i1)
++	ld $t1, 8($i1)
++	ld $t2, 16($i1)
++	ld $t3, 24($i1)
++
++	// 2*a
++	add $t4, $t0, $t0
++	sltu $c0, $t4, $t0
++
++	slli $t5, $t1, 1
++	sltu $c1, $t5, $t1
++	add $t5, $t5, $c0
++
++	slli $t6, $t2, 1
++	sltu $c3, $t6, $t2
++	add $t6, $t6, $c1
++
++	slli $t7, $t3, 1
++	sltu $c0, $t7, $t3
++	add $t7, $t7, $c3
++
++	la $i2, .Lpoly
++	ld $s0, 0($i2)
++	ld $s1, 8($i2)
++	ld $s2, 16($i2)
++	ld $s3, 24($i2)
++
++	// Sub polynomial
++	sltu $c3, $t4, $s0
++	sub $s4, $t4, $s0
++
++	sltu $c1, $t5, $c3
++	sub $s5, $t5, $c3
++	sltu $c3, $s5, $s1
++	sub $s5, $s5, $s1
++	add $c3, $c3, $c1
++
++	sltu $c1, $t6, $c3
++	sub $s6, $t6, $c3
++	sltu $c3, $s6, $s2
++	sub $s6, $s6, $s2
++	add $c3, $c3, $c1
++
++	sltu $c1, $t7, $c3
++	sub $s7, $t7, $c3
++	sltu $c3, $s7, $s3
++	sub $s7, $s7, $s3
++	add $c3, $c3, $c1
++
++	slt $c0, $c0, $c3
++	negw $c1, $c0
++	addw $c0, $c0, -1
++
++	and $t4, $t4, $c1
++	and $t5, $t5, $c1
++	and $t6, $t6, $c1
++	and $t7, $t7, $c1
++	and $s4, $s4, $c0
++	and $s5, $s5, $c0
++	and $s6, $s6, $c0
++	and $s7, $s7, $c0
++	or $t4, $t4, $s4
++	or $t5, $t5, $s5
++	or $t6, $t6, $s6
++	or $t7, $t7, $s7
++
++	// 3*a
++	add $t4, $t4, $t0
++	sltu $c0, $t4, $t0
++
++	add $t5, $t5, $t1
++	sltu $c1, $t5, $t1
++	add $t5, $t5, $c0
++	sltu $c0, $t5, $c0
++	add $c0, $c0, $c1
++
++	add $t6, $t6, $t2
++	sltu $c1, $t6, $t2
++	add $t6, $t6, $c0
++	sltu $c0, $t6, $c0
++	add $c0, $c0, $c1
++
++	add $t7, $t7, $t3
++	sltu $c1, $t7, $t3
++	add $t7, $t7, $c0
++	sltu $c0, $t7, $c0
++	add $c0, $c0, $c1
++
++	// Sub polynomial
++	sltu $c3, $t4, $s0
++       sub $s4, $t4, $s0
++
++	sltu $c1, $t5, $c3
++	sub $s5, $t5, $c3
++	sltu $c3, $s5, $s1
++	sub $s5, $s5, $s1
++	add $c3, $c3, $c1
++
++	sltu $c1, $t6, $c3
++	sub $s6, $t6, $c3
++	sltu $c3, $s6, $s2
++	sub $s6, $s6, $s2
++	add $c3, $c3, $c1
++
++	sltu $c1, $t7, $c3
++	sub $s7, $t7, $c3
++	sltu $c3, $s7, $s3
++	sub $s7, $s7, $s3
++	add $c3, $c3, $c1
++
++	slt $c0, $c0, $c3
++	negw $c1, $c0
++	addw $c0, $c0, -1
++
++	and $t4, $t4, $c1
++	and $t5, $t5, $c1
++	and $t6, $t6, $c1
++	and $t7, $t7, $c1
++	and $s4, $s4, $c0
++	and $s5, $s5, $c0
++	and $s6, $s6, $c0
++	and $s7, $s7, $c0
++	or $t4, $t4, $s4
++	or $t5, $t5, $s5
++	or $t6, $t6, $s6
++	or $t7, $t7, $s7
++
++	// Store results
++	sd $t4, 0($i0)
++	sd $t5, 8($i0)
++	sd $t6, 16($i0)
++	sd $t7, 24($i0)
++___
++$code.= load_regs();
++$code.=<<___;
++	ret
++.size ecp_sm2p256_mul_by_3,.-ecp_sm2p256_mul_by_3
++
++
++// void ecp_sm2p256_add(BN_ULONG *r,const BN_ULONG *a,const BN_ULONG *b);
++.globl	ecp_sm2p256_add
++.type	ecp_sm2p256_add,%function
++.p2align 5
++ecp_sm2p256_add:
++___
++    &bn_mod_add(".Lpoly");
++$code.=<<___;
++	ret
++.size ecp_sm2p256_add,.-ecp_sm2p256_add
++
++// void ecp_sm2p256_sub(BN_ULONG *r,const BN_ULONG *a,const BN_ULONG *b);
++.globl	ecp_sm2p256_sub
++.type	ecp_sm2p256_sub,%function
++.p2align 5
++ecp_sm2p256_sub:
++___
++    &bn_mod_sub(".Lpoly");
++$code.=<<___;
++	ret
++.size ecp_sm2p256_sub,.-ecp_sm2p256_sub
++
++// void ecp_sm2p256_sub_mod_ord(BN_ULONG *r,const BN_ULONG *a,const BN_ULONG *b);
++.globl	ecp_sm2p256_sub_mod_ord
++.type	ecp_sm2p256_sub_mod_ord,%function
++.p2align 5
++ecp_sm2p256_sub_mod_ord:
++___
++    &bn_mod_sub(".Lord");
++$code.=<<___;
++	ret
++.size ecp_sm2p256_sub_mod_ord,.-ecp_sm2p256_sub_mod_ord
++
++// void ecp_sm2p256_div_by_2(BN_ULONG *r,const BN_ULONG *a);
++.globl	ecp_sm2p256_div_by_2
++.type	ecp_sm2p256_div_by_2,%function
++.p2align 5
++ecp_sm2p256_div_by_2:
++___
++    &bn_mod_div_by_2(".Lpoly_div_2");
++$code.=<<___;
++	ret
++.size ecp_sm2p256_div_by_2,.-ecp_sm2p256_div_by_2
++
++// void ecp_sm2p256_div_by_2_mod_ord(BN_ULONG *r,const BN_ULONG *a);
++.globl	ecp_sm2p256_div_by_2_mod_ord
++.type	ecp_sm2p256_div_by_2_mod_ord,%function
++.p2align 5
++ecp_sm2p256_div_by_2_mod_ord:
++___
++    &bn_mod_div_by_2(".Lord_div_2");
++$code.=<<___;
++	ret
++.size ecp_sm2p256_div_by_2_mod_ord,.-ecp_sm2p256_div_by_2_mod_ord
++
++.macro RDC
++// Fast Modular reduction of 512 bits in t7..t0 mod p
++// See https://en.wikipedia.org/wiki/Solinas_prime#Modular_reduction_algorithm
++//
++// For SM2 p = 2^256 -2^224 - 2^96 + 2^64 - 1
++//
++// p is a Generalized Mersenne prime of the form
++// p = 2^(32*8) - (2^(32*7) + 2^(32*3) - 2^(32*2) + 2^(32*0))
++//
++// Giving f(x) = x^7 + x^3 - x^2 + 1 (for x = 2^32)
++//
++// For j = 0 to 7
++//  sum(a(j) * x^j) = (s0 s1 .. s7) + ((s8 s9 .. s15))[matrix of coefficients][1 x x^2.. x^7]
++//
++// where the higher order terms can be expressed as
++//    x^8 ~= x^7 + x^3 - x^2 + 1
++//    x^9 ~= x * x^8 ~= x * (x^7 + x^3 - x^2 + 1)
++//       ~= x^8 + x^4 - x^3 + x mod p ~= x^7 + x^3 - x^2 + 1 + x^4 - x^3 + x
++//       ~= x^7 + x^4 - x^2 + x + 1
++//    Similarly:
++//    x^10 ~= x * x^9 ~= x * (x^7 + x^4 - x^2 + x + 1) ~= (x^8 + x^5 - x^3 + x2 + x)
++//         ~= x^7 + x^5 + x + 1
++//    x^11 ~= x^8 + x^6 + x^2 + x
++//         ~= x^7 + x^6 + x^3 + x + 1
++//    x^12 ~= x^8 + x^7 + x^4 + x^2 + x
++//         ~= 2x^7 + x^4 + x^3 + x + 1
++//    x^13 ~= 2x^8 + x^5 + x^4 + x^2 + x
++//         ~= 2x^7 + x^5 + x^4 + 2x^3 - x^2 + x + 2
++//    x^14 ~= 2x^8 + x^6 + x^5 + 2x^4 - x^3 + x^2 + 2x
++//         ~= 2x^7 + x^6 + x^5 + 2x^4 + x^3 - x^2 + 2x + 2
++//    x^15 ~= 2x^8 + x^7 + x^6 + 2x^5 + x^4 - x^3 + 2x^2 + 2x
++//         ~= 3x^7 + x^6 + 2x^5 + x^4 + x^3 + 2x + 2
++// ====>
++//      x^0     x^1     x^2     x^3     x^4     x^5     x^6     x^7
++//------------------------------------------------------------------
++// x^8      1       0      -1       1       0       0       0       1
++// x^9      1       1      -1       0       1       0       0       1
++// x^10     1       1       0       0       0       1       0       1
++// x^11     1       1       0       1       0       0       1       1
++// x^12     1       1       0       1       1       0       0       2
++// x^13     2       1      -1       2       1       1       0       2
++// x^14     2       2      -1       1       2       1       1       2
++// x^15     2       2       0       1       1       2       1       3
++// ====>
++// c0 = x0 + x8 + x9 + x10 + x11 + x12 + 2*x13 + 2*x14 + 2*x15
++// c1 = x1 + 0 + x9 + x10 + x11 + x12 + x13 + 2*x14 + 2*x15
++// c2 = x2 - x8 - x9 + 0 + 0 + 0 - x13 - x14 + 0
++// c3 = x3 + x8 + 0 + 0 + x11 + x12 + 2*x13 + x14 + x15
++// c4 = x4 + 0 + x9 + 0 + 0 + x12 + x13 + 2*x14 + x15
++// c5 = x5 + 0 + 0 + x10 + 0 + 0 + x13 + x14 + 2*x15
++// c6 = x6 + 0 + 0 + 0 + x11 + 0 + 0 + x14 + x15
++// c7 = x7 + x8 + x9 + x10 + x11 + 2*x12 + 2*x13 + 2*x14 + 3*x15
++// ===>
++// The input values are 8 64 bit values t0..t7
++// t4-t7 can be represented as 16*32 bit values s0..s7
++// a = |  t7   | ... | t0  |, where ti are 64-bit quantitiet
++//   = | s7| s6| ... |--|--|, where ai are 32-bit quantitiet
++// |    t7     |    t6     |    t5     |    t4     |
++// |  s7 |  s6 |  s5 |  s4 |  s3 |  s2 | s1  | s0  |
++// |    t3     |    t2     |    t1     |    t0     |
++// |           |           |           |           |
++// =================================================
++// |  s0 |  s3 |  s2 | s1  |  s0 |   0 |    t4     | (+)
++// |  s1 |  s7 |    t6     |  s3 |   0 |  s2 |  s1 | (+)
++// |  s2 |   0 |  s6 |  s5 |  s4 |   0 |    t5     | (+)
++// |  s3 |   0 |    t7     |  s5 |   0 |  s4 |  s3 | (+)
++// |  s4 |   0 |    t7     |  s5 |   0 |    t6     | (+)
++// |  s4 |   0 |   0 |  s7 |  s6 |   0 |  s6 |  s5 | (+)
++// |  s5 |   0 |   0 |   0 |  s7 |   0 |  s6 |  s5 | (+)
++// |  s5 |   0 |   0 |   0 |   0 |   0 |    t7     | (+)
++// |  s6 |   0 |   0 |   0 |   0 |   0 |    t7     | (+)
++// |  s6 |   0 |   0 |   0 |   0 |   0 |   0 |  s7 | (+)
++// |  s7 |   0 |   0 |   0 |   0 |   0 |   0 |  s7 | (+)
++// |  s7 |   0 |   0 |   0 |   0 |   0 |   0 |   0 | (+)
++// |    t7     |   0 |   0 |   0 |   0 |   0 |   0 | (+)
++// |   0 |   0 |   0 |   0 |   0 | s0  |   0 |   0 | (-)
++// |   0 |   0 |   0 |   0 |   0 | s1  |   0 |   0 | (-)
++// |   0 |   0 |   0 |   0 |   0 | s5  |   0 |   0 | (-)
++// |   0 |   0 |   0 |   0 |   0 | s6  |   0 |   0 | (-)
++// | U[7]| U[6]| U[5]| U[4]| U[3]| U[2]| U[1]| U[0]|
++// |  t7 |  t6 |  t5 |  t4 |  s3 |  s2 |   s1 | s0 | (+)
++// |    V[3]   |    V[2]   |    V[1]   |    V[0]   |
++
++	// 1. 64-bit addition
++	// s0=t6+t7+t7
++	add $s0, $t6, $t7
++	sltu $c0, $s0, $t6
++	add $s0, $s0, $t7
++	sltu $c1, $s0, $t7
++	add $s10, $c0, $c1  //t6+t7+t7 carry
++
++	// s2=t4+t5+s0
++	add $s2, $t4, $t5
++	sltu $c2, $s2, $t4
++	add $c0, $c2, $s10
++	add $s2, $s2, $s0
++	sltu $c3, $s2, $s0
++	add $c0, $c0, $c3  //t4+t5+t6+t7+t7 carry
++
++	// sum
++	add $t0, $t0, $s2 // t0 += (t4 + t5 + t6 + 2 * t7)
++	sltu $c1, $t0, $s2
++	add $t1, $t1, $c0
++	sltu $c0, $t1, $c0
++	add $t1, $t1, $c1
++	sltu $c1, $t1, $c1
++	add $c0, $c0, $c1
++	add $t2, $t2, $s0  //t2 += t6 + 2 * t7
++	sltu $c2, $t2, $s0
++	add $t2, $t2, $c0
++	sltu $c0, $t2, $c0
++	add $c0, $c0, $c2
++	add $t3, $t3, $t7 // t3 += t7
++	sltu $c1, $t3, $t7
++	add $t3, $t3, $c0
++	sltu $c0, $t3, $c0
++	add $c0, $c0, $c1
++	add $t3, $t3, $s10
++	sltu $c1, $t3, $s10
++	add $s8, $c0, $c1  // s8 = carry from t3
++
++	// 2. 64-bit to 32-bit spread
++	zext.w $s0, $t4
++	zext.w $s2, $t5
++	zext.w $s4, $t6
++	zext.w $s6, $t7
++
++	srli $s1, $t4, 32
++	srli $s3, $t5, 32
++	srli $s5, $t6, 32
++	srli $s7, $t7, 32
++
++	// 3. 32-bit addition
++	add $c0, $s4, $s6
++	add $c1, $s5, $s7
++	add $c2, $s0, $s1
++	add $t5, $s6, $s2  // t5 :s2 + s6
++	add $t6, $s7, $s3  // t6: s3 + s7
++	add $s4, $c1, $c0  // s4 + s5 + s6 + s7
++	add $s2, $s2, $s4
++	add $s2, $s2, $s4
++	add $c3, $s3, $c2
++	add $t7, $s2, $c3  //  t7: s0 + s1 + s2 + s3 + 2*(s4 + s5 + s6 + s7)
++	add $s4, $s4, $s5
++	add $s4, $s4, $s3
++	add $s4, $s4, $s0  // s0 + s3 + s4 + s5*2 + s6 + s7
++	add $c2, $c2, $s6
++	add $s2, $c2, $s5  // s2: s0 + s1 + s5 + s6
++	add $t4, $s1, $c1  // t4: s1 +s5 +s7
++	add $s3, $s3, $t4
++	add $s0, $s3, $c1  // s0: s1 + s3 + (s5 + s7)*2
++	add $s1, $c0, $t5  // s1: s2 + s4 + s6*2
++	mv $s3, $s4   // s3: s4 + s5 + s6 + s7
++
++	// 4. 32-bit to 64-bit
++	slli $s9, $s1, 32
++	slli $c0, $s3, 32
++	srli $c1, $s1, 32
++	or $s1, $c1, $c0
++	slli $c2, $t5, 32
++	srli $c3, $s3, 32
++	or $s3, $c3, $c2
++	slli $c0, $t7, 32
++	srli $c1, $t5, 32
++	or $t5, $c0, $c1
++	srli $t7, $t7, 32
++
++	// 5. 64-bit addition
++	add $s0, $s0, $s9
++	sltu $c0, $s0, $s9
++	add $s1, $s1, $c0
++	sltu $c1, $s1, $c0
++	add $s3, $t4, $s3
++	sltu $c2, $s3, $t4
++	add $s3, $s3, $c1
++	sltu $c3, $s3, $c1
++	add $c0, $c2, $c3
++	add $s4, $t6, $t5
++	sltu $c1, $s4, $t6
++	add $s4, $s4, $c0
++	sltu $c2, $s4, $c0
++	add $c0, $c1, $c2
++	add $c0, $c0, $s8
++	add $c0, $c0, $t7
++
++	// V[0]	s0
++	// V[1]	s1
++	// V[2]	s3
++	// V[3]	s4
++	// carry	c0
++	// sub	s2
++
++	// add with V0-V3
++	add $t0, $t0, $s0
++	sltu $c1, $t0, $s0
++	add $t1, $t1, $s1
++	sltu $c2, $t1, $s1
++	add $t1, $t1, $c1
++	sltu $c1, $t1, $c1
++	add $c1, $c1, $c2
++	add $t2, $t2, $s3
++	sltu $c2, $t2, $s3
++	add $t2, $t2, $c1
++	sltu $c1, $t2, $c1
++	add $c1, $c1, $c2
++	add $t3, $t3, $s4
++	sltu $c2, $t3, $s4
++	add $t3, $t3, $c1
++	sltu $c1, $t3, $c1
++	add $c1, $c1, $c2
++	add $c0, $c0, $c1
++	// sub with s2
++	sltu $c2, $t1, $s2
++	sub $t1, $t1, $s2
++	sltu $c3, $t2, $c2
++	sub $t2, $t2, $c2
++	sltu $c1, $t3, $c3
++	sub $t3, $t3, $c3
++	sub $c0, $c0, $c1
++
++	// 6. MOD
++	// First Mod
++	slli $s5, $c0, 32
++	sub $s6, $s5, $c0
++
++	add $t0, $t0, $c0
++	sltu $c1, $t0, $c0
++	add $t1, $t1, $s6
++	sltu $c2, $t1, $s6
++	add $t1, $t1, $c1
++	sltu $c1, $t1, $c1
++	add $c1, $c1, $c2
++	add $t2, $t2, $c1
++	sltu $c1, $t2, $c1
++	add $t3, $t3, $s5
++	sltu $c2, $t3, $s5
++	add $t3, $t3, $c1
++	sltu $c1, $t3, $c1
++	add $c0, $c2, $c1
++
++	// Last Mod
++	// return y - p if y > p else y
++	la $i2, .Lpoly
++	ld $s0, 0($i2)
++	ld $s1, 8($i2)
++	ld $s2, 16($i2)
++	ld $s3, 24($i2)
++
++	sltu $c1, $t0, $s0
++	sub $t4, $t0, $s0
++	sltu $c2, $t1, $s1
++	sub $t5, $t1, $s1
++	sltu $c3, $t5, $c1
++	sub $t5, $t5, $c1
++	add $c1, $c2, $c3
++	sltu $c2, $t2, $s2
++	sub $t6, $t2, $s2
++	sltu $c3, $t6, $c1
++	sub $t6, $t6, $c1
++	add $c1, $c2, $c3
++	sltu $c2, $t3, $s3
++	sub $t7, $t3, $s3
++	sltu $c3, $t7, $c1
++	sub $t7, $t7, $c1
++	add $c1, $c2, $c3
++
++	slt $c0, $c0, $c1
++	negw $c1, $c0
++	addw $c0, $c0, -1
++
++	and $t0, $t0, $c1
++	and $t1, $t1, $c1
++	and $t2, $t2, $c1
++	and $t3, $t3, $c1
++	and $t4, $t4, $c0
++	and $t5, $t5, $c0
++	and $t6, $t6, $c0
++	and $t7, $t7, $c0
++	or $t0, $t0, $t4
++	or $t1, $t1, $t5
++	or $t2, $t2, $t6
++	or $t3, $t3, $t7
++
++	sd $t0, 0($i0)
++	sd $t1, 8($i0)
++	sd $t2, 16($i0)
++	sd $t3, 24($i0)
++.endm
++
++
++// void ecp_sm2p256_mul(BN_ULONG *r, const BN_ULONG *a, const BN_ULONG *b);
++.globl	ecp_sm2p256_mul
++.type	ecp_sm2p256_mul,%function
++.p2align 5
++ecp_sm2p256_mul:
++___
++$code.= save_regs();
++$code.=<<___;
++	// Load inputs
++	ld $t0, 0($i1)
++	ld $t1, 8($i1)
++	ld $t2, 16($i1)
++	ld $t3, 24($i1)
++	ld $t4, 0($i2)
++	ld $t5, 8($i2)
++	ld $t6, 16($i2)
++	ld $t7, 24($i2)
++// ### multiplication ###
++	// ========================
++	//             t3 t2 t1 t0
++	// *           t7 t6 t5 t4
++	// ------------------------
++	// +           t0 t0 t0 t0
++	//              *  *  *  *
++	//             t7 t6 t5 t4
++	//          t1 t1 t1 t1
++	//           *  *  *  *
++	//          t7 t6 t5 t4
++	//       t2 t2 t2 t2
++	//        *  *  *  *
++	//       t7 t6 t5 t4
++	//    t3 t3 t3 t3
++	//     *  *  *  *
++	//    t7 t6 t5 t4
++	// ------------------------
++	// t7 t6 t5 t4 t3 t2 t1 t0
++	// ========================
++
++// ### t0*t4 ###
++	mul $s0, $t0, $t4
++	mulhu $s1, $t0, $t4
++
++//	### t0*t5+t1*t4 ###
++	mul $s2, $t0, $t5
++	mulhu $s3, $t0, $t5
++	mul $s4, $t1, $t4
++	mulhu $s5, $t1, $t4
++
++	add $s1, $s1, $s2
++	sltu $c0, $s1, $s2
++	add $s3, $s3, $s5
++	sltu $c1, $s3, $s5
++
++	add $s1, $s1, $s4
++	sltu $c2, $s1, $s4
++	add $c0, $c0, $c2
++	add $s3, $s3, $c0
++	sltu $c0, $s3, $c0
++	add $c0, $c0, $c1
++
++//	### t0*t6+t1*t5+t2*t4 ###
++	mul $s2, $t0, $t6
++	mulhu $s4, $t0, $t6
++	mul $s5, $t1, $t5
++	mulhu $s6, $t1, $t5
++	mul $s7, $t2, $t4
++	mulhu $s8, $t2, $t4
++
++	add $s2, $s2, $s3
++	sltu $c1, $s2, $s3
++	add $s5, $s5, $s7
++	sltu $c3, $s5, $s7
++	add $s2, $s2, $s5
++	sltu $c2, $s2, $s5
++	add $c1, $c1, $c3
++	add $c0, $c0, $c2
++	add $c0, $c0, $c1
++
++	add $s4, $s4, $s6
++	sltu $c2, $s4, $s6
++	add $s8, $s8, $c0
++	sltu $c0, $s8, $c0
++	add $s4, $s4, $s8
++	sltu $c3, $s4, $s8
++	add $c0, $c2, $c0
++	add $c0, $c0, $c3
++
++//	### t0*t7+t1*t6+t2*t5+t3*t4 ###
++	mul $s3, $t0, $t7
++	mulhu $s5, $t0, $t7
++	mv $t0, $s0
++	mul $s9, $t1, $t6
++	mulhu $s10, $t1, $t6
++	mul $s0, $t2, $t5
++	mulhu $s6, $t2, $t5
++	mul $s7, $t3, $t4
++	mulhu $s8, $t3, $t4
++
++	add $s3, $s3, $s9
++	sltu $c1, $s3, $s9
++	add $s0, $s0, $s4
++	sltu $c2, $s0, $s4
++	add $c1, $c1, $c2
++	add $s3, $s3, $s7
++	sltu $c3, $s3, $s7
++	add $s3, $s3, $s0
++	sltu $c2, $s3, $s0
++	add $c3, $c3, $c2
++	add $c0, $c0, $c1
++	add $c0, $c0, $c3
++
++	add $s5, $s5, $s10
++	sltu $c1, $s5, $s10
++	add $s6, $s6, $s8
++	sltu $c2, $s6, $s8
++	add $c1, $c1, $c2
++	add $s5, $s5, $c0
++	sltu $c0, $s5, $c0
++	add $s5, $s5, $s6
++	sltu $c3, $s5, $s6
++	add $c0, $c0, $c1
++	add $c0, $c0, $c3
++
++//	### t1*t7+t2*t6+t3*t5 ###
++	mul $s4, $t1, $t7
++	mulhu $s6, $t1, $t7
++	mv $t1, $s1
++	mul $s0, $t2, $t6
++	mulhu $s1, $t2, $t6
++	mul $s7, $t3, $t5
++	mulhu $s8, $t3, $t5
++
++	add $s4, $s4, $s5
++	sltu $c1, $s4, $s5
++	add $s0, $s0, $s7
++	sltu $c2, $s0, $s7
++	add $c1, $c1, $c2
++	add $t4, $s4, $s0
++	sltu $c3, $t4, $s0
++	add $c1, $c1, $c3
++	add $c0, $c0, $c1
++
++	add $s6, $s6, $s1
++	sltu $c2, $s6, $s1
++	add $s8, $s8, $c0
++	sltu $c0, $s8, $c0
++	add $c0, $c0, $c2
++	add $s6, $s6, $s8
++	sltu $c3, $s6, $s8
++	add $c0, $c0, $c3
++
++//	### t2*t7+t3*t6 ###
++	mul $s0, $t2, $t7
++	mulhu $s1, $t2, $t7
++	mv $t2, $s2
++	mul $s5, $t3, $t6
++	mulhu $t6, $t3, $t6
++
++	add $s0, $s0, $s5
++	sltu $c1, $s0, $s5
++	add $t5, $s0, $s6
++	sltu $c2, $t5, $s6
++	add $c0, $c0, $c1
++	add $c0, $c0, $c2
++
++	add $t6, $t6, $s1
++	sltu $c1, $t6, $s1
++	add $t6, $t6, $c0
++	sltu $c0, $t6, $c0
++	add $c0, $c0, $c1
++
++//	### t3*t7 ###
++	mul $s2, $t3, $t7
++	mulhu $t7, $t3, $t7
++	mv $t3, $s3
++
++	add $t6, $t6, $s2
++	sltu $c1, $t6, $s2
++	add $t7, $t7, $c0
++	add $t7, $t7, $c1
++
++	// ### Reduction ###
++	RDC
++___
++$code.= load_regs();
++$code.=<<___;
++	ret
++.size ecp_sm2p256_mul,.-ecp_sm2p256_mul
++
++// void ecp_sm2p256_sqr(BN_ULONG *r, const BN_ULONG *a);
++.globl	ecp_sm2p256_sqr
++.type	ecp_sm2p256_sqr,%function
++.p2align 5
++ecp_sm2p256_sqr:
++___
++$code.= save_regs();
++$code.=<<___;
++	// Load inputs
++	ld $s0, 0($i1)
++	ld $s1, 8($i1)
++	ld $s2, 16($i1)
++	ld $s3, 24($i1)
++
++	// ========================
++	//             s3 s2 s1 s0
++	// *           s3 s2 s1 s0
++	// ------------------------
++	// +           s0 s0 s0 s0
++	//              *  *  *  *
++	//             s3 s2 s1 s0
++	//          s1 s1 s1 s1
++	//           *  *  *  *
++	//          s3 s2 s1 s0
++	//       s2 s2 s2 s2
++	//        *  *  *  *
++	//       s3 s2 s1 s0
++	//    s3 s3 s3 s3
++	//     *  *  *  *
++	//    s3 s2 s1 s0
++	// ------------------------
++	// t7 t6 t5 t4 t3 t2 t1 t0
++	// ========================
++
++// ### s0*s0 ###
++	mul $t0, $s0, $s0
++	mulhu $t1, $s0, $s0
++
++// ### s0*s1*2 ###
++	mul $s4, $s0, $s1
++	mulhu $s5, $s0, $s1
++
++	slli $s6, $s4, 1
++	sltu $c0, $s6, $s4
++	add $t1, $t1, $s6
++	sltu $c1, $t1, $s6
++	add $c0, $c0, $c1
++
++	slli $t2, $s5, 1
++	sltu $c2, $t2, $s5
++	add $t2, $t2, $c0
++	sltu $c3, $t2, $c0
++	add $c0, $c2, $c3
++
++// ### s0*s2*2+s1*s1 ###
++	mul $s7, $s0, $s2
++	mulhu $s8, $s0, $s2
++	mul $s9, $s1, $s1
++	mulhu $s10, $s1, $s1
++
++	slli $t4, $s7, 1
++	sltu $c1, $t4, $s7
++	add $t2, $t2, $s9
++	sltu $c2, $t2, $s9
++	add $c0, $c0, $c1
++	add $t2, $t2, $t4
++	sltu $c3, $t2, $t4
++	add $c0, $c0, $c2
++	add $c0, $c0, $c3
++
++	slli $t3, $s8, 1
++	sltu $c1, $t3, $s8
++	add $s10, $s10, $c0
++	sltu $c0, $s10, $c0
++	add $t3, $t3, $s10
++	sltu $c2, $t3, $s10
++	add $c0, $c0, $c1
++	add $c0, $c0, $c2
++
++// ### (s0*s3+s1*s2)*2 ###
++	mul $s4, $s0, $s3
++	mulhu $s5, $s0, $s3
++	mul $s6, $s1, $s2
++	mulhu $s7, $s1, $s2
++
++	add $s4, $s4, $s6
++	sltu $c1, $s4, $s6
++	slli $c1, $c1, 1
++	slli $s6, $s4, 1
++	sltu $c2, $s6, $s4
++	add $c1, $c1, $c2
++	add $t3, $t3, $s6
++	sltu $c3, $t3, $s6
++	add $c0, $c0, $c1
++	add $c0, $c0, $c3
++
++	add $s5, $s5, $s7
++	sltu $c1, $s5, $s7
++	slli $c1, $c1, 1
++	slli $s8, $s5, 1
++	sltu $c2, $s8, $s5
++	add $c1, $c1, $c2
++	add $t4, $c0, $s8
++	sltu $c3, $t4, $s8
++	add $c0, $c1, $c3
++
++// ### s1*s3*2+s2*s2 ###
++	mul $s4, $s1, $s3
++	mulhu $s5, $s1, $s3
++	mul $s6, $s2, $s2
++	mulhu $s7, $s2, $s2
++
++	slli $s8, $s4, 1
++	sltu $c1, $s8, $s4
++	add $c0, $c0, $c1
++	add $t4, $t4, $s6
++	sltu $c2, $t4, $s6
++	add $c0, $c0, $c2
++	add $t4, $t4, $s8
++	sltu $c3, $t4, $s8
++	add $c0, $c0, $c3
++
++	slli $s9, $s5, 1
++	sltu $c1, $s9, $s5
++	add $t5, $c0, $s7
++	sltu $c2, $t5, $s7
++	add $c0, $c1, $c2
++	add $t5, $t5, $s9
++	sltu $c3, $t5, $s9
++	add $c0, $c0, $c3
++
++// ### s2*s3*2 ###
++	mul $s4, $s2, $s3
++	mulhu $s5, $s2, $s3
++
++	slli $s6, $s4, 1
++	sltu $c1, $s6, $s4
++	add $t5, $t5, $s6
++	sltu $c2, $t5, $s6
++	add $c0, $c0, $c1
++	add $c0, $c0, $c2
++
++	slli $t6, $s5, 1
++	sltu $c3, $t6, $s5
++	add $t6, $t6, $c0
++	sltu $c0, $t6, $c0
++	add $c0, $c0, $c3
++
++// ### s3*s3 ###
++	mul $s8, $s3, $s3
++	mulhu $s9, $s3, $s3
++
++	add $t6, $t6, $s8
++	sltu $c1, $t6, $s8
++
++	add $t7, $s9, $c0
++	add $t7, $t7, $c1
++
++	// ### Reduction ###
++	RDC
++___
++$code.= load_regs();
++$code.=<<___;
++	ret
++.size ecp_sm2p256_sqr,.-ecp_sm2p256_sqr
++___
++}
++
++foreach (split("\n",$code)) {
++    s/\`([^\`]*)\`/eval $1/ge;
++
++    print $_,"\n";
++}
++close STDOUT or die "error closing STDOUT: $!";		# enforce flush
+diff --git a/crypto/ec/build.info b/crypto/ec/build.info
+index dbe6957..b6d1a93 100644
+--- a/crypto/ec/build.info
++++ b/crypto/ec/build.info
+@@ -59,6 +59,14 @@ IF[{- !$disabled{asm} -}]
+ 
+   $ECASM_c64xplus=
+ 
++  IF[{- !$disabled{'sm2'} -}]
++    $ECASM_riscv64=ecp_sm2p256.c  ecp_sm2p256-riscv64.S
++    IF[{- !$disabled{'sm2-precomp'} -}]
++      $ECASM_riscv64=$ECASM_riscv64 ecp_sm2p256_table.c
++    ENDIF
++    $ECDEF_riscv64=ECP_SM2P256_ASM
++  ENDIF
++
+   # Now that we have defined all the arch specific variables, use the
+   # appropriate one, and define the appropriate macros
+   IF[$ECASM_{- $target{asm_arch} -}]
+@@ -139,3 +147,8 @@ IF[{- !$disabled{'sm2'} -}]
+   GENERATE[ecp_sm2p256-armv8.S]=asm/ecp_sm2p256-armv8.pl
+   INCLUDE[ecp_sm2p256-armv8.o]=..
+ ENDIF
++
++IF[{- !$disabled{'sm2'} -}]
++  GENERATE[ecp_sm2p256-riscv64.S]=asm/ecp_sm2p256-riscv64.pl
++  INCLUDE[ecp_sm2p256-riscv64.o]=..
++ENDIF
+-- 
+2.52.0
+

--- a/SPECS/openssl/openssl.spec
+++ b/SPECS/openssl/openssl.spec
@@ -56,6 +56,17 @@ Requires:       %{name}%{?_isa} = %{version}-%{release}
 0007-RISC-V-GHASH-Zvkg-multi-block-aggregation.patch
 # https://github.com/openssl/openssl/pull/28673
 0008-Backport-Instruction-rearrangement-optimization-for-SHA256-on-RISCV.patch
+# https://github.com/openssl/openssl/pull/30194
+0009-Backport-riscv-AES-XTS-Code-Comment-Correction.patch
+# https://github.com/openssl/openssl/pull/29134
+# https://github.com/openssl/openssl/pull/29137
+# https://github.com/openssl/openssl/pull/29451
+# https://github.com/openssl/openssl/pull/29544
+0010-Backport-riscv-Performance-Optimization-of-SM4-CBC-on-RISC-V-Architecture.patch
+# https://github.com/openssl/openssl/pull/31116
+0011-Backport-riscv-Further-improve-the-decryption-performance-of-AES-128-CBC-on-RISC-V.patch
+# https://github.com/openssl/openssl/pull/25918
+0012-Add-SM2-implementation-in-generic-riscv64-asm.patch
 
 %description    devel
 This package contains the header files, pkgconfig/cmake files, development


### PR DESCRIPTION
## Summary

This PR backports a series of RISC-V cryptography optimization and assembly implementation patches from upstream OpenSSL to the openRuyi `openssl` package.

Specifically, it adds the following patches to `SPECS/openssl`:
1. **0009**: `AES-XTS Code Comment Correction` (Upstream PR #30194)
2. **0010**: `Performance Optimization of SM4-CBC on RISC-V Architecture` (Upstream PRs #29134, #29137, #29451, #29544)
   - *Improves SM4-CBC encryption performance by 41%~50% and decryption by 9%~33% on RISC-V.*
3. **0011**: `Further improve the decryption performance of AES-128-CBC on RISC-V` (Upstream PR #31116)
   - *Improves AES-128-CBC decryption performance by 6%~15% via instruction reordering and block processing adjustments.*
4. **0012**: `Add SM2 implementation in generic riscv64 asm` (Upstream PR #25918)
   - *Introduces generic RISC-V assembly implementation for SM2 to accelerate elliptic curve operations.*

These changes significantly enhance the cryptographic performance and hardware-specific support for RISC-V architecture in openRuyi.

## Related Issue

N/A --

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!-- 
If this PR includes non-trivial AI-assisted content, check the box below and add attribution 
using the `AGENT_NAME:MODEL_VERSION` format. 
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking 
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: Trae:Claude-3.5-Sonnet <!-- 如果你完全使用当前生成的模板，可以保留此声明 -->

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]: https://openruyi.cn/governance/policy/ai-contribution-policy