### PR TITLE
SPECS: go: Set profile level to RVA23 when distribution using RVA23.

### DIFF
--- a/SPECS/go/go.spec
+++ b/SPECS/go/go.spec
@@ -25,6 +25,9 @@
 %endif
 %ifarch riscv64
 %global gohostarch riscv64
+%if "%{openruyi_riscv_arch}" == "-march=rva23u64"
+%global goriscv64 rva23u64
+%endif
 %endif
 
 # we are shipping the full contents of src in the data subpackage, which
@@ -126,6 +129,9 @@ tar -xf %{SOURCE2} -C %{_builddir}/%{name}-bootstrap --strip-components=1
 export GOROOT_FINAL=%{_libdir}/%{name}
 export GOHOSTOS=linux
 export GOHOSTARCH=%{gohostarch}
+%ifarch riscv64
+export GORISCV64=%{goriscv64}
+%endif
 %if %{with bootstrap}
 export GOROOT_BOOTSTRAP=%{_builddir}/%{name}-bootstrap
 %else
@@ -173,6 +179,9 @@ export GOROOT_FINAL=%{_libdir}/%{name}/
 export PATH="%{buildroot}%{_libdir}/%{name}/bin:$PATH"
 export GOTOOLDIR="%{buildroot}%{_libdir}/%{name}/pkg/tool/linux_%{gohostarch}"
 export GO_TEST_TIMEOUT_SCALE=20
+%ifarch riscv64
+export GORISCV64=%{goriscv64}
+%endif
 pushd src
 ./run.bash --no-rebuild -v -v -v -k -run "!(cmd/cgo/internal/testsanitizers|syscall)"
 popd


### PR DESCRIPTION
## Summary

Set `GORISCV64` to rva23u64  when openRuyi building with rva23 profile level.

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

No.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
