### PR TITLE
SPECS: Qt6 P3a: websockets/5compat/connectivity and Quick consumers to 6.11.1

### DIFF
--- a/SPECS/qt6-qt5compat/qt6-qt5compat.spec
+++ b/SPECS/qt6-qt5compat/qt6-qt5compat.spec
@@ -6,17 +6,17 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qt5compat
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 Name:           qt6-qt5compat
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - Qt 5 Compatibility Libraries
 License:        LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://github.com/qt/qt5compat
-#!RemoteAsset:  sha256:72396d160a153dee01b41cf0cae9ad46204cf613adb791b3ee85a7efeadffe24
+#!RemoteAsset:  sha256:cfcb9fdaa051aad54b0e61b24ac5693b4887a86e07609f665fea67328a6f161b
 Source0:        https://download.qt.io/official_releases/qt/%{short_version}/%{real_version}/submodules/%{qt_module}-everywhere-src-%{real_version}.tar.xz
 BuildSystem:    cmake
 

--- a/SPECS/qt6-qtcoap/qt6-qtcoap.spec
+++ b/SPECS/qt6-qtcoap/qt6-qtcoap.spec
@@ -6,17 +6,17 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qtcoap
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 Name:           qt6-qtcoap
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - CoAP component
 License:        GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://github.com/qt/qtcoap
-#!RemoteAsset:  sha256:de077e00ef5a938ee3e86e093ca860e564dcdd00c13f62a8df98515a6a5cf782
+#!RemoteAsset:  sha256:4fa5790a48fe98d6373b5b3d0d8ee34a990da8fb39305d37128b6a959fb24fbd
 Source0:        https://github.com/qt/%{qt_module}/archive/refs/tags/v%{version}.tar.gz
 BuildSystem:    cmake
 

--- a/SPECS/qt6-qtconnectivity/qt6-qtconnectivity.spec
+++ b/SPECS/qt6-qtconnectivity/qt6-qtconnectivity.spec
@@ -6,17 +6,17 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qtconnectivity
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 Name:           qt6-qtconnectivity
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - Connectivity components
 License:        LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://github.com/qt/qtconnectivity
-#!RemoteAsset:  sha256:7baefd3a90c73820e33ddc59ded8c018e233d14d23eaa4eadbf332b5ac2154ff
+#!RemoteAsset:  sha256:2105289ea414b46ed5fa53ba8782230045b9e47cc8156b5940c9e31e3980e591
 Source0:        https://download.qt.io/official_releases/qt/%{short_version}/%{real_version}/submodules/%{qt_module}-everywhere-src-%{real_version}.tar.xz
 BuildSystem:    cmake
 

--- a/SPECS/qt6-qtopcua/qt6-qtopcua.spec
+++ b/SPECS/qt6-qtopcua/qt6-qtopcua.spec
@@ -6,17 +6,17 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qtopcua
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 Name:           qt6-qtopcua
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - OPC UA component
 License:        LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://github.com/qt/qtopcua
-#!RemoteAsset:  sha256:15b70b358d7ffefe8693539505c8ef5b03641d3744d1d3ef728f6646119d0d58
+#!RemoteAsset:  sha256:d261f2ac7ee8d5dc8ac3d23de79bde6acd1abbfeeeaa7a56974eac1f0594c932
 Source0:        https://github.com/qt/%{qt_module}/archive/refs/tags/v%{version}.tar.gz
 BuildSystem:    cmake
 

--- a/SPECS/qt6-qtpositioning/qt6-qtpositioning.spec
+++ b/SPECS/qt6-qtpositioning/qt6-qtpositioning.spec
@@ -6,17 +6,17 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qtpositioning
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 Name:           qt6-qtpositioning
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - Positioning component
 License:        LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://github.com/qt/qtpositioning
-#!RemoteAsset:  sha256:abb311ef1bd6e39f090d22480e265d13f8537d2e2f4c88f22d6519547f46be23
+#!RemoteAsset:  sha256:d5e6b91801ae286e7630016caea3bdc5e1978b4291d6741d0d64c125650f78f5
 Source0:        https://download.qt.io/official_releases/qt/%{short_version}/%{real_version}/submodules/%{qt_module}-everywhere-src-%{real_version}.tar.xz
 BuildSystem:    cmake
 

