### PR TITLE
Let llvm-static be a MUST explicit dependency.

### DIFF
--- a/SPECS/bpftrace/bpftrace.spec
+++ b/SPECS/bpftrace/bpftrace.spec
@@ -23,7 +23,9 @@ BuildRequires:  gcc-c++
 BuildRequires:  pkgconfig(libelf)
 BuildRequires:  pkgconfig(zlib)
 BuildRequires:  llvm-devel
+BuildRequires:  llvm-static
 BuildRequires:  clang-devel
+BuildRequires:  clang-static
 BuildRequires:  bcc-devel >= 0.19.0-1
 BuildRequires:  libbpf-devel
 BuildRequires:  libiberty-devel

--- a/SPECS/libclc/libclc.spec
+++ b/SPECS/libclc/libclc.spec
@@ -11,7 +11,7 @@ Summary:        An open source implementation of the OpenCL 1.1 library requirem
 License:        Apache-2.0 WITH LLVM-exception OR NCSA OR MIT
 URL:            https://libclc.llvm.org
 VCS:            git:https://github.com/llvm/llvm-project
-#!RemoteAsset
+#!RemoteAsset:  sha256:de1c8dbffdce898a4c5e70fb7f5aa6dea1e429f63471773da8cb3cdf9e945403
 Source0:        https://github.com/llvm/llvm-project/releases/download/llvmorg-%{version}/libclc-%{version}.src.tar.xz
 BuildArch:      noarch
 BuildSystem:    cmake
@@ -24,6 +24,7 @@ BuildRequires:  python3
 BuildRequires:  pkgconfig(zlib)
 BuildRequires:  clang-devel >= %{version}
 BuildRequires:  llvm-devel >= %{version}
+BuildRequires:  llvm-static >= %{version}
 BuildRequires:  pkgconfig(libedit)
 BuildRequires:  spirv-llvm-translator
 
@@ -51,4 +52,4 @@ which are the subset required for upstream Mesa OpenCL support with RustiCL.
 %{_datadir}/clc/*.bc
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/llvm22/llvm22.spec
+++ b/SPECS/llvm22/llvm22.spec
@@ -152,9 +152,6 @@ Requires:       llvm%{maj_ver}-libs%{?_isa} = %{version}-%{release}
 # libedit-devel is available.
 Requires:       pkgconfig(libedit)
 Requires:       pkgconfig(libzstd)
-# The installed cmake files reference binaries from llvm-test, llvm-static, and
-# llvm-gtest.
-Requires:       llvm%{maj_ver}-static%{?_isa} = %{version}-%{release}
 Provides:       llvm-devel(major) = %{maj_ver}
 
 %description -n llvm%{maj_ver}-devel
@@ -169,6 +166,7 @@ Shared libraries for the LLVM compiler infrastructure.
 
 %package     -n llvm%{maj_ver}-static
 Summary:        LLVM static libraries (%{maj_ver})
+Requires:       llvm%{maj_ver}-devel%{?_isa} = %{version}-%{release}
 Provides:       llvm-static(major) = %{maj_ver}
 
 %description -n llvm%{maj_ver}-static

--- a/SPECS/qt6-qttools/qt6-qttools.spec
+++ b/SPECS/qt6-qttools/qt6-qttools.spec
@@ -46,6 +46,7 @@ BuildRequires:  qt6-qtdeclarative-static >= %{version}
 BuildRequires:  clang-devel
 BuildRequires:  clang-static
 BuildRequires:  llvm-devel
+BuildRequires:  llvm-static
 BuildRequires:  libzstd-devel
 
 %description

--- a/SPECS/rocclr/rocclr.spec
+++ b/SPECS/rocclr/rocclr.spec
@@ -56,6 +56,7 @@ BuildRequires:  cmake
 BuildRequires:  cmake(amd_comgr)
 BuildRequires:  cmake(hsa-runtime64)
 BuildRequires:  llvm22-devel
+BuildRequires:  llvm22-static
 BuildRequires:  cmake(rocprofiler-register)
 BuildRequires:  hipcc
 BuildRequires:  lld(major) = %{llvm_maj_ver}

--- a/SPECS/rocr-runtime/rocr-runtime.spec
+++ b/SPECS/rocr-runtime/rocr-runtime.spec
@@ -45,6 +45,7 @@ BuildRequires:  cmake
 BuildRequires:  lld22
 BuildRequires:  lld22-devel
 BuildRequires:  llvm22-devel
+BuildRequires:  llvm22-static
 BuildRequires:  pkgconfig(numa)
 BuildRequires:  pkgconfig(libdrm)
 BuildRequires:  pkgconfig(libelf)

--- a/SPECS/spirv-llvm-translator/spirv-llvm-translator.spec
+++ b/SPECS/spirv-llvm-translator/spirv-llvm-translator.spec
@@ -30,6 +30,7 @@ BuildRequires:  gcc
 BuildRequires:  gcc-c++
 BuildRequires:  ninja
 BuildRequires:  (cmake(LLVM) >= 22 with cmake(LLVM) < 23)
+BuildRequires:  (llvm-static >= 22 with llvm-static < 23)
 BuildRequires:  pkgconfig(SPIRV-Headers)
 BuildRequires:  pkgconfig(zlib)
 BuildRequires:  pkgconfig(libxml-2.0)


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->
Llvm22-static size is as big as ~4G. Now we have llvm22-devel requires llvm22-static. This is wasteful for some packages as they really only require llvm22-devel but not llvm22-static. They are:
```
bpftool
firefox
llvmir-converter
mesa
rocprim
rust
```
Making llvm22-static as a seperate, Must explicit dependency can decrease unnessesary build pressure. Doing so needs another 6 packags shoud add llvm-static as explicitly buildrequires.
 
## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
