### PR TITLE
SPECS: openzl: Install missing internal shared libraries

### DIFF
--- a/SPECS/openzl/2000-add-install-rules-for-CLI-tools-and-parser-targets.patch
+++ b/SPECS/openzl/2000-add-install-rules-for-CLI-tools-and-parser-targets.patch
@@ -1,3 +1,33 @@
+From 7c246d077c2a495ca0148794f7d323cc0aa0f217 Mon Sep 17 00:00:00 2001
+From: Yafen Fang <yafen@iscas.ac.cn>
+Date: Wed, 15 Jul 2026 18:43:25 +0800
+Subject: [PATCH] add install rules for CLI, tools, and parser targets
+
+Add conditional install rules for various build targets to support
+the OPENZL_INSTALL option. This ensures that executables and libraries
+are correctly installed to their respective bin and lib directories.
+
+Updated modules include:
+- cli: zli executable, args, commands, and utils libraries
+- custom_parsers: custom_parsers, csv_parser, parquet_graph,
+  sddl_profile, and shared_components libraries
+- tools: arg, logger, sddl_compiler_lib, and tools_training libraries
+---
+ cli/CMakeLists.txt                              | 7 +++++++
+ cli/args/CMakeLists.txt                         | 8 ++++++++
+ cli/commands/CMakeLists.txt                     | 8 ++++++++
+ cli/utils/CMakeLists.txt                        | 8 ++++++++
+ custom_parsers/CMakeLists.txt                   | 9 +++++++++
+ custom_parsers/csv/CMakeLists.txt               | 8 ++++++++
+ custom_parsers/parquet/CMakeLists.txt           | 8 ++++++++
+ custom_parsers/sddl/CMakeLists.txt              | 8 ++++++++
+ custom_parsers/shared_components/CMakeLists.txt | 8 ++++++++
+ tools/arg/CMakeLists.txt                        | 8 ++++++++
+ tools/logger/CMakeLists.txt                     | 8 ++++++++
+ tools/sddl/CMakeLists.txt                       | 8 ++++++++
+ tools/training/CMakeLists.txt                   | 9 +++++++++
+ 13 files changed, 105 insertions(+)
+
 diff --git a/cli/CMakeLists.txt b/cli/CMakeLists.txt
 index 94831a2..7331d5f 100644
 --- a/cli/CMakeLists.txt
@@ -142,3 +172,75 @@ index 028512c..0a95695 100644
 +        ARCHIVE DESTINATION ${OPENZL_INSTALL_LIBDIR}
 +        COMPONENT runtime)
 +endif()