--- a/SPECS/qt6-qtremoteobjects/qt6-qtremoteobjects.spec
+++ b/SPECS/qt6-qtremoteobjects/qt6-qtremoteobjects.spec
@@ -6,17 +6,17 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qtremoteobjects
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 Name:           qt6-qtremoteobjects
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - Qt Remote Objects
 License:        LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://github.com/qt/qtremoteobjects
-#!RemoteAsset:  sha256:7c9e56dbe2c400e33d13626a27d822a7c95b7d95f2272b198a788c2b4a9b8a0d
+#!RemoteAsset:  sha256:40629895c69531a687a9c0258316cee3f04c2d18b2bf2ad36dc83e76a58f111a
 Source0:        https://download.qt.io/official_releases/qt/%{short_version}/%{real_version}/submodules/%{qt_module}-everywhere-src-%{real_version}.tar.xz
 BuildSystem:    cmake
 

--- a/SPECS/qt6-qtscxml/qt6-qtscxml.spec
+++ b/SPECS/qt6-qtscxml/qt6-qtscxml.spec
@@ -6,17 +6,17 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qtscxml
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 Name:           qt6-qtscxml
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - ScXml component
 License:        LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://github.com/qt/qtscxml
-#!RemoteAsset:  sha256:eb67a0e5d4c6d488e3013f8dbef859a00e10bb033472eb53688fce350e3a1869
+#!RemoteAsset:  sha256:8e495245e5d1fe75de612c8a07e4043635407a1979bb1dd588f1751d1390203f
 Source0:        https://download.qt.io/official_releases/qt/%{short_version}/%{real_version}/submodules/%{qt_module}-everywhere-src-%{real_version}.tar.xz
 BuildSystem:    cmake
 

--- a/SPECS/qt6-qtsensors/qt6-qtsensors.spec
+++ b/SPECS/qt6-qtsensors/qt6-qtsensors.spec
@@ -6,17 +6,17 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qtsensors
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 Name:           qt6-qtsensors
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - Sensors component
 License:        LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://github.com/qt/qtsensors
-#!RemoteAsset
+#!RemoteAsset:  sha256:23617062da7be526d023dec7f9b76231001a1098a7e5f94c646f2e4f87cfcf8f
 Source0:        https://download.qt.io/official_releases/qt/%{short_version}/%{real_version}/submodules/%{qt_module}-everywhere-src-%{real_version}.tar.xz
 BuildSystem:    cmake
 
@@ -98,4 +98,4 @@ popd
 %{_qt6_examplesdir}/
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/qt6-qtwebsockets/qt6-qtwebsockets.spec
+++ b/SPECS/qt6-qtwebsockets/qt6-qtwebsockets.spec
@@ -6,17 +6,17 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qtwebsockets
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 Name:           qt6-qtwebsockets
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - WebSockets component
 License:        LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://github.com/qt/qtwebsockets
-#!RemoteAsset:  sha256:272ac7e94418e2b13b3384d73ba89dbd6b746d7661b44dce906f8bfc0795bd01
+#!RemoteAsset:  sha256:243e3aa11924c8c5c1645e892f62d013caa3766c57512ca926d5b58146646fbf
 Source0:        https://download.qt.io/official_releases/qt/%{short_version}/%{real_version}/submodules/%{qt_module}-everywhere-src-%{real_version}.tar.xz
 BuildSystem:    cmake
 


### PR DESCRIPTION
## Summary

Topo P3a (needs qtdeclarative 6.11.1 from #925 in repo; serialport from #924 for positioning):

- qt6-qtwebsockets
- qt6-qt5compat
- qt6-qtconnectivity
- qt6-qtcoap
- qt6-qtopcua
- qt6-qtremoteobjects
- qt6-qtscxml
- qt6-qtsensors
- qt6-qtpositioning

Do not merge before #925 (and #924 for positioning) are published.

## Checklist

- [X] I have read the [openRuyi Code of Conduct] and agree to abide by it.

- [X] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: gpt-5.6