### PR TITLE
SPECS: rocr-runtime: fix zicbom instruction missing on rva20 device

### DIFF
--- a/SPECS/rocr-runtime/0002-Replace-fence-instructions-for-riscv64.patch
+++ b/SPECS/rocr-runtime/0002-Replace-fence-instructions-for-riscv64.patch
@@ -105,14 +105,16 @@ replace _mm_clflush with cbo.flush (Zicbom extension).
    i = next_packet_;
 --- a/runtime/hsa-runtime/core/util/utils.h
 +++ b/runtime/hsa-runtime/core/util/utils.h
-@@ -409,7 +409,11 @@
+@@ -409,7 +409,13 @@
    cur += offset;
    uintptr_t lastline = (uintptr_t)(cur + len - 1) | (cacheline_size - 1);
    do {
 +#if !defined(__riscv)
      _mm_clflush((const void*)cur);
-+#else
++#elif defined(__riscv_zicbom)
 +    asm volatile("cbo.flush (%0)" :: "r"((const void*)cur) : "memory");
++#else
++    asm volatile("fence rw,rw" ::: "memory");
 +#endif
      cur += cacheline_size;
    } while (cur <= (const char*)lastline);

--- a/SPECS/rocr-runtime/rocr-runtime.spec
+++ b/SPECS/rocr-runtime/rocr-runtime.spec
@@ -32,7 +32,7 @@ Source0:        %{url}/archive/refs/tags/rocm-%{version}.tar.gz
 BuildSystem:    cmake
 
 Patch0:         0001-Add-riscv64-support.patch
-Patch1:         0002-Replace-fence-instrutions-for-riscv64.patch
+Patch1:         0002-Replace-fence-instructions-for-riscv64.patch
 
 BuildOption(conf):  -DCMAKE_PREFIX_PATH=%{rocmllvm_cmakedir}/..
 BuildOption(conf):  -DCMAKE_SHARED_LINKER_FLAGS=-ldrm_amdgpu


### PR DESCRIPTION
## Summary

Fix rocr-runtime build on rva20

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.
- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
