### PR TITLE
SPECS: add python-kernels and its dependency suite

### DIFF
--- a/SPECS/python-email-validator/python-email-validator.spec
+++ b/SPECS/python-email-validator/python-email-validator.spec
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname email-validator
+%global pypi_name email_validator
+
+Name:           python-%{srcname}
+Version:        2.3.0
+Release:        %autorelease
+Summary:        Robust email address syntax and deliverability validation library
+License:        Unlicense
+URL:            https://github.com/JoshData/python-email-validator
+VCS:            git:https://github.com/JoshData/python-email-validator.git
+#!RemoteAsset:  sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426
+Source0:        https://files.pythonhosted.org/packages/source/e/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{pypi_name}
+BuildOption(check):  %{pypi_name}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(dnspython) >= 2
+BuildRequires:  python3dist(idna) >= 2
+BuildRequires:  python3dist(setuptools)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+email-validator validates email address syntax and optionally checks domain
+deliverability using DNS. It supports internationalized domain names and
+normalized address output.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+%{_bindir}/email_validator
+
+%changelog
+%autochangelog

--- a/SPECS/python-hatchling/python-hatchling.spec
+++ b/SPECS/python-hatchling/python-hatchling.spec
@@ -8,6 +8,7 @@
 %global srcname hatchling
 
 Name:           python-%{srcname}
+# Before upgrading, check whether python-securesystemslib still requires this Hatchling version.
 Version:        1.29.0
 Release:        %autorelease
 Summary:        The build backend used by Hatch

--- a/SPECS/python-huggingface-hub/python-huggingface-hub.spec
+++ b/SPECS/python-huggingface-hub/python-huggingface-hub.spec
@@ -7,13 +7,13 @@
 %global srcname huggingface_hub
 
 Name:           python-huggingface-hub
-Version:        1.5.0
+Version:        1.10.0
 Release:        %autorelease
 Summary:        Client library for the Hugging Face Hub
 License:        Apache-2.0
 URL:            https://pypi.org/project/huggingface-hub/
 VCS:            git:https://github.com/huggingface/huggingface_hub
-#!RemoteAsset:  sha256:f281838db29265880fb543de7a23b0f81d3504675de82044307ea3c6c62f799d
+#!RemoteAsset:  sha256:f803c3aae2dc98515a4341a0ce310b4e6b96ac557bb4b5fb4a77bcf525026d5b
 Source0:        https://files.pythonhosted.org/packages/source/h/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject

--- a/SPECS/python-id/python-id.spec
+++ b/SPECS/python-id/python-id.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname id
+
+Name:           python-%{srcname}
+Version:        1.6.1
+Release:        %autorelease
+Summary:        Tool for generating OIDC identities
+License:        Apache-2.0
+URL:            https://github.com/di/id
+VCS:            git:https://github.com/di/id.git
+#!RemoteAsset:  sha256:d0732d624fb46fd4e7bc4e5152f00214450953b9e772c182c1c22964def1a069
+Source0:        https://files.pythonhosted.org/packages/source/i/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+BuildOption(check):  %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(flit-core)
+BuildRequires:  python3dist(urllib3) >= 2
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+id provides a small client for requesting OpenID Connect identity tokens from
+supported continuous integration and workload identity environments.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-kernels-data/Cargo.toml
+++ b/SPECS/python-kernels-data/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["kernels-data", "kernels-data/bindings/python"]
+resolver = "2"

