### PR TITLE
SPECS: editorconfig-core-c: Add static sub-package

### DIFF
--- a/SPECS/editorconfig-core-c/editorconfig-core-c.spec
+++ b/SPECS/editorconfig-core-c/editorconfig-core-c.spec
@@ -37,8 +37,12 @@ Requires:       %{name}%{?_isa} = %{version}-%{release}
 %description    devel
 This package contains the files needed for development.
 
-%install -a
-rm -f %{buildroot}/%{_libdir}/libeditorconfig_static.a
+%package        static
+Summary:        Static files for EditorConfig files
+Requires:       %{name}-devel%{?_isa} = %{version}-%{release}
+
+%description    static
+Static libraries for developing applications that use %{name}.
 
 %files
 %doc README.md
@@ -56,5 +60,8 @@ rm -f %{buildroot}/%{_libdir}/libeditorconfig_static.a
 %{_libdir}/cmake/EditorConfig/
 %{_libdir}/pkgconfig/editorconfig.pc
 
+%files static
+%{_libdir}/libeditorconfig_static.a
+
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
## Summary

The CMake config file references libeditorconfig_static.a, but the spec file was deleting it during %install, causing find_package(EditorConfig CONFIG) to fail.

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
