### PR TITLE
SPECS: tmt: Part 2

### DIFF
--- a/SPECS/benchmark/benchmark.spec
+++ b/SPECS/benchmark/benchmark.spec
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           benchmark
+Version:        1.9.5
+Release:        %autorelease
+Summary:        Microbenchmark support library
+License:        Apache-2.0
+URL:            https://github.com/google/benchmark
+#!RemoteAsset:  sha256:9631341c82bac4a288bef951f8b26b41f69021794184ece969f8473977eaa340
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
+BuildSystem:    cmake
+
+BuildOption(conf):  -DBENCHMARK_ENABLE_WERROR=OFF
+BuildOption(conf):  -DBENCHMARK_USE_BUNDLED_GTEST=OFF
+
+BuildRequires:  cmake
+BuildRequires:  pkgconfig(gmock)
+BuildRequires:  pkgconfig(gtest)
+
+%description
+Benchmark is a library for measuring and reporting the performance of C++
+code.
+
+%package        devel
+Summary:        Development files for benchmark
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+Header files and build metadata for developing applications with benchmark.
+
+%files
+%doc %{_docdir}/%{name}/
+%license LICENSE
+%{_libdir}/libbenchmark.so.*
+%{_libdir}/libbenchmark_main.so.*
+%{_datadir}/googlebenchmark/
+
+%files devel
+%{_includedir}/benchmark/
+%{_libdir}/cmake/benchmark/
+%{_libdir}/libbenchmark.so
+%{_libdir}/libbenchmark_main.so
+%{_libdir}/pkgconfig/benchmark.pc
+%{_libdir}/pkgconfig/benchmark_main.pc
+
+%changelog
+%autochangelog

--- a/SPECS/cfitsio/2000-use-system-cfortran.patch
+++ b/SPECS/cfitsio/2000-use-system-cfortran.patch
@@ -1,0 +1,142 @@
+Use system cfortran header.
+
+--- a/f77_wrap.h
++++ b/f77_wrap.h
+@@ -1,6 +1,6 @@
+ #define UNSIGNED_BYTE
+ 
+-#include "cfortran.h"
++#include <cfortran.h>
+ 
+ /************************************************************************
+    Some platforms creates longs as 8-byte integers.  On other machines, ints
+@@ -29,16 +29,16 @@
+ #undef LONGV_cfT
+ #undef PLONG_cfT
+ 
+-#define    LONGV_cfSTR(N,T,A,B,C,D,E) _(CFARGS,N)(T,LONGV,A,B,C,D,E)
+-#define    PLONG_cfSTR(N,T,A,B,C,D,E) _(CFARGS,N)(T,PLONG,A,B,C,D,E)
++#define    LONGV_cfSTR(N,T,A,B,C,D,E) CFORTRAN_XCAT_(CFARGS,N)(T,LONGV,A,B,C,D,E)
++#define    PLONG_cfSTR(N,T,A,B,C,D,E) CFORTRAN_XCAT_(CFARGS,N)(T,PLONG,A,B,C,D,E)
+ #define    LONGVVVVVVV_cfTYPE    int
+ #define    PLONG_cfTYPE          int
+-#define    LONGV_cfQ(B)          long *B, _(B,N);
++#define    LONGV_cfQ(B)          long *B, CFORTRAN_XCAT_(B,N);
+ #define    PLONG_cfQ(B)          long B;
+-#define    LONGV_cfT(M,I,A,B,D)  ( (_(B,N) = * _3(M,_LONGV_A,I)), \
+-				    B = F2Clongv(_(B,N),A) )
++#define    LONGV_cfT(M,I,A,B,D)  ( (CFORTRAN_XCAT_(B,N) = * CFORTRAN_XCAT_3(M,_LONGV_A,I)), \
++				    B = F2Clongv(CFORTRAN_XCAT_(B,N),A) )
+ #define    PLONG_cfT(M,I,A,B,D)  ((B=*A),&B)
+-#define    LONGV_cfR(A,B,D)      C2Flongv(_(B,N),A,B);
++#define    LONGV_cfR(A,B,D)      C2Flongv(CFORTRAN_XCAT_(B,N),A,B);
+ #define    PLONG_cfR(A,B,D)      *A=B;
+ #define    LONGV_cfH(S,U,B)
+ #define    PLONG_cfH(S,U,B)
+@@ -93,7 +93,7 @@ extern unsigned long gMinStrLen;
+                                          A->dsc$w_length, \
+                                          num_elem(A->dsc$a_pointer, \
+                                                   A->dsc$w_length, \
+-                                                  _3(M,_STRV_A,I) ) )
++                                                  CFORTRAN_XCAT_3(M,_STRV_A,I) ) )
+ #else
+ #ifdef CRAYFortran
+ #define       PPSTRING_cfT(M,I,A,B,D)     (unsigned char*)_fcdtocp(A)
+@@ -103,20 +103,20 @@ extern unsigned long gMinStrLen;
+ #endif
+ 
+ #define _cfMAX(A,B)  ( (A>B) ? A : B )
+-#define  STRINGV_cfQ(B)      char **B; unsigned int _(B,N), _(B,M);
++#define  STRINGV_cfQ(B)      char **B; unsigned int CFORTRAN_XCAT_(B,N), CFORTRAN_XCAT_(B,M);
+ #define  STRINGV_cfR(A,B,D)  free(B[0]); free(B);
+ #define  TTSTR(    A,B,D)  \
+             ((B=(char*)malloc(_cfMAX(D,gMinStrLen)+1))[D]='\0',memcpy(B,A,D), \
+                kill_trailing(B,' '))
+ #define  TTTTSTRV( A,B,D,E)  ( \
+-            _(B,N)=_cfMAX(E,1), \
+-            _(B,M)=_cfMAX(D,gMinStrLen)+1, \
+-            B=(char**)malloc(_(B,N)*sizeof(char*)), \
+-            B[0]=(char*)malloc(_(B,N)*_(B,M)), \
+-            vindex(B,_(B,M),_(B,N),f2cstrv2(A,B[0],D,_(B,M),_(B,N))) \
++            CFORTRAN_XCAT_(B,N)=_cfMAX(E,1), \
++            CFORTRAN_XCAT_(B,M)=_cfMAX(D,gMinStrLen)+1, \
++            B=(char**)malloc(CFORTRAN_XCAT_(B,N)*sizeof(char*)), \
++            B[0]=(char*)malloc(CFORTRAN_XCAT_(B,N)*CFORTRAN_XCAT_(B,M)), \
++            vindex(B,CFORTRAN_XCAT_(B,M),CFORTRAN_XCAT_(B,N),f2cstrv2(A,B[0],D,CFORTRAN_XCAT_(B,M),CFORTRAN_XCAT_(B,N))) \
+             )
+ #define  RRRRPSTRV(A,B,D)    \
+-            c2fstrv2(B[0],A,_(B,M),D,_(B,N)), \
++            c2fstrv2(B[0],A,CFORTRAN_XCAT_(B,M),D,CFORTRAN_XCAT_(B,N)), \
+             free(B[0]), \
+             free(B);
+ 
+@@ -169,10 +169,10 @@ static char *f2cstrv2(char *fstr, char*
+ #undef   BYTE_cfSTR
+ #undef   BYTEV_cfSTR
+ 
+-#define   BYTE_cfINT(N,A,B,X,Y,Z)      _(CFARGS,N)(A,BYTE,B,X,Y,Z,0)
+-#define   BYTEV_cfINT(N,A,B,X,Y,Z)     _(CFARGS,N)(A,BYTEV,B,X,Y,Z,0)
+-#define   BYTE_cfSTR(N,T,A,B,C,D,E)    _(CFARGS,N)(T,BYTE,A,B,C,D,E)
+-#define   BYTEV_cfSTR(N,T,A,B,C,D,E)   _(CFARGS,N)(T,BYTEV,A,B,C,D,E)
++#define   BYTE_cfINT(N,A,B,X,Y,Z)      CFORTRAN_XCAT_(CFARGS,N)(A,BYTE,B,X,Y,Z,0)
++#define   BYTEV_cfINT(N,A,B,X,Y,Z)     CFORTRAN_XCAT_(CFARGS,N)(A,BYTEV,B,X,Y,Z,0)
++#define   BYTE_cfSTR(N,T,A,B,C,D,E)    CFORTRAN_XCAT_(CFARGS,N)(T,BYTE,A,B,C,D,E)
++#define   BYTEV_cfSTR(N,T,A,B,C,D,E)   CFORTRAN_XCAT_(CFARGS,N)(T,BYTEV,A,B,C,D,E)
+ #define   BYTE_cfSEP(T,B)              INT_cfSEP(T,B)
+ #define   BYTEV_cfSEP(T,B)             INT_cfSEP(T,B)
+ #define   BYTE_cfH(S,U,B)              STRING_cfH(S,U,B)
+@@ -211,11 +211,11 @@ static char *f2cstrv2(char *fstr, char*
+ 
+ #undef  LOGICALV_cfSTR
+ #undef  LOGICALV_cfT
+-#define LOGICALV_cfSTR(N,T,A,B,C,D,E) _(CFARGS,N)(T,LOGICALV,A,B,C,D,E)
+-#define LOGICALV_cfQ(B)               char *B; unsigned int _(B,N);
+-#define LOGICALV_cfT(M,I,A,B,D)       (_(B,N)= * _3(M,_LOGV_A,I), \
+-                                            B=F2CcopyLogVect(_(B,N),A))
+-#define LOGICALV_cfR(A,B,D)           C2FcopyLogVect(_(B,N),A,B);
++#define LOGICALV_cfSTR(N,T,A,B,C,D,E) CFORTRAN_XCAT_(CFARGS,N)(T,LOGICALV,A,B,C,D,E)
++#define LOGICALV_cfQ(B)               char *B; unsigned int CFORTRAN_XCAT_(B,N);
++#define LOGICALV_cfT(M,I,A,B,D)       (CFORTRAN_XCAT_(B,N)= * CFORTRAN_XCAT_3(M,_LOGV_A,I), \
++                                            B=F2CcopyLogVect(CFORTRAN_XCAT_(B,N),A))
++#define LOGICALV_cfR(A,B,D)           C2FcopyLogVect(CFORTRAN_XCAT_(B,N),A,B);
+ #define LOGICALV_cfH(S,U,B)
+ 
+ static char *F2CcopyLogVect(long size, int *A)
+@@ -268,20 +268,20 @@ extern fitsfile *gFitsFiles[];       /*
+                              memchr(A,'\0',D) ? A : TTSTR(A,B,D)
+ 
+ #define FCALLSCFUN0(T0,CN,UN,LN) \
+-  CFextern _(T0,_cfFZ)(UN,LN) void ABSOFT_cf2(T0)); \
+-  CFextern _(T0,_cfFZ)(UN,LN) void ABSOFT_cf2(T0))  \
+-  {_Icf(2,UU,T0,A0,0); _Icf(0,L,T0,0,0) CN(); _Icf(0,K,T0,0,0) _(T0,_cfI)}
++  CFextern CFORTRAN_XCAT_(T0,_cfFZ)(UN,LN) void ABSOFT_cf2(T0)); \
++  CFextern CFORTRAN_XCAT_(T0,_cfFZ)(UN,LN) void ABSOFT_cf2(T0))  \
++  {_Icf(2,UU,T0,A0,0); _Icf(0,L,T0,0,0) CN(); _Icf(0,K,T0,0,0) CFORTRAN_XCAT_(T0,_cfI)}
+ 
+ #define FCALLSCFUN14(T0,CN,UN,LN,T1,T2,T3,T4,T5,T6,T7,T8,T9,TA,TB,TC,TD,TE)    \
+-  CFextern _(T0,_cfF)(UN,LN)                                                   \
++  CFextern CFORTRAN_XCAT_(T0,_cfF)(UN,LN)                                                   \
+   CFARGT14(NCF,DCF,ABSOFT_cf2(T0),T1,T2,T3,T4,T5,T6,T7,T8,T9,TA,TB,TC,TD,TE)); \
+-  CFextern _(T0,_cfF)(UN,LN)                                                   \
++  CFextern CFORTRAN_XCAT_(T0,_cfF)(UN,LN)                                                   \
+   CFARGT14(NCF,DCF,ABSOFT_cf2(T0),T1,T2,T3,T4,T5,T6,T7,T8,T9,TA,TB,TC,TD,TE))  \
+   {                 CFARGT14S(QCF,T1,T2,T3,T4,T5,T6,T7,T8,T9,TA,TB,TC,TD,TE)   \
+   _Icf(2,UU,T0,A0,0); _Icf(0,L,T0,0,0)      CN(  TCF(LN,T1,1,0) TCF(LN,T2,2,1) \
+     TCF(LN,T3,3,1) TCF(LN,T4,4,1) TCF(LN,T5,5,1) TCF(LN,T6,6,1) TCF(LN,T7,7,1) \
+     TCF(LN,T8,8,1) TCF(LN,T9,9,1) TCF(LN,TA,10,1) TCF(LN,TB,11,1) TCF(LN,TC,12,1) \
+     TCF(LN,TD,13,1) TCF(LN,TE,14,1) );                          _Icf(0,K,T0,0,0) \
+-    CFARGT14S(RCF,T1,T2,T3,T4,T5,T6,T7,T8,T9,TA,TB,TC,TD,TE)        _(T0,_cfI) \
++    CFARGT14S(RCF,T1,T2,T3,T4,T5,T6,T7,T8,T9,TA,TB,TC,TD,TE)        CFORTRAN_XCAT_(T0,_cfI) \
+   }
+
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -15,7 +15,7 @@ soname_version = @version_info@
+ soname_version_lnx = ${soname_version}.0.0
+ 
+ include_HEADERS = fitsio.h fitsio2.h longnam.h drvrsmem.h \
+-	cfortran.h f77_wrap.h region.h
++	f77_wrap.h region.h
+ 
+ noinst_HEADERS = drvrgsiftp.h eval_defs.h eval_tab.h group.h grparser.h simplerng.h \
+ 	utilities/fpack.h utilities/fverify.h

--- a/SPECS/cfitsio/cfitsio.spec
+++ b/SPECS/cfitsio/cfitsio.spec
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           cfitsio
+Version:        4.6.4
+Release:        %autorelease
+Summary:        Library for reading and writing FITS data files
+License:        CFITSIO
+URL:            https://heasarc.gsfc.nasa.gov/fitsio/
+VCS:            git:https://github.com/HEASARC/cfitsio.git
+#!RemoteAsset:  sha256:fb09b18638b0a71fa3c2612aac4fafd29cae8642266ba690803eb95f037a5268
+Source0:        https://github.com/HEASARC/%{name}/archive/refs/tags/%{name}-%{version}.tar.gz
+BuildSystem:    cmake
+
+# Use the system cfortran header, following Debian's 4.6.4 packaging.
+# https://salsa.debian.org/debian-astro-team/cfitsio/-/blob/debian/4.6.4-1/debian/patches/02-system-cfortran.patch
+Patch2000:      2000-use-system-cfortran.patch
+
+BuildOption(conf):  -DUSE_BZIP2=ON
+BuildOption(conf):  -DUSE_PTHREADS=ON
+
+BuildRequires:  cfortran
+BuildRequires:  cmake
+BuildRequires:  pkgconfig(bzip2)
+BuildRequires:  pkgconfig(libcurl)
+BuildRequires:  pkgconfig(zlib)
+
+%description
+CFITSIO is a library of C and Fortran routines for reading and writing FITS
+data files.
+
+%package        devel
+Summary:        Development files for CFITSIO
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+Headers and pkg-config metadata for developing applications with CFITSIO.
+
+%prep -a
+rm cfortran.h
+
+%files
+%license licenses/License.txt
+%{_bindir}/cookbook
+%{_bindir}/fitscopy
+%{_bindir}/fitsverify
+%{_bindir}/fpack
+%{_bindir}/funpack
+%{_bindir}/imcopy
+%{_bindir}/smem
+%{_bindir}/speed
+%{_libdir}/libcfitsio.so.*
+
+%files devel
+%{_includedir}/cfitsio_export.h
+%{_includedir}/fitsio.h
+%{_includedir}/fitsio2.h
+%{_includedir}/longnam.h
+%{_libdir}/libcfitsio.so
+%{_libdir}/cmake/cfitsio/
+%{_libdir}/pkgconfig/cfitsio.pc
+
+%changelog
+%autochangelog

--- a/SPECS/cfortran/2000-Fix-fstr_test-coredump-with-D_FORTIFY_SOURCE-3-and-O.patch
+++ b/SPECS/cfortran/2000-Fix-fstr_test-coredump-with-D_FORTIFY_SOURCE-3-and-O.patch
@@ -1,0 +1,25 @@
+From 06440e86575c9b15f571ad7bfee42698983b9a04 Mon Sep 17 00:00:00 2001
+From: jinqiang zhang <jinqiang.oerv@isrc.iscas.ac.cn>
+Date: Sat, 18 Jul 2026 23:04:08 +0800
+Subject: [PATCH] Fix fstr_test coredump with -D_FORTIFY_SOURCE=3 and -O2
+
+---
+ eg/fstr/fstr.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/eg/fstr/fstr.c b/eg/fstr/fstr.c
+index d40d7b4..83b47cd 100644
+--- a/eg/fstr/fstr.c
++++ b/eg/fstr/fstr.c
+@@ -18,7 +18,7 @@ int ls, lsave;
+ if (!s || !save) { save=s; return; }
+ ls    = strlen(s   );
+ lsave = strlen(save);
+-temp = (char *)malloc(ls>lsave?ls:lsave);
++temp = (char *)malloc((ls>lsave?ls:lsave) + 1);
+ /* Switch contents of argument with contents of saved string. */
+ strcpy(temp,save);
+ strcpy(save,s   );
+-- 
+2.54.0
+