--- a/SPECS/python-kernels-data/python-kernels-data.spec
+++ b/SPECS/python-kernels-data/python-kernels-data.spec
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname kernels-data
+%global pypi_name kernels_data
+
+Name:           python-%{srcname}
+Version:        0.16.0
+Release:        %autorelease
+Summary:        Data structures for Hugging Face compute kernels
+License:        Apache-2.0
+URL:            https://github.com/huggingface/kernels
+VCS:            git:https://github.com/huggingface/kernels.git
+#!RemoteAsset:  sha256:a4dae006305a572122ae8550a224b678d747ffaba431dff8a3f21817271e7148
+Source0:        https://files.pythonhosted.org/packages/source/k/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{pypi_name} -L
+BuildOption(check):  %{pypi_name}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(maturin) >= 1
+BuildRequires:  python3dist(maturin) < 2
+BuildRequires:  python3dist(pip)
+BuildRequires:  rust >= 1.85
+BuildRequires:  rust-rpm-macros
+BuildRequires:  crate(base64-0.22/default) >= 0.22.0
+BuildRequires:  crate(digest-0.11/default) >= 0.11.0
+BuildRequires:  crate(eyre-0.6/default) >= 0.6.12
+BuildRequires:  crate(itertools-0.13/default) >= 0.13.0
+BuildRequires:  crate(pyo3-0.26/abi3) >= 0.26.0
+BuildRequires:  crate(pyo3-0.26/abi3-py38) >= 0.26.0
+BuildRequires:  crate(pyo3-0.26/default) >= 0.26.0
+BuildRequires:  crate(regex-1/default) >= 1.0.0
+BuildRequires:  crate(serde-1/default) >= 1.0.0
+BuildRequires:  crate(serde-1/derive) >= 1.0.0
+BuildRequires:  crate(serde-json-1/default) >= 1.0.0
+BuildRequires:  crate(serde-value-0.7/default) >= 0.7.0
+BuildRequires:  crate(sha2-0.11/default) >= 0.11.0
+BuildRequires:  crate(tempfile-3/default) >= 3.0.0
+BuildRequires:  crate(thiserror-1/default) >= 1.0.0
+BuildRequires:  crate(url-2/default) >= 2.0.0
+BuildRequires:  crate(url-2/serde) >= 2.0.0
+BuildRequires:  crate(walkdir-2/default) >= 2.0.0
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Rust-backed Python data structures used to describe and validate Hugging Face
+compute kernel metadata.
+
+%prep -a
+%rust_setup_registry
+rm -f Cargo.lock
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+
+%changelog
+%autochangelog

--- a/SPECS/python-kernels/python-kernels.spec
+++ b/SPECS/python-kernels/python-kernels.spec
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname kernels
+
+Name:           python-%{srcname}
+Version:        0.16.0
+Release:        %autorelease
+Summary:        Download and load compute kernels
+License:        Apache-2.0
+URL:            https://github.com/huggingface/kernels
+VCS:            git:https://github.com/huggingface/kernels.git
+#!RemoteAsset:  sha256:5a4118396b9866209e767973d697d3f2ee76f6ed1b2f72269b72f8cd4dc90a7f
+Source0:        https://files.pythonhosted.org/packages/source/k/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname} -L
+BuildOption(check):  %{srcname}
+
+BuildRequires:  libomp-devel
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(huggingface-hub) >= 1.10
+BuildRequires:  python3dist(kernels-data) >= 0.14.0~dev1
+BuildRequires:  python3dist(packaging) >= 20
+BuildRequires:  python3dist(pyyaml) >= 6
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(sigstore) >= 4
+BuildRequires:  python3dist(sigstore) < 5
+BuildRequires:  python3dist(tomlkit) >= 0.13.3
+BuildRequires:  python3dist(torch)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+Requires:       libomp
+Requires:       python3dist(torch)
+
+%description
+Kernels downloads, verifies, and loads prebuilt compute kernels from the
+Hugging Face Hub.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%{_bindir}/kernels
+
+%changelog
+%autochangelog

--- a/SPECS/python-rfc3161-client/Cargo.toml
+++ b/SPECS/python-rfc3161-client/Cargo.toml
@@ -1,0 +1,21 @@
+[workspace]
+resolver = "2"
+exclude = ["cryptography-47.0.0"]
+
+members = [
+    "rust/",
+    "rust/tsp-asn1",
+]
+
+[workspace.dependencies]
+asn1 = "0.24.1"
+cryptography-x509 = { path = "cryptography-47.0.0/src/rust/cryptography-x509" }
+hex = "0.4"
+
+[workspace.package]
+version = "0.0.1"
+edition = "2021"
+authors = [
+    "Trail of Bits <opensource@trailofbits.com>"
+]
+publish = false

