### PR TITLE
SPECS: angelscript: Add gcc-c++ to BuildRequires

### DIFF
--- a/SPECS/angelscript/angelscript.spec
+++ b/SPECS/angelscript/angelscript.spec
@@ -21,6 +21,7 @@ BuildOption(conf):  -S angelscript/projects/cmake
 BuildOption(conf):  -DBUILD_SHARED_LIBS:BOOL=ON
 
 BuildRequires:  cmake
+BuildRequires:  gcc-c++
 BuildRequires:  unzip
 BuildRequires:  dos2unix
 


### PR DESCRIPTION
## Summary

Fix AngelScript build failure.

## Related Issue

- Resolves #905

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