+diff --git a/tools/arg/CMakeLists.txt b/tools/arg/CMakeLists.txt
+index dfbdade..c6d6aea 100644
+--- a/tools/arg/CMakeLists.txt
++++ b/tools/arg/CMakeLists.txt
+@@ -24,4 +24,12 @@ if (OPENZL_BUILD_ARG_TOOLS)
+     )
+     target_include_directories(arg PUBLIC ${PROJECT_SOURCE_DIR})
+     apply_openzl_compile_options_to_target(arg)
++
++    # Install arg library
++    if (OPENZL_INSTALL)
++        install(TARGETS arg
++            LIBRARY DESTINATION ${OPENZL_INSTALL_LIBDIR}
++            ARCHIVE DESTINATION ${OPENZL_INSTALL_LIBDIR}
++            COMPONENT runtime)
++    endif()
+ endif()
+diff --git a/tools/logger/CMakeLists.txt b/tools/logger/CMakeLists.txt
+index b5bfb84..c3b5d73 100644
+--- a/tools/logger/CMakeLists.txt
++++ b/tools/logger/CMakeLists.txt
+@@ -16,4 +16,12 @@ add_library(logger
+ 
+ target_include_directories(logger PUBLIC ${PROJECT_SOURCE_DIR})
+ apply_openzl_compile_options_to_target(logger)
++
++# Install logger library
++if (OPENZL_INSTALL)
++    install(TARGETS logger
++        LIBRARY DESTINATION ${OPENZL_INSTALL_LIBDIR}
++        ARCHIVE DESTINATION ${OPENZL_INSTALL_LIBDIR}
++        COMPONENT runtime)
++endif()
+ endif()
+diff --git a/tools/sddl/CMakeLists.txt b/tools/sddl/CMakeLists.txt
+index 564bd62..8ba4e59 100644
+--- a/tools/sddl/CMakeLists.txt
++++ b/tools/sddl/CMakeLists.txt
+@@ -66,4 +66,12 @@ if (OPENZL_BUILD_SDDL_TOOLS)
+         apply_openzl_compile_options_to_target(test_sddl_compiler)
+         gtest_discover_tests(test_sddl_compiler)
+     endif()
++
++    # Install sddl_compiler_lib library
++    if (OPENZL_INSTALL)
++        install(TARGETS sddl_compiler_lib
++            LIBRARY DESTINATION ${OPENZL_INSTALL_LIBDIR}
++            ARCHIVE DESTINATION ${OPENZL_INSTALL_LIBDIR}
++            COMPONENT runtime)
++    endif()
+ endif()
+diff --git a/tools/training/CMakeLists.txt b/tools/training/CMakeLists.txt
+index 8096d34..34e1e4e 100644
+--- a/tools/training/CMakeLists.txt
++++ b/tools/training/CMakeLists.txt
+@@ -57,4 +57,13 @@ add_dependencies(tools_training openzl openzl_cpp tools_io custom_parsers logger
+     apply_openzl_compile_options_to_target(test_training)
+     gtest_discover_tests(test_training)
+   endif()
++
++  # Install tools_training library
++  if (OPENZL_INSTALL)
++    install(TARGETS tools_training
++        LIBRARY DESTINATION ${OPENZL_INSTALL_LIBDIR}
++        ARCHIVE DESTINATION ${OPENZL_INSTALL_LIBDIR}
++        COMPONENT runtime)
++  endif()
++
+ endif()
+-- 
+2.34.1
+

--- a/SPECS/openzl/2001-feat-prefer-system-installed-zstd-over-bundled-depen.patch
+++ b/SPECS/openzl/2001-feat-prefer-system-installed-zstd-over-bundled-depen.patch
@@ -1,3 +1,18 @@
+From 1df4dd3ab929e33351a03b7783c51be193aa6313 Mon Sep 17 00:00:00 2001
+From: Yafen Fang <yafen@iscas.ac.cn>
+Date: Wed, 15 Jul 2026 18:44:34 +0800
+Subject: [PATCH] feat: prefer system-installed zstd over bundled
+ dependency
+
+Check for a system-installed zstd via pkg-config or CMake
+find_package before falling back to the git submodule or
+FetchContent download. This avoids redundant bundled builds
+in environments where zstd is already available as a system
+package.
+---
+ build/cmake/openzl-deps.cmake | 134 ++++++++++++++++++++++------------
+ 1 file changed, 87 insertions(+), 47 deletions(-)
+
 diff --git a/build/cmake/openzl-deps.cmake b/build/cmake/openzl-deps.cmake
 index 59b691a..6b3a489 100644
 --- a/build/cmake/openzl-deps.cmake
@@ -167,3 +182,6 @@ index 59b691a..6b3a489 100644
  
  find_library(MATH_LIBRARY m)
  if(MATH_LIBRARY)
+-- 
+2.34.1
+

--- a/SPECS/openzl/openzl.spec
+++ b/SPECS/openzl/openzl.spec
@@ -11,14 +11,12 @@ Release:        %autorelease
 Summary:        A specialized compressor optimized for specific data formats
 License:        BSD-3-Clause
 URL:            https://github.com/facebook/openzl
-#!RemoteAsset
+#!RemoteAsset:  sha256:3278546dcdbae3aef3887f07b435ebe0aa9f6943a5ac74cf9b7baeefe6526c2e
 Source0:        https://github.com/facebook/openzl/archive/refs/tags/v%{version}.tar.gz
 BuildSystem:    cmake
 
-# add install for some files.
-Patch0:         0001-fix_install_rules.patch
-# disable download form network.
-Patch1:         0002-fix-use-system-zstd.patch
+Patch2000:      2000-add-install-rules-for-CLI-tools-and-parser-targets.patch
+Patch2001:      2001-feat-prefer-system-installed-zstd-over-bundled-depen.patch
 
 BuildOption(conf):  -DOPENZL_BUILD_TESTS:BOOL=OFF
 BuildOption(conf):  -DOPENZL_BUILD_BENCHMARKS:BOOL=OFF
@@ -70,4 +68,4 @@ rm -f %{buildroot}%{_libdir}/libzstd*
 %{_libdir}/cmake/openzl/*.cmake
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
## Summary

The CLI tool (zli) links against arg, logger, tools_training and
sddl_compiler_lib, but these internal libraries were not installed
by the upstream CMakeLists.txt. This causes RPM dependency resolution
failures because the auto-generated DT_NEEDED requires cannot be
satisfied. Add install() rules for all four libraries so they are
included in the built package.

Error info:

```
 Problem 1: conflicting requests
          - nothing provides libarg.so()(64bit) needed by openzl-devel-0.1.0-4.15.or.riscv64 from Base
          - nothing provides liblogger.so()(64bit) needed by openzl-devel-0.1.0-4.15.or.riscv64 from Base
          - nothing provides libsddl_compiler_lib.so()(64bit) needed by openzl-devel-0.1.0-4.15.or.riscv64 from Base
          - nothing provides libtools_training.so()(64bit) needed by openzl-devel-0.1.0-4.15.or.riscv64 from Base
```


## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: DeepSeek

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
