### PR TITLE
SPECS: python-pyside6: add llvm22-static BR, drop redundant cmake path sed

### DIFF
--- a/SPECS/python-pyside6/python-pyside6.spec
+++ b/SPECS/python-pyside6/python-pyside6.spec
@@ -40,6 +40,7 @@ BuildRequires:  ninja
 BuildRequires:  gcc
 BuildRequires:  gcc-c++
 BuildRequires:  clang-devel
+BuildRequires:  llvm22-static
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(numpy)
 BuildRequires:  python3dist(setuptools)
@@ -185,12 +186,6 @@ mkdir -p %{buildroot}%{python3_sitelib}/%{camel_name}/scripts
 mv %{buildroot}%{_bindir}/{android_deploy.py,deploy_lib,deploy.py,metaobjectdump.py,project_lib,project.py,pyside_tool.py,qml.py,qtpy2cpp_lib,qtpy2cpp.py,requirements-android.txt} %{buildroot}%{python3_sitelib}/%{camel_name}/scripts
 mkdir -p %{buildroot}%{python3_sitelib}/shiboken6_generator/scripts
 mv %{buildroot}%{_bindir}/shiboken_tool.py %{buildroot}%{python3_sitelib}/shiboken6_generator/scripts
-
-# Fix CMake config files to use correct absolute paths (OpenSUSE solution)
-# The upstream build is designed for wheel installation with relative paths,
-# but for system installation we need absolute paths
-sed -i 's#/typesystems#/share/PySide6/typesystems#g' %{buildroot}%{_libdir}/cmake/PySide6/*.cmake
-sed -i 's#/glue#/share/PySide6/glue#g' %{buildroot}%{_libdir}/cmake/PySide6/*.cmake
 
 # Fix all Python shebangs recursively
 # -p preserves timestamps


### PR DESCRIPTION
## Summary

- Add llvm22-static to BuildRequires
- Remove sed commands that incorrectly duplicated share/PySide6/ in
  PYSIDE_TYPESYSTEMS and PYSIDE_GLUE cmake config paths.

  - Before (incorrect):
      ```
      # grep -rn typesystem /usr/lib64/cmake/PySide6/*.cmake
      /usr/lib64/cmake/PySide6/PySide6Config.cpython-313-riscv64-linux-gnu.cmake:53:set_and_check(PYSIDE_TYPESYSTEMS "${PACKAGE_PREFIX_DIR}/share/PySide6/share/PySide6/typesystems")
      # grep -rn glue /usr/lib64/cmake/PySide6/*.cmake
      /usr/lib64/cmake/PySide6/PySide6Config.cpython-313-riscv64-linux-gnu.cmake:3:#  PYSIDE_GLUE          - Path to module glue files.
      /usr/lib64/cmake/PySide6/PySide6Config.cpython-313-riscv64-linux-gnu.cmake:54:set_and_check(PYSIDE_GLUE "${PACKAGE_PREFIX_DIR}/share/PySide6/share/PySide6/glue")
      ```
  - After (fixed):
      ```
      # grep -rn typesystem /usr/lib64/cmake/PySide6/*.cmake
      ./usr/lib64/cmake/PySide6/PySide6Config.cpython-313-x86_64-linux-gnu.cmake:53:set_and_check(PYSIDE_TYPESYSTEMS "${PACKAGE_PREFIX_DIR}/share/PySide6/typesystems")
      # grep -rn glue /usr/lib64/cmake/PySide6/*.cmake
      ./usr/lib64/cmake/PySide6/PySide6Config.cpython-313-x86_64-linux-gnu.cmake:3:#  PYSIDE_GLUE          - Path to module glue files.
      ./usr/lib64/cmake/PySide6/PySide6Config.cpython-313-x86_64-linux-gnu.cmake:54:set_and_check(PYSIDE_GLUE "${PACKAGE_PREFIX_DIR}/share/PySide6/glue")
      ```
 


## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