--- a/SPECS/python-rfc3161-client/python-rfc3161-client.spec
+++ b/SPECS/python-rfc3161-client/python-rfc3161-client.spec
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname rfc3161-client
+%global pypi_name rfc3161_client
+# Upstream Cargo.toml pins the cryptography-x509 Git dependency to this tag.
+%global cryptography_version 47.0.0
+
+Name:           python-%{srcname}
+Version:        1.0.7
+Release:        %autorelease
+Summary:        Python client for RFC 3161 timestamping services
+License:        Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause)
+URL:            https://github.com/trailofbits/rfc3161-client
+VCS:            git:https://github.com/trailofbits/rfc3161-client.git
+#!RemoteAsset:  sha256:8c02330b8b09cbf88f2f5f1ecdb6e6b76c0c9bd7c4199a5068ab43b95d7ab8e5
+Source0:        https://files.pythonhosted.org/packages/source/r/%{srcname}/%{pypi_name}-%{version}.tar.gz
+#!RemoteAsset:  sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb
+Source1:        https://files.pythonhosted.org/packages/source/c/cryptography/cryptography-%{cryptography_version}.tar.gz
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{pypi_name}
+BuildOption(check):  %{pypi_name}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(openssl)
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(cryptography) >= 43
+BuildRequires:  python3dist(maturin) >= 1.7
+BuildRequires:  python3dist(maturin) < 2
+BuildRequires:  python3dist(pip)
+BuildRequires:  rust
+BuildRequires:  rust-rpm-macros
+BuildRequires:  crate(asn1-0.24/default) >= 0.24.1
+BuildRequires:  crate(hex-0.4/default) >= 0.4.0
+BuildRequires:  crate(openssl-0.10/default) >= 0.10.80
+BuildRequires:  crate(pyo3-0.29/abi3) >= 0.29.0
+BuildRequires:  crate(pyo3-0.29/default) >= 0.29.0
+BuildRequires:  crate(pyo3-0.29/extension-module) >= 0.29.0
+BuildRequires:  crate(pyo3-build-config-0.29/default) >= 0.29.0
+BuildRequires:  crate(pyo3-build-config-0.29/resolve-config) >= 0.29.0
+BuildRequires:  crate(rand-0.10/default) >= 0.10.0
+BuildRequires:  crate(self-cell-1/default) >= 1.0.0
+BuildRequires:  crate(sha2-0.11/default) >= 0.11.0
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3-%{srcname}%{?_isa} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+rfc3161-client provides a Python API for requesting and verifying RFC 3161
+cryptographic timestamps.
+
+%prep -a
+%rust_setup_registry
+tar -xf %{SOURCE1}
+rm -f Cargo.lock cryptography-%{cryptography_version}/Cargo.lock
+# Build the pinned cryptography-x509 crate from an auditable source archive.
+sed -i 's|cryptography-x509 = { git = "https://github.com/pyca/cryptography.git", tag = "47.0.0" }|cryptography-x509 = { path = "cryptography-%{cryptography_version}/src/rust/cryptography-x509" }|' Cargo.toml
+# Keep the extracted crate attached to its own workspace metadata.
+sed -i '/^resolver = "2"$/a exclude = ["cryptography-%{cryptography_version}"]' Cargo.toml
+# Link to the distribution OpenSSL instead of compiling a vendored copy.
+sed -i 's/openssl = { version = "0.10.80", features = \["vendored"\] }/openssl = "0.10.80"/' rust/Cargo.toml
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc CHANGELOG.md README.md
+%license LICENSE
+%license cryptography-%{cryptography_version}/LICENSE
+%license cryptography-%{cryptography_version}/LICENSE.APACHE
+%license cryptography-%{cryptography_version}/LICENSE.BSD
+
+%changelog
+%autochangelog

