### PR TITLE
SPECS: Qt6 P3b: charts/3d/tools/wayland/vkb/timeline to 6.11.1

### DIFF
--- a/SPECS/qt6-qt3d/qt6-qt3d.spec
+++ b/SPECS/qt6-qt3d/qt6-qt3d.spec
@@ -6,19 +6,19 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qt3d
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 %bcond system_assimp 0
 
 Name:           qt6-qt3d
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - Qt3D QML bindings and C++ APIs
 License:        LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://code.qt.io/qt/qt3d.git
-#!RemoteAsset:  sha256:60593fd54f7b1e48dc67ddce0f1113e4593878872539677104c92926ef039c9a
+#!RemoteAsset:  sha256:a66d8c8e049d1ee7a7687b34940f3555d0d7084858b6dc78d1e1cb7df40a0107
 Source0:        https://download.qt.io/official_releases/qt/%{short_version}/%{real_version}/submodules/%{qt_module}-everywhere-src-%{real_version}.tar.xz
 BuildSystem:    cmake
 
@@ -55,7 +55,6 @@ support for 2D and 3D rendering in both Qt C++ and Qt Quick applications.
 %package        devel
 Summary:        Development files for %{name}
 Requires:       %{name}%{?_isa} = %{version}-%{release}
-Requires:       pkgconfig(Qt6Quick3D)
 
 %description    devel
 Development files for %{name}.

--- a/SPECS/qt6-qtcharts/qt6-qtcharts.spec
+++ b/SPECS/qt6-qtcharts/qt6-qtcharts.spec
@@ -6,17 +6,17 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qtcharts
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 Name:           qt6-qtcharts
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - Charts component
 License:        GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://github.com/qt/qtcharts
-#!RemoteAsset:  sha256:17992278017cfb8fafef74b61e35559d29482df959ba469327a45b3bb66e2af4
+#!RemoteAsset:  sha256:3fe3ed318c2a86d1417c5c29cf7494275e8fd4b537cd37453f5599c57365515c
 Source0:        https://download.qt.io/official_releases/qt/%{short_version}/%{real_version}/submodules/%{qt_module}-everywhere-src-%{real_version}.tar.xz
 BuildSystem:    cmake
 

--- a/SPECS/qt6-qtdatavis3d/qt6-qtdatavis3d.spec
+++ b/SPECS/qt6-qtdatavis3d/qt6-qtdatavis3d.spec
@@ -6,17 +6,17 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qtdatavis3d
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 Name:           qt6-qtdatavis3d
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - Qt Data Visualization component
 License:        GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://github.com/qt/qtdatavis3d
-#!RemoteAsset:  sha256:601c7cfafd6ae525258fe5bc0f759c67237a0aa61f91fb71db2a9c5eaa50bb07
+#!RemoteAsset:  sha256:1e1a7b9c0a947731655334f5d79252d40cdaf58c1801074ea5e9e0821d6693ac
 Source0:        https://download.qt.io/official_releases/qt/%{short_version}/%{real_version}/submodules/%{qt_module}-everywhere-src-%{real_version}.tar.xz
 BuildSystem:    cmake
 

--- a/SPECS/qt6-qtgrpc/2000-install-magic8ball-plugin.patch
+++ b/SPECS/qt6-qtgrpc/2000-install-magic8ball-plugin.patch
@@ -1,0 +1,14 @@
+diff --git a/examples/grpc/magic8ball/CMakeLists.txt b/examples/grpc/magic8ball/CMakeLists.txt
+--- a/examples/grpc/magic8ball/CMakeLists.txt
++++ b/examples/grpc/magic8ball/CMakeLists.txt
+@@ -55,6 +55,10 @@ install(TARGETS magic8ball
+     LIBRARY DESTINATION "${INSTALL_EXAMPLEDIR}"
+ )
+
++install(TARGETS magic8ball_plugin
++    LIBRARY DESTINATION "${INSTALL_EXAMPLEDIR}"
++)
++
+ add_subdirectory(server)
+ if(TARGET magic8ball_server)
+     add_dependencies(magic8ball magic8ball_server)

--- a/SPECS/qt6-qtgrpc/qt6-qtgrpc.spec
+++ b/SPECS/qt6-qtgrpc/qt6-qtgrpc.spec
@@ -7,19 +7,22 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qtgrpc
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 Name:           qt6-qtgrpc
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - Support for using gRPC and Protobuf
 License:        LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://github.com/qt/qtgrpc
