### PR TITLE
SPECS: rpm: Restore auto-config-update patch.

### DIFF
--- a/SPECS/rpm/6464-auto-config-update.diff
+++ b/SPECS/rpm/6464-auto-config-update.diff
@@ -1,0 +1,31 @@
+--- a/build/parseSimpleScript.cc
++++ b/build/parseSimpleScript.cc
+@@ -59,6 +59,28 @@ int parseSimpleScript(rpmSpec spec, const char * name,
+ 	target = &buf;
+     }
+ 
++    if (!mode && !*target && !strcmp(name, "conf")) {
++        *target = newStringBuf();
++        appendLineStringBuf(*target,
++            "ref=/usr/lib/rpm\n"
++            "mints=0\n"
++            "case $(uname -m) in\n"
++            "    aarch64) mints=20120610;;\n"
++            "    ppc64le) mints=20130610;;\n"
++            "    riscv64) mints=20160911;;\n"
++            "    loongarch64) mints=20201222;;\n"
++            "esac\n"
++            "for s in guess sub; do\n"
++            "    for c in $(find -maxdepth 8 -name \"config.$s\"); do\n"
++            "         grep -q config-patches@ $c || continue\n"
++            "         timestamp=$(sed -n \"/^timestamp=/{s///;s/[-'\\\"]//g;p;q;}\" $c)\n"
++            "         test -n \"$timestamp\" || timestamp=0\n"
++            "         test $timestamp -ge $mints || install -m 755 $ref/config.$s $c\n"
++            "     done\n"
++            "done\n"
++        );
++    }
++
+     res = parseLines(spec, STRIP_NOTHING, NULL, target);
+ 
+     if (buf) {

--- a/SPECS/rpm/rpm.spec
+++ b/SPECS/rpm/rpm.spec
@@ -44,6 +44,8 @@ Patch151:       buildroot-symlink.diff
 Patch2000:      2000-fix-rpmuncompress-handle-dir-without-slash.patch
 # We are currently always using the v4 format until we are ready.
 Patch2001:      2001-macros.in-fallback-to-rpmformat-4.patch
+# Support auto update package bundled config.{guess,sub} if they are too old.
+Patch6464:      6464-auto-config-update.diff
 
 BuildRequires:  binutils
 BuildRequires:  bzip2
@@ -171,6 +173,7 @@ rm -rf sqlite
 %patch 25 26 33 60 70 85 102 103 138 150 151
 %patch 2000 -p1
 %patch 2001 -p1
+%patch 6464 -p1
 rm -f m4/libtool.m4
 rm -f m4/lt*.m4
 


### PR DESCRIPTION
## Summary
Currently, some packages failed with:
```
[  131s] checking for ld... ld
[  131s] checking for riscv64-openruyi-linux-ranlib... no
[  131s] checking for ranlib... ranlib
[  131s] checking build system type... Invalid configuration `riscv64-openruyi-linux': machine `riscv64-openruyi' not recognized
[  131s] configure: error: /usr/bin/bash ./config.sub riscv64-openruyi-linux failed
[  131s] error: Bad exit status from /var/tmp/rpm-tmp.DlNymB (%conf)
```

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->
Some packages bundled config.{guess,sub} are too old that less riscv support. With the patch, rpm build can auto update the config scripts.

The patch original no. is 6464.


## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
