### PR TITLE
SPECS: glibc: Remove lib64/lp64d path

### DIFF
--- a/SPECS/glibc/glibc.spec
+++ b/SPECS/glibc/glibc.spec
@@ -226,6 +226,9 @@ cd build-%{_target_cpu}
     --disable-build-nscd \
     --disable-nscd \
 %endif
+    libdir=%{_libdir} \
+    slibdir=%{_libdir} \
+    complocaledir=%{_prefix}/lib/locale \
     --disable-crypt || \
   {
     rc=$?;
@@ -235,7 +238,7 @@ cd build-%{_target_cpu}
     exit $rc;
   }
 
-%make_build
+%make_build libdir=%{_libdir} slibdir=%{_libdir} complocaledir=%{_prefix}/lib/locale
 cd ..
 
 %check
@@ -269,16 +272,16 @@ ln -s %{buildroot}%{_sbindir} %{buildroot}/sbin
 ln -s bin %{buildroot}/%{_prefix}/sbin
 %endif
 
-%ifarch riscv64
 mkdir -p %{buildroot}%{_libdir}
-ln -s . %{buildroot}%{_libdir}/lp64d
-%endif
+mkdir -p %{buildroot}%{_prefix}/lib
+mkdir -p %{buildroot}%{_prefix}/lib/locale
 
 # Install base glibc
-%make_install install_root=%{buildroot} -C build-%{_target_cpu}
-cd build-%{_target_cpu}
-make %{?_smp_mflags} %{?make_output_sync} install_root=%{buildroot} localedata/install-locale-files
-cd ..
+%make_install libdir=%{_libdir} slibdir=%{_libdir} install_root=%{buildroot} \
+              complocaledir=%{_prefix}/lib/locale -C build-%{_target_cpu}
+make %{?_smp_mflags} %{?make_output_sync} install_root=%{buildroot} \
+     complocaledir=%{_prefix}/lib/locale \
+     -C build-%{_target_cpu} localedata/install-locale-files
 
 %find_lang libc --generate-subpackages
 
@@ -297,9 +300,10 @@ cat > %{buildroot}/etc/ld.so.conf <<EOF
 %endif
 /usr/local/lib
 include /etc/ld.so.conf.d/*.conf
-# /lib64, /lib, /usr/lib64 and /usr/lib gets added
-# automatically by ldconfig after parsing this file.
-# So, they do not need to be listed.
+%if "%{_lib}" != "lib"
+/usr/%{_lib}
+%endif
+/usr/lib
 EOF
 # Add ldconfig cache directory for directory ownership
 mkdir -p %{buildroot}/var/cache/ldconfig
@@ -406,9 +410,6 @@ rpm.spawn({"%{_sbindir}/ldconfig"})
 %attr(755,root,root) %{rtlddir}/%{rtld_name}
 %if 0%{?rtld_oldname:1}
 %attr(755,root,root) %{rtlddir}/%{rtld_oldname}
-%endif
-%ifarch riscv64
-%{_libdir}/lp64d
 %endif
 %{_libdir}/libBrokenLocale.so.1
 %{_libdir}/libanl.so.1


### PR DESCRIPTION
## Summary

This change make ldd find library from /usr/lib64/
``` diff
-libc.so.6 => /lib64/lp64d/libc.so.6 (0x00007f54a48f6000)
+libc.so.6 => /usr/lib64/libc.so.6 (0x00007f3a3d9c0000)
```

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy

<!-- Message of single commit: -->