### PR TITLE
SPECS: libsquish: fix broken cmake paths from manual file relocation

### DIFF
--- a/SPECS/libsquish/2000-OBCMake-Replace-hardcoded-cmake-install-paths-with-C.patch
+++ b/SPECS/libsquish/2000-OBCMake-Replace-hardcoded-cmake-install-paths-with-C.patch
@@ -1,0 +1,88 @@
+From f951bc33544b1e9c45dcc4a9878b855c23cdea72 Mon Sep 17 00:00:00 2001
+From: Yafen Fang <yafen@iscas.ac.cn>
+Date: Thu, 13 Aug 2026 16:32:04 +0800
+Subject: [PATCH] OBCMake: Replace hardcoded cmake install paths with
+ CMAKE_INSTALL_LIBDIR
+
+Replace all hardcoded "cmake" and "cmake/${alias}" install
+destinations with paths using ${CMAKE_INSTALL_LIBDIR}/cmake/libsquish.
+---
+ cmake/module/OB/Executable.cmake | 2 +-
+ cmake/module/OB/Library.cmake    | 2 +-
+ cmake/module/OB/Project.cmake    | 6 +++---
+ cmake/private/common.cmake       | 2 +-
+ 4 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/cmake/module/OB/Executable.cmake b/cmake/module/OB/Executable.cmake
+index d05a30a..0eb9711 100644
+--- a/cmake/module/OB/Executable.cmake
++++ b/cmake/module/OB/Executable.cmake
+@@ -407,7 +407,7 @@ function(ob_add_standard_executable target)
+             COMPONENT ${_TARGET_NAME}
+             FILE "${_NAMESPACE}${_ALIAS}Targets.cmake"
+             NAMESPACE ${_NAMESPACE}::
+-            DESTINATION "cmake/${_ALIAS}"
++            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libsquish/${_ALIAS}"
+             ${SUB_PROJ_EXCLUDE_FROM_ALL} # "EXCLUDE_FROM_ALL" if project is not top-level
+         )
+ 
+diff --git a/cmake/module/OB/Library.cmake b/cmake/module/OB/Library.cmake
+index ab7e6a9..bfe8aa1 100644
+--- a/cmake/module/OB/Library.cmake
++++ b/cmake/module/OB/Library.cmake
+@@ -526,7 +526,7 @@ function(ob_add_standard_library target)
+             COMPONENT ${_TARGET_NAME}
+             FILE "${_NAMESPACE}${_ALIAS}Targets.cmake"
+             NAMESPACE ${_NAMESPACE}::
+-            DESTINATION "cmake/${_ALIAS}"
++            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libsquish/${_ALIAS}"
+             ${SUB_PROJ_EXCLUDE_FROM_ALL} # "EXCLUDE_FROM_ALL" if project is not top-level
+         )
+ 
+diff --git a/cmake/module/OB/Project.cmake b/cmake/module/OB/Project.cmake
+index 7013afa..487466d 100644
+--- a/cmake/module/OB/Project.cmake
++++ b/cmake/module/OB/Project.cmake
+@@ -316,7 +316,7 @@ function(__ob_process_config_opt_std pkg_name gen_file)
+     configure_package_config_file(
+         "${CFG_TEMPLATE_FILE}"
+         "${gen_file}"
+-        INSTALL_DESTINATION "cmake"
++        INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libsquish"
+         NO_SET_AND_CHECK_MACRO
+     )    
+ endfunction()
+@@ -327,7 +327,7 @@ function(__ob_process_config_opt_custom in_path gen_file)
+         configure_package_config_file(
+             "${in_path}"
+             "${gen_file}"
+-            INSTALL_DESTINATION "cmake"
++            INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libsquish"
+         )
+ endfunction()
+ 
+@@ -488,7 +488,7 @@ function(ob_standard_project_package_config)
+         "${ver_gen_path}"
+         "${cfg_gen_path}"
+         COMPONENT ${PROJECT_NAMESPACE_LC}
+-        DESTINATION "cmake"
++        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libsquish"
+         ${SUB_PROJ_EXCLUDE_FROM_ALL} # "EXCLUDE_FROM_ALL" if project is not top-level
+     )
+ endfunction()
+diff --git a/cmake/private/common.cmake b/cmake/private/common.cmake
+index d22ddd4..21596b8 100644
+--- a/cmake/private/common.cmake
++++ b/cmake/private/common.cmake
+@@ -195,7 +195,7 @@ function(__ob_parse_std_target_config_option target ns alias)
+     install(FILES
+         "${cfg_gen_path}"
+         COMPONENT ${target}
+-        DESTINATION "cmake/${alias}"
++        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libsquish/${alias}"
+         ${SUB_PROJ_EXCLUDE_FROM_ALL} # "EXCLUDE_FROM_ALL" if project is not top-level
+     )
+ endfunction()
+-- 
+2.34.1
+

--- a/SPECS/libsquish/libsquish.spec
+++ b/SPECS/libsquish/libsquish.spec
@@ -18,6 +18,8 @@ Source:         https://github.com/oblivioncth/libsquish/archive/refs/tags/v%{ve
 Source1:        https://github.com/oblivioncth/OBCMake/archive/refs/tags/v%{OBCMake_version}.tar.gz
 BuildSystem:    cmake
 
+Patch2000:      2000-OBCMake-Replace-hardcoded-cmake-install-paths-with-C.patch
+
 BuildRequires:  cmake
 
 BuildOption(conf):  -DNO_VERBOSE_VERSION=ON
@@ -35,16 +37,16 @@ Requires:       %{name}%{?_isa} = %{version}-%{release}
 The %{name}-devel package contains libraries and header files for
 developing applications that use %{name}.
 
-%prep -a
-%autosetup -p1
+%prep
+%autosetup -N
 tar -xf %{SOURCE1} -C .
+pushd OBCmake-%{OBCMake_version}
+%patch -P 2000 -p1
+popd
 
 %install -a
 rm -f %{buildroot}%{_prefix}/LICENSE
 rm -f %{buildroot}%{_prefix}/README.md
-mkdir -p %{buildroot}%{_libdir}/cmake/libsquish
-mv %{buildroot}%{_prefix}/cmake/* %{buildroot}%{_libdir}/cmake/libsquish/
-rmdir %{buildroot}%{_prefix}/cmake
 
 %files
 %doc README.md


### PR DESCRIPTION
## Summary

**Commit title:**
```
libsquish: fix cmake files installed to wrong path by patching OBCMake
```

**PR description:**

Replace the manual `mkdir/mv/rmdir` workaround in `%install` with sed
patches applied to OBCMake source during `%prep`, fixing the root cause.

OBCMake v0.3.12 hardcodes `cmake/` (relative to prefix) as the install
destination for all cmake configuration files, instead of using
`${CMAKE_INSTALL_LIBDIR}/cmake/<name>`. This causes cmake files to be
placed under `/usr/cmake/` rather than `/usr/lib64/cmake/libsquish/`,
and breaks the relocatable `_IMPORT_PREFIX` computation in generated
`*Targets.cmake` files.

With these fixes the `mkdir/mv/rmdir` relocation in `%install` is no
longer needed and has been removed.

Fixes: `find_package(libsquish CONFIG)` broken `_IMPORT_PREFIX` leading
to incorrect `.so` path(`/usr/lib64/cmake/lib64/libsquish.so.1.15.1.4`) resolution.


## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
