### PR TITLE
SPECS: flac: Add requires on flac for cmake support in flac-devel

### DIFF
--- a/SPECS/flac/flac.spec
+++ b/SPECS/flac/flac.spec
@@ -11,8 +11,8 @@ Release:        %autorelease
 Summary:        An encoder/decoder for the Free Lossless Audio Codec
 License:        BSD-3-Clause AND GPL-2.0-or-later AND GFDL-1.3-or-later
 URL:            https://github.com/xiph/flac
-#!RemoteAsset
-Source:         https://downloads.xiph.org/releases/flac/flac-%{version}.tar.xz
+#!RemoteAsset:  sha256:f2c1c76592a82ffff8413ba3c4a1299b6c7ab06c734dee03fd88630485c2b920
+Source0:        https://downloads.xiph.org/releases/flac/flac-%{version}.tar.xz
 BuildSystem:    cmake
 
 BuildRequires:  cmake
@@ -37,6 +37,7 @@ This package contains the shared libraries for the Free Lossless Audio Codec.
 %package        devel
 Summary:        Development files for the FLAC libraries
 Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
 
 %description    devel
 This package contains the header files, libraries, and documentation
@@ -78,4 +79,4 @@ install src/libFLAC++/libFLAC++.m4 %{buildroot}%{_datadir}/aclocal/
 %{_datadir}/aclocal/*.m4
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
## Summary

 The flac binary is needed by the cmake support.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
