### PR TITLE
SPECS: Qt6 P1: serialport/networkauth/serialbus to 6.11.1

### DIFF
--- a/SPECS/qt6-qtnetworkauth/qt6-qtnetworkauth.spec
+++ b/SPECS/qt6-qtnetworkauth/qt6-qtnetworkauth.spec
@@ -6,17 +6,17 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qtnetworkauth
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 Name:           qt6-qtnetworkauth
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - NetworkAuth component
 License:        GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://github.com/qt/qtnetworkauth
-#!RemoteAsset:  sha256:1435eb598172d888d7d1795a297c7623f7d8f3afe010c8f40c5aa100abcf380d
+#!RemoteAsset:  sha256:9f1d5bf22ccc033e42076186b964f9d4d4179fd0312a2c0f1aa19db42516563d
 Source0:        https://download.qt.io/official_releases/qt/%{short_version}/%{real_version}/submodules/%{qt_module}-everywhere-src-%{real_version}.tar.xz
 BuildSystem:    cmake
 

--- a/SPECS/qt6-qtserialbus/qt6-qtserialbus.spec
+++ b/SPECS/qt6-qtserialbus/qt6-qtserialbus.spec
@@ -6,17 +6,17 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qtserialbus
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 Name:           qt6-qtserialbus
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - SerialBus component
 License:        LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://github.com/qt/qtserialbus
-#!RemoteAsset
+#!RemoteAsset:  sha256:c46c9c0c8d6815301a669cdbd5866c10bcfb9e56889f5d7da14e11d6ad24f20a
 Source0:        https://download.qt.io/official_releases/qt/%{short_version}/%{real_version}/submodules/%{qt_module}-everywhere-src-%{real_version}.tar.xz
 BuildSystem:    cmake
 
@@ -77,4 +77,4 @@ Programming examples for %{name}.
 %{_qt6_examplesdir}/
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/qt6-qtserialport/qt6-qtserialport.spec
+++ b/SPECS/qt6-qtserialport/qt6-qtserialport.spec
@@ -6,17 +6,17 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qtserialport
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 Name:           qt6-qtserialport
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - SerialPort component
 License:        LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://github.com/qt/qtserialport
-#!RemoteAsset:  sha256:17b2f68435f67785a0c75fd70125f3e1892282efdab2098dcdac02d1d70f4c4c
+#!RemoteAsset:  sha256:9af31a898ffd9a7e4faf6fed845d29e783c716885789055cbe319f3e072d3974
 Source0:        https://download.qt.io/official_releases/qt/%{short_version}/%{real_version}/submodules/%{qt_module}-everywhere-src-%{real_version}.tar.xz
 BuildSystem:    cmake
 


### PR DESCRIPTION
## Summary

Topo P1 (depends only on qtbase 6.11.1 already on main/repo):

- qt6-qtserialport
- qt6-qtnetworkauth
- qt6-qtserialbus (needs serialport; same PR multibuild)

Merge after #923 published to repo.build (optional for these; they only need base).

## Checklist

- [X] I have read the [openRuyi Code of Conduct] and agree to abide by it.

- [X] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: gpt-5.6