### PR TITLE
SPECS: fltk: Add static sub-package for cmake support

### DIFF
--- a/SPECS/fltk/fltk.spec
+++ b/SPECS/fltk/fltk.spec
@@ -54,6 +54,13 @@ Requires:       pkgconfig(x11)
 %description    devel
 Development files for FLTK.
 
+%package        static
+Summary:        Static libraries for %{name}
+Requires:       %{name}-devel = %{version}-%{release}
+
+%description    static
+Static libraries for FLTK.
+
 %package        fluid
 Summary:        Fast Light User Interface Designer
 Requires:       %{name}%{?_isa} = %{version}-%{release}
@@ -67,7 +74,6 @@ make docs -C %{_vpath_builddir}
 
 %install -a
 mv src/xutf8/COPYING ./COPYING.xutf8
-rm -f %{buildroot}%{_libdir}/*.a
 
 %check
 desktop-file-validate %{buildroot}%{_datadir}/applications/fluid.desktop
@@ -102,6 +108,12 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/fluid.desktop
 %{_mandir}/man1/fltk-config.1*
 %{_mandir}/man3/fltk.3*
 %{_mandir}/man6/*.6*
+
+%files static
+%{_libdir}/libfltk.a
+%{_libdir}/libfltk_forms.a
+%{_libdir}/libfltk_gl.a
+%{_libdir}/libfltk_images.a
 
 %files fluid
 %{_bindir}/fluid


### PR DESCRIPTION
## Summary

The CMake config file references libfltk.a, but the spec file was deleting it during %install, causing find_package(FLTK CONFIG) to fail.

Move the static libraries into a -static subpackage instead of removing them, so the CMake package config is satisfied.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
