### PR TITLE
SPECS: add nexttrace

### DIFF
--- a/SPECS/go-github-akamensky-argparse/go-github-akamensky-argparse.spec
+++ b/SPECS/go-github-akamensky-argparse/go-github-akamensky-argparse.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           argparse
+%define go_import_path  github.com/akamensky/argparse
+
+Name:           go-github-akamensky-argparse
+Version:        1.4.0
+Release:        %autorelease
+Summary:        Argument parser for Go
+License:        MIT
+URL:            https://github.com/akamensky/argparse
+VCS:            git:https://github.com/akamensky/argparse
+#!RemoteAsset:  sha256:755bc41205468e0fb7264bee5c0f14585ee8eeaa377e96a23655c12f65df7016
+Source0:        https://github.com/akamensky/argparse/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/akamensky/argparse) = %{version}
+
+%description
+Argparse is an argument parser for Go command-line applications. It supports
+positional arguments, flags, commands, validation, and generated help output.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-google-gopacket/2000-fix-dns-test-format-for-go1.26.patch
+++ b/SPECS/go-github-google-gopacket/2000-fix-dns-test-format-for-go1.26.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+Date: Tue, 14 Jul 2026 00:00:00 +0000
+Subject: [PATCH] Fix DNS URI test format verbs
+
+Go 1.26 vet rejects %q for the uint16 priority and weight fields. Use the
+numeric %d verb so the existing tests remain enabled.
+---
+ layers/dns_test.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/layers/dns_test.go b/layers/dns_test.go
+--- a/layers/dns_test.go
++++ b/layers/dns_test.go
+@@ -192 +192 @@
+-		t.Errorf("Incorrect URI priority value, expected %q, got %q", testParseDNSTypeURIPriority, priority)
++		t.Errorf("Incorrect URI priority value, expected %d, got %d", testParseDNSTypeURIPriority, priority)
+@@ -196 +196 @@
+-		t.Errorf("Incorrect URI weight value, expected %q, got %q", testParseDNSTypeURIWeight, weight)
++		t.Errorf("Incorrect URI weight value, expected %d, got %d", testParseDNSTypeURIWeight, weight)