-#!RemoteAsset:  sha256:98138fb8633c4922ef7ef49b8301f7cbfb7beb7897d44d72e639120a29f4577f
+#!RemoteAsset:  sha256:437b04f0c550ccdb1739ca5f9119b73dfa0376564815e8bfc199890643e2a250
 Source0:        https://download.qt.io/official_releases/qt/%{short_version}/%{real_version}/submodules/%{qt_module}-everywhere-src-%{real_version}.tar.xz
 BuildSystem:    cmake
+
+#  nothing provides libmagic8ball_plugin.so()
+Patch0:         2000-install-magic8ball-plugin.patch
 
 BuildOption(conf):  -DQT_BUILD_EXAMPLES:BOOL=ON
 BuildOption(conf):  -DQT_INSTALL_EXAMPLES_SOURCES:BOOL=ON

--- a/SPECS/qt6-qtlottie/qt6-qtlottie.spec
+++ b/SPECS/qt6-qtlottie/qt6-qtlottie.spec
@@ -6,17 +6,17 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qtlottie
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 Name:           qt6-qtlottie
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - Lottie Animation
 License:        GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://github.com/qt/qtlottie
-#!RemoteAsset:  sha256:bc9c363c48486d790a998d25119bc0e7d2499266c3be96e61e3032422b0457c2
+#!RemoteAsset:  sha256:e0d0fadbdc33e97c8241c56273b54b6a7b1139e076fdd21281bc4662ee4b2679
 Source0:        https://download.qt.io/official_releases/qt/%{short_version}/%{real_version}/submodules/%{qt_module}-everywhere-src-%{real_version}.tar.xz
 BuildSystem:    cmake
 
@@ -29,7 +29,9 @@ BuildRequires:  qt6-macros
 BuildRequires:  pkgconfig(Qt6Core)
 BuildRequires:  pkgconfig(Qt6Gui)
 BuildRequires:  qt6-qtbase-private-devel
+BuildRequires:  qt6-qtbase-static
 BuildRequires:  pkgconfig(Qt6Quick) >= %{version}
+BuildRequires:  qt6-qtdeclarative-static >= %{version}
 BuildRequires:  pkgconfig(Qt6Svg) >= %{version}
 BuildRequires:  pkgconfig(xkbcommon)
 BuildRequires:  pkgconfig(openssl)

--- a/SPECS/qt6-qtquick3d/qt6-qtquick3d.spec
+++ b/SPECS/qt6-qtquick3d/qt6-qtquick3d.spec
@@ -6,20 +6,20 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qtquick3d
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 %bcond system_assimp 0
 %bcond system_openxr 0
 
 Name:           qt6-qtquick3d
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - Quick3D Libraries and utilities
 License:        LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://github.com/qt/qtquick3d
-#!RemoteAsset:  sha256:17d40272becef0dab71b60333bcf0c23d1d25dcf1df16ee9bf0daa7e4de403e6
+#!RemoteAsset:  sha256:c76b85de3f8aa2a4bee64987acfef560675c1b378b92076c7c6264613e5b456f
 Source0:        https://download.qt.io/official_releases/qt/%{short_version}/%{real_version}/submodules/%{qt_module}-everywhere-src-%{real_version}.tar.xz
 BuildSystem:    cmake
 
@@ -127,7 +127,9 @@ popd
 %{_bindir}/materialeditor-qt6
 %{_bindir}/shapegen-qt6
 %{_bindir}/lightmapviewer-qt6
+%{_bindir}/particleshadergen
 %{_qt6_bindir}/balsam
+%{_qt6_bindir}/particleshadergen
 %{_qt6_bindir}/meshdebug
 %{_qt6_bindir}/shadergen
 %{_qt6_bindir}/balsamui

--- a/SPECS/qt6-qtquicktimeline/qt6-qtquicktimeline.spec
+++ b/SPECS/qt6-qtquicktimeline/qt6-qtquicktimeline.spec
@@ -6,17 +6,17 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qtquicktimeline
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 Name:           qt6-qtquicktimeline
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - QuickTimeline plugin
 License:        GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://github.com/qt/qtquicktimeline
-#!RemoteAsset:  sha256:882ed289b4c229ace324e2545a71d7611c201626bc007d50e514bfd2f6e251b7
+#!RemoteAsset:  sha256:af53f643fd9e4045e1b9ba919998e5c048ca877452c08036c9c8c5ee07ea8c27
 Source0:        https://download.qt.io/official_releases/qt/%{short_version}/%{real_version}/submodules/%{qt_module}-everywhere-src-%{real_version}.tar.xz
 BuildSystem:    cmake
 

--- a/SPECS/qt6-qttools/2000-adapt-to-llvm22.patch
+++ b/SPECS/qt6-qttools/2000-adapt-to-llvm22.patch
@@ -1,21 +1,20 @@
 diff --git a/src/qdoc/cmake/QDocConfiguration.cmake b/src/qdoc/cmake/QDocConfiguration.cmake
