### PR TITLE
SPECS: add nexttrace-tiny 

### DIFF
--- a/SPECS/go-github-akamensky-argparse/go-github-akamensky-argparse.spec
+++ b/SPECS/go-github-akamensky-argparse/go-github-akamensky-argparse.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           argparse
+%define go_import_path  github.com/akamensky/argparse
+
+Name:           go-github-akamensky-argparse
+Version:        1.4.0
+Release:        %autorelease
+Summary:        Argument parser for Go
+License:        MIT
+URL:            https://github.com/akamensky/argparse
+VCS:            git:https://github.com/akamensky/argparse
+#!RemoteAsset:  sha256:755bc41205468e0fb7264bee5c0f14585ee8eeaa377e96a23655c12f65df7016
+Source0:        https://github.com/akamensky/argparse/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/akamensky/argparse) = %{version}
+
+%description
+Argparse is an argument parser for Go command-line applications. It supports
+positional arguments, flags, commands, validation, and generated help output.
+
+%files
+%license LICENSE
+%doc README.md
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-google-gopacket/2000-fix-dns-test-format-for-go1.26.patch
+++ b/SPECS/go-github-google-gopacket/2000-fix-dns-test-format-for-go1.26.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+Date: Tue, 14 Jul 2026 00:00:00 +0000
+Subject: [PATCH] Fix DNS URI test format verbs
+
+Go 1.26 vet rejects %q for the uint16 priority and weight fields. Use the
+numeric %d verb so the existing tests remain enabled.
+---
+ layers/dns_test.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/layers/dns_test.go b/layers/dns_test.go
+--- a/layers/dns_test.go
++++ b/layers/dns_test.go
+@@ -192 +192 @@
+-		t.Errorf("Incorrect URI priority value, expected %q, got %q", testParseDNSTypeURIPriority, priority)
++		t.Errorf("Incorrect URI priority value, expected %d, got %d", testParseDNSTypeURIPriority, priority)
+@@ -196 +196 @@
+-		t.Errorf("Incorrect URI weight value, expected %q, got %q", testParseDNSTypeURIWeight, weight)
++		t.Errorf("Incorrect URI weight value, expected %d, got %d", testParseDNSTypeURIWeight, weight)

