### PR TITLE
SPECS: Qt6 L1: shadertools/svg/languageserver/imageformats to 6.11.1

### DIFF
--- a/SPECS/qt6-qtimageformats/qt6-qtimageformats.spec
+++ b/SPECS/qt6-qtimageformats/qt6-qtimageformats.spec
@@ -5,17 +5,17 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qtimageformats
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 Name:           qt6-qtimageformats
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - QtImageFormats component
 License:        LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://github.com/qt/qtimageformats
-#!RemoteAsset
+#!RemoteAsset:  sha256:b2bf6c6845ac175ed7f819145483ba4676f617aaa6a5012c8efee63c8bbac413
 Source0:        https://download.qt.io/official_releases/qt/%{short_version}/%{real_version}/submodules/%{qt_module}-everywhere-src-%{real_version}.tar.xz
 BuildSystem:    cmake
 
@@ -51,4 +51,4 @@ rm -rv src/3rdparty
 %{_qt6_archdatadir}/sbom/%{qt_module}-%{real_version}.spdx
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/qt6-qtlanguageserver/qt6-qtlanguageserver.spec
+++ b/SPECS/qt6-qtlanguageserver/qt6-qtlanguageserver.spec
@@ -5,17 +5,17 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qtlanguageserver
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 Name:           qt6-qtlanguageserver
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - LanguageServer component
 License:        GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://github.com/qt/qtlanguageserver
-#!RemoteAsset:  sha256:3360526b4f4d556673b31e29a49e15d02da52d5eaa53b0204d56a0ba160a556c
+#!RemoteAsset:  sha256:50008537f2ca54abb3b8dc3f26759864e9cad2b2ad39e92e42fa718de2dd8aef
 Source0:        https://download.qt.io/official_releases/qt/%{short_version}/%{real_version}/submodules/%{qt_module}-everywhere-src-%{real_version}.tar.xz
 BuildSystem:    cmake
 

--- a/SPECS/qt6-qtshadertools/qt6-qtshadertools.spec
+++ b/SPECS/qt6-qtshadertools/qt6-qtshadertools.spec
@@ -6,17 +6,17 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qtshadertools
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 Name:           qt6-qtshadertools
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - Qt Shader Tools module builds on the SPIR-V Open Source Ecosystem
 License:        LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://github.com/qt/qtshadertools
-#!RemoteAsset
+#!RemoteAsset:  sha256:2075052f9b23bcf9de045bbd180037084942f82cce870aab14a1454902c982fc
 Source0:        https://download.qt.io/official_releases/qt/%{short_version}/%{real_version}/submodules/%{qt_module}-everywhere-src-%{real_version}.tar.xz
 BuildSystem:    cmake
 
@@ -86,4 +86,4 @@ popd
 %{_qt6_libdir}/pkgconfig/Qt6ShaderTools.pc
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/qt6-qtsvg/qt6-qtsvg.spec
+++ b/SPECS/qt6-qtsvg/qt6-qtsvg.spec
@@ -6,17 +6,17 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qtsvg
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 Name:           qt6-qtsvg
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - Support for rendering and displaying SVG
 License:        LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://code.qt.io/qt/qtsvg.git
-#!RemoteAsset:  sha256:c02f355a58f3bbcf404a628bf488b6aeb2d84a94c269afdb86f6e529343ab01f
+#!RemoteAsset:  sha256:7f3cf02f4824bf03c2c5859ea6db173bf1482a1daf24e6cdf7bc78cfa26a8a94
 Source0:        https://download.qt.io/official_releases/qt/%{short_version}/%{real_version}/submodules/%{qt_module}-everywhere-src-%{real_version}.tar.xz
 BuildSystem:    cmake
 


### PR DESCRIPTION
## Summary

Update Layer-1 Qt modules required before qtdeclarative: qt6-qtshadertools, qt6-qtsvg, qt6-qtlanguageserver, qt6-qtimageformats to 6.11.1.

## Checklist

- [X] I have read the [openRuyi Code of Conduct] and agree to abide by it.
- [X] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: gpt-5.6