-index 72d27db9e..8a3cba463 100644
 --- a/src/qdoc/cmake/QDocConfiguration.cmake
 +++ b/src/qdoc/cmake/QDocConfiguration.cmake
-@@ -5,6 +5,6 @@ set(QDOC_MINIMUM_CLANG_VERSION "17")
-
+@@ -8,7 +8,7 @@
+ 
  # List of explicitly supported Clang versions for QDoc
  set(QDOC_SUPPORTED_CLANG_VERSIONS
 -    "21.1" "20.1" "19.1" "18.1" "17.0.6"
 +    "22.1" "22.0" "21.1" "20.1" "19.1" "18.1" "17.0.6"
  )
-
+ 
+ # Check for QDoc coverage dependencies
 diff --git a/src/qdoc/qdoc/CMakeLists.txt b/src/qdoc/qdoc/CMakeLists.txt
-index 90f1d7c23..84ebc3a28 100644
 --- a/src/qdoc/qdoc/CMakeLists.txt
 +++ b/src/qdoc/qdoc/CMakeLists.txt
-@@ -97,6 +97,7 @@ qt_internal_add_tool(${target_name}
-     DEFINES
+@@ -107,6 +107,7 @@
+         QT_NO_KEYWORDS
          # To provide the ability to workaround version-specific Clang issues.
          # A re-export of (LLVM|CLANG)_VERSION_MAJOR done in WrapLibClang.cmake
 +        QT_NO_EMIT
@@ -23,13 +22,12 @@ index 90f1d7c23..84ebc3a28 100644
  )
  qt_internal_return_unless_building_tools()
 diff --git a/src/qdoc/qdoc/src/qdoc/clangcodeparser.cpp b/src/qdoc/qdoc/src/qdoc/clangcodeparser.cpp
-index 66a750a3d..3f54ddff5 100644
 --- a/src/qdoc/qdoc/src/qdoc/clangcodeparser.cpp
 +++ b/src/qdoc/qdoc/src/qdoc/clangcodeparser.cpp
-@@ -43,7 +43,12 @@
+@@ -42,7 +42,12 @@
  #include <clang/Lex/Lexer.h>
  #include <llvm/Support/Casting.h>
-
+ 
 -#include "clang/AST/QualTypeNames.h"
 +#if LIBCLANG_VERSION_MAJOR >= 22
 +// LLVM 22 provides a compatible QualTypeNames implementation in libclang.
@@ -38,5 +36,5 @@ index 66a750a3d..3f54ddff5 100644
 +#  include "clang/AST/QualTypeNames.h"
 +#endif
  #include "template_declaration.h"
-
+ 
  #include <cstdio>

--- a/SPECS/qt6-qttools/qt6-qttools.spec
+++ b/SPECS/qt6-qttools/qt6-qttools.spec
@@ -8,16 +8,16 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qttools
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 Name:           qt6-qttools
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - QtTool components
 License:        LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
-#!RemoteAsset:  sha256:8148408380ffea03101a26305c812b612ea30dbc07121e58707601522404d49b
+#!RemoteAsset:  sha256:8e61835a679c93fa9c6065b142353c2071ba68e297898937c32a03777fcaf50d
 Source0:        https://download.qt.io/official_releases/qt/%{short_version}/%{real_version}/submodules/%{qt_module}-everywhere-src-%{real_version}.tar.xz
 Source1:        assistant.desktop
 Source2:        designer.desktop
@@ -44,6 +44,7 @@ BuildRequires:  qt6-qtbase-static >= %{version}
 BuildRequires:  pkgconfig(Qt6Quick) >= %{version}
 BuildRequires:  qt6-qtdeclarative-static >= %{version}
 BuildRequires:  clang-devel
+BuildRequires:  clang-static
 BuildRequires:  llvm-devel
 BuildRequires:  libzstd-devel
 
@@ -139,6 +140,9 @@ for prl_file in libQt6*.prl ; do
 done
 popd
 
+# Drop CMake object files accidentally installed under objects-$CONFIG/
+find %{buildroot}%{_qt6_libdir} -type f -name "*.o" -delete -print
+
 %files
 %{_qt6_archdatadir}/sbom/%{qt_module}-%{real_version}.spdx
 %{_bindir}/qdbus-qt6
@@ -186,9 +190,10 @@ popd
 %{_qt6_bindir}/lconvert*
 %{_qt6_bindir}/lrelease*
 %{_qt6_bindir}/lupdate*