--- a/SPECS/python-rfc8785/python-rfc8785.spec
+++ b/SPECS/python-rfc8785/python-rfc8785.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname rfc8785
+
+Name:           python-%{srcname}
+Version:        0.1.4
+Release:        %autorelease
+Summary:        Pure Python implementation of RFC 8785 JSON canonicalization
+License:        Apache-2.0
+URL:            https://github.com/trailofbits/rfc8785.py
+VCS:            git:https://github.com/trailofbits/rfc8785.py.git
+#!RemoteAsset:  sha256:e545841329fe0eee4f6a3b44e7034343100c12b4ec566dc06ca9735681deb4da
+Source0:        https://files.pythonhosted.org/packages/source/r/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+BuildOption(check):  %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(flit-core)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+rfc8785 implements the JSON Canonicalization Scheme described by RFC 8785,
+producing deterministic JSON encodings suitable for hashing and signing.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-securesystemslib/python-securesystemslib.spec
+++ b/SPECS/python-securesystemslib/python-securesystemslib.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname securesystemslib
+
+Name:           python-%{srcname}
+Version:        1.4.0
+Release:        %autorelease
+Summary:        Cryptographic and general-purpose routines for secure systems
+License:        MIT
+URL:            https://github.com/secure-systems-lab/securesystemslib
+VCS:            git:https://github.com/secure-systems-lab/securesystemslib.git
+#!RemoteAsset:  sha256:faea87be0f9c4b4277a5fa1b54bf9bfd807be9a94ab11be6c557dc8b75c43285
+Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+BuildOption(check):  %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+# Upstream pyproject.toml pins build-system.requires to hatchling==1.29.0.
+BuildRequires:  python3dist(hatchling) = 1.29
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+securesystemslib provides cryptographic key, signature, and canonical JSON
+helpers shared by The Update Framework and other secure software systems.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc CHANGELOG.md README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-sigstore-models/python-sigstore-models.spec
+++ b/SPECS/python-sigstore-models/python-sigstore-models.spec
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname sigstore-models
+%global pypi_name sigstore_models
+
+Name:           python-%{srcname}
+Version:        0.0.6
+Release:        %autorelease
+Summary:        Pydantic models for Sigstore protobuf specifications
+License:        MIT
+URL:            https://github.com/astral-sh/sigstore-models
+VCS:            git:https://github.com/astral-sh/sigstore-models.git
+#!RemoteAsset:  sha256:c766c09470c2a7e8a4a333c893f07e2001c56a3ff1757b1a246119f53169a849
+Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{pypi_name}
+BuildOption(check):  %{pypi_name}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(pydantic) >= 2.12
+BuildRequires:  python3dist(typing-extensions) >= 4.14.1
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Python models for Sigstore's protobuf specifications, implemented with
+Pydantic.
+
+%prep -a
+# Use the packaged pure-Python backend because uv_build is not packaged.
+sed -i 's/uv_build>=0.9.0,<0.10/hatchling/' pyproject.toml
+sed -i 's/uv_build/hatchling.build/' pyproject.toml
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-sigstore-rekor-types/python-sigstore-rekor-types.spec
+++ b/SPECS/python-sigstore-rekor-types/python-sigstore-rekor-types.spec
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname sigstore-rekor-types
+%global pypi_name sigstore_rekor_types
+
+Name:           python-%{srcname}
+Version:        0.0.18
+Release:        %autorelease
+Summary:        Python models for Rekor API types
+License:        Apache-2.0
+URL:            https://github.com/trailofbits/sigstore-rekor-types
+VCS:            git:https://github.com/trailofbits/sigstore-rekor-types.git
+#!RemoteAsset:  sha256:19aef25433218ebf9975a1e8b523cc84aaf3cd395ad39a30523b083ea7917ec5
+Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l rekor_types
+BuildOption(check):  rekor_types
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(email-validator) >= 2
+BuildRequires:  python3dist(pydantic) >= 2
+BuildRequires:  python3dist(pydantic) < 3
+BuildRequires:  python3dist(setuptools) >= 75
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Python models generated from the API types used by Sigstore's Rekor
+transparency log.
+
+%prep -a
+# Expand the pydantic email extra because it has no RPM virtual provide.
+sed -i 's/pydantic\[email\]/pydantic/' pyproject.toml
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-sigstore/python-sigstore.spec
+++ b/SPECS/python-sigstore/python-sigstore.spec
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname sigstore
+
+Name:           python-%{srcname}
+Version:        4.4.0
+Release:        %autorelease
+Summary:        Python tool for signing and verifying artifacts with Sigstore
+License:        Apache-2.0
+URL:            https://github.com/sigstore/sigstore-python
+VCS:            git:https://github.com/sigstore/sigstore-python.git
+#!RemoteAsset:  sha256:20ffe791c1fa33ce62148c0291b46280d29c1910964d9afac419e9b1a8afc56b
+Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+BuildOption(check):  %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(cryptography) >= 42
+BuildRequires:  python3dist(flit-core) >= 3.2
+BuildRequires:  python3dist(flit-core) < 4
+BuildRequires:  python3dist(id) >= 1.1
+BuildRequires:  python3dist(platformdirs) >= 4.2
+BuildRequires:  python3dist(platformdirs) < 5
+BuildRequires:  python3dist(pyasn1) >= 0.6
+BuildRequires:  python3dist(pyasn1) < 0.7
+BuildRequires:  python3dist(pydantic) >= 2
+BuildRequires:  python3dist(pydantic) < 3
+BuildRequires:  python3dist(pyjwt) >= 2.1
+BuildRequires:  python3dist(pyopenssl) >= 23
+BuildRequires:  python3dist(requests)
+BuildRequires:  python3dist(rfc3161-client) >= 1.0.3
+BuildRequires:  python3dist(rfc3161-client) < 1.1
+BuildRequires:  python3dist(rfc8785) >= 0.1.2
+BuildRequires:  python3dist(rfc8785) < 0.2
+BuildRequires:  python3dist(rich) >= 13
+BuildRequires:  python3dist(rich) < 16
+BuildRequires:  python3dist(sigstore-models) = 0.0.6
+BuildRequires:  python3dist(sigstore-rekor-types) = 0.0.18
+BuildRequires:  python3dist(tuf) >= 6
+BuildRequires:  python3dist(tuf) < 8
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Sigstore provides keyless signing and verification of software artifacts with
+identity-based certificates and transparency logs.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+%{_bindir}/sigstore
+
+%changelog
+%autochangelog

