### PR TITLE
SPECS/clang-wrap: Update clang-wrap to 20260720

### DIFF
--- a/SPECS/clang-wrap/clang-wrap.spec
+++ b/SPECS/clang-wrap/clang-wrap.spec
@@ -4,8 +4,8 @@
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
-%global git_ver git20260717.b329f3b
-%global git_commit b329f3b109d4ef2d82a0506929d5dd92448bfb79
+%global git_ver git20260720.c9b91a6
+%global git_commit c9b91a6f08ff34ebf3a23631afd94b8c2fafc51b
 
 Name:           clang-wrap
 Version:        0+%{git_ver}
@@ -13,7 +13,7 @@ Release:        %{autorelease}
 License:        Mulan-2.0
 Summary:        clang-wrap to collect LLVM IR
 URL:            https://github.com/openRuyi-Project/clang-wrap
-#!RemoteAsset:  sha256:3c26fe2ef147b34e64b4f2e02301d75cb2652f7b627aa6afd49e83e66cea910f
+#!RemoteAsset:  sha256:0238b50f64af8cfaef0b0c12efd01ef4debfb9813a6e8900d06f1ad4b3451ddb
 Source0:        https://github.com/openRuyi-Project/clang-wrap/archive/%{git_commit}.tar.gz
 Source1:        macros.clang-wrap
 BuildSystem:    rust
@@ -22,6 +22,7 @@ BuildRequires:  cargo
 BuildRequires:  rust
 BuildRequires:  rust-rpm-macros
 BuildRequires:  crate(pathdiff-0.2/default)
+BuildRequires:  crate(serde-json-1)
 
 %description
 %{summary}


### PR DESCRIPTION
## Summary

The commit hash is: c9b91a6f08ff34ebf3a23631afd94b8c2fafc51b

The changes include:
  Add O3 fallback to LLVM IR command scripts
  Support Meson ar operation flags
  Add Meson LLVM IR installation support

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