--- a/SPECS/go-github-google-gopacket/go-github-google-gopacket.spec
+++ b/SPECS/go-github-google-gopacket/go-github-google-gopacket.spec
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           gopacket
+%define go_import_path  github.com/google/gopacket
+# Skip optional native capture backends and examples that require unpackaged
+# local libraries; nexttrace only needs the pure-Go core. libpcap fails with
+# "fatal error: pcap.h: No such file or directory", while PF_RING fails with
+# "fatal error: pfring.h: No such file or directory" and is not in the repo.
+# Keep pcapgo testable by spelling out pcap and its children instead of pcap*.
+%define go_test_exclude_glob %{shrink:
+    %{go_import_path}/pcap
+    %{go_import_path}/pcap/*
+    %{go_import_path}/pfring
+    %{go_import_path}/examples/*
+}
+
+Name:           go-github-google-gopacket
+Version:        1.1.19
+Release:        %autorelease
+Summary:        Packet decoding library for Go
+License:        BSD-3-Clause
+URL:            https://github.com/google/gopacket
+VCS:            git:https://github.com/google/gopacket
+#!RemoteAsset:  sha256:31efa87cc9d2b41e5e66c7daa8839d841d2a43cc477bf595c9e8c24ef6903830
+Source0:        https://github.com/google/gopacket/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Fix Go 1.26 vet errors: %q is invalid for uint16 DNS priority and weight.
+Patch2000:      2000-fix-dns-test-format-for-go1.26.patch
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(golang.org/x/net)
+BuildRequires:  go(golang.org/x/sys)
+
+Provides:       go(github.com/google/gopacket) = %{version}
+
+Requires:       go(golang.org/x/net)
+Requires:       go(golang.org/x/sys)
+
+%description
+Gopacket provides packet decoding for Go. It includes support for many network
+protocols and packet capture formats, along with packet filtering and assembly
+utilities.
+
+%prep -a
+# These source-only generator files are not installed as executable commands.
+chmod a-x layers/test_creator.py pcapgo/write.go
+
+%files
+%license LICENSE
+%doc AUTHORS CONTRIBUTING.md README.md
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-oschwald-maxminddb-golang/go-github-oschwald-maxminddb-golang.spec
+++ b/SPECS/go-github-oschwald-maxminddb-golang/go-github-oschwald-maxminddb-golang.spec
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           maxminddb-golang
+%define go_import_path  github.com/oschwald/maxminddb-golang
+%global testdata_commit 3e225a82e492a58eef738ef2b6e94aa4f50ef932
+
+Name:           go-github-oschwald-maxminddb-golang
+Version:        1.13.1
+Release:        %autorelease
+Summary:        MaxMind DB reader for Go
+License:        ISC AND CC-BY-SA-3.0
+URL:            https://github.com/oschwald/maxminddb-golang
+VCS:            git:https://github.com/oschwald/maxminddb-golang
+#!RemoteAsset:  sha256:d337efdac8d906cf3853f048fb74f96ecff4f70c2e64d869fdd87c83eb797bfd
+Source0:        https://github.com/oschwald/maxminddb-golang/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+# Source1 only restores the exact MaxMind-DB test-data submodule commit pinned
+# by upstream.
+#!RemoteAsset:  sha256:d73bcaaa6f96ffe06e6dcdb843cf43b5eb8dbebaec8361fce352ecc61c04bccd
+Source1:        https://github.com/maxmind/MaxMind-DB/archive/%{testdata_commit}/MaxMind-DB-%{testdata_commit}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(golang.org/x/sys)
+
+Provides:       go(github.com/oschwald/maxminddb-golang) = %{version}
+
+Requires:       go(golang.org/x/sys)
+
+%description
+Maxminddb-golang is a Go reader for the MaxMind DB file format. It provides
+memory-mapped and in-memory access to MaxMind database records.
+
+%prep -a
+rm -rf test-data
+mkdir -p test-data
+tar -xf %{SOURCE1} --strip-components=1 -C test-data
+
+%files
+%license LICENSE
+%doc README.md
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-rodaine-table/go-github-rodaine-table.spec
+++ b/SPECS/go-github-rodaine-table/go-github-rodaine-table.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           table
+%define go_import_path  github.com/rodaine/table
+
+Name:           go-github-rodaine-table
+Version:        1.3.1
+Release:        %autorelease
+Summary:        Go library for simple terminal tables
+License:        MIT
+URL:            https://github.com/rodaine/table
+VCS:            git:https://github.com/rodaine/table
+#!RemoteAsset:  sha256:06c9dd4211e76ffca2df995497354272532230b17c0989ebc5a19b6f5ec8fc63
+Source0:        https://github.com/rodaine/table/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/google/go-cmp)
+BuildRequires:  go(github.com/mattn/go-runewidth)
+BuildRequires:  go(github.com/stretchr/testify)
+
+Provides:       go(github.com/rodaine/table) = %{version}
+
+Requires:       go(github.com/mattn/go-runewidth)
+
+%description
+Table is a small Go library for generating simple, lightweight tables
+for terminal output.
+
+%files
+%doc readme.md
+%license license
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-syndtr-gocapability/go-github-syndtr-gocapability.spec
+++ b/SPECS/go-github-syndtr-gocapability/go-github-syndtr-gocapability.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           gocapability
+%define go_import_path  github.com/syndtr/gocapability
+%global commit_id       42c35b4376354fd554efc7ad35e0b7f94e3a0ffb
+
+Name:           go-github-syndtr-gocapability
+Version:        0+git20200815.42c35b4
+Release:        %autorelease
+Summary:        Linux capability support for Go
+License:        BSD-2-Clause
+URL:            https://github.com/syndtr/gocapability
+VCS:            git:https://github.com/syndtr/gocapability
+#!RemoteAsset:  sha256:4993ab545cd5832080c4dfcfa9e71b3ed7ebe7e51454c1ac711cf06e5b5ad923
+Source0:        https://github.com/syndtr/gocapability/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{_name}-%{commit_id}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/syndtr/gocapability) = %{version}
+
+%description
+Gocapability provides Linux capability support for Go programs.
+
+%files
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-tsosunchia-powclient/go-github-tsosunchia-powclient.spec
+++ b/SPECS/go-github-tsosunchia-powclient/go-github-tsosunchia-powclient.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           powclient
+%define go_import_path  github.com/tsosunchia/powclient
+
+Name:           go-github-tsosunchia-powclient
+Version:        0.3.0
+Release:        %autorelease
+Summary:        Proof-of-work challenge client for Go
+License:        GPL-3.0-only
+URL:            https://github.com/tsosunchia/powclient
+VCS:            git:https://github.com/tsosunchia/powclient
+#!RemoteAsset:  sha256:a6145c64373e97a576df9aee4ab2cc399396cd17847f0b3b7dab86a03b393217
+Source0:        https://github.com/tsosunchia/powclient/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/stretchr/testify)
+
+Provides:       go(github.com/tsosunchia/powclient) = %{version}
+
+%description
+Powclient is a Go client library for solving proof-of-work challenges.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-golang-x-net/go-golang-x-net.spec
+++ b/SPECS/go-golang-x-net/go-golang-x-net.spec
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
 # SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
 # SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
@@ -14,13 +15,13 @@
 }
 
 Name:           go-golang-x-net
-Version:        0.48.0
+Version:        0.56.0
 Release:        %autorelease
 Summary:        Go supplementary network libraries
 License:        BSD-3-Clause
 URL:            https://golang.org/x/net
 VCS:            git:https://github.com/golang/net
-#!RemoteAsset:  sha256:999b4eeae1b018ce0e2353cd656b47297c57fedcb9a419904ff856de0438898f
+#!RemoteAsset:  sha256:c2097a7d1043e482386bf71f4df9d4e269685809ad057e1c42fa58e5dd8ff4ec
 Source0:        https://github.com/golang/net/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
@@ -41,6 +42,11 @@ Requires:       go(golang.org/x/text)
 
 %description
 This package provides supplementary Go networking libraries.
+
+%check -p
+# GOPATH mode does not read the module's Go version, but synctest requires the
+# modern timer channel implementation selected by the upstream go directive.
+export GODEBUG=asynctimerchan=0
 
 %files
 %doc README*

--- a/SPECS/nexttrace-tiny/2000-disable-windivert-on-non-windows.patch
+++ b/SPECS/nexttrace-tiny/2000-disable-windivert-on-non-windows.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+Date: Tue, 14 Jul 2026 00:00:00 +0000
+Subject: [PATCH] Disable embedded WinDivert runtime on non-Windows
+
+The WinDivert DLL and driver are useful only on Windows. Allow distributions
+to remove those prebuilt binaries while retaining the common command code on
+other operating systems.
+---
+ assets/windivert/divert.go      | 2 ++
+ assets/windivert/divert_stub.go | 9 +++++++++
+ 2 files changed, 11 insertions(+)
+ create mode 100644 assets/windivert/divert_stub.go
+
+diff --git a/assets/windivert/divert.go b/assets/windivert/divert.go
+index fdb55e2..7a19416 100644
+--- a/assets/windivert/divert.go
++++ b/assets/windivert/divert.go
+@@ -1 +1,3 @@
++//go:build windows
++
+ package windivert
+diff --git a/assets/windivert/divert_stub.go b/assets/windivert/divert_stub.go
+new file mode 100644
+index 0000000..25390ea
+--- /dev/null
++++ b/assets/windivert/divert_stub.go
+@@ -0,0 +1,9 @@
++//go:build !windows
++
++package windivert
++
++import "errors"
++
++func PrepareWinDivertRuntime() error {
++	return errors.New("WinDivert runtime preparation is unsupported on non-Windows platforms")
++}

--- a/SPECS/nexttrace-tiny/nexttrace-tiny.spec
+++ b/SPECS/nexttrace-tiny/nexttrace-tiny.spec
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+# Go -trimpath removes filesystem source paths, leaving no files for an
+# automatically generated debugsource subpackage.
+%undefine _debugsource_packages
+
+%define _name           nexttrace-tiny
+%define go_import_path  github.com/nxtrace/NTrace-core
+
+Name:           nexttrace-tiny
+Version:        1.7.1
+Release:        %autorelease
+Summary:        Lightweight visual route tracing tool
+License:        GPL-3.0-only
+URL:            https://github.com/nxtrace/NTrace-core
+VCS:            git:https://github.com/nxtrace/NTrace-core.git
+#!RemoteAsset:  sha256:ac5c3f4181b061b8fff2430e2b34eee165e7a8f41eb694a07ab0b4b219e5a4bb
+Source0:        https://github.com/nxtrace/NTrace-core/archive/refs/tags/v%{version}.tar.gz#/NTrace-core-%{version}.tar.gz
+# Corresponding source for the WinDivert 2.2.2-A DLL/SYS files in Source0.
+#!RemoteAsset:  sha256:300c1b14e08652e0f8647bf06e9b212f924af76cb2459bd0f88da481c9b08336
+Source1:        https://github.com/basil00/WinDivert/archive/refs/tags/v2.2.2.tar.gz#/WinDivert-2.2.2.tar.gz
+BuildSystem:    golang
+
+BuildOption(build):  -tags flavor_tiny
+BuildOption(build):  -ldflags "-X github.com/nxtrace/NTrace-core/config.Version=v1.7.1 -X github.com/nxtrace/NTrace-core/config.BuildDate=2026-06-16T12:29:35Z -X github.com/nxtrace/NTrace-core/config.CommitID=c991982"
+
+# Avoid embedding and shipping Windows-only prebuilt DLL/SYS files on Linux.
+Patch2000:      2000-disable-windivert-on-non-windows.patch
+
+BuildRequires:  go >= 1.26.4
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/akamensky/argparse)
+BuildRequires:  go(github.com/fatih/color)
+BuildRequires:  go(github.com/google/gopacket)
+BuildRequires:  go(github.com/gorilla/websocket)
+BuildRequires:  go(github.com/mattn/go-runewidth)
+BuildRequires:  go(github.com/oschwald/maxminddb-golang)
+BuildRequires:  go(github.com/rodaine/table)
+BuildRequires:  go(github.com/spf13/viper)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(github.com/syndtr/gocapability)
+BuildRequires:  go(github.com/tidwall/gjson)
+BuildRequires:  go(github.com/tsosunchia/powclient)
+BuildRequires:  go(golang.org/x/net)
+BuildRequires:  go(golang.org/x/sync)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(golang.org/x/term)
+
+%description
+NextTrace is an open source visual route tracing tool. This package builds the
+reduced nexttrace-tiny flavor without the full server, MCP, Globalping, MTR,
+speed-test, or Nali feature set.
+
+%prep
+%autosetup -p1 -n NTrace-core-%{version}
+rm -rf assets/windivert/x64 assets/windivert/x86
+
+# Audit that the corresponding WinDivert source archive is intact and licensed.
+windivert_source_dir="$(mktemp -d)"
+tar -xzf %{SOURCE1} -C "${windivert_source_dir}"
+test -f "${windivert_source_dir}/WinDivert-2.2.2/LICENSE"
+rm -rf "${windivert_source_dir}"
+
+%go_prep
+
+%check
+%go_common
+cd %{_builddir}/go/src/%{go_import_path}
+go test -tags flavor_tiny . ./cmd ./dn42 ./fast_trace ./ipgeo ./pow ./printer ./reporter ./trace/... ./tracelog ./tracemap ./util ./wshandle
+
+%files
+%{_bindir}/%{_name}
+%license LICENSE
+%doc README.md
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

Including NextTrace in the next release improves the default networking toolkit by providing a fast, user-friendly alternative for route analysis and connectivity troubleshooting. It helps users quickly diagnose network paths, latency issues, and routing problems without additional setup.

Please note that this is not the full NextTrace package. The complete version is still under packaging.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #888

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: GPT-5.6-Sol high

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
