### PR TITLE
SPECS: go: Fix missing profile level on RVA20

### DIFF
--- a/SPECS/go/go.spec
+++ b/SPECS/go/go.spec
@@ -27,6 +27,8 @@
 %global gohostarch riscv64
 %if "%{openruyi_riscv_arch}" == "-march=rva23u64"
 %global goriscv64 rva23u64
+%else
+%global goriscv64 rva20u64
 %endif
 %endif
 


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

Since #954 had set the profile level to RVA23, it will cause build failed while building without special `openruyi_riscv_arch`. This PR fixes missing profile level on RVA20.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #954

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