--- a/SPECS/python-tuf/python-tuf.spec
+++ b/SPECS/python-tuf/python-tuf.spec
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname tuf
+
+Name:           python-%{srcname}
+Version:        7.0.0
+Release:        %autorelease
+Summary:        Secure updater framework for Python
+License:        Apache-2.0 OR MIT
+URL:            https://www.updateframework.com
+VCS:            git:https://github.com/theupdateframework/python-tuf.git
+#!RemoteAsset:  sha256:9d2e6723538e0d5a3e482b6de805fcfe64481448d5853039ba6b06ba541efd7f
+Source0:        https://files.pythonhosted.org/packages/source/t/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname}
+BuildOption(check):  %{srcname}
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(hatchling) = 1.29
+BuildRequires:  python3dist(requests)
+BuildRequires:  python3dist(securesystemslib) >= 1
+BuildRequires:  python3dist(urllib3) < 3
+BuildRequires:  python3dist(urllib3) >= 1.21.1
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+Requires:       python3dist(requests)
+
+%description
+The Update Framework secures software update systems against repository and
+signing-key compromise. This package provides its Python metadata, repository,
+and client implementations.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE LICENSE-MIT
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

Add `python-kernels` 0.16.0 and the complete dependency suite required to build and use it in openRuyi.

`kernels` is Hugging Face's runtime layer for downloading, verifying, and loading optimized compute kernels. Packaging it is necessary to support AI workloads that consume prebuilt kernels through the Hugging Face ecosystem, including PyTorch-based applications.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves [Gitea#3375](https://git.openruyi.cn/openRuyi/openruyi-repo/issues/3375)

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.


[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
