### PR TITLE
SPECS: llvm-default: Modify clang-{devel,static} dependency.

### DIFF
--- a/SPECS/llvm-defaults/llvm-defaults.spec
+++ b/SPECS/llvm-defaults/llvm-defaults.spec
@@ -81,7 +81,6 @@ Summary:        Default symlinks for clang development tools
 Requires:       clang%{?_isa} = %{version}-%{release}
 Requires:       clang%{maj_ver}-devel > %{maj_ver}
 Requires:       llvm-devel = %{version}-%{release}
-Requires:       clang-static = %{version}-%{release}
 Provides:       cmake(Clang) = %{maj_ver}
 
 %description -n clang-devel
@@ -123,6 +122,7 @@ This package provides default unversioned symlinks for clang static analyzer %{m
 # ============================================================================
 %package     -n clang-static
 Summary:        Default dependency package for Clang static libraries
+Requires:       clang-devel = %{version}-%{release}
 Requires:       clang%{maj_ver}-static > %{maj_ver}
 
 # ============================================================================


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->
Per llvm22 SPEC, let clang-static requires clang-devel, clang-devel not requires clang-static.

Llvm21 doesn't package clang static libraries(patch 0003), so the modification should not have side effect on the current packages.


## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
