### PR TITLE
SPECS: Remove self-added SPDX contributor lines

### DIFF
--- a/SPECS/go-github-cpuguy83-tar2go/go-github-cpuguy83-tar2go.spec
+++ b/SPECS/go-github-cpuguy83-tar2go/go-github-cpuguy83-tar2go.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-docker-go-metrics/go-github-docker-go-metrics.spec
+++ b/SPECS/go-github-docker-go-metrics/go-github-docker-go-metrics.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-hashicorp-consul-api/go-github-hashicorp-consul-api.spec
+++ b/SPECS/go-github-hashicorp-consul-api/go-github-hashicorp-consul-api.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-hashicorp-consul-sdk/go-github-hashicorp-consul-sdk.spec
+++ b/SPECS/go-github-hashicorp-consul-sdk/go-github-hashicorp-consul-sdk.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-hashicorp-go-msgpack/go-github-hashicorp-go-msgpack.spec
+++ b/SPECS/go-github-hashicorp-go-msgpack/go-github-hashicorp-go-msgpack.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-hashicorp-go-sockaddr/go-github-hashicorp-go-sockaddr.spec
+++ b/SPECS/go-github-hashicorp-go-sockaddr/go-github-hashicorp-go-sockaddr.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 # SPDX-FileContributor: Julian Zhu <julian.oerv@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0

--- a/SPECS/go-github-hashicorp-logutils/go-github-hashicorp-logutils.spec
+++ b/SPECS/go-github-hashicorp-logutils/go-github-hashicorp-logutils.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-hashicorp-mdns/go-github-hashicorp-mdns.spec
+++ b/SPECS/go-github-hashicorp-mdns/go-github-hashicorp-mdns.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-hashicorp-memberlist/go-github-hashicorp-memberlist.spec
+++ b/SPECS/go-github-hashicorp-memberlist/go-github-hashicorp-memberlist.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-hashicorp-nomad-api/go-github-hashicorp-nomad-api.spec
+++ b/SPECS/go-github-hashicorp-nomad-api/go-github-hashicorp-nomad-api.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-hetznercloud-hcloud-go-v2/go-github-hetznercloud-hcloud-go-v2.spec
+++ b/SPECS/go-github-hetznercloud-hcloud-go-v2/go-github-hetznercloud-hcloud-go-v2.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-influxdata-influxdb-client-go-v2/go-github-influxdata-influxdb-client-go-v2.spec
+++ b/SPECS/go-github-influxdata-influxdb-client-go-v2/go-github-influxdata-influxdb-client-go-v2.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-influxdata-line-protocol/go-github-influxdata-line-protocol.spec
+++ b/SPECS/go-github-influxdata-line-protocol/go-github-influxdata-line-protocol.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-ionos-cloud-sdk-go-v6/go-github-ionos-cloud-sdk-go-v6.spec
+++ b/SPECS/go-github-ionos-cloud-sdk-go-v6/go-github-ionos-cloud-sdk-go-v6.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-jarcoal-httpmock/go-github-jarcoal-httpmock.spec
+++ b/SPECS/go-github-jarcoal-httpmock/go-github-jarcoal-httpmock.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-linode-linodego/go-github-linode-linodego.spec
+++ b/SPECS/go-github-linode-linodego/go-github-linode-linodego.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-maxatome-go-testdeep/go-github-maxatome-go-testdeep.spec
+++ b/SPECS/go-github-maxatome-go-testdeep/go-github-maxatome-go-testdeep.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-mitchellh-cli/go-github-mitchellh-cli.spec
+++ b/SPECS/go-github-mitchellh-cli/go-github-mitchellh-cli.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-moby-docker-image-spec/go-github-moby-docker-image-spec.spec
+++ b/SPECS/go-github-moby-docker-image-spec/go-github-moby-docker-image-spec.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-moby-locker/go-github-moby-locker.spec
+++ b/SPECS/go-github-moby-locker/go-github-moby-locker.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-moby-patternmatcher/go-github-moby-patternmatcher.spec
+++ b/SPECS/go-github-moby-patternmatcher/go-github-moby-patternmatcher.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-moby-pubsub/go-github-moby-pubsub.spec
+++ b/SPECS/go-github-moby-pubsub/go-github-moby-pubsub.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-oapi-codegen-runtime/go-github-oapi-codegen-runtime.spec
+++ b/SPECS/go-github-oapi-codegen-runtime/go-github-oapi-codegen-runtime.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-opencontainers-runtime-spec/go-github-opencontainers-runtime-spec.spec
+++ b/SPECS/go-github-opencontainers-runtime-spec/go-github-opencontainers-runtime-spec.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-posener-complete/go-github-posener-complete.spec
+++ b/SPECS/go-github-posener-complete/go-github-posener-complete.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-ryanuber-columnize/go-github-ryanuber-columnize.spec
+++ b/SPECS/go-github-ryanuber-columnize/go-github-ryanuber-columnize.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-sean--seed/go-github-sean--seed.spec
+++ b/SPECS/go-github-sean--seed/go-github-sean--seed.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-tonistiigi-go-archvariant/go-github-tonistiigi-go-archvariant.spec
+++ b/SPECS/go-github-tonistiigi-go-archvariant/go-github-tonistiigi-go-archvariant.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/go-github-vbatts-tar-split/go-github-vbatts-tar-split.spec
+++ b/SPECS/go-github-vbatts-tar-split/go-github-vbatts-tar-split.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/ranger/ranger.spec
+++ b/SPECS/ranger/ranger.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 

--- a/SPECS/serf/serf.spec
+++ b/SPECS/serf/serf.spec
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
-# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 


### PR DESCRIPTION
## Summary

Remove the previously added `SPDX-FileContributor` lines naming this contributor from 31 existing package specs.

The package contents and build metadata are unchanged. Contributor declarations already present from other people are preserved; contribution identity remains recorded by Git author metadata and DCO sign-offs.

## Validation

- each commit changes one source package and removes exactly one line
- pre-commit checks passed for all affected specs
- all commits include DCO sign-off
- no `Co-Authored-By` trailers

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.
- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: Claude Code:GPT-5.6 Sol High

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]: https://openruyi.cn/governance/policy/ai-contribution-policy