--- a/SPECS/go-github-google-gopacket/go-github-google-gopacket.spec
+++ b/SPECS/go-github-google-gopacket/go-github-google-gopacket.spec
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           gopacket
+%define go_import_path  github.com/google/gopacket
+# Skip optional native capture backends and examples that require unpackaged
+# local libraries; nexttrace only needs the pure-Go core. libpcap fails with
+# "fatal error: pcap.h: No such file or directory", while PF_RING fails with
+# "fatal error: pfring.h: No such file or directory" and is not in the repo.
+# Keep pcapgo testable by spelling out pcap and its children instead of pcap*.
+%define go_test_exclude_glob %{shrink:
+    %{go_import_path}/pcap
+    %{go_import_path}/pcap/*
+    %{go_import_path}/pfring
+    %{go_import_path}/examples/*
+}
+
+Name:           go-github-google-gopacket
+Version:        1.1.19
+Release:        %autorelease
+Summary:        Packet decoding library for Go
+License:        BSD-3-Clause
+URL:            https://github.com/google/gopacket
+VCS:            git:https://github.com/google/gopacket
+#!RemoteAsset:  sha256:31efa87cc9d2b41e5e66c7daa8839d841d2a43cc477bf595c9e8c24ef6903830
+Source0:        https://github.com/google/gopacket/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Fix Go 1.26 vet errors: %q is invalid for uint16 DNS priority and weight.
+Patch2000:      2000-fix-dns-test-format-for-go1.26.patch
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(golang.org/x/net)
+BuildRequires:  go(golang.org/x/sys)
+
+Provides:       go(github.com/google/gopacket) = %{version}
+
+Requires:       go(golang.org/x/net)
+Requires:       go(golang.org/x/sys)
+
+%description
+Gopacket provides packet decoding for Go. It includes support for many network
+protocols and packet capture formats, along with packet filtering and assembly
+utilities.
+
+%prep -a
+# These source-only generator files are not installed as executable commands.
+chmod a-x layers/test_creator.py pcapgo/write.go
+
+%files
+%doc AUTHORS CONTRIBUTING.md README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-google-jsonschema-go/go-github-google-jsonschema-go.spec
+++ b/SPECS/go-github-google-jsonschema-go/go-github-google-jsonschema-go.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           jsonschema-go
+%define go_import_path  github.com/google/jsonschema-go
+
+Name:           go-github-google-jsonschema-go
+Version:        0.4.3
+Release:        %autorelease
+Summary:        JSON Schema implementation for Go
+License:        MIT
+URL:            https://github.com/google/jsonschema-go
+VCS:            git:https://github.com/google/jsonschema-go.git
+#!RemoteAsset:  sha256:de9198fe0050ea4306c0a362fabc69be46373290160d416d2ce5627f460ea4e5
+Source0:        https://github.com/google/jsonschema-go/archive/refs/tags/v%{version}.tar.gz#/jsonschema-go-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n jsonschema-go-%{version}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+# go-cmp is used only by the test suite.
+BuildRequires:  go(github.com/google/go-cmp)
+
+Provides:       go(github.com/google/jsonschema-go) = %{version}
+
+%description
+Jsonschema-go provides JSON Schema types, resolution, validation, and related
+utilities for Go programs.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-icza-backscanner/go-github-icza-backscanner.spec
+++ b/SPECS/go-github-icza-backscanner/go-github-icza-backscanner.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           backscanner
+%define go_import_path  github.com/icza/backscanner
+%define commit_id       dff01ac5025040317bf654624506b84cb2f74e29
+
+Name:           go-github-icza-backscanner
+Version:        0+git20260716.dff01ac
+Release:        %autorelease
+Summary:        Scanner for reading lines backwards in Go
+License:        Apache-2.0
+URL:            https://github.com/icza/backscanner
+VCS:            git:https://github.com/icza/backscanner.git
+#!RemoteAsset:  sha256:44f02969457f6d8d3492da576ebe54b0e3d438a48a2a092e4e67c37223603008
+Source0:        https://codeload.github.com/icza/backscanner/tar.gz/%{commit_id}#/backscanner-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n backscanner-%{commit_id}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+# mighty is used only by the test suite.
+BuildRequires:  go(github.com/icza/mighty)
+
+Provides:       go(github.com/icza/backscanner) = %{version}
+
+%description
+Backscanner is a Go package that scans lines from an input source in reverse
+order.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-icza-mighty/go-github-icza-mighty.spec
+++ b/SPECS/go-github-icza-mighty/go-github-icza-mighty.spec
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           mighty
+%define go_import_path  github.com/icza/mighty
+%define commit_id       cfd07d671de60f8c16c2833ce36bafb6f6c83c7f
+
+Name:           go-github-icza-mighty
+Version:        0+git20260716.cfd07d6
+Release:        %autorelease
+Summary:        Lightweight extension to Go's testing package
+License:        Apache-2.0
+URL:            https://github.com/icza/mighty
+VCS:            git:https://github.com/icza/mighty.git
+#!RemoteAsset:  sha256:1ba704924d398a6c880f811a7d136c3819519056ac1bba37648fa319f4598720
+Source0:        https://github.com/icza/mighty/archive/%{commit_id}.tar.gz#/mighty-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n mighty-%{commit_id}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/icza/mighty) = %{version}
+
+%description
+Mighty is a lightweight extension to Go's testing package that removes
+repetitive assertion code while keeping tests readable.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-jsdelivr-globalping-cli/go-github-jsdelivr-globalping-cli.spec
+++ b/SPECS/go-github-jsdelivr-globalping-cli/go-github-jsdelivr-globalping-cli.spec
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           globalping-cli
+%define go_import_path  github.com/jsdelivr/globalping-cli
+
+Name:           go-github-jsdelivr-globalping-cli
+Version:        1.5.1
+Release:        %autorelease
+Summary:        Command-line client and Go library for Globalping
+License:        MPL-2.0
+URL:            https://github.com/jsdelivr/globalping-cli
+VCS:            git:https://github.com/jsdelivr/globalping-cli.git
+#!RemoteAsset:  sha256:235c96480e66b23c1393a5da56f1456908399207948300f1202b6fb335b71550
+Source0:        https://github.com/jsdelivr/globalping-cli/archive/refs/tags/v%{version}.tar.gz#/globalping-cli-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n globalping-cli-%{version}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/andybalholm/brotli)
+BuildRequires:  go(github.com/icza/backscanner)
+BuildRequires:  go(github.com/mattn/go-runewidth)
+BuildRequires:  go(github.com/pkg/errors)
+BuildRequires:  go(github.com/shirou/gopsutil)
+BuildRequires:  go(github.com/spf13/cobra)
+BuildRequires:  go(github.com/spf13/pflag)
+# testify is used by the selected library tests only.
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(github.com/tklauser/go-sysconf)
+BuildRequires:  go(go.uber.org/mock/gomock)
+BuildRequires:  go(golang.org/x/term)
+
+Provides:       go(github.com/jsdelivr/globalping-cli) = %{version}
+
+Requires:       go(github.com/andybalholm/brotli)
+Requires:       go(github.com/icza/backscanner)
+Requires:       go(github.com/mattn/go-runewidth)
+Requires:       go(github.com/pkg/errors)
+Requires:       go(github.com/shirou/gopsutil)
+Requires:       go(github.com/spf13/cobra)
+Requires:       go(github.com/spf13/pflag)
+Requires:       go(github.com/tklauser/go-sysconf)
+Requires:       go(go.uber.org/mock/gomock)
+Requires:       go(golang.org/x/term)
+
+%description
+Globalping CLI is a command-line client and reusable Go library for running
+network measurements through the Globalping platform.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-modelcontextprotocol-go-sdk/go-github-modelcontextprotocol-go-sdk.spec
+++ b/SPECS/go-github-modelcontextprotocol-go-sdk/go-github-modelcontextprotocol-go-sdk.spec
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-sdk
+%define go_import_path  github.com/modelcontextprotocol/go-sdk
+
+Name:           go-github-modelcontextprotocol-go-sdk
+Version:        1.6.1
+Release:        %autorelease
+Summary:        Official Go SDK for the Model Context Protocol
+License:        Apache-2.0 AND MIT AND CC-BY-4.0
+URL:            https://github.com/modelcontextprotocol/go-sdk
+VCS:            git:https://github.com/modelcontextprotocol/go-sdk.git
+#!RemoteAsset:  sha256:a161e098e8fbcd4bede636837c6e2665eba6ef39b87436c19973e3584aaaf9bd
+Source0:        https://github.com/modelcontextprotocol/go-sdk/archive/refs/tags/v%{version}.tar.gz#/go-sdk-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n go-sdk-%{version}
+# Skip OAuth resource metadata test: expected success endpoint returns HTTP 404.
+BuildOption(check):  -skip TestGetProtectedResourceMetadata
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/golang-jwt/jwt/v5)
+BuildRequires:  go(github.com/google/go-cmp)
+BuildRequires:  go(github.com/google/jsonschema-go)
+BuildRequires:  go(github.com/segmentio/encoding)
+BuildRequires:  go(github.com/yosida95/uritemplate/v3)
+BuildRequires:  go(golang.org/x/oauth2)
+BuildRequires:  go(golang.org/x/time)
+BuildRequires:  go(golang.org/x/tools)
+
+Provides:       go(github.com/modelcontextprotocol/go-sdk) = %{version}
+
+Requires:       go(github.com/google/jsonschema-go)
+Requires:       go(github.com/segmentio/encoding)
+Requires:       go(github.com/yosida95/uritemplate/v3)
+Requires:       go(golang.org/x/oauth2)
+Requires:       go(golang.org/x/time)
+
+%description
+The Model Context Protocol Go SDK provides client and server APIs for building
+MCP integrations in Go.
+
+%check -p
+# synctest requires the modern timer channel implementation under GOPATH mode.
+export GODEBUG=asynctimerchan=0
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-oschwald-maxminddb-golang/go-github-oschwald-maxminddb-golang.spec
+++ b/SPECS/go-github-oschwald-maxminddb-golang/go-github-oschwald-maxminddb-golang.spec
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           maxminddb-golang
+%define go_import_path  github.com/oschwald/maxminddb-golang
+%global testdata_commit 3e225a82e492a58eef738ef2b6e94aa4f50ef932
+
+Name:           go-github-oschwald-maxminddb-golang
+Version:        1.13.1
+Release:        %autorelease
+Summary:        MaxMind DB reader for Go
+License:        ISC AND CC-BY-SA-3.0
+URL:            https://github.com/oschwald/maxminddb-golang
+VCS:            git:https://github.com/oschwald/maxminddb-golang
+#!RemoteAsset:  sha256:d337efdac8d906cf3853f048fb74f96ecff4f70c2e64d869fdd87c83eb797bfd
+Source0:        https://github.com/oschwald/maxminddb-golang/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+# Source1 only restores the exact MaxMind-DB test-data submodule commit pinned
+# by upstream.
+#!RemoteAsset:  sha256:d73bcaaa6f96ffe06e6dcdb843cf43b5eb8dbebaec8361fce352ecc61c04bccd
+Source1:        https://github.com/maxmind/MaxMind-DB/archive/%{testdata_commit}/MaxMind-DB-%{testdata_commit}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(golang.org/x/sys)
+
+Provides:       go(github.com/oschwald/maxminddb-golang) = %{version}
+
+Requires:       go(golang.org/x/sys)
+
+%description
+Maxminddb-golang is a Go reader for the MaxMind DB file format. It provides
+memory-mapped and in-memory access to MaxMind database records.
+
+%prep -a
+rm -rf test-data
+mkdir -p test-data
+tar -xf %{SOURCE1} --strip-components=1 -C test-data
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-rodaine-table/go-github-rodaine-table.spec
+++ b/SPECS/go-github-rodaine-table/go-github-rodaine-table.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           table
+%define go_import_path  github.com/rodaine/table
+
+Name:           go-github-rodaine-table
+Version:        1.3.1
+Release:        %autorelease
+Summary:        Go library for simple terminal tables
+License:        MIT
+URL:            https://github.com/rodaine/table
+VCS:            git:https://github.com/rodaine/table
+#!RemoteAsset:  sha256:06c9dd4211e76ffca2df995497354272532230b17c0989ebc5a19b6f5ec8fc63
+Source0:        https://github.com/rodaine/table/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/google/go-cmp)
+BuildRequires:  go(github.com/mattn/go-runewidth)
+BuildRequires:  go(github.com/stretchr/testify)
+
+Provides:       go(github.com/rodaine/table) = %{version}
+
+Requires:       go(github.com/mattn/go-runewidth)
+
+%description
+Table is a small Go library for generating simple, lightweight tables
+for terminal output.
+
+%files
+%doc readme.md
+%license license
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-syndtr-gocapability/go-github-syndtr-gocapability.spec
+++ b/SPECS/go-github-syndtr-gocapability/go-github-syndtr-gocapability.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           gocapability
+%define go_import_path  github.com/syndtr/gocapability
+%global commit_id       42c35b4376354fd554efc7ad35e0b7f94e3a0ffb
+
+Name:           go-github-syndtr-gocapability
+Version:        0+git20260716.42c35b4
+Release:        %autorelease
+Summary:        Linux capability support for Go
+License:        BSD-2-Clause
+URL:            https://github.com/syndtr/gocapability
+VCS:            git:https://github.com/syndtr/gocapability
+#!RemoteAsset:  sha256:4993ab545cd5832080c4dfcfa9e71b3ed7ebe7e51454c1ac711cf06e5b5ad923
+Source0:        https://github.com/syndtr/gocapability/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{_name}-%{commit_id}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/syndtr/gocapability) = %{version}
+
+%description
+Gocapability provides Linux capability support for Go programs.
+
+%files
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-tsosunchia-powclient/go-github-tsosunchia-powclient.spec
+++ b/SPECS/go-github-tsosunchia-powclient/go-github-tsosunchia-powclient.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           powclient
+%define go_import_path  github.com/tsosunchia/powclient
+
+Name:           go-github-tsosunchia-powclient
+Version:        0.3.0
+Release:        %autorelease
+Summary:        Proof-of-work challenge client for Go
+License:        GPL-3.0-only
+URL:            https://github.com/tsosunchia/powclient
+VCS:            git:https://github.com/tsosunchia/powclient
+#!RemoteAsset:  sha256:a6145c64373e97a576df9aee4ab2cc399396cd17847f0b3b7dab86a03b393217
+Source0:        https://github.com/tsosunchia/powclient/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/stretchr/testify)
+
+Provides:       go(github.com/tsosunchia/powclient) = %{version}
+
+%description
+Powclient is a Go client library for solving proof-of-work challenges.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-yosida95-uritemplate-v3/go-github-yosida95-uritemplate-v3.spec
+++ b/SPECS/go-github-yosida95-uritemplate-v3/go-github-yosida95-uritemplate-v3.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           uritemplate
+%define go_import_path  github.com/yosida95/uritemplate/v3
+
+Name:           go-github-yosida95-uritemplate-v3
+Version:        3.0.2
+Release:        %autorelease
+Summary:        RFC 6570 URI Template implementation for Go
+License:        BSD-3-Clause
+URL:            https://github.com/yosida95/uritemplate
+VCS:            git:https://github.com/yosida95/uritemplate.git
+#!RemoteAsset:  sha256:7421e5ed342a20a7eec91139de06cf91157e8f4267bdd61d7d94ae746873145a
+Source0:        https://github.com/yosida95/uritemplate/archive/refs/tags/v%{version}.tar.gz#/uritemplate-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n uritemplate-%{version}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/yosida95/uritemplate/v3) = %{version}
+
+%description
+Uritemplate is an RFC 6570 URI Template implementation for Go.
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-golang-x-net/go-golang-x-net.spec
+++ b/SPECS/go-golang-x-net/go-golang-x-net.spec
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
 # SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
 # SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
@@ -14,13 +15,13 @@
 }
 
 Name:           go-golang-x-net
-Version:        0.48.0
+Version:        0.56.0
 Release:        %autorelease
 Summary:        Go supplementary network libraries
 License:        BSD-3-Clause
 URL:            https://golang.org/x/net
 VCS:            git:https://github.com/golang/net
-#!RemoteAsset:  sha256:999b4eeae1b018ce0e2353cd656b47297c57fedcb9a419904ff856de0438898f
+#!RemoteAsset:  sha256:c2097a7d1043e482386bf71f4df9d4e269685809ad057e1c42fa58e5dd8ff4ec
 Source0:        https://github.com/golang/net/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
@@ -41,6 +42,11 @@ Requires:       go(golang.org/x/text)
 
 %description
 This package provides supplementary Go networking libraries.
+
+%check -p
+# GOPATH mode does not read the module's Go version, but synctest requires the
+# modern timer channel implementation selected by the upstream go directive.
+export GODEBUG=asynctimerchan=0
 
 %files
 %doc README*

--- a/SPECS/go-uber-mock/go-uber-mock.spec
+++ b/SPECS/go-uber-mock/go-uber-mock.spec
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           mock
+%define go_import_path  go.uber.org/mock
+
+Name:           go-uber-mock
+Version:        0.4.0
+Release:        %autorelease
+Summary:        Mocking framework for Go
+License:        Apache-2.0
+URL:            https://github.com/uber/mock
+VCS:            git:https://github.com/uber/mock.git
+#!RemoteAsset:  sha256:30f28caf179b14a3a4f0ed28135904728e1bf61d78ba5fc4b89a36e301dd621b
+Source0:        https://github.com/uber/mock/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+# Nested test modules are included by the GOPATH-mode test discovery.
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(golang.org/x/exp)
+BuildRequires:  go(golang.org/x/mod)
+BuildRequires:  go(golang.org/x/tools)
+
+Provides:       go(go.uber.org/mock) = %{version}
+Provides:       go(go.uber.org/mock/gomock) = %{version}
+Provides:       go(go.uber.org/mock/mockgen) = %{version}
+
+Requires:       go(golang.org/x/mod)
+Requires:       go(golang.org/x/tools)
+
+%description
+Gomock is a mocking framework for Go. It integrates with Go's built-in testing
+package and includes the mockgen source generator.
+
+%files
+%doc AUTHORS CHANGELOG.md CONTRIBUTING.md README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/nexttrace/2000-disable-windivert-on-non-windows.patch
+++ b/SPECS/nexttrace/2000-disable-windivert-on-non-windows.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+Date: Tue, 14 Jul 2026 00:00:00 +0000
+Subject: [PATCH] Disable embedded WinDivert runtime on non-Windows
+
+The WinDivert DLL and driver are useful only on Windows. Allow distributions
+to remove those prebuilt binaries while retaining the common command code on
+other operating systems.
+---
+ assets/windivert/divert.go      | 2 ++
+ assets/windivert/divert_stub.go | 9 +++++++++
+ 2 files changed, 11 insertions(+)
+ create mode 100644 assets/windivert/divert_stub.go
+
+diff --git a/assets/windivert/divert.go b/assets/windivert/divert.go
+index fdb55e2..7a19416 100644
+--- a/assets/windivert/divert.go
++++ b/assets/windivert/divert.go
+@@ -1 +1,3 @@
++//go:build windows
++
+ package windivert
+diff --git a/assets/windivert/divert_stub.go b/assets/windivert/divert_stub.go
+new file mode 100644
+index 0000000..25390ea
+--- /dev/null
++++ b/assets/windivert/divert_stub.go
+@@ -0,0 +1,9 @@
++//go:build !windows
++
++package windivert
++
++import "errors"
++
++func PrepareWinDivertRuntime() error {
++	return errors.New("WinDivert runtime preparation is unsupported on non-Windows platforms")
++}

--- a/SPECS/nexttrace/nexttrace.spec
+++ b/SPECS/nexttrace/nexttrace.spec
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+# Go -trimpath removes filesystem source paths, leaving no files for an
+# automatically generated debugsource subpackage.
+%undefine _debugsource_packages
+
+%define _name           nexttrace
+%define go_import_path  github.com/nxtrace/NTrace-core
+
+Name:           nexttrace
+Version:        1.7.1
+Release:        %autorelease
+Summary:        Full-featured visual route tracing tool
+License:        GPL-3.0-only
+URL:            https://github.com/nxtrace/NTrace-core
+VCS:            git:https://github.com/nxtrace/NTrace-core.git
+#!RemoteAsset:  sha256:ac5c3f4181b061b8fff2430e2b34eee165e7a8f41eb694a07ab0b4b219e5a4bb
+Source0:        https://github.com/nxtrace/NTrace-core/archive/refs/tags/v%{version}.tar.gz#/NTrace-core-%{version}.tar.gz
+BuildSystem:    golang
+
+# Avoid embedding and shipping Windows-only prebuilt DLL/SYS files on Linux.
+Patch2000:      2000-disable-windivert-on-non-windows.patch
+
+# Inject fixed release metadata because upstream defaults are placeholders; a fixed date also keeps builds reproducible.
+BuildOption(build):  -ldflags "-X github.com/nxtrace/NTrace-core/config.Version=v1.7.1 -X github.com/nxtrace/NTrace-core/config.BuildDate=2026-06-16T12:29:35Z -X github.com/nxtrace/NTrace-core/config.CommitID=c991982"
+
+BuildRequires:  go >= 1.26.4
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/akamensky/argparse)
+BuildRequires:  go(github.com/fatih/color)
+BuildRequires:  go(github.com/gin-gonic/gin)
+BuildRequires:  go(github.com/google/gopacket)
+BuildRequires:  go(github.com/gorilla/websocket)
+BuildRequires:  go(github.com/jsdelivr/globalping-cli)
+BuildRequires:  go(github.com/mattn/go-runewidth)
+BuildRequires:  go(github.com/modelcontextprotocol/go-sdk)
+BuildRequires:  go(github.com/oschwald/maxminddb-golang)
+BuildRequires:  go(github.com/rodaine/table)
+BuildRequires:  go(github.com/spf13/viper)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(github.com/syndtr/gocapability)
+BuildRequires:  go(github.com/tidwall/gjson)
+BuildRequires:  go(github.com/tsosunchia/powclient)
+BuildRequires:  go(golang.org/x/net)
+BuildRequires:  go(golang.org/x/sync)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(golang.org/x/term)
+
+%description
+NextTrace is an open-source network tracing tool that provides fast route analysis, IP/ASN information, and latency diagnostics with a user-friendly interface.
+
+%prep
+%autosetup -p1 -n NTrace-core-%{version}
+rm -rf assets/windivert/x64 assets/windivert/x86
+
+%go_prep
+
+%check
+%go_common
+cd %{_builddir}/go/src/%{go_import_path}
+go test . ./cmd ./dn42 ./fast_trace ./internal/service ./ipgeo ./pow ./printer ./reporter ./server ./trace/... ./tracelog ./tracemap ./util ./wshandle
+
+%files
+%doc README.md README_zh_CN.md
+%license LICENSE
+%{_bindir}/nexttrace
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

Including NextTrace in the next release improves the default networking toolkit by providing a fast, user-friendly alternative for route analysis and connectivity troubleshooting. It helps users quickly diagnose network paths, latency issues, and routing problems without additional setup.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #888

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: GPT-5.6-Sol High

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
