### PR TITLE
ci: exclude src.rpm from install job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,7 +98,7 @@ jobs:
         dnf update --assumeyes
     - name: Install all
       run: |
-        rpms=$(find . -name '*.rpm')
+        rpms=$(find . -name '*.rpm' ! -name '*.src.rpm')
         [ -n "$rpms" ]
         ls -lah $rpms
         dnf install --assumeyes $rpms


### PR DESCRIPTION
## Summary


Fix: https://github.com/openRuyi-Project/openRuyi/actions/runs/29390983732/job/87275023257

```
file /github/home/rpmbuild/SOURCES/2000-drop-unpackaged-features.patch conflicts between attempted installs of rust-linked-hash-map-0.5-0.5.6-1.or.noarch and rust-gzp-2-2.0.2-1.or.noarch
```

## Related Issue

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy