### PR TITLE
SPECS: some pkgs: Add `-f %{name}.lang` to main filelist.

### DIFF
--- a/SPECS/acl/acl.spec
+++ b/SPECS/acl/acl.spec
@@ -51,7 +51,7 @@ rm -rvf %{buildroot}/%{_defaultdocdir}/%{name}
 %install -a
 %find_lang %{name} --generate-subpackages
 
-%files
+%files -f %{name}.lang
 %license doc/COPYING doc/COPYING.LGPL
 %doc doc/extensions.txt doc/libacl.txt doc/CHANGES
 %{_docdir}/acl

--- a/SPECS/attr/attr.spec
+++ b/SPECS/attr/attr.spec
@@ -48,7 +48,7 @@ IRIX compatibility interface is also provided.
 %install -a
 %find_lang %{name} --generate-subpackages
 
-%files
+%files -f %{name}.lang
 %license doc/COPYING*
 %doc doc/CHANGES
 %{_libdir}/libattr.so.1*

--- a/SPECS/bash/bash.spec
+++ b/SPECS/bash/bash.spec
@@ -82,7 +82,7 @@ rm -f $RPM_BUILD_ROOT%{_infodir}/dir
 
 %find_lang %{name} --generate-subpackages
 
-%files
+%files -f %{name}.lang
 %config(noreplace) /etc/skel/.b*
 %license COPYING
 %{_bindir}/bash

--- a/SPECS/flex/flex.spec
+++ b/SPECS/flex/flex.spec
@@ -41,7 +41,7 @@ This package contains files required to build programs with flex libraries.
 %install -a
 %find_lang %{name} --generate-subpackages
 
-%files
+%files -f %{name}.lang
 %license COPYING
 %doc AUTHORS ChangeLog NEWS ONEWS README.md THANKS
 %exclude %_docdir/%{name}/COPYING

--- a/SPECS/gnupg/gnupg.spec
+++ b/SPECS/gnupg/gnupg.spec
@@ -68,7 +68,7 @@ install -d -m 755 %{buildroot}%{_userunitdir}
 %post
 %udev_rules_update
 
-%files
+%files -f gnupg2.lang
 %{_mandir}/*/[aghsw]*%{?ext_man}
 %license COPYING*
 %doc AUTHORS NEWS THANKS TODO ChangeLog

--- a/SPECS/grub/grub.spec
+++ b/SPECS/grub/grub.spec
@@ -186,7 +186,7 @@ install -D -m 0644 %{SOURCE1} %{buildroot}%{_sysconfdir}/default/grub
 
 %find_lang %{name} --generate-subpackages
 
-%files
+%files -f %{name}.lang
 %license COPYING
 %dir %{_sysconfdir}/grub.d
 %dir %{_libdir}/%{name}/


### PR DESCRIPTION

## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->
Rpm can deal with locale names containing '@' now. Some packages 'en' locales can also containing '@', and these locale files been put into %{name}.lang file. So add it to the main %file list. Missing this might failed like this:
```
[    9s] error: Installed (but unpackaged) file(s) found:
[    9s]    /usr/share/locale/en@boldquot/LC_MESSAGES/attr.mo
[    9s]    /usr/share/locale/en@quot/LC_MESSAGES/attr.mo
```

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
