### PR TITLE
SPECS: spirv-cross: Add static sub-package for cmake support

### DIFF
--- a/SPECS/spirv-cross/spirv-cross.spec
+++ b/SPECS/spirv-cross/spirv-cross.spec
@@ -34,9 +34,14 @@ Requires:       %{name}%{?_isa} = %{version}-%{release}
 %description    devel
 This package contains the development headers and libraries for SPIRV-Cross.
 
-%install -a
-rm -fv %{buildroot}/%{_libdir}/*.a
+%package        static
+Summary:        Static files for the SPIRV-Cross library
+Requires:       %{name}-devel%{?_isa} = %{version}-%{release}
 
+%description    static
+This package contains the static libraries for developing applications that use SPIRV-Cross.
+
+%install -a
 for i in c core cpp glsl hlsl msl reflect util; do
 	ln -s "libspirv-cross-c-shared.so" "%{buildroot}/%{_libdir}/libspirv-cross-$i.so"
 done
@@ -54,6 +59,9 @@ done
 %{_includedir}/spirv_cross/
 %dir %_datadir/spirv*
 %_datadir/spirv*/cmake/
+
+%files static
+%_libdir/*.a
 
 %changelog
 %autochangelog


### PR DESCRIPTION
## Summary

The CMake config file references libspirv-cross-c.a, but the spec file was deleting it during %install, causing find_package(spirv_cross_c CONFIG) to fail.

Move the static libraries into a -static subpackage instead of removing them, so the CMake package config is satisfied.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