-%{_qt6_libexecdir}/lprodump*
-%{_qt6_libexecdir}/lrelease*
-%{_qt6_libexecdir}/lupdate*
+%{_bindir}/lcheck*
+%{_bindir}/ltext2id*
+%{_qt6_bindir}/lcheck*
+%{_qt6_bindir}/ltext2id*
 
 %files -n qt6-qdbusviewer
 %{_bindir}/qdbusviewer*

--- a/SPECS/qt6-qtvirtualkeyboard/qt6-qtvirtualkeyboard.spec
+++ b/SPECS/qt6-qtvirtualkeyboard/qt6-qtvirtualkeyboard.spec
@@ -6,17 +6,17 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qtvirtualkeyboard
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 Name:           qt6-qtvirtualkeyboard
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - VirtualKeyboard component
 License:        GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://github.com/qt/qtvirtualkeyboard
-#!RemoteAsset
+#!RemoteAsset:  sha256:a1c6967b326243b2ca8d50bc7b7f7852c3975d9aa6ce4b186ebdf35bb1007e1c
 Source0:        https://download.qt.io/official_releases/qt/%{short_version}/%{real_version}/submodules/%{qt_module}-everywhere-src-%{real_version}.tar.xz
 
 BuildSystem:    cmake
@@ -102,4 +102,4 @@ Programming examples for %{name}.
 %{_qt6_examplesdir}/
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/qt6-qtwayland/qt6-qtwayland.spec
+++ b/SPECS/qt6-qtwayland/qt6-qtwayland.spec
@@ -6,17 +6,17 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %define qt_module qtwayland
-%define real_version 6.10.1
-%define short_version 6.10
+%define real_version 6.11.1
+%define short_version 6.11
 
 Name:           qt6-qtwayland
-Version:        6.10.1
+Version:        6.11.1
 Release:        %autorelease
 Summary:        Qt6 - Wayland platform support and QtCompositor module
 License:        LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0
 URL:            https://www.qt.io
 VCS:            git:https://github.com/qt/qtwayland
-#!RemoteAsset:  sha256:49bf6db800227a6b2c971f4c5d03dd1e81297e7ffb296ce4a96437304f27cb13
+#!RemoteAsset:  sha256:95788aa502f75441d4edf65932b235f76523084e13dbbb7b9ee2d207b32bd9b3
 Source0:        https://download.qt.io/official_releases/qt/%{short_version}/%{real_version}/submodules/%{qt_module}-everywhere-src-%{real_version}.tar.xz
 BuildSystem:    cmake
 
@@ -142,7 +142,6 @@ popd
 %{_qt6_libdir}/cmake/Qt6/*.cmake
 %{_qt6_libdir}/cmake/Qt6BuildInternals/StandaloneTests/QtWaylandTestsConfig.cmake
 %{_qt6_libdir}/cmake/Qt6Qml/QmlPlugins/*.cmake
-%{_qt6_libdir}/cmake/Qt6WaylandClient/*.cmake
 %{_qt6_libdir}/qt6/metatypes/qt6*_metatypes.json
 %{_qt6_datadir}/modules/*.json
 %{_qt6_libdir}/pkgconfig/Qt6WaylandCompositor.pc
@@ -150,11 +149,10 @@ popd
 %{_qt6_libdir}/pkgconfig/Qt6WaylandCompositorPresentationTime.pc
 %{_qt6_libdir}/pkgconfig/Qt6WaylandCompositorWLShell.pc
 %{_qt6_libdir}/pkgconfig/Qt6WaylandCompositorXdgShell.pc
-%exclude %{_qt6_libdir}/cmake/Qt6WaylandClient/Qt6QWaylandAdwaitaDecoration*.cmake
 
 %files adwaita-decoration
 %{_qt6_pluginsdir}/wayland-decoration-client/libadwaita.so
-%{_qt6_libdir}/cmake/Qt6WaylandClient/Qt6QWaylandAdwaitaDecoration*.cmake
+%{_qt6_libdir}/cmake/Qt6Gui/Qt6QWayland*.cmake
 
 %files examples
 %{_qt6_examplesdir}/wayland/


### PR DESCRIPTION
## Summary

Topo P3b (needs qtdeclarative 6.11.1 from #925 in repo; same layer as #926, merge after #926 for PR-number order):

- qt6-qtcharts
- qt6-qtdatavis3d
- qt6-qt3d
- qt6-qtgrpc
- qt6-qtlottie
- qt6-qttools
- qt6-qtwayland
- qt6-qtvirtualkeyboard
- qt6-qtquicktimeline

## Checklist

- [X] I have read the [openRuyi Code of Conduct] and agree to abide by it.

- [X] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: gpt-5.6