### PR TITLE
SPECS: libssh: Update to 0.11.5 [security-fixes]

### DIFF
--- a/SPECS/libssh/libssh.spec
+++ b/SPECS/libssh/libssh.spec
@@ -10,16 +10,14 @@
 %bcond gssapi 0
 
 Name:           libssh
-Version:        0.11.3
+Version:        0.11.5
 Release:        %autorelease
 Summary:        A library implementing the SSH protocol
 License:        LGPL-2.1-or-later
 URL:            http://www.libssh.org
 VCS:            git:git://git.libssh.org/projects/libssh.git
-#!RemoteAsset
+#!RemoteAsset:  sha256:6898ba9dd836d618b71dc7a4bb786a502c173cef5cafbf20fe5e0567ba4ea30c
 Source0:        https://www.libssh.org/files/0.11/%{name}-%{version}.tar.xz
-#!RemoteAsset
-Source1:        https://www.libssh.org/files/0.11/%{name}-%{version}.tar.xz.asc
 Source2:        libssh_client.config
 Source3:        libssh_server.config
 BuildSystem:    cmake
@@ -111,4 +109,4 @@ install -m644 %{SOURCE3} %{buildroot}%{_sysconfdir}/libssh/libssh_server.config
 %attr(0644,root,root) %config(noreplace) %{_sysconfdir}/libssh/libssh_server.config
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
## Summary
SPECS: libssh: Update to 0.11.5 [security-fixes]

CVE-2026-15370: Stack buffer overflow in SFTP server longname
construction
CVE-2026-59843: Denial of service via zero advertised channel
packet size
CVE-2026-59844: Denial of service via oversized SFTP read length
CVE-2026-59845: Denial of service via unchecked ProxyCommand
fork() failure
CVE-2026-59846: Information disclosure via ProxyCommand %r
username expansion
CVE-2026-59847: Integrity downgrade via OpenSSL AES-GCM tag
verification
CVE-2026-59848: Denial of service via SFTP responses with unknown
request IDs
CVE-2026-59849: Denial of service via automatic certificate
authentication loop
CVE-2026-59850: Use-after-free via data callbacks on closed
channels
Zero-initialize every ssh_string

See https://www.libssh.org/2026/07/21/libssh-0-12-1-and-0-11-5-security-releases/

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy

<!-- Message of single commit: -->