--- a/SPECS/cfortran/cfortran.spec
+++ b/SPECS/cfortran/cfortran.spec
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           cfortran
+Version:        20210827
+Release:        %autorelease
+Summary:        Header for interfacing C or C++ with Fortran
+License:        LGPL-2.0-or-later
+URL:            https://github.com/bastien-roucaries/cfortran
+#!RemoteAsset:  sha256:d1e3ce2c1d85fa4854d6a9276df333962a662426c618c4f011a9546bae55afda
+Source0:        %{url}/archive/refs/tags/%{version}.tar.gz
+BuildSystem:    autotools
+
+# https://github.com/bastien-roucaries/cfortran/pull/3
+Patch2000:      2000-Fix-fstr_test-coredump-with-D_FORTIFY_SOURCE-3-and-O.patch
+
+# need add -std=gnu17: https://github.com/bastien-roucaries/cfortran/issues/2
+BuildOption(build):  CFLAGS="%{optflags} -std=gnu17"
+BuildOption(check):  CFLAGS="%{optflags} -std=gnu17"
+
+BuildRequires:  autoconf
+BuildRequires:  automake
+BuildRequires:  gcc-fortran
+BuildRequires:  libtool
+BuildRequires:  make
+
+%description
+cfortran.h provides portable preprocessor macros for interfacing C or C++
+code with Fortran routines.
+
+%conf -p
+autoreconf -fiv
+
+%check -a
+make distclean
+rmdir eg/*/.deps
+
+%files
+%doc NEWS README.html eg
+%license COPYING
+%{_includedir}/cfortran.h
+
+%changelog
+%autochangelog

--- a/SPECS/crc32c/1000-Fix-CMake-4.0-compatibility.patch
+++ b/SPECS/crc32c/1000-Fix-CMake-4.0-compatibility.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e0b8e7c..e75211f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2,7 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file. See the AUTHORS file for names of contributors.
+ 
+-cmake_minimum_required(VERSION 3.1)
++cmake_minimum_required(VERSION 3.16)
+ project(Crc32c VERSION 1.1.0 LANGUAGES C CXX)
+ 
+ # C standard can be overridden when this is used as a sub-project.

--- a/SPECS/crc32c/2000-use-system-deps-fix-missing-thirdparty.patch
+++ b/SPECS/crc32c/2000-use-system-deps-fix-missing-thirdparty.patch
@@ -1,0 +1,109 @@
+From 2bd7e0bc90c5622d0c7aa65b9d95dffde3eddb4f Mon Sep 17 00:00:00 2001
+From: jinqiang zhang <jinqiang.oerv@isrc.iscas.ac.cn>
+Date: Wed, 12 Aug 2026 17:33:27 +0800
+Subject: [PATCH] use system deps fix missing thirdparty
+
+---
+ CMakeLists.txt | 55 +++++++-------------------------------------------
+ 1 file changed, 7 insertions(+), 48 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e75211f..c8c7e71 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -180,33 +180,7 @@ int main() {
+ " HAVE_WEAK_GETAUXVAL)
+ 
+ if(CRC32C_USE_GLOG)
+-  # glog requires this setting to avoid using dynamic_cast.
+-  set(DISABLE_RTTI ON CACHE BOOL "" FORCE)
+-
+-  # glog's test targets trigger deprecation warnings, and compiling them burns
+-  # CPU cycles on the CI.
+-  set(BUILD_TESTING_SAVED "${BUILD_TESTING}")
+-  set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+-  add_subdirectory("third_party/glog" EXCLUDE_FROM_ALL)
+-  set(BUILD_TESTING "${BUILD_TESTING_SAVED}" CACHE BOOL "" FORCE)
+-
+-  # glog triggers deprecation warnings on OSX.
+-  # https://github.com/google/glog/issues/185
+-  if(CRC32C_HAVE_NO_DEPRECATED)
+-    set_property(TARGET glog APPEND PROPERTY COMPILE_OPTIONS -Wno-deprecated)
+-  endif(CRC32C_HAVE_NO_DEPRECATED)
+-
+-  # glog triggers sign comparison warnings on gcc.
+-  if(CRC32C_HAVE_NO_SIGN_COMPARE)
+-    set_property(TARGET glog APPEND PROPERTY COMPILE_OPTIONS -Wno-sign-compare)
+-  endif(CRC32C_HAVE_NO_SIGN_COMPARE)
+-
+-  # glog triggers unused parameter warnings on clang.
+-  if(CRC32C_HAVE_NO_UNUSED_PARAMETER)
+-    set_property(TARGET glog
+-                 APPEND PROPERTY COMPILE_OPTIONS -Wno-unused-parameter)
+-  endif(CRC32C_HAVE_NO_UNUSED_PARAMETER)
+-
++  find_package(glog REQUIRED)
+   set(CRC32C_TESTS_BUILT_WITH_GLOG 1)
+ endif(CRC32C_USE_GLOG)
+ 
+@@ -309,21 +283,8 @@ endif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+ if(CRC32C_BUILD_TESTS)
+   enable_testing()
+ 
+-  # Prevent overriding the parent project's compiler/linker settings on Windows.
+-  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+-  set(install_gtest OFF)
+-  set(install_gmock OFF)
+-
+   # This project is tested using GoogleTest.
+-  add_subdirectory("third_party/googletest")
+-
+-  # GoogleTest triggers a missing field initializers warning.
+-  if(CRC32C_HAVE_NO_MISSING_FIELD_INITIALIZERS)
+-    set_property(TARGET gtest
+-        APPEND PROPERTY COMPILE_OPTIONS -Wno-missing-field-initializers)
+-    set_property(TARGET gmock
+-        APPEND PROPERTY COMPILE_OPTIONS -Wno-missing-field-initializers)
+-  endif(CRC32C_HAVE_NO_MISSING_FIELD_INITIALIZERS)
++  find_package(GTest REQUIRED)
+ 
+   add_executable(crc32c_tests "")
+   target_sources(crc32c_tests
+@@ -339,7 +300,7 @@ if(CRC32C_BUILD_TESTS)
+       "src/crc32c_unittest.cc"
+       "src/crc32c_test_main.cc"
+   )
+-  target_link_libraries(crc32c_tests crc32c gtest)
++  target_link_libraries(crc32c_tests crc32c GTest::gtest)
+ 
+   # Warnings as errors in Visual Studio for this project's targets.
+   if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+@@ -347,7 +308,7 @@ if(CRC32C_BUILD_TESTS)
+   endif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+ 
+   if(CRC32C_USE_GLOG)
+-    target_link_libraries(crc32c_tests glog)
++    target_link_libraries(crc32c_tests glog::glog)
+   endif(CRC32C_USE_GLOG)
+ 
+   add_test(NAME crc32c_tests COMMAND crc32c_tests)
+@@ -383,13 +344,11 @@ if(CRC32C_BUILD_BENCHMARKS)
+   target_link_libraries(crc32c_bench crc32c)
+ 
+   # This project uses Google benchmark for benchmarking.
+-  set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+-  set(BENCHMARK_ENABLE_EXCEPTIONS OFF CACHE BOOL "" FORCE)
+-  add_subdirectory("third_party/benchmark")
+-  target_link_libraries(crc32c_bench benchmark)
++  find_package(benchmark REQUIRED)
++  target_link_libraries(crc32c_bench benchmark::benchmark)
+ 
+   if(CRC32C_USE_GLOG)
+-    target_link_libraries(crc32c_bench glog)
++    target_link_libraries(crc32c_bench glog::glog)
+   endif(CRC32C_USE_GLOG)
+ 
+   # Warnings as errors in Visual Studio for this project's targets.
+-- 
+2.54.0
+

--- a/SPECS/crc32c/crc32c.spec
+++ b/SPECS/crc32c/crc32c.spec
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           crc32c
+Version:        1.1.2
+Release:        %autorelease
+Summary:        CRC32C implementation with CPU-specific acceleration
+License:        BSD-3-Clause
+URL:            https://github.com/google/crc32c
+#!RemoteAsset:  sha256:ac07840513072b7fcebda6e821068aa04889018f24e10e46181068fb214d7e56
+Source0:        %{url}/archive/refs/tags/%{version}.tar.gz
+BuildSystem:    cmake
+
+# Fix CMake 4.0 compatibility
+# https://github.com/google/crc32c/pull/68
+Patch1000:      1000-Fix-CMake-4.0-compatibility.patch
+# Use system libraries for missing third-party submodules.
+Patch2000:      2000-use-system-deps-fix-missing-thirdparty.patch
+
+BuildRequires:  cmake
+BuildRequires:  cmake(glog)
+BuildRequires:  pkgconfig(benchmark)
+BuildRequires:  pkgconfig(gflags)
+BuildRequires:  pkgconfig(gtest)
+
+%description
+CRC32C is a portable implementation of the CRC32C checksum with
+CPU-specific acceleration.
+
+%package        devel
+Summary:        Development files for crc32c
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+Header files and CMake metadata for developing applications using crc32c.
+
+%files
+%doc AUTHORS
+%doc README.md
+%license LICENSE
+%{_libdir}/libcrc32c.so.*
+
+%files devel
+%{_includedir}/crc32c/
+%{_libdir}/cmake/Crc32c/
+%{_libdir}/libcrc32c.so
+
+%changelog
+%autochangelog

--- a/SPECS/ecbuild/ecbuild.spec
+++ b/SPECS/ecbuild/ecbuild.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           ecbuild
+Version:        3.12.0
+Release:        %autorelease
+Summary:        ECMWF CMake build system
+License:        Apache-2.0
+URL:            https://github.com/ecmwf/ecbuild
+#!RemoteAsset:  sha256:70c7fc9b17f736a3312167c2c36d13b3b5833a255fe2b168b2886ad7c743ffdf
+Source0:        %{url}/archive/refs/tags/%{version}/%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    cmake
+
+BuildRequires:  cmake
+BuildRequires:  gcc-fortran
+BuildRequires:  pkgconfig(python3)
+
+%description
+ecbuild is the CMake-based build system used by ECMWF software.
+
+%files
+%doc AUTHORS
+%doc README.rst
+%license LICENSE
+%{_bindir}/ecbuild
+%{_datadir}/ecbuild/
+%{_prefix}/lib/cmake/ecbuild/
+
+%changelog
+%autochangelog

--- a/SPECS/eccodes/eccodes.spec
+++ b/SPECS/eccodes/eccodes.spec
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           eccodes
+Version:        2.48.0
+Release:        %autorelease
+Summary:        Library for decoding and encoding GRIB and BUFR messages
+License:        Apache-2.0
+URL:            https://github.com/ecmwf/eccodes
+#!RemoteAsset:  sha256:c7552ce91ebd868f65e43f1f4dacfd9d3a642e257b5132eb304679d1f168b960
+Source0:        %{url}/archive/refs/tags/%{version}/%{version}.tar.gz
+BuildSystem:    cmake
+
+BuildRequires:  cmake
+BuildRequires:  ecbuild
+BuildRequires:  gcc-fortran
+BuildRequires:  libaec-devel
+
+%description
+ecCodes provides an application programming interface and tools for decoding
+and encoding weather data in GRIB and BUFR formats.
+
+%package        devel
+Summary:        Development files for ecCodes
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+Headers and build-system metadata for developing applications with ecCodes.
+
+%conf -p
+# https://github.com/ecmwf/eccodes/issues/514
+export FFLAGS=`echo %{build_fflags} | sed -e "s/-Wformat//g"`
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/bufr_compare
+%{_bindir}/bufr_compare_dir
+%{_bindir}/bufr_copy
+%{_bindir}/bufr_count
+%{_bindir}/bufr_dump
+%{_bindir}/bufr_filter
+%{_bindir}/bufr_get
+%{_bindir}/bufr_index_build
+%{_bindir}/bufr_ls
+%{_bindir}/bufr_set
+%{_bindir}/codes_bufr_filter
+%{_bindir}/codes_config
+%{_bindir}/codes_count
+%{_bindir}/codes_export_resource
+%{_bindir}/codes_info
+%{_bindir}/codes_parser
+%{_bindir}/codes_split_file
+%{_bindir}/grib2ppm
+%{_bindir}/grib_compare
+%{_bindir}/grib_copy
+%{_bindir}/grib_count
+%{_bindir}/grib_dump
+%{_bindir}/grib_filter
+%{_bindir}/grib_get
+%{_bindir}/grib_get_data
+%{_bindir}/grib_histogram
+%{_bindir}/grib_index_build
+%{_bindir}/grib_ls
+%{_bindir}/grib_set
+%{_bindir}/gts_compare
+%{_bindir}/gts_copy
+%{_bindir}/gts_count
+%{_bindir}/gts_dump
+%{_bindir}/gts_filter
+%{_bindir}/gts_get
+%{_bindir}/gts_ls
+%{_datadir}/eccodes/
+%{_libdir}/libeccodes.so
+%{_libdir}/libeccodes_f90.so
+
+%files devel
+%{_includedir}/eccodes.h
+%{_includedir}/eccodes.mod
+%{_includedir}/eccodes_config.h
+%{_includedir}/eccodes_ecbuild_config.h
+%{_includedir}/eccodes_version.h
+%{_includedir}/eccodes_windef.h
+%{_includedir}/grib_api.h
+%{_includedir}/grib_api.mod
+%{_libdir}/cmake/eccodes/
+%{_libdir}/pkgconfig/eccodes.pc
+%{_libdir}/pkgconfig/eccodes_f90.pc
+
+%changelog
+%autochangelog

--- a/SPECS/gdal/gdal.spec
+++ b/SPECS/gdal/gdal.spec
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           gdal
+Version:        3.13.1
+Release:        %autorelease
+Summary:        Geospatial data abstraction library
+License:        MIT
+URL:            https://github.com/OSGeo/gdal
+#!RemoteAsset:  sha256:8023c9a6e08f151f4723f08982cc73d2bc95095df65e5c1ea563cafafb864ec6
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
+BuildSystem:    cmake
+
+BuildRequires:  cmake
+BuildRequires:  pkgconfig(gtest)
+BuildRequires:  pkgconfig(proj)
+
+%description
+GDAL is a library and set of tools for raster and vector geospatial data.
+
+%package        devel
+Summary:        Development files for GDAL
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+Headers, libraries, and CMake files for developing applications with GDAL.
+
+%files
+%doc NEWS.md
+%doc README.md
+%license LICENSE.TXT
+%{_bindir}/gdal
+%{_bindir}/gdal_contour
+%{_bindir}/gdal_create
+%{_bindir}/gdal_footprint
+%{_bindir}/gdal_grid
+%{_bindir}/gdal_rasterize
+%{_bindir}/gdal_translate
+%{_bindir}/gdal_viewshed
+%{_bindir}/gdaladdo
+%{_bindir}/gdalbuildvrt
+%{_bindir}/gdaldem
+%{_bindir}/gdalenhance
+%{_bindir}/gdalinfo
+%{_bindir}/gdallocationinfo
+%{_bindir}/gdalmanage
+%{_bindir}/gdalmdiminfo
+%{_bindir}/gdalmdimtranslate
+%{_bindir}/gdalsrsinfo
+%{_bindir}/gdaltindex
+%{_bindir}/gdaltransform
+%{_bindir}/gdalwarp
+%{_bindir}/gnmanalyse
+%{_bindir}/gnmmanage
+%{_bindir}/nearblack
+%{_bindir}/ogr2ogr
+%{_bindir}/ogrinfo
+%{_bindir}/ogrlineref
+%{_bindir}/ogrtindex
+%{_bindir}/sozip
+%{_datadir}/bash-completion/completions/gdal*
+%{_datadir}/bash-completion/completions/ogr*
+%{_datadir}/bash-completion/completions/sozip
+%{_datadir}/gdal/
+%{_libdir}/gdalplugins/
+%{_libdir}/libgdal.so.*
+
+%files devel
+%{_bindir}/gdal-config
+%{_includedir}/*
+%{_libdir}/cmake/gdal/
+%{_libdir}/libgdal.so
+%{_libdir}/pkgconfig/gdal.pc
+
+%changelog
+%autochangelog

--- a/SPECS/jxrlib/CMakeLists.txt
+++ b/SPECS/jxrlib/CMakeLists.txt
@@ -1,0 +1,108 @@
+cmake_minimum_required(VERSION 3.13)
+project(jxrlib VERSION 1.4.2 LANGUAGES C)
+
+include(GNUInstallDirs)
+
+set(JXRLIB_LIB_VERSION ${PROJECT_VERSION})
+set(JXRLIB_SO_VERSION 0)
+
+#find_package(JNI)
+#if (JNI_FOUND)
+#    message (STATUS "JNI_INCLUDE_DIRS=${JNI_INCLUDE_DIRS}")
+#    message (STATUS "JNI_LIBRARIES=${JNI_LIBRARIES}")
+#    message (STATUS "JAVA_INCLUDE_PATH=${JAVA_INCLUDE_PATH}")
+#    message (STATUS "JAVA_INCLUDE_PATH2=${JAVA_INCLUDE_PATH2}")
+#endif()
+#INCLUDE_DIRECTORIES(${JAVA_INCLUDE_PATH})
+#INCLUDE_DIRECTORIES(${JAVA_INCLUDE_PATH2})
+
+include(TestBigEndian)
+test_big_endian(ISBIGENDIAN)
+if(ISBIGENDIAN)
+  set(DEF_ENDIAN -D_BIG__ENDIAN_)
+endif()
+
+add_definitions(-D__ANSI__ -DDISABLE_PERF_MEASUREMENT ${DEF_ENDIAN})
+
+include_directories(
+  common/include
+  image/sys
+  jxrgluelib
+  jxrtestlib
+)
+
+# JXR Library
+file(GLOB jpegxr_SRC image/sys/*.c image/decode/*.c image/encode/*.c)
+file(GLOB jpegxr_HDR image/sys/*.h image/decode/*.h image/encode/*.h)
+
+add_library(jpegxr SHARED ${jpegxr_SRC} ${jpegxr_HDR})
+set_target_properties(jpegxr PROPERTIES VERSION ${JXRLIB_LIB_VERSION} SOVERSION ${JXRLIB_SO_VERSION})
+
+install(TARGETS jpegxr
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+# JXR-GLUE Library
+file(GLOB jxrglue_SRC jxrgluelib/*.c jxrtestlib/*.c)
+file(GLOB jxrglue_HDR jxrgluelib/*.h jxrtestlib/*.h)
+
+add_library(jxrglue SHARED ${jxrglue_SRC} ${jxrglue_HDR})
+set_target_properties(jxrglue PROPERTIES VERSION ${JXRLIB_LIB_VERSION} SOVERSION ${JXRLIB_SO_VERSION})
+target_link_libraries(jxrglue jpegxr m)
+
+install(TARGETS jxrglue
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+# JXR-JAVA Library
+#file(GLOB jxrjava_SRC java/target/swig/JXR_wrap.cxx cpp/lib/*.cpp)
+#file(GLOB jxrjava_SRC cpp/lib/*.hpp)
+
+#add_library(jxrjava SHARED ${jxrjava_SRC} ${jxrjava_HDR})
+#set_target_properties(jxrjava PROPERTIES VERSION ${JXRLIB_LIB_VERSION} SOVERSION ${JXRLIB_SO_VERSION})
+#target_link_libraries(jxrjava jpegxr m)
+
+#install(TARGETS jxrjava
+#  RUNTIME DESTINATION bin
+#  LIBRARY DESTINATION lib${LIB_SUFFIX}
+#  ARCHIVE DESTINATION lib${LIB_SUFFIX}
+#)
+
+# JxrEncApp Executable
+add_executable(JxrEncApp jxrencoderdecoder/JxrEncApp.c)
+target_link_libraries(JxrEncApp jxrglue)
+install(TARGETS JxrEncApp RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# JxrDecApp Executable
+add_executable(JxrDecApp jxrencoderdecoder/JxrDecApp.c)
+target_link_libraries(JxrDecApp jxrglue)
+install(TARGETS JxrDecApp RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# Headers
+install(FILES jxrgluelib/JXRGlue.h jxrgluelib/JXRMeta.h jxrgluelib/JXRVersion.h
+  jxrtestlib/JXRTest.h image/sys/windowsmediaphoto.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/jxrlib
+)
+install(DIRECTORY common/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/jxrlib
+  FILES_MATCHING PATTERN "*.h"
+)
+
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/libjxr.pc
+  "prefix=${CMAKE_INSTALL_PREFIX}\n"
+  "exec_prefix=\${prefix}\n"
+  "libdir=${CMAKE_INSTALL_FULL_LIBDIR}\n"
+  "includedir=\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}\n\n"
+  "Name: libjxr\n"
+  "Description: A library for reading JPEG XR images.\n"
+  "Version: ${PROJECT_VERSION}\n"
+  "Libs: -L\${libdir} -ljpegxr -ljxrglue\n"
+  "Libs.private: -lm\n"
+  "Cflags: -I\${includedir}/jxrlib -D__ANSI__ -DDISABLE_PERF_MEASUREMENT\n"
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libjxr.pc
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+)

--- a/SPECS/jxrlib/jxrlib.spec
+++ b/SPECS/jxrlib/jxrlib.spec
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           jxrlib
+Version:        1.4.2
+Release:        %autorelease
+Summary:        JPEG XR reference implementation library
+License:        BSD-2-Clause
+URL:            https://github.com/mircomir/jxrlib
+#!RemoteAsset:  sha256:1ccc2b6e3afd758c8b33cabc1f05ff56c9babb8b91a99b8281136a1a329b8adb
+Source0:        %{url}/archive/refs/tags/%{version}/%{version}.tar.gz
+# https://gitlab.archlinux.org/archlinux/packaging/packages/jxrlib/-/blob/1.3.2-1/CMakeLists.txt
+Source1:        CMakeLists.txt
+BuildSystem:    cmake
+
+BuildRequires:  cmake
+
+%description
+Jxrlib is the reference implementation of the JPEG XR image codec. It provides
+the codec and glue libraries as well as command-line encoding and decoding tools.
+
+%package        devel
+Summary:        Development files for jxrlib
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+Headers and pkg-config metadata for developing applications using jxrlib.
+
+%prep -a
+# The upstream release does not ship a CMake build description.
+install -pm 0644 %{SOURCE1} CMakeLists.txt
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/JxrDecApp
+%{_bindir}/JxrEncApp
+%{_libdir}/libjpegxr.so.*
+%{_libdir}/libjxrglue.so.*
+
+%files devel
+%{_includedir}/jxrlib/
+%{_libdir}/libjpegxr.so
+%{_libdir}/libjxrglue.so
+%{_libdir}/pkgconfig/libjxr.pc
+
+%changelog
+%autochangelog

--- a/SPECS/lerc/lerc.spec
+++ b/SPECS/lerc/lerc.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           lerc
+Version:        4.1.1
+Release:        %autorelease
+Summary:        Limited Error Raster Compression library
+License:        Apache-2.0
+URL:            https://github.com/Esri/lerc
+#!RemoteAsset:  sha256:fe2860e10635166cd9f2144e429ec6b870d471e9957f5812ba2da0973770b022
+Source0:        %{url}/archive/refs/tags/v%{version}/%{version}.tar.gz
+BuildSystem:    cmake
+
+BuildRequires:  cmake
+
+%description
+LERC is an image and raster compression library that supports controlled
+lossy and lossless compression for all common pixel types.
+
+%package        devel
+Summary:        Development files for LERC
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+Headers and pkg-config metadata for developing applications with LERC.
+
+%files
+%license LICENSE
+%{_libdir}/libLerc.so.*
+
+%files devel
+%{_includedir}/Lerc_c_api.h
+%{_includedir}/Lerc_types.h
+%{_libdir}/libLerc.so
+%{_libdir}/pkgconfig/Lerc.pc
+
+%changelog
+%autochangelog

--- a/SPECS/libdeflate/libdeflate.spec
+++ b/SPECS/libdeflate/libdeflate.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           libdeflate
+Version:        1.25
+Release:        %autorelease
+Summary:        Fast DEFLATE, zlib, and gzip compression and decompression
+License:        MIT
+URL:            https://github.com/ebiggers/libdeflate
+#!RemoteAsset:  sha256:fed5cd22f00f30cc4c2e5329f94e2b8a901df9fa45ee255cb70e2b0b42344477
+Source0:        %{url}/releases/download/v%{version}/%{name}-%{version}.tar.gz
+BuildSystem:    cmake
+
+BuildOption(conf):  -DLIBDEFLATE_BUILD_STATIC_LIB=OFF
+
+BuildRequires:  cmake
+
+%description
+Libdeflate is a library for fast, whole-buffer DEFLATE-based compression and
+decompression. It provides zlib and gzip format support through a simple C API.
+
+%package        devel
+Summary:        Development files for libdeflate
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+This package contains the headers, pkg-config metadata, and CMake files needed
+to develop applications using libdeflate.
+
+%files
+%license COPYING
+%{_bindir}/libdeflate-gunzip
+%{_bindir}/libdeflate-gzip
+%{_libdir}/libdeflate.so.0*
+
+%files devel
+%{_includedir}/libdeflate.h
+%{_libdir}/libdeflate.so
+%{_libdir}/pkgconfig/libdeflate.pc
+%{_libdir}/cmake/libdeflate/
+
+%changelog
+%autochangelog

--- a/SPECS/proj/proj.spec
+++ b/SPECS/proj/proj.spec
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           proj
+Version:        9.8.1
+Release:        %autorelease
+Summary:        Cartographic projection and coordinate transformation library
+License:        MIT
+URL:            https://proj.org/
+VCS:            git:https://github.com/OSGeo/PROJ.git
+#!RemoteAsset:  sha256:af5b731c145c1d13c4e3b4eeb7d167e94e845e440f71e3496b4ed8dae0291960
+Source0:        https://download.osgeo.org/proj/%{name}-%{version}.tar.gz
+BuildSystem:    cmake
+
+BuildRequires:  cmake
+BuildRequires:  pkgconfig(libcurl)
+BuildRequires:  pkgconfig(libtiff-4)
+BuildRequires:  pkgconfig(sqlite3)
+
+%description
+PROJ transforms geospatial coordinates between coordinate reference systems.
+
+%package        devel
+Summary:        Development files for PROJ
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+Headers, libraries, and CMake files for developing applications with PROJ.
+
+%install -a
+rm -rf %{buildroot}%{_docdir}/%{name}
+
+%files
+%doc AUTHORS.md
+%doc NEWS.md
+%doc README.md
+%license COPYING
+%{_bindir}/cct
+%{_bindir}/cs2cs
+%{_bindir}/geod
+%{_bindir}/gie
+%{_bindir}/invgeod
+%{_bindir}/invproj
+%{_bindir}/proj
+%{_bindir}/projinfo
+%{_bindir}/projsync
+%{_datadir}/bash-completion/completions/projinfo
+%{_datadir}/proj/
+%{_libdir}/libproj.so.*
+%{_mandir}/man1/*
+
+%files devel
+%{_includedir}/*
+%{_libdir}/cmake/proj/
+%{_libdir}/cmake/proj4/
+%{_libdir}/libproj.so
+%{_libdir}/pkgconfig/proj.pc
+
+%changelog
+%autochangelog

--- a/SPECS/python-argon2-cffi-bindings/python-argon2-cffi-bindings.spec
+++ b/SPECS/python-argon2-cffi-bindings/python-argon2-cffi-bindings.spec
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname argon2-cffi-bindings
+%global pypi_name argon2_cffi_bindings
+
+Name:           python-%{srcname}
+Version:        25.1.0
+Release:        %autorelease
+Summary:        Low-level CFFI bindings for Argon2
+License:        MIT
+URL:            https://github.com/hynek/argon2-cffi-bindings
+#!RemoteAsset:  sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d
+Source0:        https://files.pythonhosted.org/packages/source/a/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l _argon2_cffi_bindings
+BuildOption(check):  _argon2_cffi_bindings
+
+BuildRequires:  pkgconfig(libargon2)
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(cffi)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(setuptools-scm[toml])
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+argon2-cffi-bindings provides low-level Python CFFI bindings for the Argon2
+password hashing library.
+
+%build -p
+export ARGON2_CFFI_USE_SYSTEM=1
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%check -a
+%pytest -v
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-argon2-cffi/python-argon2-cffi.spec
+++ b/SPECS/python-argon2-cffi/python-argon2-cffi.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname argon2-cffi
+%global pypi_name argon2_cffi
+
+Name:           python-%{srcname}
+Version:        25.1.0
+Release:        %autorelease
+Summary:        Secure Argon2 password hashing library for Python
+License:        MIT
+URL:            https://github.com/hynek/argon2-cffi
+#!RemoteAsset:  sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1
+Source0:        https://files.pythonhosted.org/packages/source/a/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l argon2
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(argon2-cffi-bindings)
+BuildRequires:  python3dist(hatch-fancy-pypi-readme)
+BuildRequires:  python3dist(hatch-vcs)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(pip)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+argon2-cffi provides secure Argon2 password hashing and verification for
+Python, backed by low-level CFFI bindings.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-astropy-iers-data/python-astropy-iers-data.spec
+++ b/SPECS/python-astropy-iers-data/python-astropy-iers-data.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname astropy-iers-data
+%global pypi_name astropy_iers_data
+
+Name:           python-%{srcname}
+Version:        0.2026.7.13.0.54.2
+Release:        %autorelease
+Summary:        IERS Earth rotation and leap second data for Astropy
+License:        BSD-3-Clause
+URL:            https://github.com/astropy/astropy-iers-data
+#!RemoteAsset:  sha256:d86e32e95e98a86f83b5b073627442924a0f45cf61a7828da4f565a17d726c2f
+Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l astropy_iers_data
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(hatch-vcs)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(pip)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+This package provides IERS Earth rotation and leap second tables used by
+Astropy.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE.rst
+
+%changelog
+%autochangelog

--- a/SPECS/python-astropy/python-astropy.spec
+++ b/SPECS/python-astropy/python-astropy.spec
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname astropy
+
+Name:           python-%{srcname}
+Version:        8.0.1
+Release:        %autorelease
+Summary:        Astronomy and astrophysics core library
+License:        BSD-3-Clause
+URL:            https://www.astropy.org/
+VCS:            git:https://github.com/astropy/astropy.git
+#!RemoteAsset:  sha256:45ca31d5b91fa294cd590a4791a32db94de7f9c8a343155f4d5877baa82351da
+Source0:        https://files.pythonhosted.org/packages/source/a/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l astropy
+# Build helper modules require the source tree as their working directory
+BuildOption(check):  -e 'astropy.io.ascii.setup_package'
+BuildOption(check):  -e 'astropy.table.setup_package'
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(astropy-iers-data)
+BuildRequires:  python3dist(cython)
+BuildRequires:  python3dist(dask)
+BuildRequires:  python3dist(extension-helpers)
+BuildRequires:  python3dist(fitsio)
+BuildRequires:  python3dist(hypothesis)
+BuildRequires:  python3dist(matplotlib)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pandas)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pyarrow)
+BuildRequires:  python3dist(pyerfa)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(pytest-remotedata)
+BuildRequires:  python3dist(pyyaml)
+BuildRequires:  python3dist(scipy)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Astropy is a core Python package for astronomy and astrophysics.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE.rst licenses/
+%{_bindir}/fits2bitmap
+%{_bindir}/fitscheck
+%{_bindir}/fitsdiff
+%{_bindir}/fitsheader
+%{_bindir}/fitsinfo
+%{_bindir}/samp_hub
+%{_bindir}/showtable
+%{_bindir}/showtable-astropy
+%{_bindir}/volint
+%{_bindir}/wcslint
+
+%changelog
+%autochangelog

--- a/SPECS/python-backports-zstd/python-backports-zstd.spec
+++ b/SPECS/python-backports-zstd/python-backports-zstd.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname backports-zstd
+%global pypi_name backports_zstd
+
+Name:           python-%{srcname}
+Version:        1.6.0
+Release:        %autorelease
+Summary:        Backport of compression.zstd
+License:        PSF-2.0 AND BSD-3-Clause
+URL:            https://github.com/rogdham/backports.zstd
+#!RemoteAsset:  sha256:80a7859ffe70bf239d7a2ce15293bdeb5b4280ff7dc326ffab312b0e254dbb24
+Source0:        https://files.pythonhosted.org/packages/source/b/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(build):  -C--build-option=--system-zstd
+BuildOption(install):  -l backports
+
+BuildRequires:  pkgconfig(libzstd)
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Backport of the compression.zstd module from Python 3.14.
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE.txt
+%license LICENSE_zstd.txt
+
+%changelog
+%autochangelog

--- a/SPECS/python-bleach/python-bleach.spec
+++ b/SPECS/python-bleach/python-bleach.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname bleach
+
+Name:           python-%{srcname}
+Version:        6.4.0
+Release:        %autorelease
+Summary:        Safelist-based HTML sanitizing library
+License:        Apache-2.0
+URL:            https://github.com/mozilla/bleach
+#!RemoteAsset:  sha256:4202482733d85cedd04e59fcb2f89f4e4c7c385a78d3c3c23c30446843a37452
+Source0:        https://files.pythonhosted.org/packages/source/b/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l bleach
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(tinycss2)
+BuildRequires:  python3dist(webencodings)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Bleach is a safelist-based HTML sanitizing library that removes potentially
+unsafe markup from untrusted input.
+
+%pyproject_extras_subpkg -n python-%{srcname} css
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-cfgrib/python-cfgrib.spec
+++ b/SPECS/python-cfgrib/python-cfgrib.spec
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname cfgrib
+
+Name:           python-%{srcname}
+Version:        0.9.15.1
+Release:        %autorelease
+Summary:        Map GRIB files to the CF data model with ecCodes
+License:        Apache-2.0
+URL:            https://github.com/ecmwf/cfgrib
+#!RemoteAsset:  sha256:d959d8b97e55a63646fa86686b297905ff7f2918a91e3a11d6292dab09598e4d
+Source0:        https://files.pythonhosted.org/packages/source/c/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l cf2cdm cfgrib
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(attrs)
+BuildRequires:  python3dist(click)
+BuildRequires:  python3dist(eccodes)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools-scm)
+BuildRequires:  python3dist(xarray)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+cfgrib maps GRIB files to the NetCDF Common Data Model following the CF
+Convention using ecCodes.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+%{_bindir}/cfgrib
+
+%changelog
+%autochangelog

--- a/SPECS/python-comm/python-comm.spec
+++ b/SPECS/python-comm/python-comm.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname comm
+
+Name:           python-%{srcname}
+Version:        0.2.3
+Release:        %autorelease
+Summary:        Jupyter Python Comm implementation
+License:        BSD-3-Clause
+URL:            https://github.com/ipython/comm
+#!RemoteAsset:  sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971
+Source0:        https://files.pythonhosted.org/packages/source/c/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l comm
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(pip)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Comm provides the Jupyter Python communication abstraction used by kernels and
+frontends to exchange custom messages.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-dask/python-dask.spec
+++ b/SPECS/python-dask/python-dask.spec
@@ -27,16 +27,12 @@ BuildOption(check):  -e 'dask.dataframe.dask_expr.io.tests.test_distributed'
 BuildOption(check):  -e 'dask.dataframe.dask_expr.tests.test_diagnostics'
 # skip tests: No module named 'cupy'
 BuildOption(check):  -e 'dask.array.tests.test_cupy*'
-# skip tests: No module named 'skimage'
+# Skip tests: RuntimeError: Memory error in scipy.linalg.inv
+# https://github.com/openRuyi-Project/openRuyi/issues/992
+BuildOption(check):  -e 'dask.array.image'
 BuildOption(check):  -e 'dask.array.tests.test_image'
-# skip tests: No module named 'sparse'
-BuildOption(check):  -e 'dask.array.tests.test_sparse'
 # skip tests: No module named 'xarray' (circular dependency)
 BuildOption(check):  -e 'dask.array.tests.test_xarray'
-# skip tests: No module named 'ipycytoscape'
-BuildOption(check):  -e 'dask.tests.test_dot'
-# skip tests: No module named 'pyspark'
-BuildOption(check):  -e 'dask.tests.test_spark_compat'
 # skip tests: pyarrow ORC support not available (No module named 'pyarrow._orc')
 BuildOption(check):  -e 'dask.dataframe.io.orc.arrow'
 BuildOption(check):  -e 'dask.dataframe.io.tests.test_orc'
@@ -51,6 +47,8 @@ BuildRequires:  python3dist(cloudpickle)
 BuildRequires:  python3dist(fastavro)
 BuildRequires:  python3dist(flask)
 BuildRequires:  python3dist(fsspec)
+BuildRequires:  python3dist(graphviz)
+BuildRequires:  python3dist(ipycytoscape)
 BuildRequires:  python3dist(jinja2)
 BuildRequires:  python3dist(moto)
 BuildRequires:  python3dist(numpy)
@@ -60,12 +58,14 @@ BuildRequires:  python3dist(partd)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(pyarrow)
 BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(pyspark)
 BuildRequires:  python3dist(pyyaml)
 BuildRequires:  python3dist(requests)
 BuildRequires:  python3dist(s3fs)
+BuildRequires:  python3dist(scikit-image)
 BuildRequires:  python3dist(scipy)
-BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(setuptools-scm)
+BuildRequires:  python3dist(sparse)
 BuildRequires:  python3dist(sqlalchemy)
 BuildRequires:  python3dist(toolz)
 

--- a/SPECS/python-debugpy/python-debugpy.spec
+++ b/SPECS/python-debugpy/python-debugpy.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname debugpy
+
+Name:           python-%{srcname}
+Version:        1.8.21
+Release:        %autorelease
+Summary:        Debug Adapter Protocol implementation for Python
+License:        MIT
+URL:            https://github.com/microsoft/debugpy
+#!RemoteAsset:  sha256:a3c53278e84c94e11bd87c53970ec391d1a67396c8b22609fcac576520e611a6
+Source0:        https://files.pythonhosted.org/packages/source/d/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l debugpy
+# Windows-only module: ctypes has no attribute 'windll' on Linux.
+BuildOption(check):  -e debugpy.launcher.winapi
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Debugpy is an implementation of the Debug Adapter Protocol for Python.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+%{_bindir}/debugpy
+%{_bindir}/debugpy-adapter
+
+%changelog
+%autochangelog

--- a/SPECS/python-defusedxml/python-defusedxml.spec
+++ b/SPECS/python-defusedxml/python-defusedxml.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname defusedxml
+
+Name:           python-%{srcname}
+Version:        0.7.1
+Release:        %autorelease
+Summary:        XML bomb protection for Python standard library modules
+License:        PSF-2.0
+URL:            https://github.com/tiran/defusedxml
+#!RemoteAsset:  sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69
+Source0:        https://files.pythonhosted.org/packages/source/d/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l defusedxml
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(lxml)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+defusedxml provides safer replacements for Python standard library XML
+parsers that protect applications from common XML attacks.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.txt
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-deprecation/python-deprecation.spec
+++ b/SPECS/python-deprecation/python-deprecation.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname deprecation
+
+Name:           python-%{srcname}
+Version:        2.1.0
+Release:        %autorelease
+Summary:        Library to handle automated deprecations
+License:        Apache-2.0
+URL:            https://github.com/briancurtin/deprecation
+#!RemoteAsset:  sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff
+Source0:        https://files.pythonhosted.org/packages/source/d/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l deprecation
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Deprecation is a library that enables automated deprecation messages.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-distributed/python-distributed.spec
+++ b/SPECS/python-distributed/python-distributed.spec
@@ -28,12 +28,8 @@ BuildOption(check):  -e 'distributed.protocol.cupy'
 BuildOption(check):  -e 'distributed.protocol.keras'
 # No module named 'netCDF4'
 BuildOption(check):  -e 'distributed.protocol.netcdf4'
-# No module named 'numba.cuda'
-BuildOption(check):  -e 'distributed.protocol.numba'
 # No module named 'rmm'
 BuildOption(check):  -e 'distributed.protocol.rmm'
-# No module named 'sparse'
-BuildOption(check):  -e 'distributed.protocol.sparse'
 # No module named 'distributed.utils_test'
 BuildOption(check):  -e 'distributed.utils_test'
 
@@ -49,6 +45,7 @@ BuildRequires:  python3dist(locket)
 BuildRequires:  python3dist(memray)
 BuildRequires:  python3dist(msgpack)
 BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(numba)
 BuildRequires:  python3dist(packaging)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(prometheus-client)
@@ -58,6 +55,7 @@ BuildRequires:  python3dist(pyyaml)
 BuildRequires:  python3dist(scipy)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(setuptools-scm)
+BuildRequires:  python3dist(sparse)
 BuildRequires:  python3dist(sortedcontainers)
 BuildRequires:  python3dist(tblib)
 BuildRequires:  python3dist(toolz)
@@ -65,6 +63,11 @@ BuildRequires:  python3dist(torch)
 BuildRequires:  python3dist(tornado)
 BuildRequires:  python3dist(urllib3)
 BuildRequires:  python3dist(zict)
+# TODO: remove libomp after PR merged
+# https://github.com/openRuyi-Project/openRuyi/pull/970/
+# Importing distributed.protocol.torch fails with:
+# ImportError: libomp.so: cannot open shared object file: No such file or directory
+BuildRequires:  libomp
 
 Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}

--- a/SPECS/python-donfig/python-donfig.spec
+++ b/SPECS/python-donfig/python-donfig.spec
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname donfig
+
+Name:           python-%{srcname}
+Version:        0.8.1.post1
+Release:        %autorelease
+Summary:        Python package for configuring a Python package
+License:        MIT
+URL:            https://github.com/pytroll/donfig
+#!RemoteAsset:  sha256:3bef3413a4c1c601b585e8d297256d0c1470ea012afa6e8461dc28bfb7c23f52
+Source0:        https://files.pythonhosted.org/packages/source/d/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l donfig
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(cloudpickle)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(pyyaml)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(versioneer[toml])
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Donfig is a Python package that provides configuration management for
+Python applications.
+
+%prep -a
+# Remove the pinned versioneer version
+sed -i 's/versioneer\[toml\]==0.28/versioneer[toml]/' pyproject.toml
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE.txt
+
+%changelog
+%autochangelog

--- a/SPECS/python-eccodes/python-eccodes.spec
+++ b/SPECS/python-eccodes/python-eccodes.spec
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname eccodes
+
+Name:           python-%{srcname}
+Version:        2.47.0
+Release:        %autorelease
+Summary:        Python interface to the ecCodes GRIB and BUFR library
+License:        Apache-2.0
+URL:            https://github.com/ecmwf/eccodes-python
+#!RemoteAsset:  sha256:ae9207ef27c67656d068aab97f172abeb85fc3620f56faa22fdac5b1be75de69
+Source0:        https://files.pythonhosted.org/packages/source/e/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l eccodes gribapi
+
+BuildRequires:  pkgconfig(eccodes)
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(attrs)
+BuildRequires:  python3dist(cffi)
+BuildRequires:  python3dist(findlibs)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
+Requires:       eccodes
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+This package exposes the ecCodes GRIB and BUFR decoder and encoder to Python.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-extension-helpers/python-extension-helpers.spec
+++ b/SPECS/python-extension-helpers/python-extension-helpers.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname extension-helpers
+%global pypi_name extension_helpers
+
+Name:           python-%{srcname}
+Version:        1.4.0
+Release:        %autorelease
+Summary:        Utilities for building Python extension modules
+License:        BSD-3-Clause
+URL:            https://github.com/astropy/extension-helpers
+#!RemoteAsset:  sha256:78d04185f196e3e0bc5fd8418ce298b014c46f7ac609f6a8c10bf70e8c978324
+Source0:        https://files.pythonhosted.org/packages/source/e/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l extension_helpers
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Extension helpers provides utilities for building Python extension modules.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE.rst
+
+%changelog
+%autochangelog

--- a/SPECS/python-findlibs/python-findlibs.spec
+++ b/SPECS/python-findlibs/python-findlibs.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname findlibs
+
+Name:           python-%{srcname}
+Version:        0.1.3
+Release:        %autorelease
+Summary:        Locate shared libraries on various platforms
+License:        Apache-2.0
+URL:            https://github.com/ecmwf/findlibs
+#!RemoteAsset:  sha256:49bbe509c8b439ecd9c0d021c301aa9db643a2e6ab4e189a40b505ee4a49db62
+Source0:        https://files.pythonhosted.org/packages/source/f/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  findlibs
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Findlibs searches for shared libraries using platform-specific conventions.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-fitsio/python-fitsio.spec
+++ b/SPECS/python-fitsio/python-fitsio.spec
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname fitsio
+
+Name:           python-%{srcname}
+Version:        1.4.2
+Release:        %autorelease
+Summary:        Python interface to CFITSIO
+License:        GPL-2.0-or-later
+URL:            https://github.com/esheldon/fitsio
+#!RemoteAsset:  sha256:92a02f0e63d539d85ca5a185ae0cc8d40029270858275964ee2539ee0136f0c3
+Source0:        https://files.pythonhosted.org/packages/source/f/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l fitsio
+
+BuildRequires:  pkgconfig(cfitsio)
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pkgconfig(zlib)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Fitsio is a Python interface for reading and writing FITS files using CFITSIO.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%build -p
+export FITSIO_USE_SYSTEM_FITSIO=1
+
+%check -a
+cd ..
+%pytest -v --pyargs fitsio.tests
+
+%files -f %{pyproject_files}
+%doc CHANGES.md README.md
+%license LICENSE.txt
+
+%changelog
+%autochangelog

--- a/SPECS/python-fqdn/python-fqdn.spec
+++ b/SPECS/python-fqdn/python-fqdn.spec
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname fqdn
+
+Name:           python-%{srcname}
+Version:        1.5.1
+Release:        %autorelease
+Summary:        Fully qualified domain name validation
+License:        MPL-2.0
+URL:            https://github.com/ypcrts/fqdn
+#!RemoteAsset:  sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f
+Source0:        https://files.pythonhosted.org/packages/source/f/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  fqdn
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+fqdn validates fully qualified domain names according to RFC 1123.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+
+%changelog
+%autochangelog

--- a/SPECS/python-gdal/2000-use-numpy-fft.patch
+++ b/SPECS/python-gdal/2000-use-numpy-fft.patch
@@ -1,0 +1,42 @@
+From 969fe9cea482256a4a538a45e7b9ef6ecb4a6762 Mon Sep 17 00:00:00 2001
+From: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+Date: Fri, 17 Jul 2026 15:50:00 +0000
+Subject: [PATCH] Use NumPy FFT
+
+---
+ gdal-utils/osgeo_utils/samples/fft.py | 11 +++--------
+ 1 file changed, 3 insertions(+), 8 deletions(-)
+
+diff --git a/gdal-utils/osgeo_utils/samples/fft.py b/gdal-utils/osgeo_utils/samples/fft.py
+index bee0c09eec..cdea72edb0 100644
+--- a/gdal-utils/osgeo_utils/samples/fft.py
++++ b/gdal-utils/osgeo_utils/samples/fft.py
+@@ -14,12 +14,7 @@
+ ###############################################################################
+ 
+ import sys
+-
+-try:
+-    import FFT
+-except ModuleNotFoundError:
+-    print("Module FFT not found, cannot continue")
+-    sys.exit(1)
++from numpy import fft
+ from osgeo import gdal
+ 
+ # =============================================================================
+@@ -123,9 +118,9 @@ def main(argv=sys.argv):
+ 
+         data = inband.ReadAsArray(0, 0)
+         if transformation == "forward":
+-            data_tr = FFT.fft2d(data)
++            data_tr = fft.fft2(data)
+         else:
+-            data_tr = FFT.inverse_fft2d(data)
++            data_tr = fft.ifft2(data)
+         outband.WriteArray(data_tr)
+     return 0
+ 
+-- 
+2.54.0
+

--- a/SPECS/python-gdal/python-gdal.spec
+++ b/SPECS/python-gdal/python-gdal.spec
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname gdal
+%global pypi_name gdal
+
+Name:           python-%{srcname}
+Version:        3.13.1
+Release:        %autorelease
+Summary:        Python bindings for GDAL
+License:        MIT
+URL:            https://gdal.org/
+VCS:            git:https://github.com/OSGeo/gdal.git
+#!RemoteAsset:  sha256:94bb64d729ce73ceb75a314a15cba92696cdd854d99b6bf6b88a7b551227db74
+Source0:        https://files.pythonhosted.org/packages/source/g/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+# Use NumPy's supported FFT implementation
+Patch2000:      2000-use-numpy-fft.patch
+
+BuildOption(install):  osgeo osgeo_utils
+
+BuildRequires:  pkgconfig(gdal)
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(fsspec)
+BuildRequires:  python3dist(h5py)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Requires:       gdal%{?_isa} >= %{version}
+Requires:       python3dist(fsspec)
+Requires:       python3dist(h5py)
+Requires:       python3dist(numpy)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Python bindings and utilities for GDAL.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%{_bindir}/gdal*
+%{_bindir}/ogr*
+%{_bindir}/pct2rgb*
+%{_bindir}/rgb2pct*
+
+%changelog
+%autochangelog

--- a/SPECS/python-google-crc32c/python-google-crc32c.spec
+++ b/SPECS/python-google-crc32c/python-google-crc32c.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname google-crc32c
+%global pypi_name google_crc32c
+
+Name:           python-%{srcname}
+Version:        1.8.0
+Release:        %autorelease
+Summary:        Python wrapper for Google CRC32C
+License:        Apache-2.0
+URL:            https://github.com/googleapis/python-crc32c
+#!RemoteAsset:  sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79
+Source0:        https://files.pythonhosted.org/packages/source/g/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l google_crc32c
+
+BuildRequires:  crc32c-devel
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Google CRC32C provides a Python implementation of the CRC32C checksum.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-graphviz/python-graphviz.spec
+++ b/SPECS/python-graphviz/python-graphviz.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname graphviz
+
+Name:           python-%{srcname}
+Version:        0.21
+Release:        %autorelease
+Summary:        Python interface for Graphviz
+License:        MIT
+URL:            https://github.com/xflr6/graphviz
+#!RemoteAsset:  sha256:20743e7183be82aaaa8ad6c93f8893c923bd6658a04c32ee115edb3c8a835f78
+Source0:        https://files.pythonhosted.org/packages/source/g/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l graphviz
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Requires:       graphviz
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Python interface for creating and rendering Graphviz graph descriptions.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE.txt
+
+%changelog
+%autochangelog

--- a/SPECS/python-grpcio-status/python-grpcio-status.spec
+++ b/SPECS/python-grpcio-status/python-grpcio-status.spec
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname grpcio-status
+%global pypi_name grpcio_status
+
+Name:           python-%{srcname}
+Version:        1.80.0
+Release:        %autorelease
+Summary:        Status proto mapping for gRPC
+License:        Apache-2.0
+URL:            https://grpc.io/
+VCS:            git:https://github.com/grpc/grpc.git
+#!RemoteAsset:  sha256:df73802a4c89a3ea88aa2aff971e886fccce162bc2e6511408b3d67a144381cd
+Source0:        https://files.pythonhosted.org/packages/source/g/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l grpc_status
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(googleapis-common-protos)
+BuildRequires:  python3dist(grpcio)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(protobuf)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+grpcio-status provides a mapping between rich Protobuf status messages and
+gRPC status codes.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+
+%changelog
+%autochangelog

--- a/SPECS/python-hatch-jupyter-builder/python-hatch-jupyter-builder.spec
+++ b/SPECS/python-hatch-jupyter-builder/python-hatch-jupyter-builder.spec
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname hatch-jupyter-builder
+%global pypi_name hatch_jupyter_builder
+
+Name:           python-%{srcname}
+Version:        0.9.1
+Release:        %autorelease
+Summary:        Hatch plugin for building Jupyter packages
+License:        BSD-3-Clause
+URL:            https://github.com/jupyterlab/hatch-jupyter-builder
+#!RemoteAsset:  sha256:79278198d124c646b799c5e8dca8504aed9dcaaa88d071a09eb0b5c2009a58ad
+Source0:        https://files.pythonhosted.org/packages/source/h/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l hatch_jupyter_builder
+# This test case only works during migration
+BuildOption(check):  -e 'hatch_jupyter_builder.migrate.jupyter_packaging'
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(tomli-w)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+hatch-jupyter-builder is a Hatch plugin for building Jupyter packages and
+prebuilt extensions.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE.txt
+%{_bindir}/hatch-jupyter-builder
+
+%changelog
+%autochangelog

--- a/SPECS/python-imagecodecs/python-imagecodecs.spec
+++ b/SPECS/python-imagecodecs/python-imagecodecs.spec
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname imagecodecs
+
+Name:           python-%{srcname}
+Version:        2026.6.26
+Release:        %autorelease
+Summary:        Image transformation and compression codecs
+License:        BSD-3-Clause
+URL:            https://github.com/cgohlke/imagecodecs
+#!RemoteAsset:  sha256:da95b145f6b4f746acc9e0b8707b164eefc6a36ade3b6e70f74d102e9affad8c
+Source0:        https://files.pythonhosted.org/packages/source/i/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l imagecodecs
+
+BuildRequires:  pkgconfig(Lerc)
+BuildRequires:  pkgconfig(lcms2)
+BuildRequires:  pkgconfig(libdeflate)
+BuildRequires:  pkgconfig(libjpeg)
+BuildRequires:  pkgconfig(libjxr)
+BuildRequires:  pkgconfig(liblz4)
+BuildRequires:  pkgconfig(liblzma)
+BuildRequires:  pkgconfig(libopenjp2)
+BuildRequires:  pkgconfig(libpng)
+BuildRequires:  pkgconfig(libtiff-4)
+BuildRequires:  pkgconfig(libwebp)
+BuildRequires:  pkgconfig(libwebpdemux)
+BuildRequires:  pkgconfig(libwebpmux)
+BuildRequires:  pkgconfig(libzstd)
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pkgconfig(zlib)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(cython)
+BuildRequires:  python3dist(numcodecs)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+BuildRequires:  python3dist(zarr)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Imagecodecs provides block-oriented image transformation, compression, and
+decompression codecs for scientific image I/O libraries.
+
+%files -f %{pyproject_files}
+%doc CHANGES.rst
+%doc README.rst
+%license LICENSE
+%{_bindir}/imagecodecs
+
+%changelog
+%autochangelog

--- a/SPECS/python-imageio-ffmpeg/python-imageio-ffmpeg.spec
+++ b/SPECS/python-imageio-ffmpeg/python-imageio-ffmpeg.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname imageio-ffmpeg
+%global pypi_name imageio_ffmpeg
+
+Name:           python-%{srcname}
+Version:        0.6.0
+Release:        %autorelease
+Summary:        FFMPEG wrapper for Python ImageIO
+License:        BSD-2-Clause
+URL:            https://github.com/imageio/imageio-ffmpeg
+#!RemoteAsset:  sha256:e2556bed8e005564a9f925bb7afa4002d82770d6b08825078b7697ab88ba1755
+Source0:        https://files.pythonhosted.org/packages/source/i/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l imageio_ffmpeg
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Python bindings for FFMPEG using ImageIO.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-imageio/1000-support-tifffile-axes-codes.patch
+++ b/SPECS/python-imageio/1000-support-tifffile-axes-codes.patch
@@ -1,0 +1,18 @@
+diff --git a/tests/test_tifffile_v3.py b/tests/test_tifffile_v3.py
+index 66f665b..c9f1310 100644
+--- a/tests/test_tifffile_v3.py
++++ b/tests/test_tifffile_v3.py
+@@ -94,7 +94,12 @@ def test_planarconfig(tmp_path):
+         if tuple(int(x) for x in tifffile.__version__.split(".")) <= (2021, 11, 2):
+             assert tif.series[0].pages[0].tags[284].value == 2
+         else:
+-            assert tif.series[0].dims == ("sample", "height", "width")
++            # tifffile 2026.6.1+ (Python >= 3.12) uses axes codes; earlier
++            # releases still report long dim names.
++            assert tif.series[0].dims in (
++                ("sample", "height", "width"),
++                ("S", "Y", "X"),
++            )
+ 
+ 
+ def test_metadata_reading(test_images):

--- a/SPECS/python-imageio/python-imageio.spec
+++ b/SPECS/python-imageio/python-imageio.spec
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname imageio
+
+Name:           python-%{srcname}
+Version:        2.37.3
+Release:        %autorelease
+Summary:        Library for reading and writing a wide range of image formats
+License:        BSD-2-Clause
+URL:            https://imageio.readthedocs.io/
+VCS:            git:https://github.com/imageio/imageio
+#!RemoteAsset:  sha256:bbb37efbfc4c400fcd534b367b91fcd66d5da639aaa138034431a1c5e0a41451
+Source0:        https://files.pythonhosted.org/packages/source/i/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+# https://github.com/imageio/imageio/commit/dfdc909c225662784c7c9469232bbe46ea983501
+Patch1000:      1000-support-tifffile-axes-codes.patch
+
+BuildOption(install):  -l imageio
+# skip tests: recursion is detected during loading of "cv2" binary extensions
+# https://github.com/openRuyi-Project/openRuyi/issues/998
+BuildOption(check):  -e 'imageio.plugins.opencv'
+# Skip tests: No module named 'SimpleITK'
+# Wait for SimpleITK 3.0 release, it will switch from setuptools.build_meta to scikit-build-core.
+BuildOption(check):  -e 'imageio.plugins.simpleitk'
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(astropy)
+BuildRequires:  python3dist(av)
+BuildRequires:  python3dist(fsspec)
+BuildRequires:  python3dist(gdal)
+BuildRequires:  python3dist(imageio-ffmpeg)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(opencv)
+BuildRequires:  python3dist(pillow)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(psutil)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(pytest-cov)
+BuildRequires:  python3dist(rawpy)
+BuildRequires:  python3dist(requests)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(tifffile)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Imageio is a Python library that provides an easy interface to read and
+write a wide range of image data, including animated images, volumetric
+data, and scientific formats.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+%{_bindir}/imageio_download_bin
+%{_bindir}/imageio_remove_bin
+
+%changelog
+%autochangelog

--- a/SPECS/python-ipycytoscape/2000-use-prebuilt-jupyter-assets.patch
+++ b/SPECS/python-ipycytoscape/2000-use-prebuilt-jupyter-assets.patch
@@ -1,0 +1,36 @@
+From 0fbde2ffc25eeb0426b9d31ac86c069e4a071bdf Mon Sep 17 00:00:00 2001
+From: jinqiang zhang <jinqiang.oerv@isrc.iscas.ac.cn>
+Date: Wed, 12 Aug 2026 18:23:48 +0800
+Subject: [PATCH] Use the prebuilt Jupyter assets included in the sdist
+
+---
+ pyproject.toml | 2 +-
+ setup.py       | 1 -
+ 2 files changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 554c4dc..d454a5e 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["jupyter_packaging~=0.7.0", "jupyterlab>=3.0.0rc4,==3.*", "setuptools>=40.8.0", "wheel"]
++requires = ["jupyter_packaging", "setuptools>=40.8.0", "wheel"]
+ build-backend = "setuptools.build_meta"
+ 
+ 
+diff --git a/setup.py b/setup.py
+index 67294a1..53fdacd 100644
+--- a/setup.py
++++ b/setup.py
+@@ -33,7 +33,6 @@ lab_path = path.join(HERE, name, "labextension")
+ # Representative files that should exist after a successful build
+ jstargets = [
+     path.join(nb_path, "index.js"),
+-    path.join(HERE, "lib", "plugin.js"),
+ ]
+ 
+ package_data_spec = {name: ["*"]}
+-- 
+2.54.0
+

--- a/SPECS/python-ipycytoscape/python-ipycytoscape.spec
+++ b/SPECS/python-ipycytoscape/python-ipycytoscape.spec
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname ipycytoscape
+
+Name:           python-%{srcname}
+Version:        1.3.3
+Release:        %autorelease
+Summary:        Interactive Cytoscape graphs in Jupyter
+License:        BSD-3-Clause
+URL:            https://github.com/cytoscape/ipycytoscape
+#!RemoteAsset:  sha256:b6f3199df034f088e92d388e27e629f58ae2901b213cb9299e5b564272f9a2f8
+Source0:        https://files.pythonhosted.org/packages/source/i/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+# Use the prebuilt Jupyter assets included in the sdist.
+Patch2000:      2000-use-prebuilt-jupyter-assets.patch
+
+BuildOption(install):  -l ipycytoscape
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(ipykernel)
+BuildRequires:  python3dist(ipywidgets)
+BuildRequires:  python3dist(jupyter-packaging)
+BuildRequires:  python3dist(networkx)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(spectate)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Interactive graph visualization using Cytoscape in Jupyter notebooks.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%install -a
+mv %{buildroot}%{_prefix}%{_sysconfdir} %{buildroot}%{_sysconfdir}
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+%{_datadir}/jupyter/labextensions/jupyter-cytoscape/
+%{_datadir}/jupyter/nbextensions/jupyter-cytoscape/
+%{_sysconfdir}/jupyter/nbconfig/notebook.d/jupyter-cytoscape.json
+
+%changelog
+%autochangelog

--- a/SPECS/python-ipykernel/python-ipykernel.spec
+++ b/SPECS/python-ipykernel/python-ipykernel.spec
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname ipykernel
+
+Name:           python-%{srcname}
+Version:        6.25.2
+Release:        %autorelease
+Summary:        IPython kernel for Jupyter
+License:        BSD-3-Clause
+URL:            https://github.com/ipython/ipykernel
+#!RemoteAsset:  sha256:f468ddd1f17acb48c8ce67fcfa49ba6d46d4f9ac0438c1f441be7c3d1372230b
+Source0:        https://files.pythonhosted.org/packages/source/i/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l ipykernel ipykernel_launcher
+
+BuildRequires:  gtk3
+BuildRequires:  pkgconfig(gobject-introspection-1.0)
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(comm)
+BuildRequires:  python3dist(debugpy)
+BuildRequires:  python3dist(flaky)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(ipyparallel)
+BuildRequires:  python3dist(ipython)
+BuildRequires:  python3dist(jupyter-client)
+BuildRequires:  python3dist(jupyter-core)
+BuildRequires:  python3dist(matplotlib)
+BuildRequires:  python3dist(matplotlib-inline)
+BuildRequires:  python3dist(nest-asyncio)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(psutil)
+BuildRequires:  python3dist(pygobject)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(pyzmq)
+BuildRequires:  python3dist(tornado)
+BuildRequires:  python3dist(traitlets)
+BuildRequires:  python3dist(trio)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+IPykernel provides the IPython kernel used by Jupyter frontends.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+%{_datadir}/jupyter/kernels/python3/
+
+%changelog
+%autochangelog

--- a/SPECS/python-ipyparallel/2000-drop-jupyterlab-build-requirement.patch
+++ b/SPECS/python-ipyparallel/2000-drop-jupyterlab-build-requirement.patch
@@ -1,0 +1,24 @@
+From b0eca904b3e657c0663f7116dac842ff1ecd0247 Mon Sep 17 00:00:00 2001
+From: jinqiang zhang <jinqiang.oerv@isrc.iscas.ac.cn>
+Date: Wed, 12 Aug 2026 18:26:20 +0800
+Subject: [PATCH] Drop jupyterlab build requirement
+
+Use the prebuilt labextension from the sdist to break the JupyterLab cycle
+---
+ pyproject.toml | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index da4494b1..fd6b1ffe 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,6 +1,5 @@
+ [build-system]
+ requires = [
+-  "jupyterlab==4.*",
+   "hatchling>=0.25",
+ ]
+ build-backend = "hatchling.build"
+-- 
+2.54.0
+

--- a/SPECS/python-ipyparallel/2001-fix-shellcmd-import.patch
+++ b/SPECS/python-ipyparallel/2001-fix-shellcmd-import.patch
@@ -1,0 +1,58 @@
+From 6ca7cba3ec416ceb9f7806f956999136d4908b68 Mon Sep 17 00:00:00 2001
+From: jinqiang zhang <jinqiang.oerv@isrc.iscas.ac.cn>
+Date: Fri, 17 Jul 2026 07:55:28 +0800
+Subject: [PATCH 1/2] add testcase test_shellcmd_module_import
+
+---
+ ipyparallel/tests/test_shellcmd.py | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/ipyparallel/tests/test_shellcmd.py b/ipyparallel/tests/test_shellcmd.py
+index 748dd83c..6fce5d51 100644
+--- a/ipyparallel/tests/test_shellcmd.py
++++ b/ipyparallel/tests/test_shellcmd.py
+@@ -128,6 +128,12 @@ sender_ids = [
+ ]
+ 
+ 
++def test_shellcmd_module_import():
++    import ipyparallel.shellcmd
++
++    assert callable(ipyparallel.shellcmd.main)
++
++
+ @pytest.fixture
+ def shellcmd_test_cmd():
+     """returns a command that runs for 5 seconds"""
+-- 
+2.54.0
+
+
+From e4500428737df9364117f5f45a68083ff95b5f3f Mon Sep 17 00:00:00 2001
+From: jinqiang zhang <jinqiang.oerv@isrc.iscas.ac.cn>
+Date: Fri, 17 Jul 2026 07:57:59 +0800
+Subject: [PATCH 2/2] fix ShellCommandReceive ImportError
+
+File "/.../ipyparallel/shellcmd.py", line 19, in <module>
+    from .cluster.shellcmd import ShellCommandReceive
+ImportError: cannot import name 'ShellCommandReceive' from 'ipyparallel.cluster.shellcmd'
+---
+ ipyparallel/shellcmd.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ipyparallel/shellcmd.py b/ipyparallel/shellcmd.py
+index 3f76c725..5755b2a4 100644
+--- a/ipyparallel/shellcmd.py
++++ b/ipyparallel/shellcmd.py
+@@ -16,7 +16,7 @@ import os
+ import sys
+ from argparse import ArgumentParser
+ 
+-from .cluster.shellcmd import ShellCommandReceive
++from .cluster.shellcmd_receive import ShellCommandReceive
+ 
+ 
+ def main():
+-- 
+2.54.0
+

--- a/SPECS/python-ipyparallel/python-ipyparallel.spec
+++ b/SPECS/python-ipyparallel/python-ipyparallel.spec
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname ipyparallel
+
+Name:           python-%{srcname}
+Version:        9.2.0
+Release:        %autorelease
+Summary:        Interactive parallel computing with IPython
+License:        BSD-3-Clause
+URL:            https://github.com/ipython/ipyparallel
+#!RemoteAsset:  sha256:2b31bb4e94708e7ffb4ee6501d7f5f664df7e1c4c572e91e9e0d12484c6a6910
+Source0:        https://files.pythonhosted.org/packages/source/i/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+# Use the prebuilt labextension from the sdist to break the JupyterLab cycle.
+Patch2000:      2000-drop-jupyterlab-build-requirement.patch
+# https://github.com/ipython/ipyparallel/pull/1035
+Patch2001:      2001-fix-shellcmd-import.patch
+
+BuildOption(install):  -l ipyparallel
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(decorator)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(ipython)
+BuildRequires:  python3dist(joblib)
+BuildRequires:  python3dist(jupyter-client)
+BuildRequires:  python3dist(jupyter-server)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(psutil)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(python-dateutil)
+BuildRequires:  python3dist(pyzmq)
+BuildRequires:  python3dist(tornado)
+BuildRequires:  python3dist(tqdm)
+BuildRequires:  python3dist(traitlets)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+IPyParallel provides tools for using IPython to run parallel and distributed
+computations interactively.
+
+%prep -a
+# Remove ipykernel from build requirements to break the circular dependency.
+sed -i '/"ipykernel>=6.9.1",/d' pyproject.toml
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%install -a
+mv %{buildroot}%{_prefix}%{_sysconfdir} %{buildroot}%{_sysconfdir}
+
+# skip tests: No module named 'ipykernel' (circular dependency)
+%check
+
+%files -f %{pyproject_files}
+%doc README.md
+%license COPYING.md
+%{_bindir}/ipcluster
+%{_bindir}/ipcontroller
+%{_bindir}/ipengine
+%{_datadir}/jupyter/labextensions/ipyparallel-labextension/
+%{_datadir}/jupyter/nbextensions/ipyparallel/
+%{_sysconfdir}/jupyter/jupyter_notebook_config.d/ipyparallel.json
+%{_sysconfdir}/jupyter/jupyter_server_config.d/ipyparallel.json
+%{_sysconfdir}/jupyter/nbconfig/tree.d/ipyparallel.json
+
+%changelog
+%autochangelog

--- a/SPECS/python-ipywidgets/python-ipywidgets.spec
+++ b/SPECS/python-ipywidgets/python-ipywidgets.spec
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname ipywidgets
+
+Name:           python-%{srcname}
+Version:        8.1.8
+Release:        %autorelease
+Summary:        Jupyter interactive widgets
+License:        BSD-3-Clause
+URL:            https://github.com/jupyter-widgets/ipywidgets
+#!RemoteAsset:  sha256:61f969306b95f85fba6b6986b7fe45d73124d1d9e3023a8068710d47a22ea668
+Source0:        https://files.pythonhosted.org/packages/source/i/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l ipywidgets
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(comm)
+BuildRequires:  python3dist(ipykernel)
+BuildRequires:  python3dist(ipython)
+BuildRequires:  python3dist(jupyterlab-widgets)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(pytz)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(traitlets)
+BuildRequires:  python3dist(wheel)
+BuildRequires:  python3dist(widgetsnbextension)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Interactive HTML widgets for Jupyter notebooks and the IPython kernel.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-isoduration/python-isoduration.spec
+++ b/SPECS/python-isoduration/python-isoduration.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname isoduration
+
+Name:           python-%{srcname}
+Version:        20.11.0
+Release:        %autorelease
+Summary:        Operations with ISO 8601 durations
+License:        ISC
+URL:            https://github.com/bolsote/isoduration
+#!RemoteAsset:  sha256:ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9
+Source0:        https://files.pythonhosted.org/packages/source/i/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l isoduration
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(arrow)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+isoduration provides parsing and arithmetic for ISO 8601 durations.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-jsonschema/python-jsonschema.spec
+++ b/SPECS/python-jsonschema/python-jsonschema.spec
@@ -24,17 +24,20 @@ BuildOption(check):  -e 'jsonschema.benchmarks*' -e 'jsonschema.tests.test_jsons
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
-BuildRequires:  python3dist(hatchling)
-BuildRequires:  python3dist(hatch-vcs)
-BuildRequires:  python3dist(pip)
-BuildRequires:  python3dist(setuptools)
-BuildRequires:  python3dist(hatch-fancy-pypi-readme)
-# for tests
-BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(attrs)
-BuildRequires:  python3dist(pyrsistent)
+BuildRequires:  python3dist(hatch-fancy-pypi-readme)
+BuildRequires:  python3dist(hatch-vcs)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(jsonschema-specifications)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(referencing)
+BuildRequires:  python3dist(rpds-py)
+BuildRequires:  python3dist(setuptools)
+# for tests
 BuildRequires:  python3dist(hypothesis)
 BuildRequires:  python3dist(jsonpath-ng)
+BuildRequires:  python3dist(pyrsistent)
+BuildRequires:  python3dist(pytest)
 
 Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}
@@ -47,6 +50,8 @@ jsonschema is an implementation of JSON Schema for Python (supporting
  - Lazy validation that can iteratively report all validation errors.
  - Small and extensible
  - Programmatic querying of which properties or items failed validation.
+
+%pyproject_extras_subpkg -n python-jsonschema format format-nongpl
 
 %generate_buildrequires
 %pyproject_buildrequires

--- a/SPECS/python-jupyter-client/python-jupyter-client.spec
+++ b/SPECS/python-jupyter-client/python-jupyter-client.spec
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname jupyter-client
+%global pypi_name jupyter_client
+
+Name:           python-%{srcname}
+Version:        8.9.1
+Release:        %autorelease
+Summary:        Jupyter protocol implementation and client libraries
+License:        BSD-3-Clause
+URL:            https://github.com/jupyter/jupyter_client
+#!RemoteAsset:  sha256:a58f730dd9e728ba16ba1d62ebccf7ffe1ebbdbce4e95cfae941b7321ae1f4fa
+Source0:        https://files.pythonhosted.org/packages/source/j/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l jupyter_client
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(jupyter-core)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(python-dateutil)
+BuildRequires:  python3dist(pyzmq)
+BuildRequires:  python3dist(tornado)
+BuildRequires:  python3dist(traitlets)
+BuildRequires:  python3dist(typing-extensions)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Jupyter Client implements the Jupyter messaging protocol and client libraries
+for communicating with kernels.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+%{_bindir}/jupyter-kernel
+%{_bindir}/jupyter-kernelspec
+%{_bindir}/jupyter-run
+
+%changelog
+%autochangelog

--- a/SPECS/python-jupyter-core/python-jupyter-core.spec
+++ b/SPECS/python-jupyter-core/python-jupyter-core.spec
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname jupyter-core
+%global pypi_name jupyter_core
+
+Name:           python-%{srcname}
+Version:        5.9.1
+Release:        %autorelease
+Summary:        Core common functionality of Jupyter projects
+License:        BSD-3-Clause
+URL:            https://github.com/jupyter/jupyter_core
+#!RemoteAsset:  sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508
+Source0:        https://files.pythonhosted.org/packages/source/j/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l jupyter_core jupyter
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(platformdirs)
+BuildRequires:  python3dist(traitlets)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Jupyter Core contains common base functionality and command-line tools shared
+by Jupyter projects.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+%{_bindir}/jupyter
+%{_bindir}/jupyter-migrate
+%{_bindir}/jupyter-troubleshoot
+
+%changelog
+%autochangelog

--- a/SPECS/python-jupyter-events/python-jupyter-events.spec
+++ b/SPECS/python-jupyter-events/python-jupyter-events.spec
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname jupyter-events
+%global pypi_name jupyter_events
+
+Name:           python-%{srcname}
+Version:        0.12.1
+Release:        %autorelease
+Summary:        Jupyter Event System library
+License:        BSD-3-Clause
+URL:            https://github.com/jupyter/jupyter_events
+#!RemoteAsset:  sha256:faff25f77218335752f35f23c5fe6e4a392a7bd99a5939ccb9b8fbf594636cf3
+Source0:        https://files.pythonhosted.org/packages/source/j/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l jupyter_events
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(click)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(jsonschema[format-nongpl])
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(python-json-logger)
+BuildRequires:  python3dist(pyyaml)
+BuildRequires:  python3dist(referencing)
+BuildRequires:  python3dist(rfc3339-validator)
+BuildRequires:  python3dist(rfc3986-validator)
+BuildRequires:  python3dist(rich)
+BuildRequires:  python3dist(traitlets)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+jupyter-events provides event schema validation, logging, and registration for
+Jupyter applications.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+%{_bindir}/jupyter-events
+
+%changelog
+%autochangelog

--- a/SPECS/python-jupyter-packaging/python-jupyter-packaging.spec
+++ b/SPECS/python-jupyter-packaging/python-jupyter-packaging.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname jupyter-packaging
+%global pypi_name jupyter_packaging
+
+Name:           python-%{srcname}
+Version:        0.12.3
+Release:        %autorelease
+Summary:        Jupyter packaging utilities
+License:        BSD-3-Clause
+URL:            https://github.com/jupyter/jupyter-packaging
+#!RemoteAsset:  sha256:9d9b2b63b97ffd67a8bc5391c32a421bc415b264a32c99e4d8d8dd31daae9cf4
+Source0:        https://files.pythonhosted.org/packages/source/j/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l jupyter_packaging
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(deprecation)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(tomlkit)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Utilities for building and distributing Jupyter extensions.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-jupyter-server-terminals/python-jupyter-server-terminals.spec
+++ b/SPECS/python-jupyter-server-terminals/python-jupyter-server-terminals.spec
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname jupyter-server-terminals
+%global pypi_name jupyter_server_terminals
+
+Name:           python-%{srcname}
+Version:        0.5.4
+Release:        %autorelease
+Summary:        Terminal support for Jupyter Server
+License:        BSD-3-Clause
+URL:            https://github.com/jupyter-server/jupyter_server_terminals
+#!RemoteAsset:  sha256:bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5
+Source0:        https://files.pythonhosted.org/packages/source/j/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l jupyter_server_terminals
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(terminado)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Jupyter Server Terminals provides a Jupyter Server extension for terminal
+sessions.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%install -a
+mv %{buildroot}%{_prefix}%{_sysconfdir} %{buildroot}%{_sysconfdir}
+
+# Skip tests: No module named 'jupyter_server' (circular dependency)
+%check
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+%{_sysconfdir}/jupyter/jupyter_server_config.d/jupyter_server_terminals.json
+
+%changelog
+%autochangelog

--- a/SPECS/python-jupyter-server/python-jupyter-server.spec
+++ b/SPECS/python-jupyter-server/python-jupyter-server.spec
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname jupyter-server
+%global pypi_name jupyter_server
+
+Name:           python-%{srcname}
+Version:        2.20.0
+Release:        %autorelease
+Summary:        Backend services and REST APIs for Jupyter applications
+License:        BSD-3-Clause
+URL:            https://github.com/jupyter-server/jupyter_server
+#!RemoteAsset:  sha256:b5778ba337d8015a3dc2b80803ecdd5ac18d3797fddf61a50ea5fb472b4ebe14
+Source0:        https://files.pythonhosted.org/packages/source/j/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l jupyter_server
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(anyio)
+BuildRequires:  python3dist(argon2-cffi)
+BuildRequires:  python3dist(hatch-jupyter-builder)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(jinja2)
+BuildRequires:  python3dist(jupyter-client)
+BuildRequires:  python3dist(jupyter-core)
+BuildRequires:  python3dist(jupyter-events)
+BuildRequires:  python3dist(jupyter-server-terminals)
+BuildRequires:  python3dist(nbconvert)
+BuildRequires:  python3dist(nbformat)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(prometheus-client)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(pyzmq)
+BuildRequires:  python3dist(send2trash)
+BuildRequires:  python3dist(terminado)
+BuildRequires:  python3dist(tornado)
+BuildRequires:  python3dist(traitlets)
+BuildRequires:  python3dist(websocket-client)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Jupyter Server provides the core services, APIs, and REST endpoints used by
+Jupyter web applications.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc CHANGELOG.md README.md
+%license LICENSE
+%{_bindir}/jupyter-server
+
+%changelog
+%autochangelog

--- a/SPECS/python-jupyterlab-pygments/2000-drop-jupyterlab-build-requirement.patch
+++ b/SPECS/python-jupyterlab-pygments/2000-drop-jupyterlab-build-requirement.patch
@@ -1,0 +1,25 @@
+From bc974b55eab190998c6ab7ab18418765e28f0c4c Mon Sep 17 00:00:00 2001
+From: jinqiang zhang <jinqiang.oerv@isrc.iscas.ac.cn>
+Date: Wed, 12 Aug 2026 18:29:42 +0800
+Subject: [PATCH] Drop jupyterlab build requirement
+
+Use the prebuilt labextension from the sdist to break the JupyterLab cycle
+---
+ pyproject.toml | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index b21c51a..23da000 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,7 +1,6 @@
+ [build-system]
+ requires = [
+     "hatchling>=1.5.0",
+-    "jupyterlab>=4.0.0,<5",
+     "hatch-nodejs-version>=0.3.2",
+ ]
+ build-backend = "hatchling.build"
+-- 
+2.54.0
+

--- a/SPECS/python-jupyterlab-pygments/python-jupyterlab-pygments.spec
+++ b/SPECS/python-jupyterlab-pygments/python-jupyterlab-pygments.spec
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname jupyterlab-pygments
+%global pypi_name jupyterlab_pygments
+
+Name:           python-%{srcname}
+Version:        0.3.0
+Release:        %autorelease
+Summary:        Pygments theme using JupyterLab CSS variables
+License:        BSD-3-Clause
+URL:            https://github.com/jupyterlab/jupyterlab_pygments
+#!RemoteAsset:  sha256:721aca4d9029252b11cfa9d185e5b5af4d54772bb8072f9b7036f4170054d35d
+Source0:        https://files.pythonhosted.org/packages/source/j/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+# Use the prebuilt labextension to break the JupyterLab dependency cycle.
+Patch2000:      2000-drop-jupyterlab-build-requirement.patch
+
+BuildOption(install):  -l jupyterlab_pygments
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(hatch-jupyter-builder)
+BuildRequires:  python3dist(hatch-nodejs-version)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pygments)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+jupyterlab-pygments provides a Pygments theme based on JupyterLab CSS
+variables for consistent notebook syntax highlighting.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+%{_datadir}/jupyter/labextensions/%{pypi_name}
+
+%changelog
+%autochangelog

--- a/SPECS/python-jupyterlab-widgets/2000-drop-jupyterlab-build-requirement.patch
+++ b/SPECS/python-jupyterlab-widgets/2000-drop-jupyterlab-build-requirement.patch
@@ -1,0 +1,26 @@
+From ae85ad9aabfc9d7b09471ac2b16c74388a69c30d Mon Sep 17 00:00:00 2001
+From: jinqiang zhang <jinqiang.oerv@isrc.iscas.ac.cn>
+Date: Wed, 12 Aug 2026 18:34:37 +0800
+Subject: [PATCH] Drop jupyterlab build requirement
+
+Use the prebuilt JupyterLab extension included in the sdist
+---
+ pyproject.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index f7aae5e9..e95936b6 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -38,7 +38,7 @@ dynamic = ["version"]
+ path = "jupyterlab_widgets/_version.py"
+ 
+ [build-system]
+-requires = ["hatchling>=1.5.0", "jupyterlab~=4.0"]
++requires = ["hatchling>=1.5.0"]
+ build-backend = "hatchling.build"
+ 
+ [tool.check-manifest]
+-- 
+2.54.0
+

--- a/SPECS/python-jupyterlab-widgets/python-jupyterlab-widgets.spec
+++ b/SPECS/python-jupyterlab-widgets/python-jupyterlab-widgets.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname jupyterlab-widgets
+%global pypi_name jupyterlab_widgets
+
+Name:           python-%{srcname}
+Version:        3.0.16
+Release:        %autorelease
+Summary:        Jupyter interactive widgets for JupyterLab
+License:        BSD-3-Clause
+URL:            https://github.com/jupyter-widgets/ipywidgets
+#!RemoteAsset:  sha256:423da05071d55cf27a9e602216d35a3a65a3e41cdf9c5d3b643b814ce38c19e0
+Source0:        https://files.pythonhosted.org/packages/source/j/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+# Use the prebuilt JupyterLab extension included in the sdist.
+Patch2000:      2000-drop-jupyterlab-build-requirement.patch
+
+BuildOption(install):  -l jupyterlab_widgets
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(hatch-jupyter-builder)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(pip)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Prebuilt JupyterLab extension for Jupyter interactive widgets.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+%{_datadir}/jupyter/labextensions/@jupyter-widgets/jupyterlab-manager/
+
+%changelog
+%autochangelog

--- a/SPECS/python-kerchunk/python-kerchunk.spec
+++ b/SPECS/python-kerchunk/python-kerchunk.spec
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname kerchunk
+
+Name:           python-%{srcname}
+Version:        0.2.10
+Release:        %autorelease
+Summary:        Functions to create references for chunked data
+License:        MIT
+URL:            https://fsspec.github.io/kerchunk/
+VCS:            git:https://github.com/fsspec/kerchunk.git
+#!RemoteAsset:  sha256:aae63c0fe4ca2e97025f026578a0577545011fe6679751392c815e0d1d6bf954
+Source0:        https://files.pythonhosted.org/packages/source/k/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l kerchunk
+# Skip tests: No module named 'tifffile' (circular dependency)
+BuildOption(check):  -e 'kerchunk.tiff'
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(astropy)
+BuildRequires:  python3dist(cfgrib)
+BuildRequires:  python3dist(fsspec)
+BuildRequires:  python3dist(h5py)
+BuildRequires:  python3dist(numcodecs)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(pandas)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(scipy)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm)
+BuildRequires:  python3dist(ujson)
+BuildRequires:  python3dist(xarray)
+BuildRequires:  python3dist(zarr)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Kerchunk creates references that expose archival and scientific data through
+fsspec-compatible virtual Zarr stores without copying the original data.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-llvmlite/python-llvmlite.spec
+++ b/SPECS/python-llvmlite/python-llvmlite.spec
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname llvmlite
+
+Name:           python-%{srcname}
+Version:        0.48.0
+Release:        %autorelease
+Summary:        Lightweight LLVM Python binding for writing JIT compilers
+License:        BSD-2-Clause AND Apache-2.0 WITH LLVM-exception
+URL:            https://github.com/numba/llvmlite
+#!RemoteAsset:  sha256:543b19f9ef8f3c7c60d1468191e4ee1b1537bf9f8a3d56f64c0ddd98de92edd2
+Source0:        https://files.pythonhosted.org/packages/source/l/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l llvmlite
+# libllvmlite.so is a ctypes-loaded shared library, not a CPython extension
+BuildOption(check):  -e llvmlite.binding.libllvmlite
+
+BuildRequires:  cmake
+BuildRequires:  llvm-devel
+BuildRequires:  llvm-static
+BuildRequires:  pkgconfig(libffi)
+BuildRequires:  pkgconfig(libxml-2.0)
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pkgconfig(zlib)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+llvmlite is a lightweight LLVM Python binding for writing JIT compilers. It
+provides a Python API for generating LLVM IR and a C API wrapper around LLVM.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%check -a
+%ifarch riscv64
+# vector.body missing on riscv64
+# https://github.com/numba/llvmlite/issues/1449
+%pytest -v llvmlite/tests \
+    --deselect llvmlite/tests/test_binding.py::TestNewModulePassManager::test_optsize_minsize
+%else
+%pytest -v llvmlite/tests
+%endif
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+%license LICENSE.thirdparty
+
+%changelog
+%autochangelog

--- a/SPECS/python-mistune/python-mistune.spec
+++ b/SPECS/python-mistune/python-mistune.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname mistune
+
+Name:           python-%{srcname}
+Version:        3.3.3
+Release:        %autorelease
+Summary:        Fast and extensible Markdown parser in Python
+License:        BSD-3-Clause
+URL:            https://github.com/lepture/mistune
+#!RemoteAsset:  sha256:c4c6c0c840b8637a2e9b8b6d607eb7c8f00888bf14c754409bcd339e848c2477
+Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l mistune
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Mistune is a fast and extensible Markdown parser with useful plugins and
+renderers.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+%{_bindir}/mistune
+
+%changelog
+%autochangelog

--- a/SPECS/python-nbclient/python-nbclient.spec
+++ b/SPECS/python-nbclient/python-nbclient.spec
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname nbclient
+
+Name:           python-%{srcname}
+Version:        0.11.0
+Release:        %autorelease
+Summary:        Client library for executing Jupyter notebooks
+License:        BSD-3-Clause
+URL:            https://github.com/jupyter/nbclient
+#!RemoteAsset:  sha256:04a134a5b087f2c5887f228aca155db50169b8cd9334dee6942c8e927e56081a
+Source0:        https://files.pythonhosted.org/packages/source/n/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l nbclient
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(jupyter-client)
+BuildRequires:  python3dist(jupyter-core)
+BuildRequires:  python3dist(nbformat)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(traitlets)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+nbclient is a client library for executing Jupyter notebooks and handling
+their kernel messages.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+%{_bindir}/jupyter-execute
+
+%changelog
+%autochangelog

--- a/SPECS/python-nbconvert/python-nbconvert.spec
+++ b/SPECS/python-nbconvert/python-nbconvert.spec
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname nbconvert
+
+Name:           python-%{srcname}
+Version:        7.17.1
+Release:        %autorelease
+Summary:        Convert Jupyter notebooks to other formats
+License:        BSD-3-Clause
+URL:            https://github.com/jupyter/nbconvert
+#!RemoteAsset:  sha256:34d0d0a7e73ce3cbab6c5aae8f4f468797280b01fd8bd2ca746da8569eddd7d2
+Source0:        https://files.pythonhosted.org/packages/source/n/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l nbconvert
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(beautifulsoup4)
+BuildRequires:  python3dist(bleach[css])
+BuildRequires:  python3dist(defusedxml)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(ipython)
+BuildRequires:  python3dist(jinja2)
+BuildRequires:  python3dist(jupyter-core)
+BuildRequires:  python3dist(jupyterlab-pygments)
+BuildRequires:  python3dist(markupsafe)
+BuildRequires:  python3dist(mistune)
+BuildRequires:  python3dist(nbclient)
+BuildRequires:  python3dist(nbformat)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pandocfilters)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pygments)
+BuildRequires:  python3dist(traitlets)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+nbconvert converts Jupyter notebooks to formats including HTML, Markdown,
+LaTeX, PDF, reStructuredText, and executable scripts.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc CHANGELOG.md README.md
+%license LICENSE
+%{_bindir}/jupyter-dejavu
+%{_bindir}/jupyter-nbconvert
+%{_datadir}/jupyter/nbconvert/templates
+
+%changelog
+%autochangelog

--- a/SPECS/python-nbformat/python-nbformat.spec
+++ b/SPECS/python-nbformat/python-nbformat.spec
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname nbformat
+
+Name:           python-%{srcname}
+Version:        5.10.4
+Release:        %autorelease
+Summary:        Jupyter Notebook format implementation
+License:        BSD-3-Clause
+URL:            https://github.com/jupyter/nbformat
+#!RemoteAsset:  sha256:322168b14f937a5d11362988ecac2a4952d3d8e3a2cbeb2319584631226d5b3a
+Source0:        https://files.pythonhosted.org/packages/source/n/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l nbformat
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(fastjsonschema)
+BuildRequires:  python3dist(hatch-nodejs-version)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(jsonschema)
+BuildRequires:  python3dist(jupyter-core)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(traitlets)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Nbformat contains the base implementation and Python APIs for the Jupyter
+Notebook file format.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%license LICENSE
+%{_bindir}/jupyter-trust
+
+%changelog
+%autochangelog

--- a/SPECS/python-numba/python-numba.spec
+++ b/SPECS/python-numba/python-numba.spec
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname numba
+
+Name:           python-%{srcname}
+Version:        0.66.0
+Release:        %autorelease
+Summary:        NumPy-aware dynamic Python compiler using LLVM
+License:        BSD-2-Clause
+URL:            https://numba.pydata.org/
+VCS:            git:https://github.com/numba/numba.git
+#!RemoteAsset:  sha256:b900e63a0e26c05ea9a6d5a3a5a0a177cb64c5011887bf43edb8c3ed2c38d363
+Source0:        https://files.pythonhosted.org/packages/source/n/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l numba
+# missing CUDA
+BuildOption(check):  -e 'numba.cuda.tests*'
+# No module named '_gdb'
+BuildOption(check):  -e 'numba.misc.gdb_print_extension'
+# No module named 'source_module'
+BuildOption(check):  -e 'numba.tests.pycc_distutils_usecase.setup_distutils'
+BuildOption(check):  -e 'numba.tests.pycc_distutils_usecase.setup_setuptools'
+# No module named 'nested'
+BuildOption(check):  -e 'numba.tests.pycc_distutils_usecase.setup_distutils_nested'
+BuildOption(check):  -e 'numba.tests.pycc_distutils_usecase.setup_setuptools_nested'
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(ipykernel)
+BuildRequires:  python3dist(llvmlite)
+BuildRequires:  python3dist(nbformat)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pygments)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Numba is an open source JIT compiler that translates a subset of Python and
+NumPy code into fast machine code using LLVM.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc CHANGE_LOG
+%doc README.rst
+%license LICENSE
+%license LICENSES.third-party
+%exclude %{python3_sitearch}/%{srcname}/tests/__pycache__/cfunc_cache_usecases.*.nbc
+%exclude %{python3_sitearch}/%{srcname}/tests/__pycache__/cfunc_cache_usecases.*.nbi
+%{_bindir}/numba
+
+%changelog
+%autochangelog

--- a/SPECS/python-numcodecs/python-numcodecs.spec
+++ b/SPECS/python-numcodecs/python-numcodecs.spec
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname numcodecs
+
+Name:           python-%{srcname}
+Version:        0.16.5
+Release:        %autorelease
+Summary:        Buffer compression and transformation codecs
+License:        MIT
+URL:            https://github.com/zarr-developers/numcodecs
+#!RemoteAsset:  sha256:0d0fb60852f84c0bd9543cc4d2ab9eefd37fc8efcc410acd4777e62a1d300318
+Source0:        https://files.pythonhosted.org/packages/source/n/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l numcodecs
+# No module named 'zarr' (circular dependency)
+BuildOption(check):  -e 'numcodecs.zarr3'
+# No module named 'zarr' (circular dependency)
+BuildOption(check):  -e 'numcodecs.tests.test_zarr3'
+# No module named 'pcodec'
+BuildOption(check):  -e 'numcodecs.pcodec'
+BuildOption(check):  -e 'numcodecs.tests.test_pcodec'
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(cython)
+BuildRequires:  python3dist(google-crc32c)
+BuildRequires:  python3dist(importlib-metadata)
+BuildRequires:  python3dist(msgpack)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(py-cpuinfo)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(pyzstd)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm[toml])
+BuildRequires:  python3dist(typing-extensions)
+BuildRequires:  python3dist(zfpy)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Numcodecs provides buffer compression and transformation codecs for use
+in data storage and communication applications.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE.txt
+
+%changelog
+%autochangelog

--- a/SPECS/python-pandocfilters/python-pandocfilters.spec
+++ b/SPECS/python-pandocfilters/python-pandocfilters.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pandocfilters
+
+Name:           python-%{srcname}
+Version:        1.5.1
+Release:        %autorelease
+Summary:        Utilities for writing Pandoc filters in Python
+License:        BSD-3-Clause
+URL:            https://github.com/jgm/pandocfilters
+#!RemoteAsset:  sha256:002b4a555ee4ebc03f8b66307e287fa492e4a77b4ea14d3f934328297bb4939e
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l pandocfilters
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+pandocfilters provides utilities for writing Pandoc filters in Python.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-pint/python-pint.spec
+++ b/SPECS/python-pint/python-pint.spec
@@ -18,11 +18,6 @@ BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}
-# skip tests: missing python-matplotlib
-BuildOption(check):  -e 'pint.matplotlib'
-BuildOption(check):  -e 'pint.testsuite.test_matplotlib'
-# skip tests: No module named 'sparse'
-BuildOption(check):  -e 'pint.testsuite.test_compat_downcast'
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
@@ -32,11 +27,13 @@ BuildRequires:  python3dist(flexcache)
 BuildRequires:  python3dist(flexparser)
 BuildRequires:  python3dist(hatch-vcs)
 BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(matplotlib)
 BuildRequires:  python3dist(numpy)
 BuildRequires:  python3dist(packaging)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(platformdirs)
 BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(sparse)
 BuildRequires:  python3dist(typing-extensions)
 BuildRequires:  python3dist(xarray)
 

--- a/SPECS/python-protobuf/python-protobuf.spec
+++ b/SPECS/python-protobuf/python-protobuf.spec
@@ -7,12 +7,12 @@
 %global srcname protobuf
 
 Name:           python-%{srcname}
-Version:        6.33.2
+Version:        6.33.6
 Release:        %autorelease
 Summary:        Python bindings for Protocol Buffers
 License:        BSD-3-Clause
 URL:            https://developers.google.com/protocol-buffers/
-#!RemoteAsset:  sha256:56dc370c91fbb8ac85bc13582c9e373569668a290aa2e66a590c2a0d35ddb9e4
+#!RemoteAsset:  sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildSystem:    pyproject
 

--- a/SPECS/python-py4j/python-py4j.spec
+++ b/SPECS/python-py4j/python-py4j.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname py4j
+
+Name:           python-%{srcname}
+Version:        0.10.9.9
+Release:        %autorelease
+Summary:        Dynamic access to Java objects from Python
+License:        BSD-3-Clause
+URL:            https://www.py4j.org/
+VCS:            git:https://github.com/bartdag/py4j.git
+#!RemoteAsset:  sha256:f694cad19efa5bd1dee4f3e5270eb406613c974394035e5bfc4ec1aba870b879
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l py4j
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Py4J enables Python programs to dynamically access Java objects in a Java
+virtual machine.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE.txt
+%{_datadir}/py4j/
+
+%changelog
+%autochangelog

--- a/SPECS/python-pyerfa/python-pyerfa.spec
+++ b/SPECS/python-pyerfa/python-pyerfa.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pyerfa
+
+Name:           python-%{srcname}
+Version:        2.0.1.5
+Release:        %autorelease
+Summary:        Python bindings for ERFA
+License:        BSD-3-Clause
+URL:            https://github.com/liberfa/pyerfa
+#!RemoteAsset:  sha256:17d6b24fe4846c65d5e7d8c362dcb08199dc63b30a236aedd73875cc83e1f6c0
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l erfa
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(jinja2)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+PyERFA provides Python bindings for the ERFA astronomy library.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc AUTHORS.rst CHANGES.rst README.rst
+%license LICENSE.rst licenses/
+
+%changelog
+%autochangelog

--- a/SPECS/python-pyspark/python-pyspark.spec
+++ b/SPECS/python-pyspark/python-pyspark.spec
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pyspark
+
+Name:           python-%{srcname}
+Version:        4.2.0
+Release:        %autorelease
+Summary:        Apache Spark Python API
+License:        Apache-2.0
+URL:            https://spark.apache.org/
+VCS:            git:https://github.com/apache/spark.git
+#!RemoteAsset:  sha256:5ad689d53570ee1674193fd4f9bda065f0db3be9363a27d2a3406cc457b70b61
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l pyspark
+# PySparkRuntimeError: [JAVA_GATEWAY_EXITED] Java gateway process exited before sending its port number.
+BuildOption(check):  -e 'pyspark.python.pyspark.shell'
+BuildOption(check):  -e 'pyspark.shell'
+
+# TODO: remove libomp after PR merged
+# https://github.com/openRuyi-Project/openRuyi/pull/970/
+# Importing pyspark.ml.torch.data fails with:
+# ImportError: libomp.so: cannot open shared object file: No such file or directory
+BuildRequires:  libomp
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(grpcio)
+BuildRequires:  python3dist(grpcio-status)
+BuildRequires:  python3dist(matplotlib)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(pandas)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(protobuf) >= 6.33.5
+BuildRequires:  python3dist(py4j)
+BuildRequires:  python3dist(pyarrow)
+BuildRequires:  python3dist(pyyaml)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(torch)
+BuildRequires:  python3dist(wheel)
+BuildRequires:  python3dist(zstandard)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Python bindings and command-line tools for Apache Spark.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE NOTICE
+%exclude %{_bindir}/*.cmd
+%exclude %{python3_sitelib}/pyspark/bin/*.cmd
+%{_bindir}/beeline
+%{_bindir}/docker-image-tool.sh
+%{_bindir}/find-spark-home
+%{_bindir}/find_spark_home.py
+%{_bindir}/load-spark-env.sh
+%{_bindir}/pyspark
+%{_bindir}/run-example
+%{_bindir}/spark-class
+%{_bindir}/spark-connect-shell
+%{_bindir}/spark-pipelines
+%{_bindir}/spark-shell
+%{_bindir}/spark-sql
+%{_bindir}/spark-submit
+%{_bindir}/sparkR
+
+%changelog
+%autochangelog

--- a/SPECS/python-pytest-remotedata/python-pytest-remotedata.spec
+++ b/SPECS/python-pytest-remotedata/python-pytest-remotedata.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pytest-remotedata
+
+Name:           python-%{srcname}
+Version:        0.4.1
+Release:        %autorelease
+Summary:        Pytest plugin for controlling remote data access
+License:        BSD-3-Clause
+URL:            https://github.com/astropy/pytest-remotedata
+#!RemoteAsset:  sha256:05c08bf638cdd1ed66eb01738a1647c3c714737c3ec3abe009d2c1f793b4bb59
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l pytest_remotedata
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+pytest-remotedata is a pytest plugin for controlling access to data hosted on
+remote servers.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc CHANGES.rst README.rst
+%license LICENSE.rst
+
+%changelog
+%autochangelog

--- a/SPECS/python-pytest-runner/2000-stop-using-pkg_resources.patch
+++ b/SPECS/python-pytest-runner/2000-stop-using-pkg_resources.patch
@@ -1,0 +1,77 @@
+From: Colin Watson <cjwatson@debian.org>
+Date: Sun, 4 Jan 2026 18:01:44 +0000
+Subject: Stop using pkg_resources
+
+The upstream project has been archived, so there's nowhere to forward
+this to.
+
+Bug-Debian: https://bugs.debian.org/1083591
+Last-Update: 2026-01-04
+---
+ ptr/__init__.py | 31 ++++++++++++++-----------------
+ 1 file changed, 14 insertions(+), 17 deletions(-)
+
+diff --git a/ptr/__init__.py b/ptr/__init__.py
+index 41192fa..cb099f4 100644
+--- a/ptr/__init__.py
++++ b/ptr/__init__.py
+@@ -8,9 +8,8 @@ import contextlib as _contextlib
+ import sys as _sys
+ import operator as _operator
+ import itertools as _itertools
+-import warnings as _warnings
+ 
+-import pkg_resources
++from packaging.markers import InvalidMarker, Marker
+ import setuptools.command.test as orig
+ from setuptools import Distribution
+ 
+@@ -121,7 +120,10 @@ class PyTest(orig.test):
+         instead of declaring the dependency in the package
+         metadata, assert the requirement at run time.
+         """
+-        pkg_resources.require('setuptools>=27.3')
++        # For Debian, do nothing.  pkg_resources is deprecated with no
++        # natural replacement for pkg_resources.require (see e.g.
++        # https://github.com/pypa/packaging-problems/issues/664), and the
++        # last several stable Debian releases have shipped setuptools>=27.3.
+ 
+     def finalize_options(self):
+         if self.addopts:
+@@ -133,11 +135,12 @@ class PyTest(orig.test):
+         Given an environment marker, return True if the marker is valid
+         and matches this environment.
+         """
+-        return (
+-            not marker
+-            or not pkg_resources.invalid_marker(marker)
+-            and pkg_resources.evaluate_marker(marker)
+-        )
++        if not marker:
++            return True
++        try:
++            return Marker(marker).evaluate()
++        except InvalidMarker:
++            return False
+ 
+     def install_dists(self, dist):
+         """
+@@ -170,15 +173,9 @@ class PyTest(orig.test):
+ 
+     @staticmethod
+     def _warn_old_setuptools():
+-        msg = (
+-            "pytest-runner will stop working on this version of setuptools; "
+-            "please upgrade to setuptools 30.4 or later or pin to "
+-            "pytest-runner < 5."
+-        )
+-        ver_str = pkg_resources.get_distribution('setuptools').version
+-        ver = pkg_resources.parse_version(ver_str)
+-        if ver < pkg_resources.parse_version('30.4'):
+-            _warnings.warn(msg)
++        # For Debian, do nothing.  The last several stable Debian releases
++        # have shipped setuptools>=30.4.
++        return
+ 
+     def run(self):
+         """

--- a/SPECS/python-pytest-runner/python-pytest-runner.spec
+++ b/SPECS/python-pytest-runner/python-pytest-runner.spec
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pytest-runner
+
+Name:           python-%{srcname}
+Version:        6.0.1
+Release:        %autorelease
+Summary:        Invoke pytest as a distutils command
+License:        MIT
+URL:            https://github.com/pytest-dev/pytest-runner
+#!RemoteAsset:  sha256:70d4739585a7008f37bf4933c013fdb327b8878a5a69fcbb3316c88882f0f49b
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+# Dead upstream, remove pkg_resources
+# https://salsa.debian.org/python-team/packages/pytest-runner/-/blob/debian/6.0.1-1/debian/patches/stop-using-pkg_resources.patch
+Patch2000:      2000-stop-using-pkg_resources.patch
+
+BuildOption(install):  -l ptr
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm[toml])
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+pytest-runner provides setuptools commands for invoking pytest with dependency
+resolution.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-pyzstd/python-pyzstd.spec
+++ b/SPECS/python-pyzstd/python-pyzstd.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname pyzstd
+
+Name:           python-%{srcname}
+Version:        0.19.1
+Release:        %autorelease
+Summary:        Python bindings to Zstandard
+License:        BSD-3-Clause
+URL:            https://github.com/Rogdham/pyzstd
+#!RemoteAsset:  sha256:36723d3c915b3981de9198d0a2c82b2f5fe3eaa36e4d8d586937830a8afc7d72
+Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l pyzstd
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(backports-zstd)
+BuildRequires:  python3dist(hatch-vcs)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(pip)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Pyzstd provides Python interfaces for Zstandard compression.
+
+%files -f %{pyproject_files}
+%doc CHANGELOG.md
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-rawpy/python-rawpy.spec
+++ b/SPECS/python-rawpy/python-rawpy.spec
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname rawpy
+
+Name:           python-%{srcname}
+Version:        0.27.0
+Release:        %autorelease
+Summary:        RAW image processing for Python, a wrapper for libraw
+License:        MIT
+URL:            https://github.com/letmaik/rawpy
+#!RemoteAsset:  sha256:45251e46c1d891a62919a4ac200a9828f825e3c59f89cea2f1daee0900ff15ec
+Source0:        https://files.pythonhosted.org/packages/source/r/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l rawpy
+# skip tests: No module named 'skimage' (circular dependency)
+BuildOption(check):  -e 'rawpy.enhance'
+
+BuildRequires:  pkgconfig(libraw)
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(cython)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+rawpy is an easy-to-use Python wrapper for the LibRaw library. It
+provides a simple interface to read and process RAW images.
+
+%prep -a
+# cmake is not python distributions
+sed -i '/"cmake",/d' pyproject.toml
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%build -p
+export RAWPY_USE_SYSTEM_LIBRAW=1
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-rfc3339-validator/python-rfc3339-validator.spec
+++ b/SPECS/python-rfc3339-validator/python-rfc3339-validator.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname rfc3339-validator
+%global pypi_name rfc3339_validator
+
+Name:           python-%{srcname}
+Version:        0.1.4
+Release:        %autorelease
+Summary:        Pure Python RFC 3339 validator
+License:        MIT
+URL:            https://github.com/naimetti/rfc3339-validator
+#!RemoteAsset:  sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b
+Source0:        https://files.pythonhosted.org/packages/source/r/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l rfc3339_validator
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(six)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+A pure Python validator for RFC 3339 date-time strings.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-rfc3986-validator/python-rfc3986-validator.spec
+++ b/SPECS/python-rfc3986-validator/python-rfc3986-validator.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname rfc3986-validator
+%global pypi_name rfc3986_validator
+
+Name:           python-%{srcname}
+Version:        0.1.1
+Release:        %autorelease
+Summary:        Pure Python RFC 3986 validator
+License:        MIT
+URL:            https://github.com/naimetti/rfc3986-validator
+#!RemoteAsset:  sha256:3d44bde7921b3b9ec3ae4e3adca370438eccebc676456449b145d533b240d055
+Source0:        https://files.pythonhosted.org/packages/source/r/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l rfc3986_validator
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pytest-runner)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+A pure Python validator for RFC 3986 URI strings.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-rfc3987-syntax/python-rfc3987-syntax.spec
+++ b/SPECS/python-rfc3987-syntax/python-rfc3987-syntax.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname rfc3987-syntax
+%global pypi_name rfc3987_syntax
+
+Name:           python-%{srcname}
+Version:        1.1.0
+Release:        %autorelease
+Summary:        RFC 3987 syntax validation helpers
+License:        MIT
+URL:            https://github.com/willynilly/rfc3987-syntax
+#!RemoteAsset:  sha256:717a62cbf33cffdd16dfa3a497d81ce48a660ea691b1ddd7be710c22f00b4a0d
+Source0:        https://files.pythonhosted.org/packages/source/r/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l rfc3987_syntax
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(lark)
+BuildRequires:  python3dist(pip)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+rfc3987-syntax provides helpers for syntactically validating RFC 3987 IRIs.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-rfc3987/python-rfc3987.spec
+++ b/SPECS/python-rfc3987/python-rfc3987.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname rfc3987
+
+Name:           python-%{srcname}
+Version:        1.3.8
+Release:        %autorelease
+Summary:        Parsing and validation of URIs and IRIs
+License:        GPL-3.0-or-later
+URL:            https://github.com/dgerber/rfc3987
+#!RemoteAsset:  sha256:d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733
+Source0:        https://files.pythonhosted.org/packages/source/r/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l rfc3987
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+rfc3987 provides parsing and validation helpers for RFC 3986 URIs and RFC
+3987 IRIs.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.txt
+
+%changelog
+%autochangelog

--- a/SPECS/python-scikit-image/2000-use-python3-for-cythoner.patch
+++ b/SPECS/python-scikit-image/2000-use-python3-for-cythoner.patch
@@ -1,0 +1,22 @@
+From 4c617fb8c9b681a584ee52970aa40865d25b21ab Mon Sep 17 00:00:00 2001
+From: jinqiang zhang <jinqiang.oerv@isrc.iscas.ac.cn>
+Date: Wed, 12 Aug 2026 18:39:33 +0800
+Subject: [PATCH] use python3 for cythoner
+
+---
+ src/skimage/_build_utils/cythoner.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/skimage/_build_utils/cythoner.py b/src/skimage/_build_utils/cythoner.py
+index 83bc34a48..117c55ee9 100755
+--- a/src/skimage/_build_utils/cythoner.py
++++ b/src/skimage/_build_utils/cythoner.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ """Scipy variant of Cython command
+ 
+ Cython, as applied to single pyx file.
+-- 
+2.54.0
+

--- a/SPECS/python-scikit-image/python-scikit-image.spec
+++ b/SPECS/python-scikit-image/python-scikit-image.spec
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname scikit-image
+%global pypi_name scikit_image
+
+Name:           python-%{srcname}
+Version:        0.26.0
+Release:        %autorelease
+Summary:        Image processing in Python
+License:        BSD-3-Clause
+URL:            https://scikit-image.org
+VCS:            git:https://github.com/scikit-image/scikit-image
+#!RemoteAsset:  sha256:f5f970ab04efad85c24714321fcc91613fcb64ef2a892a13167df2f3e59199fa
+Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+# fix python not found
+Patch2000:         2000-use-python3-for-cythoner.patch
+
+BuildOption(install):  skimage skimage2
+# Skip tests: RuntimeError: Memory error in scipy.linalg.inv
+# https://github.com/openRuyi-Project/openRuyi/issues/992
+BuildOption(check):  -e 'skimage.color.colorconv'
+BuildOption(check):  -e 'skimage.color.colorlabel'
+BuildOption(check):  -e 'skimage.color.delta_e'
+BuildOption(check):  -e 'skimage.feature.haar'
+BuildOption(check):  -e 'skimage.feature.texture'
+BuildOption(check):  -e 'skimage.io'
+BuildOption(check):  -e 'skimage.io.collection'
+BuildOption(check):  -e 'skimage.io.manage_plugins'
+BuildOption(check):  -e 'skimage.io.sift'
+BuildOption(check):  -e 'skimage.io.util'
+BuildOption(check):  -e 'skimage.segmentation.boundaries'
+BuildOption(check):  -e 'skimage.segmentation.slic_superpixels'
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(av)
+BuildRequires:  python3dist(cython)
+BuildRequires:  python3dist(imageio)
+BuildRequires:  python3dist(imageio-ffmpeg)
+BuildRequires:  python3dist(lazy-loader)
+BuildRequires:  python3dist(meson-python)
+BuildRequires:  python3dist(networkx)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(pillow)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(pythran)
+BuildRequires:  python3dist(scipy)
+BuildRequires:  python3dist(tifffile)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+scikit-image is a collection of algorithms for image processing in Python.
+It is designed to interoperate with NumPy and SciPy.
+
+%generate_buildrequires
+%pyproject_buildrequires -p
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE.txt
+
+%changelog
+%autochangelog

--- a/SPECS/python-send2trash/python-send2trash.spec
+++ b/SPECS/python-send2trash/python-send2trash.spec
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname send2trash
+%global pypi_name send2trash
+
+Name:           python-%{srcname}
+Version:        2.1.0
+Release:        %autorelease
+Summary:        Send files to the trash natively
+License:        BSD-3-Clause
+URL:            https://github.com/arsenetar/send2trash
+#!RemoteAsset:  sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459
+Source0:        https://files.pythonhosted.org/packages/source/s/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l send2trash
+# https://github.com/arsenetar/send2trash/issues/110
+BuildOption(check):  -e 'send2trash.mac'
+BuildOption(check):  -e 'send2trash.mac.legacy'
+BuildOption(check):  -e 'send2trash.mac.modern'
+BuildOption(check):  -e 'send2trash.win'
+BuildOption(check):  -e 'send2trash.win.IFileOperationProgressSink'
+BuildOption(check):  -e 'send2trash.win.legacy'
+BuildOption(check):  -e 'send2trash.win.modern'
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pygobject)
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Send2Trash sends files and directories to the platform trash directory.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+%{_bindir}/send2trash
+
+%changelog
+%autochangelog

--- a/SPECS/python-sparse/python-sparse.spec
+++ b/SPECS/python-sparse/python-sparse.spec
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname sparse
+
+Name:           python-%{srcname}
+Version:        0.19.0
+Release:        %autorelease
+Summary:        Sparse n-dimensional arrays for the PyData ecosystem
+License:        BSD-3-Clause
+URL:            https://sparse.pydata.org/
+VCS:            git:https://github.com/pydata/sparse.git
+#!RemoteAsset:  sha256:a95a52c63b45e2071df014d3f60080d36d160288131533a3b844021450677430
+Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l sparse
+# Skip test: No module named 'finch' (missing julia)
+BuildOption(check):  -e 'sparse.finch_backend*'
+# Skip test: No module named 'mlir_finch' (missing julia)
+BuildOption(check):  -e 'sparse.mlir_backend*'
+# Skip test: No module named 'dask' (circular dependency)
+BuildOption(check):  -e 'sparse.numba_backend.tests.test_dask_interop'
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(numba)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(scipy)
+BuildRequires:  python3dist(setuptools-scm)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Sparse implements sparse multidimensional arrays for the PyData ecosystem. It
+supports NumPy-like operations while storing only nonzero values.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-spectate/python-spectate.spec
+++ b/SPECS/python-spectate/python-spectate.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname spectate
+
+Name:           python-%{srcname}
+Version:        1.0.1
+Release:        %autorelease
+Summary:        Track changes to mutable data types
+License:        MIT
+URL:            https://github.com/rmorshea/spectate
+#!RemoteAsset:  sha256:49a2dde0962fcecf120cb361cc293989489078eb29ba1d8c3d342a741e898b7e
+Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l spectate
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Spectate provides observable mutable data structures.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-terminado/python-terminado.spec
+++ b/SPECS/python-terminado/python-terminado.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname terminado
+
+Name:           python-%{srcname}
+Version:        0.18.1
+Release:        %autorelease
+Summary:        Tornado websocket backend for terminals
+License:        BSD-2-Clause
+URL:            https://github.com/jupyter/terminado
+#!RemoteAsset:  sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e
+Source0:        https://files.pythonhosted.org/packages/source/t/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l terminado
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(ptyprocess)
+BuildRequires:  python3dist(tornado)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Terminado provides a Tornado websocket backend for browser-based terminal
+emulators.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-tifffile/python-tifffile.spec
+++ b/SPECS/python-tifffile/python-tifffile.spec
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname tifffile
+
+Name:           python-%{srcname}
+Version:        2026.6.1
+Release:        %autorelease
+Summary:        Read and write TIFF files
+License:        BSD-3-Clause
+URL:            https://github.com/cgohlke/tifffile
+#!RemoteAsset:  sha256:626c892c0e899d959b9438e7c0e1491dc154a7fead1f1f37a991724a50eceba9
+Source0:        https://files.pythonhosted.org/packages/source/t/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l tifffile
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(dask)
+BuildRequires:  python3dist(fsspec)
+BuildRequires:  python3dist(imagecodecs)
+BuildRequires:  python3dist(kerchunk)
+BuildRequires:  python3dist(lxml)
+BuildRequires:  python3dist(matplotlib)
+BuildRequires:  python3dist(numcodecs)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(requests)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(xarray)
+BuildRequires:  python3dist(zarr)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Tifffile is a Python library for reading and writing TIFF image files.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+%{_bindir}/lsm2bin
+%{_bindir}/tiff2fsspec
+%{_bindir}/tiffcomment
+%{_bindir}/tifffile
+
+%changelog
+%autochangelog

--- a/SPECS/python-tinycss2/python-tinycss2.spec
+++ b/SPECS/python-tinycss2/python-tinycss2.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname tinycss2
+
+Name:           python-%{srcname}
+Version:        1.5.1
+Release:        %autorelease
+Summary:        Tiny CSS parser
+License:        BSD-3-Clause
+URL:            https://github.com/Kozea/tinycss2
+#!RemoteAsset:  sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957
+Source0:        https://files.pythonhosted.org/packages/source/t/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l tinycss2
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(flit-core)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(webencodings)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Tinycss2 is a low-level CSS parser and generator written in Python.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-uri-template/python-uri-template.spec
+++ b/SPECS/python-uri-template/python-uri-template.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname uri-template
+
+Name:           python-%{srcname}
+Version:        1.3.0
+Release:        %autorelease
+Summary:        RFC 6570 URI Template processor
+License:        MIT
+URL:            https://gitlab.linss.com/open-source/python/uri-template
+#!RemoteAsset:  sha256:0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7
+Source0:        https://files.pythonhosted.org/packages/source/u/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l uri_template
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+uri-template implements expansion of RFC 6570 URI templates.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-webcolors/python-webcolors.spec
+++ b/SPECS/python-webcolors/python-webcolors.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname webcolors
+
+Name:           python-%{srcname}
+Version:        25.10.0
+Release:        %autorelease
+Summary:        Library for HTML and CSS color formats
+License:        BSD-3-Clause
+URL:            https://github.com/ubernostrum/webcolors
+#!RemoteAsset:  sha256:62abae86504f66d0f6364c2a8520de4a0c47b80c03fc3a5f1815fedbef7c19bf
+Source0:        https://files.pythonhosted.org/packages/source/w/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  webcolors
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pdm-backend)
+BuildRequires:  python3dist(pip)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+webcolors converts and normalizes color formats defined by HTML and CSS.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-widgetsnbextension/python-widgetsnbextension.spec
+++ b/SPECS/python-widgetsnbextension/python-widgetsnbextension.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname widgetsnbextension
+
+Name:           python-%{srcname}
+Version:        4.0.15
+Release:        %autorelease
+Summary:        Jupyter interactive widget extension for Notebook
+License:        BSD-3-Clause
+URL:            https://github.com/jupyter-widgets/ipywidgets
+#!RemoteAsset:  sha256:de8610639996f1567952d763a5a41af8af37f2575a41f9852a38f947eb82a3b9
+Source0:        https://files.pythonhosted.org/packages/source/w/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l widgetsnbextension
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(jupyter-packaging)
+BuildRequires:  python3dist(pip)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Classic Jupyter Notebook extension for Jupyter interactive widgets.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%install -a
+mv %{buildroot}%{_prefix}%{_sysconfdir} %{buildroot}%{_sysconfdir}
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+%{_datadir}/jupyter/nbextensions/jupyter-js-widgets/
+%{_sysconfdir}/jupyter/nbconfig/notebook.d/widgetsnbextension.json
+
+%changelog
+%autochangelog

--- a/SPECS/python-xarray/python-xarray.spec
+++ b/SPECS/python-xarray/python-xarray.spec
@@ -19,11 +19,9 @@ BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  -l %{srcname}
-# skip tests: No module named 'cupy'
+# skip test: No module named 'cupy'
 BuildOption(check):  -e 'xarray.tests.test_cupy'
-# skip tests: No module named 'sparse'
-BuildOption(check):  -e 'xarray.tests.test_sparse'
-# skip tests: circular dependency with python-pint
+# skip test: No module named 'pint' (circular dependency)
 BuildOption(check):  -e 'xarray.tests.test_units'
 
 BuildRequires:  pyproject-rpm-macros
@@ -43,6 +41,7 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(pytz)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(setuptools-scm)
+BuildRequires:  python3dist(sparse)
 
 Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}

--- a/SPECS/python-zarr/python-zarr.spec
+++ b/SPECS/python-zarr/python-zarr.spec
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname zarr
+
+Name:           python-%{srcname}
+Version:        3.2.1
+Release:        %autorelease
+Summary:        Chunked compressed N-dimensional arrays
+License:        MIT
+URL:            https://github.com/zarr-developers/zarr-python
+#!RemoteAsset:  sha256:71565b738a0e7e8ed226f0516eba8c6bb53440ad7669a8c48ebb3534a161d035
+Source0:        https://files.pythonhosted.org/packages/source/z/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l zarr
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(donfig)
+BuildRequires:  python3dist(google-crc32c)
+BuildRequires:  python3dist(hatch-vcs)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(hypothesis)
+BuildRequires:  python3dist(numcodecs)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(packaging)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pytest)
+BuildRequires:  python3dist(typing-extensions)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Zarr is an implementation of chunked, compressed, N-dimensional arrays
+for Python.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE.txt
+%{_bindir}/zarr
+
+%changelog
+%autochangelog

--- a/SPECS/python-zfpy/2000-use-system-zfp-headers.patch
+++ b/SPECS/python-zfpy/2000-use-system-zfp-headers.patch
@@ -1,0 +1,25 @@
+From 1fa1b0df438326ab3dad12243ddbc781fa2ab654 Mon Sep 17 00:00:00 2001
+From: jinqiang zhang <jinqiang.oerv@isrc.iscas.ac.cn>
+Date: Wed, 12 Aug 2026 18:42:15 +0800
+Subject: [PATCH] use system zfp headers
+
+---
+ setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 90b3786..4f89ab1 100644
+--- a/setup.py
++++ b/setup.py
+@@ -22,7 +22,7 @@ setup(
+         Extension(
+             "zfpy", 
+             sources=["python/zfpy.pyx"],
+-            include_dirs=["include", str(NumpyImport())],
++            include_dirs=[str(NumpyImport())],
+             libraries=["zfp"], 
+             library_dirs=["build/lib64", "build/lib/Release"],
+             language_level=3,
+-- 
+2.54.0
+

--- a/SPECS/python-zfpy/python-zfpy.spec
+++ b/SPECS/python-zfpy/python-zfpy.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname zfpy
+
+Name:           python-%{srcname}
+Version:        1.0.1
+Release:        %autorelease
+Summary:        Python bindings for zfp
+License:        BSD-3-Clause
+URL:            https://github.com/LLNL/zfp
+#!RemoteAsset:  sha256:75c7014bdb2ad497a08846aaadca6d13de7c154a541c42557e52ec42030ca926
+Source0:        https://files.pythonhosted.org/packages/source/z/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+# Use system zfp headers instead of the bundled copy.
+Patch2000:      2000-use-system-zfp-headers.patch
+
+BuildOption(install):  -l zfpy
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(cython)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+BuildRequires:  cmake(zfp)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Zfpy provides Python bindings for compressed numerical arrays using zfp.
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+%license NOTICE
+
+%changelog
+%autochangelog

--- a/SPECS/zfp/zfp.spec
+++ b/SPECS/zfp/zfp.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           zfp
+Version:        1.0.1
+Release:        %autorelease
+Summary:        Compressed numerical arrays library
+License:        BSD-3-Clause
+URL:            https://github.com/llnl/zfp
+#!RemoteAsset:  sha256:4984db6a55bc919831966dd17ba5e47ca7ac58668f4fd278ebd98cd2200da66f
+Source0:        %{url}/archive/refs/tags/%{version}.tar.gz
+BuildSystem:    cmake
+
+BuildRequires:  cmake
+
+%description
+Zfp is a compressed format for multidimensional floating-point and integer
+arrays.
+
+%package        devel
+Summary:        Development files for zfp
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+Headers and CMake metadata for developing applications with zfp.
+
+%files
+%license LICENSE
+%{_bindir}/zfp
+%{_libdir}/libzfp.so.*
+
+%files devel
+%{_includedir}/zfp/
+%{_includedir}/zfp.h
+%{_includedir}/zfp.hpp
+%{_libdir}/cmake/zfp/
+%{_libdir}/libzfp.so
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->


This PR adds several Python dependencies that were skipped in the previous [tmt init PR](https://github.com/openRuyi-Project/openRuyi/pull/311): python-sparse, python-ipycytoscape, python-pyspark, python-numba, and python-scikit-image.


Depends tree:
- [x] python-dask
	- [x] python-graphviz
	- [x] python-ipycytoscape
		- [x] python-ipykernel
			- [x] python-comm
			- [x] python-debugpy
			- [x] python-ipyparallel
				- [x] python-jupyter-server
					- [x] python-argon2-cffi
						- [x] python-argon2-cffi-bindings
					- [x] python-jupyter-events
						- [x] python-jsonschema+format-nongpl
							- [x] python-fqdn
							- [x] python-isoduration
							- [x] python-rfc3987-syntax
							- [x] python-uri-template
							- [x] python-webcolors
							- [x] python-rfc3987
						- [x] python-rfc3339-validator
						- [x] python-rfc3986-validator
							- [x] python-pytest-runner
					- [x] python-jupyter-server-terminals
						- [x] python-terminado
					- [x] python-nbconvert
						- [x] python-bleach
							- [x] python-tinycss2
						- [x] python-defusedxml
						- [x] python-jupyter-core
						- [x] python-jupyterlab-pygments
						- [x] python-mistune
						- [x] python-nbclient
							- [x] python-jupyter-client
						- [x] python-pandocfilters
					- [x] python-send2trash
					- [x] python-terminado
			- [x] python-jupyter-client
				- [x] python-jupyter-core
			- [x] python-jupyter-core
			- [x] python-jupyterlab-widgets
				- [x] python-hatch-jupyter-builder
			- [x] python-widgetsnbextension
				- [x] python-jupyter-packaging
					- [x] python-deprecation
		- [x] python-jupyter-packaging
		- [x] python-spectate
	- [x] python-pyspark
		- [x] python-grpcio-status
		- [x] python-protobuf
		- [x] python-py4j
	- [x] python-scikit-image
		- [x] python-imageio
			- [x] python-gdal
				- [x] gdal
					- [x] proj
			- [x] python-rawpy
		- [x] python-imageio-ffmpeg
		- [x] python-tifffile
			- [x] python-imagecodecs
				- [x] lerc
				- [x] libdeflate
				- [x] jxrlib
				- [x] python-numcodecs
					- [x] python-google-crc32c
						- [x] crc32c
							- [x] benchmark
					- [x] python-pyzstd
						- [x] python-backports-zstd
					- [x] python-zfpy
						- [x] zfp
				- [x] python-zarr
					- [x] python-donfig
			- [x] python-kerchunk
				- [x] python-astropy
					- [x] python-astropy-iers-data
					- [x] python-extension-helpers
					- [x] python-fitsio
						- [x] cfitsio
							- [x] cfortran
					- [x] python-pyerfa
					- [x] python-pytest-remotedata
				- [x] python-cfgrib
					- [x] python-eccodes
						- [x] eccodes
							- [x] ecbuild
						- [x] python-findlibs
			- [x] python-numcodecs
			- [x] python-zarr
	- [x] python-sparse
		- [x] python-numba
			- [x] python-llvmlite
			- [x] python-nbformat
- [x] python-distributed
	- [x] python-numba
	- [x] python-sparse
- [x] python-pint
	- [x] python-sparse
- [x] python-xarray
	- [x] python-sparse


## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: gpt-5.6-sol in codex

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
