### PR TITLE
[openruyi k8s]: add calico

### DIFF
--- a/SPECS/calico/README.openruyi
+++ b/SPECS/calico/README.openruyi
@@ -1,0 +1,19 @@
+This package installs Calico v3.32.0 Kubernetes manifests validated on the
+openRuyi RISC-V multi-node Kata Containers and Cloud Hypervisor environment.
+
+The manifests use VXLAN mode and select the node IP from eth1. This matches the
+validated QEMU layout where eth0 is the per-VM user-network interface and eth1
+is the multi-node bridge interface.
+
+Before applying the manifest, import or provide the Calico image as:
+
+  localhost/kubernetes/calico:v3.32.0-riscv64
+
+Apply the manifests in order:
+
+  kubectl apply -f /usr/share/kubernetes/calico/calico-v3.32.0-crds.yaml
+  kubectl apply -f /usr/share/kubernetes/calico/calico-v3.32.0-openruyi-riscv64.yaml
+
+This RPM does not embed the local OCI image tarball. The current validated
+image asset is large and was produced for the RISC-V offline deployment flow;
+it should be provided by an image repository or a separate image-asset package.

--- a/SPECS/calico/calico-v3.32.0-crds.yaml.in
+++ b/SPECS/calico/calico-v3.32.0-crds.yaml.in
@@ -1,0 +1,6832 @@
+# CustomResourceDefinitions for Calico the Hard Way
+---
+# Source: crds/crd.projectcalico.org_bgpconfigurations.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: bgpconfigurations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BGPConfiguration
+    listKind: BGPConfigurationList
+    plural: bgpconfigurations
+    singular: bgpconfiguration
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                asNumber:
+                  format: int32
+                  type: integer
+                bindMode:
+                  enum:
+                    - None
+                    - NodeIP
+                  type: string
+                communities:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        pattern: ^(\d+):(\d+)$|^(\d+):(\d+):(\d+)$
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                  x-kubernetes-list-type: set
+                ignoredInterfaces:
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                ipv4NormalRoutePriority:
+                  maximum: 2147483646
+                  minimum: 1
+                  type: integer
+                ipv6NormalRoutePriority:
+                  maximum: 2147483646
+                  minimum: 1
+                  type: integer
+                listenPort:
+                  maximum: 65535
+                  minimum: 1
+                  type: integer
+                localWorkloadPeeringIPV4:
+                  type: string
+                localWorkloadPeeringIPV6:
+                  type: string
+                logSeverityScreen:
+                  default: Info
+                  pattern: ^(?i)(Trace|Debug|Info|Warning|Error|Fatal)?$
+                  type: string
+                nodeMeshMaxRestartTime:
+                  type: string
+                nodeMeshPassword:
+                  properties:
+                    secretKeyRef:
+                      properties:
+                        key:
+                          type: string
+                        name:
+                          default: ""
+                          type: string
+                        optional:
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                nodeToNodeMeshEnabled:
+                  type: boolean
+                prefixAdvertisements:
+                  items:
+                    properties:
+                      cidr:
+                        format: cidr
+                        type: string
+                      communities:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                  x-kubernetes-list-type: set
+                programClusterRoutes:
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                serviceClusterIPs:
+                  items:
+                    properties:
+                      cidr:
+                        format: cidr
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                  x-kubernetes-list-type: set
+                serviceExternalIPs:
+                  items:
+                    properties:
+                      cidr:
+                        format: cidr
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                  x-kubernetes-list-type: set
+                serviceLoadBalancerAggregation:
+                  default: Enabled
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                serviceLoadBalancerIPs:
+                  items:
+                    properties:
+                      cidr:
+                        format: cidr
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                  x-kubernetes-list-type: set
+              type: object
+              x-kubernetes-validations:
+                - message:
+                    nodeMeshPassword cannot be set when nodeToNodeMeshEnabled is
+                    false
+                  reason: FieldValueForbidden
+                  rule:
+                    "!has(self.nodeMeshPassword) || !has(self.nodeToNodeMeshEnabled)
+                    || self.nodeToNodeMeshEnabled == true"
+                - message:
+                    nodeMeshMaxRestartTime cannot be set when nodeToNodeMeshEnabled
+                    is false
+                  reason: FieldValueForbidden
+                  rule:
+                    "!has(self.nodeMeshMaxRestartTime) || !has(self.nodeToNodeMeshEnabled)
+                    || self.nodeToNodeMeshEnabled == true"
+          type: object
+      served: true
+      storage: true
+---
+# Source: crds/crd.projectcalico.org_bgpfilters.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: bgpfilters.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BGPFilter
+    listKind: BGPFilterList
+    plural: bgpfilters
+    singular: bgpfilter
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                exportV4:
+                  items:
+                    properties:
+                      action:
+                        enum:
+                          - Accept
+                          - Reject
+                        type: string
+                      asPathPrefix:
+                        items:
+                          format: int32
+                          type: integer
+                        type: array
+                      cidr:
+                        format: cidr
+                        maxLength: 18
+                        type: string
+                      communities:
+                        properties:
+                          values:
+                            items:
+                              maxLength: 32
+                              pattern: ^(([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]):([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])|([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]))$
+                              type: string
+                            maxItems: 1
+                            minItems: 1
+                            type: array
+                        required:
+                          - values
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      interface:
+                        type: string
+                      matchOperator:
+                        enum:
+                          - Equal
+                          - NotEqual
+                          - In
+                          - NotIn
+                        type: string
+                      operations:
+                        items:
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            addCommunity:
+                              properties:
+                                value:
+                                  maxLength: 32
+                                  pattern: ^(([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]):([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])|([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]))$
+                                  type: string
+                              required:
+                                - value
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prependASPath:
+                              properties:
+                                prefix:
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  maxItems: 10
+                                  minItems: 1
+                                  type: array
+                              required:
+                                - prefix
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            setPriority:
+                              properties:
+                                value:
+                                  maximum: 2147483646
+                                  minimum: 1
+                                  type: integer
+                              required:
+                                - value
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        maxItems: 10
+                        minItems: 1
+                        type: array
+                      peerType:
+                        enum:
+                          - eBGP
+                          - iBGP
+                        type: string
+                      prefixLength:
+                        properties:
+                          max:
+                            format: int32
+                            maximum: 32
+                            minimum: 0
+                            type: integer
+                          min:
+                            format: int32
+                            maximum: 32
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      priority:
+                        maximum: 2147483646
+                        minimum: 1
+                        type: integer
+                      source:
+                        enum:
+                          - RemotePeers
+                        type: string
+                    required:
+                      - action
+                    type: object
+                    x-kubernetes-map-type: atomic
+                    x-kubernetes-validations:
+                      - message: cidr and matchOperator must both be set or both be empty
+                        reason: FieldValueInvalid
+                        rule:
+                          (has(self.cidr) && size(self.cidr) > 0) == (has(self.matchOperator)
+                          && size(self.matchOperator) > 0)
+                      - message: cidr is required when prefixLength is set
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.prefixLength) || (has(self.cidr) && size(self.cidr)
+                          > 0)"
+                      - message: operations may only be used with action Accept
+                        rule:
+                          "!has(self.operations) || size(self.operations) == 0 ||
+                          self.action == 'Accept'"
+                  type: array
+                exportV6:
+                  items:
+                    properties:
+                      action:
+                        enum:
+                          - Accept
+                          - Reject
+                        type: string
+                      asPathPrefix:
+                        items:
+                          format: int32
+                          type: integer
+                        type: array
+                      cidr:
+                        format: cidr
+                        maxLength: 43
+                        type: string
+                      communities:
+                        properties:
+                          values:
+                            items:
+                              maxLength: 32
+                              pattern: ^(([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]):([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])|([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]))$
+                              type: string
+                            maxItems: 1
+                            minItems: 1
+                            type: array
+                        required:
+                          - values
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      interface:
+                        type: string
+                      matchOperator:
+                        enum:
+                          - Equal
+                          - NotEqual
+                          - In
+                          - NotIn
+                        type: string
+                      operations:
+                        items:
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            addCommunity:
+                              properties:
+                                value:
+                                  maxLength: 32
+                                  pattern: ^(([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]):([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])|([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]))$
+                                  type: string
+                              required:
+                                - value
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prependASPath:
+                              properties:
+                                prefix:
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  maxItems: 10
+                                  minItems: 1
+                                  type: array
+                              required:
+                                - prefix
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            setPriority:
+                              properties:
+                                value:
+                                  maximum: 2147483646
+                                  minimum: 1
+                                  type: integer
+                              required:
+                                - value
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        maxItems: 10
+                        minItems: 1
+                        type: array
+                      peerType:
+                        enum:
+                          - eBGP
+                          - iBGP
+                        type: string
+                      prefixLength:
+                        properties:
+                          max:
+                            format: int32
+                            maximum: 128
+                            minimum: 0
+                            type: integer
+                          min:
+                            format: int32
+                            maximum: 128
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      priority:
+                        maximum: 2147483646
+                        minimum: 1
+                        type: integer
+                      source:
+                        enum:
+                          - RemotePeers
+                        type: string
+                    required:
+                      - action
+                    type: object
+                    x-kubernetes-map-type: atomic
+                    x-kubernetes-validations:
+                      - message: cidr and matchOperator must both be set or both be empty
+                        reason: FieldValueInvalid
+                        rule:
+                          (has(self.cidr) && size(self.cidr) > 0) == (has(self.matchOperator)
+                          && size(self.matchOperator) > 0)
+                      - message: cidr is required when prefixLength is set
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.prefixLength) || (has(self.cidr) && size(self.cidr)
+                          > 0)"
+                      - message: operations may only be used with action Accept
+                        rule:
+                          "!has(self.operations) || size(self.operations) == 0 ||
+                          self.action == 'Accept'"
+                  type: array
+                importV4:
+                  items:
+                    properties:
+                      action:
+                        enum:
+                          - Accept
+                          - Reject
+                        type: string
+                      asPathPrefix:
+                        items:
+                          format: int32
+                          type: integer
+                        type: array
+                      cidr:
+                        format: cidr
+                        maxLength: 18
+                        type: string
+                      communities:
+                        properties:
+                          values:
+                            items:
+                              maxLength: 32
+                              pattern: ^(([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]):([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])|([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]))$
+                              type: string
+                            maxItems: 1
+                            minItems: 1
+                            type: array
+                        required:
+                          - values
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      interface:
+                        type: string
+                      matchOperator:
+                        enum:
+                          - Equal
+                          - NotEqual
+                          - In
+                          - NotIn
+                        type: string
+                      operations:
+                        items:
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            addCommunity:
+                              properties:
+                                value:
+                                  maxLength: 32
+                                  pattern: ^(([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]):([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])|([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]))$
+                                  type: string
+                              required:
+                                - value
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prependASPath:
+                              properties:
+                                prefix:
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  maxItems: 10
+                                  minItems: 1
+                                  type: array
+                              required:
+                                - prefix
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            setPriority:
+                              properties:
+                                value:
+                                  maximum: 2147483646
+                                  minimum: 1
+                                  type: integer
+                              required:
+                                - value
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        maxItems: 10
+                        minItems: 1
+                        type: array
+                      peerType:
+                        enum:
+                          - eBGP
+                          - iBGP
+                        type: string
+                      prefixLength:
+                        properties:
+                          max:
+                            format: int32
+                            maximum: 32
+                            minimum: 0
+                            type: integer
+                          min:
+                            format: int32
+                            maximum: 32
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      priority:
+                        maximum: 2147483646
+                        minimum: 1
+                        type: integer
+                      source:
+                        enum:
+                          - RemotePeers
+                        type: string
+                    required:
+                      - action
+                    type: object
+                    x-kubernetes-map-type: atomic
+                    x-kubernetes-validations:
+                      - message: cidr and matchOperator must both be set or both be empty
+                        reason: FieldValueInvalid
+                        rule:
+                          (has(self.cidr) && size(self.cidr) > 0) == (has(self.matchOperator)
+                          && size(self.matchOperator) > 0)
+                      - message: cidr is required when prefixLength is set
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.prefixLength) || (has(self.cidr) && size(self.cidr)
+                          > 0)"
+                      - message: operations may only be used with action Accept
+                        rule:
+                          "!has(self.operations) || size(self.operations) == 0 ||
+                          self.action == 'Accept'"
+                  type: array
+                importV6:
+                  items:
+                    properties:
+                      action:
+                        enum:
+                          - Accept
+                          - Reject
+                        type: string
+                      asPathPrefix:
+                        items:
+                          format: int32
+                          type: integer
+                        type: array
+                      cidr:
+                        format: cidr
+                        maxLength: 43
+                        type: string
+                      communities:
+                        properties:
+                          values:
+                            items:
+                              maxLength: 32
+                              pattern: ^(([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]):([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])|([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]))$
+                              type: string
+                            maxItems: 1
+                            minItems: 1
+                            type: array
+                        required:
+                          - values
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      interface:
+                        type: string
+                      matchOperator:
+                        enum:
+                          - Equal
+                          - NotEqual
+                          - In
+                          - NotIn
+                        type: string
+                      operations:
+                        items:
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            addCommunity:
+                              properties:
+                                value:
+                                  maxLength: 32
+                                  pattern: ^(([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]):([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])|([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]))$
+                                  type: string
+                              required:
+                                - value
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prependASPath:
+                              properties:
+                                prefix:
+                                  items:
+                                    format: int32
+                                    type: integer
+                                  maxItems: 10
+                                  minItems: 1
+                                  type: array
+                              required:
+                                - prefix
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            setPriority:
+                              properties:
+                                value:
+                                  maximum: 2147483646
+                                  minimum: 1
+                                  type: integer
+                              required:
+                                - value
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        maxItems: 10
+                        minItems: 1
+                        type: array
+                      peerType:
+                        enum:
+                          - eBGP
+                          - iBGP
+                        type: string
+                      prefixLength:
+                        properties:
+                          max:
+                            format: int32
+                            maximum: 128
+                            minimum: 0
+                            type: integer
+                          min:
+                            format: int32
+                            maximum: 128
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      priority:
+                        maximum: 2147483646
+                        minimum: 1
+                        type: integer
+                      source:
+                        enum:
+                          - RemotePeers
+                        type: string
+                    required:
+                      - action
+                    type: object
+                    x-kubernetes-map-type: atomic
+                    x-kubernetes-validations:
+                      - message: cidr and matchOperator must both be set or both be empty
+                        reason: FieldValueInvalid
+                        rule:
+                          (has(self.cidr) && size(self.cidr) > 0) == (has(self.matchOperator)
+                          && size(self.matchOperator) > 0)
+                      - message: cidr is required when prefixLength is set
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.prefixLength) || (has(self.cidr) && size(self.cidr)
+                          > 0)"
+                      - message: operations may only be used with action Accept
+                        rule:
+                          "!has(self.operations) || size(self.operations) == 0 ||
+                          self.action == 'Accept'"
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: crds/crd.projectcalico.org_bgppeers.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: bgppeers.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BGPPeer
+    listKind: BGPPeerList
+    plural: bgppeers
+    singular: bgppeer
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                asNumber:
+                  format: int32
+                  type: integer
+                filters:
+                  items:
+                    type: string
+                  type: array
+                keepOriginalNextHop:
+                  type: boolean
+                keepaliveTime:
+                  type: string
+                localASNumber:
+                  format: int32
+                  type: integer
+                localWorkloadSelector:
+                  maxLength: 4096
+                  type: string
+                maxRestartTime:
+                  type: string
+                nextHopMode:
+                  enum:
+                    - Auto
+                    - Self
+                    - Keep
+                  type: string
+                node:
+                  maxLength: 253
+                  type: string
+                nodeSelector:
+                  maxLength: 4096
+                  type: string
+                numAllowedLocalASNumbers:
+                  format: int32
+                  type: integer
+                password:
+                  properties:
+                    secretKeyRef:
+                      properties:
+                        key:
+                          type: string
+                        name:
+                          default: ""
+                          type: string
+                        optional:
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                peerIP:
+                  maxLength: 64
+                  type: string
+                peerSelector:
+                  maxLength: 4096
+                  type: string
+                reachableBy:
+                  type: string
+                reversePeering:
+                  allOf:
+                    - enum:
+                        - Auto
+                        - Manual
+                    - enum:
+                        - Auto
+                        - Manual
+                  type: string
+                sourceAddress:
+                  enum:
+                    - UseNodeIP
+                    - None
+                  type: string
+                ttlSecurity:
+                  type: integer
+              type: object
+              x-kubernetes-validations:
+                - message: node and nodeSelector cannot both be set
+                  reason: FieldValueForbidden
+                  rule:
+                    (!has(self.node) || size(self.node) == 0) || (!has(self.nodeSelector)
+                    || size(self.nodeSelector) == 0)
+                - message: peerIP and peerSelector cannot both be set
+                  reason: FieldValueForbidden
+                  rule:
+                    (!has(self.peerIP) || size(self.peerIP) == 0) || (!has(self.peerSelector)
+                    || size(self.peerSelector) == 0)
+                - message: asNumber must be empty when peerSelector is set
+                  reason: FieldValueForbidden
+                  rule:
+                    (!has(self.peerSelector) || size(self.peerSelector) == 0) || !has(self.asNumber)
+                    || self.asNumber == 0
+                - message: peerIP must be empty when localWorkloadSelector is set
+                  reason: FieldValueForbidden
+                  rule:
+                    (!has(self.localWorkloadSelector) || size(self.localWorkloadSelector)
+                    == 0) || (!has(self.peerIP) || size(self.peerIP) == 0)
+                - message: peerSelector must be empty when localWorkloadSelector is set
+                  reason: FieldValueForbidden
+                  rule:
+                    (!has(self.localWorkloadSelector) || size(self.localWorkloadSelector)
+                    == 0) || (!has(self.peerSelector) || size(self.peerSelector) == 0)
+                - message: asNumber is required when localWorkloadSelector is set
+                  reason: FieldValueInvalid
+                  rule:
+                    (!has(self.localWorkloadSelector) || size(self.localWorkloadSelector)
+                    == 0) || (has(self.asNumber) && self.asNumber != 0)
+          type: object
+      served: true
+      storage: true
+---
+# Source: crds/crd.projectcalico.org_blockaffinities.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: blockaffinities.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BlockAffinity
+    listKind: BlockAffinityList
+    plural: blockaffinities
+    singular: blockaffinity
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                cidr:
+                  type: string
+                deleted:
+                  type: string
+                node:
+                  type: string
+                state:
+                  type: string
+                type:
+                  type: string
+              required:
+                - cidr
+                - deleted
+                - node
+                - state
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: crds/crd.projectcalico.org_caliconodestatuses.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: caliconodestatuses.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: CalicoNodeStatus
+    listKind: CalicoNodeStatusList
+    plural: caliconodestatuses
+    singular: caliconodestatus
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                classes:
+                  items:
+                    enum:
+                      - Agent
+                      - BGP
+                      - Routes
+                    type: string
+                  type: array
+                node:
+                  type: string
+                updatePeriodSeconds:
+                  format: int32
+                  type: integer
+              type: object
+            status:
+              properties:
+                agent:
+                  properties:
+                    birdV4:
+                      properties:
+                        lastBootTime:
+                          type: string
+                        lastReconfigurationTime:
+                          type: string
+                        routerID:
+                          type: string
+                        state:
+                          enum:
+                            - Ready
+                            - NotReady
+                          type: string
+                        version:
+                          type: string
+                      type: object
+                    birdV6:
+                      properties:
+                        lastBootTime:
+                          type: string
+                        lastReconfigurationTime:
+                          type: string
+                        routerID:
+                          type: string
+                        state:
+                          enum:
+                            - Ready
+                            - NotReady
+                          type: string
+                        version:
+                          type: string
+                      type: object
+                  type: object
+                bgp:
+                  properties:
+                    numberEstablishedV4:
+                      type: integer
+                    numberEstablishedV6:
+                      type: integer
+                    numberNotEstablishedV4:
+                      type: integer
+                    numberNotEstablishedV6:
+                      type: integer
+                    peersV4:
+                      items:
+                        properties:
+                          peerIP:
+                            type: string
+                          since:
+                            type: string
+                          state:
+                            enum:
+                              - Idle
+                              - Connect
+                              - Active
+                              - OpenSent
+                              - OpenConfirm
+                              - Established
+                              - Close
+                            type: string
+                          type:
+                            enum:
+                              - NodeMesh
+                              - NodePeer
+                              - GlobalPeer
+                            type: string
+                        type: object
+                      type: array
+                    peersV6:
+                      items:
+                        properties:
+                          peerIP:
+                            type: string
+                          since:
+                            type: string
+                          state:
+                            enum:
+                              - Idle
+                              - Connect
+                              - Active
+                              - OpenSent
+                              - OpenConfirm
+                              - Established
+                              - Close
+                            type: string
+                          type:
+                            enum:
+                              - NodeMesh
+                              - NodePeer
+                              - GlobalPeer
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                    - numberEstablishedV4
+                    - numberEstablishedV6
+                    - numberNotEstablishedV4
+                    - numberNotEstablishedV6
+                  type: object
+                lastUpdated:
+                  format: date-time
+                  nullable: true
+                  type: string
+                routes:
+                  properties:
+                    routesV4:
+                      items:
+                        properties:
+                          destination:
+                            type: string
+                          gateway:
+                            type: string
+                          interface:
+                            type: string
+                          learnedFrom:
+                            properties:
+                              peerIP:
+                                type: string
+                              sourceType:
+                                enum:
+                                  - Kernel
+                                  - Static
+                                  - Direct
+                                  - NodeMesh
+                                  - BGPPeer
+                                type: string
+                            type: object
+                          type:
+                            enum:
+                              - FIB
+                              - RIB
+                            type: string
+                        type: object
+                      type: array
+                    routesV6:
+                      items:
+                        properties:
+                          destination:
+                            type: string
+                          gateway:
+                            type: string
+                          interface:
+                            type: string
+                          learnedFrom:
+                            properties:
+                              peerIP:
+                                type: string
+                              sourceType:
+                                enum:
+                                  - Kernel
+                                  - Static
+                                  - Direct
+                                  - NodeMesh
+                                  - BGPPeer
+                                type: string
+                            type: object
+                          type:
+                            enum:
+                              - FIB
+                              - RIB
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: crds/crd.projectcalico.org_clusterinformations.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: clusterinformations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: ClusterInformation
+    listKind: ClusterInformationList
+    plural: clusterinformations
+    singular: clusterinformation
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                calicoVersion:
+                  type: string
+                clusterGUID:
+                  type: string
+                clusterType:
+                  type: string
+                datastoreReady:
+                  type: boolean
+                variant:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: crds/crd.projectcalico.org_felixconfigurations.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: felixconfigurations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: FelixConfiguration
+    listKind: FelixConfigurationList
+    plural: felixconfigurations
+    singular: felixconfiguration
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: Felix Configuration contains the configuration for Felix.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: FelixConfigurationSpec contains the values of the Felix configuration.
+              properties:
+                allowIPIPPacketsFromWorkloads:
+                  description: |-
+                    AllowIPIPPacketsFromWorkloads controls whether Felix will add a rule to drop IPIP encapsulated traffic
+                    from workloads. [Default: false]
+                  type: boolean
+                allowVXLANPacketsFromWorkloads:
+                  description: |-
+                    AllowVXLANPacketsFromWorkloads controls whether Felix will add a rule to drop VXLAN encapsulated traffic
+                    from workloads. [Default: false]
+                  type: boolean
+                awsSrcDstCheck:
+                  description: |-
+                    AWSSrcDstCheck controls whether Felix will try to change the "source/dest check" setting on the EC2 instance
+                    on which it is running. A value of "Disable" will try to disable the source/dest check. Disabling the check
+                    allows for sending workload traffic without encapsulation within the same AWS subnet.
+                    [Default: DoNothing]
+                  enum:
+                    - DoNothing
+                    - Enable
+                    - Disable
+                  type: string
+                bpfAttachType:
+                  description: |-
+                    BPFAttachType controls how are the BPF programs at the network interfaces attached.
+                    By default `TCX` is used where available to enable easier coexistence with 3rd party programs.
+                    `TC` can force the legacy method of attaching via a qdisc. `TCX` falls back to `TC` if `TCX` is not available.
+                    [Default: TCX]
+                  enum:
+                    - TC
+                    - TCX
+                  type: string
+                bpfCTLBLogFilter:
+                  description: |-
+                    BPFCTLBLogFilter specifies, what is logged by connect time load balancer when BPFLogLevel is
+                    debug. Currently has to be specified as 'all' when BPFLogFilters is set
+                    to see CTLB logs.
+                    [Default: unset - means logs are emitted when BPFLogLevel id debug and BPFLogFilters not set.]
+                  type: string
+                bpfConnectTimeLoadBalancing:
+                  description: |-
+                    BPFConnectTimeLoadBalancing when in BPF mode, controls whether Felix installs the connect-time load
+                    balancer. The connect-time load balancer is required for the host to be able to reach Kubernetes services
+                    and it improves the performance of pod-to-service connections.When set to TCP, connect time load balancing
+                    is available only for services with TCP ports. [Default: TCP]
+                  enum:
+                    - TCP
+                    - Enabled
+                    - Disabled
+                  type: string
+                bpfConnectTimeLoadBalancingEnabled:
+                  description: |-
+                    BPFConnectTimeLoadBalancingEnabled when in BPF mode, controls whether Felix installs the connection-time load
+                    balancer.  The connect-time load balancer is required for the host to be able to reach Kubernetes services
+                    and it improves the performance of pod-to-service connections.  The only reason to disable it is for debugging
+                    purposes.
+
+                    Deprecated: Use BPFConnectTimeLoadBalancing [Default: true]
+                  type: boolean
+                bpfConntrackLogLevel:
+                  description: |-
+                    BPFConntrackLogLevel controls the log level of the BPF conntrack cleanup program, which runs periodically
+                    to clean up expired BPF conntrack entries.
+                    [Default: Off].
+                  enum:
+                    - "Off"
+                    - Debug
+                  type: string
+                bpfConntrackMode:
+                  description: |-
+                    BPFConntrackCleanupMode controls how BPF conntrack entries are cleaned up.  `Auto` will use a BPF program if supported,
+                    falling back to userspace if not.  `Userspace` will always use the userspace cleanup code.  `BPFProgram` will
+                    always use the BPF program (failing if not supported).
+
+                    /To be deprecated in future versions as conntrack map type changed to
+                    lru_hash and userspace cleanup is the only mode that is supported.
+                    [Default: Userspace]
+                  enum:
+                    - Auto
+                    - Userspace
+                    - BPFProgram
+                  type: string
+                bpfConntrackTimeouts:
+                  description: |-
+                    BPFConntrackTimers overrides the default values for the specified conntrack timer if
+                    set. Each value can be either a duration or `Auto` to pick the value from
+                    a Linux conntrack timeout.
+
+                    Configurable timers are: CreationGracePeriod, TCPSynSent,
+                    TCPEstablished, TCPFinsSeen, TCPResetSeen, UDPTimeout, GenericTimeout,
+                    ICMPTimeout.
+
+                    Unset values are replaced by the default values with a warning log for
+                    incorrect values.
+                  properties:
+                    creationGracePeriod:
+                      description: |-
+                        CreationGracePeriod gives a generic grace period to new connections
+                        before they are considered for cleanup [Default: 10s].
+                      pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                      type: string
+                    genericTimeout:
+                      description: |-
+                        GenericTimeout controls how long it takes before considering this
+                        entry for cleanup after the connection became idle. If set to 'Auto', the
+                        value from nf_conntrack_generic_timeout is used. If nil, Calico uses its
+                        own default value. [Default: 10m].
+                      pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                      type: string
+                    icmpTimeout:
+                      description: |-
+                        ICMPTimeout controls how long it takes before considering this
+                        entry for cleanup after the connection became idle. If set to 'Auto', the
+                        value from nf_conntrack_icmp_timeout is used. If nil, Calico uses its
+                        own default value. [Default: 5s].
+                      pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                      type: string
+                    tcpEstablished:
+                      description: |-
+                        TCPEstablished controls how long it takes before considering this entry for
+                        cleanup after the connection became idle. If set to 'Auto', the
+                        value from nf_conntrack_tcp_timeout_established is used. If nil, Calico uses
+                        its own default value. [Default: 1h].
+                      pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                      type: string
+                    tcpFinsSeen:
+                      description: |-
+                        TCPFinsSeen controls how long it takes before considering this entry for
+                        cleanup after the connection was closed gracefully. If set to 'Auto', the
+                        value from nf_conntrack_tcp_timeout_time_wait is used. If nil, Calico uses
+                        its own default value. [Default: Auto].
+                      pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                      type: string
+                    tcpResetSeen:
+                      description: |-
+                        TCPResetSeen controls how long it takes before considering this entry for
+                        cleanup after the connection was aborted. If nil, Calico uses its own
+                        default value. [Default: 40s].
+                      pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                      type: string
+                    tcpSynSent:
+                      description: |-
+                        TCPSynSent controls how long it takes before considering this entry for
+                        cleanup after the last SYN without a response. If set to 'Auto', the
+                        value from nf_conntrack_tcp_timeout_syn_sent is used. If nil, Calico uses
+                        its own default value. [Default: 20s].
+                      pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                      type: string
+                    udpTimeout:
+                      description: |-
+                        UDPTimeout controls how long it takes before considering this entry for
+                        cleanup after the connection became idle. If nil, Calico uses its own
+                        default value. [Default: 60s].
+                      pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                      type: string
+                  type: object
+                bpfDSROptoutCIDRs:
+                  description: |-
+                    BPFDSROptoutCIDRs is a list of CIDRs which are excluded from DSR. That is, clients
+                    in those CIDRs will access service node ports as if BPFExternalServiceMode was set to
+                    Tunnel.
+                  items:
+                    type: string
+                  type: array
+                bpfDataIfacePattern:
+                  description: |-
+                    BPFDataIfacePattern is a regular expression that controls which interfaces Felix should attach BPF programs to
+                    in order to catch traffic to/from the network.  This needs to match the interfaces that Calico workload traffic
+                    flows over as well as any interfaces that handle incoming traffic to nodeports and services from outside the
+                    cluster.  It should not match the workload interfaces (usually named cali...) or any other special device managed
+                    by Calico itself (e.g., tunnels).
+                  type: string
+                bpfDisableGROForIfaces:
+                  description: |-
+                    BPFDisableGROForIfaces is a regular expression that controls which interfaces Felix should disable the
+                    Generic Receive Offload [GRO] option.  It should not match the workload interfaces (usually named cali...).
+                  type: string
+                bpfDisableUnprivileged:
+                  description: |-
+                    BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled sysctl to disable
+                    unprivileged use of BPF.  This ensures that unprivileged users cannot access Calico's BPF maps and
+                    cannot insert their own BPF programs to interfere with Calico's. [Default: true]
+                  type: boolean
+                bpfEnabled:
+                  description:
+                    "BPFEnabled, if enabled Felix will use the BPF dataplane.
+                    [Default: false]"
+                  type: boolean
+                bpfEnforceRPF:
+                  description: |-
+                    BPFEnforceRPF enforce strict RPF on all host interfaces with BPF programs regardless of
+                    what is the per-interfaces or global setting. Possible values are Disabled, Strict
+                    or Loose. [Default: Loose]
+                  pattern: ^(?i)(Disabled|Strict|Loose)?$
+                  type: string
+                bpfExcludeCIDRsFromNAT:
+                  description: |-
+                    BPFExcludeCIDRsFromNAT is a list of CIDRs that are to be excluded from NAT
+                    resolution so that host can handle them. A typical usecase is node local
+                    DNS cache.
+                  items:
+                    type: string
+                  type: array
+                bpfExportBufferSizeMB:
+                  description: |-
+                    BPFExportBufferSizeMB in BPF mode, controls the buffer size used for sending BPF events to felix.
+                    [Default: 1]
+                  type: integer
+                bpfExtToServiceConnmark:
+                  description: |-
+                    BPFExtToServiceConnmark in BPF mode, controls a 32bit mark that is set on connections from an
+                    external client to a local service. This mark allows us to control how packets of that
+                    connection are routed within the host and how is routing interpreted by RPF check. [Default: 0]
+                  type: integer
+                bpfExternalServiceMode:
+                  description: |-
+                    BPFExternalServiceMode in BPF mode, controls how connections from outside the cluster to services (node ports
+                    and cluster IPs) are forwarded to remote workloads.  If set to "Tunnel" then both request and response traffic
+                    is tunneled to the remote node.  If set to "DSR", the request traffic is tunneled but the response traffic
+                    is sent directly from the remote node.  In "DSR" mode, the remote node appears to use the IP of the ingress
+                    node; this requires a permissive L2 network.  [Default: Tunnel]
+                  pattern: ^(?i)(Tunnel|DSR)?$
+                  type: string
+                bpfForceTrackPacketsFromIfaces:
+                  description: |-
+                    BPFForceTrackPacketsFromIfaces in BPF mode, forces traffic from these interfaces
+                    to skip Calico's iptables NOTRACK rule, allowing traffic from those interfaces to be
+                    tracked by Linux conntrack.  Should only be used for interfaces that are not used for
+                    the Calico fabric.  For example, a docker bridge device for non-Calico-networked
+                    containers. [Default: docker+]
+                  items:
+                    type: string
+                  type: array
+                bpfHostConntrackBypass:
+                  description: |-
+                    BPFHostConntrackBypass Controls whether to bypass Linux conntrack in BPF mode for
+                    workloads and services. [Default: true - bypass Linux conntrack]
+                  type: boolean
+                bpfHostNetworkedNATWithoutCTLB:
+                  description: |-
+                    BPFHostNetworkedNATWithoutCTLB when in BPF mode, controls whether Felix does a NAT without CTLB. This along with BPFConnectTimeLoadBalancing
+                    determines the CTLB behavior. [Default: Enabled]
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                bpfJITHardening:
+                  allOf:
+                    - enum:
+                        - Auto
+                        - Strict
+                    - enum:
+                        - Auto
+                        - Strict
+                  description: |-
+                    BPFJITHardening controls BPF JIT hardening. When set to "Auto", Felix will set JIT hardening to 1
+                    if it detects the current value is 2 (strict mode that hurts performance). When set to "Strict",
+                    Felix will not modify the JIT hardening setting. [Default: Auto]
+                  type: string
+                bpfKubeProxyHealthzPort:
+                  description: |-
+                    BPFKubeProxyHealthzPort, in BPF mode, controls the port that Felix's embedded kube-proxy health check server binds to.
+                    The health check server is used by external load balancers to determine if this node should receive traffic.
+                    Set to 0 to disable the health check server.  [Default: 10256]
+                  type: integer
+                bpfKubeProxyIptablesCleanupEnabled:
+                  description: |-
+                    BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF mode, Felix will proactively clean up the upstream
+                    Kubernetes kube-proxy's iptables chains.  Should only be enabled if kube-proxy is not running.  [Default: true]
+                  type: boolean
+                bpfKubeProxyMinSyncPeriod:
+                  description: |-
+                    BPFKubeProxyMinSyncPeriod, in BPF mode, controls the minimum time between updates to the dataplane for Felix's
+                    embedded kube-proxy.  Lower values give reduced set-up latency.  Higher values reduce Felix CPU usage by
+                    batching up more work.  [Default: 1s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                bpfL3IfacePattern:
+                  description: |-
+                    BPFL3IfacePattern is a regular expression that allows to list tunnel devices like wireguard or vxlan (i.e., L3 devices)
+                    in addition to BPFDataIfacePattern. That is, tunnel interfaces not created by Calico, that Calico workload traffic flows
+                    over as well as any interfaces that handle incoming traffic to nodeports and services from outside the cluster.
+                  type: string
+                bpfLogFilters:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    BPFLogFilters is a map of key=values where the value is
+                    a pcap filter expression and the key is an interface name with 'all'
+                    denoting all interfaces, 'weps' all workload endpoints and 'heps' all host
+                    endpoints.
+
+                    When specified as an env var, it accepts a comma-separated list of
+                    key=values.
+                    [Default: unset - means all debug logs are emitted]
+                  type: object
+                bpfLogLevel:
+                  description: |-
+                    BPFLogLevel controls the log level of the BPF programs when in BPF dataplane mode.  One of "Off", "Info", or
+                    "Debug".  The logs are emitted to the BPF trace pipe, accessible with the command `tc exec bpf debug`.
+                    [Default: Off].
+                  pattern: ^(?i)(Off|Info|Debug)?$
+                  type: string
+                bpfMaglevMaxEndpointsPerService:
+                  description: |-
+                    BPFMaglevMaxEndpointsPerService is the maximum number of endpoints
+                    expected to be part of a single Maglev-enabled service.
+
+                    Influences the size of the per-service Maglev lookup-tables generated by Felix
+                    and thus the amount of memory reserved.
+
+                    [Default: 100]
+                  type: integer
+                bpfMaglevMaxServices:
+                  description: |-
+                    BPFMaglevMaxServices is the maximum number of expected Maglev-enabled
+                    services that Felix will allocate lookup-tables for.
+
+                    [Default: 100]
+                  type: integer
+                bpfMapSizeConntrack:
+                  description: |-
+                    BPFMapSizeConntrack sets the size for the conntrack map.  This map must be large enough to hold
+                    an entry for each active connection.  Warning: changing the size of the conntrack map can cause disruption.
+                  type: integer
+                bpfMapSizeConntrackCleanupQueue:
+                  description: |-
+                    BPFMapSizeConntrackCleanupQueue sets the size for the map used to hold NAT conntrack entries that are queued
+                    for cleanup.  This should be big enough to hold all the NAT entries that expire within one cleanup interval.
+                  minimum: 1
+                  type: integer
+                bpfMapSizeConntrackScaling:
+                  description: |-
+                    BPFMapSizeConntrackScaling controls whether and how we scale the conntrack map size depending
+                    on its usage. 'Disabled' make the size stay at the default or whatever is set by
+                    BPFMapSizeConntrack*. 'DoubleIfFull' doubles the size when the map is pretty much full even
+                    after cleanups. [Default: DoubleIfFull]
+                  pattern: ^(?i)(Disabled|DoubleIfFull)?$
+                  type: string
+                bpfMapSizeIPSets:
+                  description: |-
+                    BPFMapSizeIPSets sets the size for ipsets map.  The IP sets map must be large enough to hold an entry
+                    for each endpoint matched by every selector in the source/destination matches in network policy.  Selectors
+                    such as "all()" can result in large numbers of entries (one entry per endpoint in that case).
+                  type: integer
+                bpfMapSizeIfState:
+                  description: |-
+                    BPFMapSizeIfState sets the size for ifstate map.  The ifstate map must be large enough to hold an entry
+                    for each device (host + workloads) on a host.
+                  type: integer
+                bpfMapSizeNATAffinity:
+                  description: |-
+                    BPFMapSizeNATAffinity sets the size of the BPF map that stores the affinity of a connection (for services that
+                    enable that feature.
+                  type: integer
+                bpfMapSizeNATBackend:
+                  description: |-
+                    BPFMapSizeNATBackend sets the size for NAT back end map.
+                    This is the total number of endpoints. This is mostly
+                    more than the size of the number of services.
+                  type: integer
+                bpfMapSizeNATFrontend:
+                  description: |-
+                    BPFMapSizeNATFrontend sets the size for NAT front end map.
+                    FrontendMap should be large enough to hold an entry for each nodeport,
+                    external IP and each port in each service.
+                  type: integer
+                bpfMapSizePerCpuConntrack:
+                  description: |-
+                    BPFMapSizePerCPUConntrack determines the size of conntrack map based on the number of CPUs. If set to a
+                    non-zero value, overrides BPFMapSizeConntrack with `BPFMapSizePerCPUConntrack * (Number of CPUs)`.
+                    This map must be large enough to hold an entry for each active connection.  Warning: changing the size of the
+                    conntrack map can cause disruption.
+                  type: integer
+                bpfMapSizeRoute:
+                  description: |-
+                    BPFMapSizeRoute sets the size for the routes map.  The routes map should be large enough
+                    to hold one entry per workload and a handful of entries per host (enough to cover its own IPs and
+                    tunnel IPs).
+                  type: integer
+                bpfPSNATPorts:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: |-
+                    BPFPSNATPorts sets the range from which we randomly pick a port if there is a source port
+                    collision. This should be within the ephemeral range as defined by RFC 6056 (1024–65535) and
+                    preferably outside the  ephemeral ranges used by common operating systems. Linux uses
+                    32768–60999, while others mostly use the IANA defined range 49152–65535. It is not necessarily
+                    a problem if this range overlaps with the operating systems. Both ends of the range are
+                    inclusive. [Default: 20000:29999]
+                  pattern: ^.*
+                  x-kubernetes-int-or-string: true
+                bpfPolicyDebugEnabled:
+                  description: |-
+                    BPFPolicyDebugEnabled when true, Felix records detailed information
+                    about the BPF policy programs, which can be examined with the calico-bpf command-line tool.
+                  type: boolean
+                bpfProfiling:
+                  description: |-
+                    BPFProfiling controls profiling of BPF programs. At the monent, it can be
+                    Disabled or Enabled. [Default: Disabled]
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                bpfRedirectToPeer:
+                  description: |-
+                    BPFRedirectToPeer controls whether traffic may be forwarded directly to the peer side of a workload’s device.
+                    Note that the legacy "L2Only" option is now deprecated and if set it is treated like "Enabled.
+                    Setting this option to "Enabled" allows direct redirection (including from L3 host devices such as IPIP tunnels or WireGuard),
+                    which can improve redirection performance but causes the redirected packets to bypass the host‑side ingress path.
+                    As a result, packet‑capture tools on the host side of the workload device (for example, tcpdump) will not see that traffic. [Default: Enabled]
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                cgroupV2Path:
+                  description:
+                    CgroupV2Path overrides the default location where to
+                    find the cgroup hierarchy.
+                  type: string
+                chainInsertMode:
+                  description: |-
+                    ChainInsertMode controls whether Felix hooks the kernel's top-level iptables chains by inserting a rule
+                    at the top of the chain or by appending a rule at the bottom. insert is the safe default since it prevents
+                    Calico's rules from being bypassed. If you switch to append mode, be sure that the other rules in the chains
+                    signal acceptance by falling through to the Calico rules, otherwise the Calico policy will be bypassed.
+                    [Default: insert]
+                  pattern: ^(?i)(Insert|Append)?$
+                  type: string
+                dataplaneDriver:
+                  description: |-
+                    DataplaneDriver filename of the external dataplane driver to use.  Only used if UseInternalDataplaneDriver
+                    is set to false.
+                  type: string
+                dataplaneWatchdogTimeout:
+                  description: |-
+                    DataplaneWatchdogTimeout is the readiness/liveness timeout used for Felix's (internal) dataplane driver.
+                    Deprecated: replaced by the generic HealthTimeoutOverrides.
+                  type: string
+                debugDisableLogDropping:
+                  description: |-
+                    DebugDisableLogDropping disables the dropping of log messages when the log buffer is full.  This can
+                    significantly impact performance if log write-out is a bottleneck. [Default: false]
+                  type: boolean
+                debugHost:
+                  description: |-
+                    DebugHost is the host IP or hostname to bind the debug port to.  Only used
+                    if DebugPort is set. [Default:localhost]
+                  type: string
+                debugMemoryProfilePath:
+                  description:
+                    DebugMemoryProfilePath is the path to write the memory
+                    profile to when triggered by signal.
+                  type: string
+                debugPort:
+                  description: |-
+                    DebugPort if set, enables Felix's debug HTTP port, which allows memory and CPU profiles
+                    to be retrieved.  The debug port is not secure, it should not be exposed to the internet.
+                  type: integer
+                debugSimulateCalcGraphHangAfter:
+                  description: |-
+                    DebugSimulateCalcGraphHangAfter is used to simulate a hang in the calculation graph after the specified duration.
+                    This is useful in tests of the watchdog system only!
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                debugSimulateDataplaneApplyDelay:
+                  description: |-
+                    DebugSimulateDataplaneApplyDelay adds an artificial delay to every dataplane operation.  This is useful for
+                    simulating a heavily loaded system for test purposes only.
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                debugSimulateDataplaneHangAfter:
+                  description: |-
+                    DebugSimulateDataplaneHangAfter is used to simulate a hang in the dataplane after the specified duration.
+                    This is useful in tests of the watchdog system only!
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                defaultEndpointToHostAction:
+                  description: |-
+                    DefaultEndpointToHostAction controls what happens to traffic that goes from a workload endpoint to the host
+                    itself (after the endpoint's egress policy is applied). By default, Calico blocks traffic from workload
+                    endpoints to the host itself with an iptables "DROP" action. If you want to allow some or all traffic from
+                    endpoint to host, set this parameter to RETURN or ACCEPT. Use RETURN if you have your own rules in the iptables
+                    "INPUT" chain; Calico will insert its rules at the top of that chain, then "RETURN" packets to the "INPUT" chain
+                    once it has completed processing workload endpoint egress policy. Use ACCEPT to unconditionally accept packets
+                    from workloads after processing workload endpoint egress policy. [Default: Drop]
+                  pattern: ^(?i)(Drop|Accept|Return)?$
+                  type: string
+                deviceRouteProtocol:
+                  description: |-
+                    DeviceRouteProtocol controls the protocol to set on routes programmed by Felix. The protocol is an 8-bit label
+                    used to identify the owner of the route.
+                  type: integer
+                deviceRouteSourceAddress:
+                  description: |-
+                    DeviceRouteSourceAddress IPv4 address to set as the source hint for routes programmed by Felix. When not set
+                    the source address for local traffic from host to workload will be determined by the kernel.
+                  type: string
+                deviceRouteSourceAddressIPv6:
+                  description: |-
+                    DeviceRouteSourceAddressIPv6 IPv6 address to set as the source hint for routes programmed by Felix. When not set
+                    the source address for local traffic from host to workload will be determined by the kernel.
+                  type: string
+                disableConntrackInvalidCheck:
+                  description: |-
+                    DisableConntrackInvalidCheck disables the check for invalid connections in conntrack. While the conntrack
+                    invalid check helps to detect malicious traffic, it can also cause issues with certain multi-NIC scenarios.
+                  type: boolean
+                endpointReportingDelay:
+                  description: |-
+                    EndpointReportingDelay is the delay before Felix reports endpoint status to the datastore. This is only used
+                    by the OpenStack integration. [Default: 1s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                endpointReportingEnabled:
+                  description: |-
+                    EndpointReportingEnabled controls whether Felix reports endpoint status to the datastore. This is only used
+                    by the OpenStack integration. [Default: false]
+                  type: boolean
+                endpointStatusPathPrefix:
+                  description: |-
+                    EndpointStatusPathPrefix is the path to the directory where endpoint status will be written. Endpoint status
+                    file reporting is disabled if field is left empty.
+
+                    Chosen directory should match the directory used by the CNI plugin for PodStartupDelay.
+                    [Default: /var/run/calico]
+                  type: string
+                externalNodesList:
+                  description: |-
+                    ExternalNodesCIDRList is a list of CIDR's of external, non-Calico nodes from which VXLAN/IPIP overlay traffic
+                    will be allowed.  By default, external tunneled traffic is blocked to reduce attack surface.
+                  items:
+                    type: string
+                  type: array
+                failsafeInboundHostPorts:
+                  description: |-
+                    FailsafeInboundHostPorts is a list of ProtoPort struct objects including UDP/TCP/SCTP ports and CIDRs that Felix will
+                    allow incoming traffic to host endpoints on irrespective of the security policy. This is useful to avoid accidentally
+                    cutting off a host with incorrect configuration. For backwards compatibility, if the protocol is not specified,
+                    it defaults to "tcp". If a CIDR is not specified, it will allow traffic from all addresses. To disable all inbound host ports,
+                    use the value "[]". The default value allows ssh access, DHCP, BGP, etcd and the Kubernetes API.
+                    [Default: tcp:22, udp:68, tcp:179, tcp:2379, tcp:2380, tcp:5473, tcp:6443, tcp:6666, tcp:6667 ]
+                  items:
+                    description:
+                      ProtoPort is combination of protocol, port, and CIDR.
+                      Protocol and port must be specified.
+                    properties:
+                      net:
+                        type: string
+                      port:
+                        type: integer
+                      protocol:
+                        type: string
+                    required:
+                      - port
+                    type: object
+                  type: array
+                failsafeOutboundHostPorts:
+                  description: |-
+                    FailsafeOutboundHostPorts is a list of PortProto struct objects including UDP/TCP/SCTP ports and CIDRs that Felix
+                    will allow outgoing traffic from host endpoints to irrespective of the security policy. This is useful to avoid accidentally
+                    cutting off a host with incorrect configuration. For backwards compatibility, if the protocol is not specified, it defaults
+                    to "tcp". If a CIDR is not specified, it will allow traffic from all addresses. To disable all outbound host ports,
+                    use the value "[]". The default value opens etcd's standard ports to ensure that Felix does not get cut off from etcd
+                    as well as allowing DHCP, DNS, BGP and the Kubernetes API.
+                    [Default: udp:53, udp:67, tcp:179, tcp:2379, tcp:2380, tcp:5473, tcp:6443, tcp:6666, tcp:6667 ]
+                  items:
+                    description:
+                      ProtoPort is combination of protocol, port, and CIDR.
+                      Protocol and port must be specified.
+                    properties:
+                      net:
+                        type: string
+                      port:
+                        type: integer
+                      protocol:
+                        type: string
+                    required:
+                      - port
+                    type: object
+                  type: array
+                featureDetectOverride:
+                  description: |-
+                    FeatureDetectOverride is used to override feature detection based on auto-detected platform
+                    capabilities.  Values are specified in a comma separated list with no spaces, example;
+                    "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=". A value of "true" or "false" will
+                    force enable/disable feature, empty or omitted values fall back to auto-detection.
+                  pattern: ^([a-zA-Z0-9-_]+=(true|false|),)*([a-zA-Z0-9-_]+=(true|false|))?$
+                  type: string
+                featureGates:
+                  description: |-
+                    FeatureGates is used to enable or disable tech-preview Calico features.
+                    Values are specified in a comma separated list with no spaces, example;
+                    "BPFConnectTimeLoadBalancingWorkaround=enabled,XyZ=false". This is
+                    used to enable features that are not fully production ready.
+                  pattern: ^([a-zA-Z0-9-_]+=([^=]+),)*([a-zA-Z0-9-_]+=([^=]+))?$
+                  type: string
+                floatingIPs:
+                  description: |-
+                    FloatingIPs configures whether or not Felix will program non-OpenStack floating IP addresses.  (OpenStack-derived
+                    floating IPs are always programmed, regardless of this setting.)
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                flowLogsCollectorDebugTrace:
+                  description: |-
+                    When FlowLogsCollectorDebugTrace is set to true, enables the logs in the collector to be
+                    printed in their entirety.
+                  type: boolean
+                flowLogsFlushInterval:
+                  description:
+                    FlowLogsFlushInterval configures the interval at which
+                    Felix exports flow logs.
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                flowLogsGoldmaneServer:
+                  description:
+                    FlowLogGoldmaneServer is the flow server endpoint to
+                    which flow data should be published.
+                  type: string
+                flowLogsLocalReporter:
+                  description:
+                    "FlowLogsLocalReporter configures local unix socket for
+                    reporting flow data from each node. [Default: Disabled]"
+                  enum:
+                    - Disabled
+                    - Enabled
+                  type: string
+                flowLogsPolicyEvaluationMode:
+                  description: |-
+                    Continuous - Felix evaluates active flows on a regular basis to determine the rule
+                    traces in the flow logs. Any policy updates that impact a flow will be reflected in the
+                    pending_policies field, offering a near-real-time view of policy changes across flows.
+                    None - Felix stops evaluating pending traces.
+                    [Default: Continuous]
+                  enum:
+                    - None
+                    - Continuous
+                  type: string
+                genericXDPEnabled:
+                  description: |-
+                    GenericXDPEnabled enables Generic XDP so network cards that don't support XDP offload or driver
+                    modes can use XDP. This is not recommended since it doesn't provide better performance than
+                    iptables. [Default: false]
+                  type: boolean
+                goGCThreshold:
+                  description: |-
+                    GoGCThreshold Sets the Go runtime's garbage collection threshold.  I.e. the percentage that the heap is
+                    allowed to grow before garbage collection is triggered.  In general, doubling the value halves the CPU time
+                    spent doing GC, but it also doubles peak GC memory overhead.  A special value of -1 can be used
+                    to disable GC entirely; this should only be used in conjunction with the GoMemoryLimitMB setting.
+
+                    This setting is overridden by the GOGC environment variable.
+
+                    [Default: 40]
+                  type: integer
+                goMaxProcs:
+                  description: |-
+                    GoMaxProcs sets the maximum number of CPUs that the Go runtime will use concurrently.  A value of -1 means
+                    "use the system default"; typically the number of real CPUs on the system.
+
+                    this setting is overridden by the GOMAXPROCS environment variable.
+
+                    [Default: -1]
+                  type: integer
+                goMemoryLimitMB:
+                  description: |-
+                    GoMemoryLimitMB sets a (soft) memory limit for the Go runtime in MB.  The Go runtime will try to keep its memory
+                    usage under the limit by triggering GC as needed.  To avoid thrashing, it will exceed the limit if GC starts to
+                    take more than 50% of the process's CPU time.  A value of -1 disables the memory limit.
+
+                    Note that the memory limit, if used, must be considerably less than any hard resource limit set at the container
+                    or pod level.  This is because felix is not the only process that must run in the container or pod.
+
+                    This setting is overridden by the GOMEMLIMIT environment variable.
+
+                    [Default: -1]
+                  type: integer
+                healthEnabled:
+                  description: |-
+                    HealthEnabled if set to true, enables Felix's health port, which provides readiness and liveness endpoints.
+                    [Default: false]
+                  type: boolean
+                healthHost:
+                  description:
+                    "HealthHost is the host that the health server should
+                    bind to. [Default: localhost]"
+                  type: string
+                healthPort:
+                  description:
+                    "HealthPort is the TCP port that the health server should
+                    bind to. [Default: 9099]"
+                  type: integer
+                healthTimeoutOverrides:
+                  description: |-
+                    HealthTimeoutOverrides allows the internal watchdog timeouts of individual subcomponents to be
+                    overridden.  This is useful for working around "false positive" liveness timeouts that can occur
+                    in particularly stressful workloads or if CPU is constrained.  For a list of active
+                    subcomponents, see Felix's logs.
+                  items:
+                    properties:
+                      name:
+                        type: string
+                      timeout:
+                        type: string
+                    required:
+                      - name
+                      - timeout
+                    type: object
+                  type: array
+                interfaceExclude:
+                  description: |-
+                    InterfaceExclude A comma-separated list of interface names that should be excluded when Felix is resolving
+                    host endpoints. The default value ensures that Felix ignores Kubernetes' internal `kube-ipvs0` device. If you
+                    want to exclude multiple interface names using a single value, the list supports regular expressions. For
+                    regular expressions you must wrap the value with `/`. For example having values `/^kube/,veth1` will exclude
+                    all interfaces that begin with `kube` and also the interface `veth1`. [Default: kube-ipvs0]
+                  type: string
+                interfacePrefix:
+                  description: |-
+                    InterfacePrefix is the interface name prefix that identifies workload endpoints and so distinguishes
+                    them from host endpoint interfaces. Note: in environments other than bare metal, the orchestrators
+                    configure this appropriately. For example our Kubernetes and Docker integrations set the 'cali' value,
+                    and our OpenStack integration sets the 'tap' value. [Default: cali]
+                  type: string
+                interfaceRefreshInterval:
+                  description: |-
+                    InterfaceRefreshInterval is the period at which Felix rescans local interfaces to verify their state.
+                    The rescan can be disabled by setting the interval to 0.
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                ipForwarding:
+                  description: |-
+                    IPForwarding controls whether Felix sets the host sysctls to enable IP forwarding.  IP forwarding is required
+                    when using Calico for workload networking.  This should be disabled only on hosts where Calico is used solely for
+                    host protection. In BPF mode, due to a kernel interaction, either IPForwarding must be enabled or BPFEnforceRPF
+                    must be disabled. [Default: Enabled]
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                ipipEnabled:
+                  description: |-
+                    IPIPEnabled overrides whether Felix should configure an IPIP interface on the host. Optional as Felix
+                    determines this based on the existing IP pools. [Default: nil (unset)]
+                  type: boolean
+                ipipMTU:
+                  description: |-
+                    IPIPMTU controls the MTU to set on the IPIP tunnel device.  Optional as Felix auto-detects the MTU based on the
+                    MTU of the host's interfaces. [Default: 0 (auto-detect)]
+                  type: integer
+                ipsetsRefreshInterval:
+                  description: |-
+                    IpsetsRefreshInterval controls the period at which Felix re-checks all IP sets to look for discrepancies.
+                    Set to 0 to disable the periodic refresh. [Default: 90s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                iptablesBackend:
+                  description: |-
+                    IptablesBackend controls which backend of iptables will be used. The default is `Auto`.
+
+                    Warning: changing this on a running system can leave "orphaned" rules in the "other" backend. These
+                    should be cleaned up to avoid confusing interactions.
+                  enum:
+                    - Legacy
+                    - NFT
+                    - Auto
+                  pattern: ^(?i)(Auto|Legacy|NFT)?$
+                  type: string
+                iptablesFilterAllowAction:
+                  description: |-
+                    IptablesFilterAllowAction controls what happens to traffic that is accepted by a Felix policy chain in the
+                    iptables filter table (which is used for "normal" policy). The default will immediately `Accept` the traffic. Use
+                    `Return` to send the traffic back up to the system chains for further processing.
+                  pattern: ^(?i)(Accept|Return)?$
+                  type: string
+                iptablesFilterDenyAction:
+                  description: |-
+                    IptablesFilterDenyAction controls what happens to traffic that is denied by network policy. By default Calico blocks traffic
+                    with an iptables "DROP" action. If you want to use "REJECT" action instead you can configure it in here.
+                  pattern: ^(?i)(Drop|Reject)?$
+                  type: string
+                iptablesLockProbeInterval:
+                  description: |-
+                    IptablesLockProbeInterval configures the interval between attempts to claim
+                    the xtables lock.  Shorter intervals are more responsive but use more CPU.  [Default: 50ms]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                iptablesMangleAllowAction:
+                  description: |-
+                    IptablesMangleAllowAction controls what happens to traffic that is accepted by a Felix policy chain in the
+                    iptables mangle table (which is used for "pre-DNAT" policy). The default will immediately `Accept` the traffic.
+                    Use `Return` to send the traffic back up to the system chains for further processing.
+                  pattern: ^(?i)(Accept|Return)?$
+                  type: string
+                iptablesMarkMask:
+                  description: |-
+                    IptablesMarkMask is the mask that Felix selects its IPTables Mark bits from. Should be a 32 bit hexadecimal
+                    number with at least 8 bits set, none of which clash with any other mark bits in use on the system.
+                    [Default: 0xffff0000]
+                  format: int32
+                  type: integer
+                iptablesNATOutgoingInterfaceFilter:
+                  description: |-
+                    This parameter can be used to limit the host interfaces on which Calico will apply SNAT to traffic leaving a
+                    Calico IPAM pool with "NAT outgoing" enabled. This can be useful if you have a main data interface, where
+                    traffic should be SNATted and a secondary device (such as the docker bridge) which is local to the host and
+                    doesn't require SNAT. This parameter uses the iptables interface matching syntax, which allows + as a
+                    wildcard. Most users will not need to set this. Example: if your data interfaces are eth0 and eth1 and you
+                    want to exclude the docker bridge, you could set this to eth+
+                  type: string
+                iptablesPostWriteCheckInterval:
+                  description: |-
+                    IptablesPostWriteCheckInterval is the period after Felix has done a write
+                    to the dataplane that it schedules an extra read back in order to check the write was not
+                    clobbered by another process. This should only occur if another application on the system
+                    doesn't respect the iptables lock. [Default: 1s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                iptablesRefreshInterval:
+                  description: |-
+                    IptablesRefreshInterval is the period at which Felix re-checks the IP sets
+                    in the dataplane to ensure that no other process has accidentally broken Calico's rules.
+                    Set to 0 to disable IP sets refresh. Note: the default for this value is lower than the
+                    other refresh intervals as a workaround for a Linux kernel bug that was fixed in kernel
+                    version 4.11. If you are using v4.11 or greater you may want to set this to, a higher value
+                    to reduce Felix CPU usage. [Default: 10s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                ipv4ElevatedRoutePriority:
+                  description: |-
+                    Route Priority value for an elevated priority Calico-programmed IPv4 route.  Note, higher
+                    values mean lower priority.  Elevated priority is used during VM live migration, and for
+                    optimal behaviour IPv4ElevatedRoutePriority must be less than IPv4NormalRoutePriority
+                    [Default: 512]
+                  type: integer
+                ipv4NormalRoutePriority:
+                  description: |-
+                    Route Priority value for a normal priority Calico-programmed IPv4 route.  Note, higher
+                    values mean lower priority. [Default: 1024]
+                  type: integer
+                ipv6ElevatedRoutePriority:
+                  description: |-
+                    Route Priority value for an elevated priority Calico-programmed IPv6 route.  Note, higher
+                    values mean lower priority.  Elevated priority is used during VM live migration, and for
+                    optimal behaviour IPv6ElevatedRoutePriority must be less than IPv6NormalRoutePriority
+                    [Default: 512]
+                  type: integer
+                ipv6NormalRoutePriority:
+                  description: |-
+                    Route Priority value for a normal priority Calico-programmed IPv6 route.  Note, higher
+                    values mean lower priority. [Default: 1024]
+                  type: integer
+                ipv6Support:
+                  description:
+                    IPv6Support controls whether Felix enables support for
+                    IPv6 (if supported by the in-use dataplane).
+                  type: boolean
+                istioAmbientMode:
+                  description: |-
+                    IstioAmbientMode configures Felix to work together with Tigera's Istio distribution.
+                    [Default: Disabled]
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                istioDSCPMark:
+                  description: |-
+                    IstioDSCPMark sets the value to use when directing traffic to Istio ZTunnel, when Istio is enabled. The mark is set only on
+                    SYN packets at the final hop to avoid interference with other protocols. This value is reserved by Calico and must not be used
+                    with other Istio installation. [Default: 23]
+                  pattern: ^.*
+                  type: integer
+                  x-kubernetes-int-or-string: true
+                kubeNodePortRanges:
+                  description: |-
+                    KubeNodePortRanges holds list of port ranges used for service node ports. Only used if felix detects kube-proxy running in ipvs mode.
+                    Felix uses these ranges to separate host and workload traffic. [Default: 30000:32767].
+                  items:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  type: array
+                liveMigrationRouteConvergenceTime:
+                  description: |-
+                    LiveMigrationRouteConvergenceTime is the time to keep elevated route priority after a
+                    VM live migration completes.  This allows routes to converge across the cluster before
+                    reverting to normal priority. [Default: 30s]
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                logActionRateLimit:
+                  description: |-
+                    LogActionRateLimit sets the rate of hitting a Log action. The value must be in the format "N/unit",
+                    where N is a number and unit is one of: second, minute, hour, or day. For example: "10/second" or "100/hour".
+                  pattern: ^[1-9]\d{0,3}/(?:second|minute|hour|day)$
+                  type: string
+                logActionRateLimitBurst:
+                  description:
+                    LogActionRateLimitBurst sets the rate limit burst of
+                    hitting a Log action when LogActionRateLimit is enabled.
+                  maximum: 9999
+                  minimum: 0
+                  type: integer
+                logDebugFilenameRegex:
+                  description: |-
+                    LogDebugFilenameRegex controls which source code files have their Debug log output included in the logs.
+                    Only logs from files with names that match the given regular expression are included.  The filter only applies
+                    to Debug level logs.
+                  type: string
+                logFilePath:
+                  description:
+                    "LogFilePath is the full path to the Felix log. Set to
+                    none to disable file logging. [Default: /var/log/calico/felix.log]"
+                  type: string
+                logPrefix:
+                  description: |-
+                    LogPrefix is the log prefix that Felix uses when rendering LOG rules. It is possible to use the following specifiers
+                    to include extra information in the log prefix.
+                    - %t: Tier name.
+                    - %k: Kind (short names).
+                    - %n: Policy or profile name.
+                    - %p: Policy or profile name (namespace/name for namespaced kinds or just name for non namespaced kinds).
+                    Calico includes ": " characters at the end of the generated log prefix.
+                    Note that iptables shows up to 29 characters for the log prefix and nftables up to 127 characters. Extra characters are truncated.
+                    [Default: calico-packet]
+                  pattern: "^([a-zA-Z0-9%: /_-])*$"
+                  type: string
+                logSeverityFile:
+                  description:
+                    "LogSeverityFile is the log severity above which logs
+                    are sent to the log file. [Default: Info]"
+                  pattern: ^(?i)(Trace|Debug|Info|Warning|Error|Fatal)?$
+                  type: string
+                logSeverityScreen:
+                  description:
+                    "LogSeverityScreen is the log severity above which logs
+                    are sent to the stdout. [Default: Info]"
+                  pattern: ^(?i)(Trace|Debug|Info|Warning|Error|Fatal)?$
+                  type: string
+                logSeveritySys:
+                  description: |-
+                    LogSeveritySys is the log severity above which logs are sent to the syslog. Set to None for no logging to syslog.
+                    [Default: Info]
+                  pattern: ^(?i)(Trace|Debug|Info|Warning|Error|Fatal)?$
+                  type: string
+                maxIpsetSize:
+                  description: |-
+                    MaxIpsetSize is the maximum number of IP addresses that can be stored in an IP set. Not applicable
+                    if using the nftables backend.
+                  type: integer
+                metadataAddr:
+                  description: |-
+                    MetadataAddr is the IP address or domain name of the server that can answer VM queries for
+                    cloud-init metadata. In OpenStack, this corresponds to the machine running nova-api (or in
+                    Ubuntu, nova-api-metadata). A value of none (case-insensitive) means that Felix should not
+                    set up any NAT rule for the metadata path. [Default: 127.0.0.1]
+                  type: string
+                metadataPort:
+                  description: |-
+                    MetadataPort is the port of the metadata server. This, combined with global.MetadataAddr (if
+                    not 'None'), is used to set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+                    In most cases this should not need to be changed [Default: 8775].
+                  type: integer
+                mtuIfacePattern:
+                  description: |-
+                    MTUIfacePattern is a regular expression that controls which interfaces Felix should scan in order
+                    to calculate the host's MTU.
+                    This should not match workload interfaces (usually named cali...).
+                  type: string
+                natOutgoingAddress:
+                  description: |-
+                    NATOutgoingAddress specifies an address to use when performing source NAT for traffic in a natOutgoing pool that
+                    is leaving the network. By default the address used is an address on the interface the traffic is leaving on
+                    (i.e. it uses the iptables MASQUERADE target).
+                  type: string
+                natOutgoingExclusions:
+                  description: |-
+                    When a IP pool setting `natOutgoing` is true, packets sent from Calico networked containers in this IP pool to destinations will be masqueraded.
+                    Configure which type of destinations is excluded from being masqueraded.
+                    - IPPoolsOnly: destinations outside of this IP pool will be masqueraded.
+                    - IPPoolsAndHostIPs: destinations outside of this IP pool and all hosts will be masqueraded.
+                    [Default: IPPoolsOnly]
+                  enum:
+                    - IPPoolsOnly
+                    - IPPoolsAndHostIPs
+                  type: string
+                natPortRange:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: |-
+                    NATPortRange specifies the range of ports that is used for port mapping when doing outgoing NAT. When unset the default behavior of the
+                    network stack is used.
+                  pattern: ^.*
+                  x-kubernetes-int-or-string: true
+                netlinkTimeout:
+                  description: |-
+                    NetlinkTimeout is the timeout when talking to the kernel over the netlink protocol, used for programming
+                    routes, rules, and other kernel objects. [Default: 10s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                nftablesFilterAllowAction:
+                  description: |-
+                    NftablesFilterAllowAction controls the nftables action that Felix uses to represent the "allow" policy verdict
+                    in the filter table. The default is to `ACCEPT` the traffic, which is a terminal action.  Alternatively,
+                    `RETURN` can be used to return the traffic back to the top-level chain for further processing by your rules.
+                  pattern: ^(?i)(Accept|Return)?$
+                  type: string
+                nftablesFilterDenyAction:
+                  description: |-
+                    NftablesFilterDenyAction controls what happens to traffic that is denied by network policy. By default, Calico
+                    blocks traffic with a "drop" action. If you want to use a "reject" action instead you can configure it here.
+                  pattern: ^(?i)(Drop|Reject)?$
+                  type: string
+                nftablesMangleAllowAction:
+                  description: |-
+                    NftablesMangleAllowAction controls the nftables action that Felix uses to represent the "allow" policy verdict
+                    in the mangle table. The default is to `ACCEPT` the traffic, which is a terminal action.  Alternatively,
+                    `RETURN` can be used to return the traffic back to the top-level chain for further processing by your rules.
+                  pattern: ^(?i)(Accept|Return)?$
+                  type: string
+                nftablesMarkMask:
+                  description: |-
+                    NftablesMarkMask is the mask that Felix selects its nftables Mark bits from. Should be a 32 bit hexadecimal
+                    number with at least 8 bits set, none of which clash with any other mark bits in use on the system.
+                    [Default: 0xffff0000]
+                  format: int32
+                  type: integer
+                nftablesMode:
+                  default: Auto
+                  description:
+                    "NFTablesMode configures nftables support in Felix. [Default:
+                    Auto]"
+                  enum:
+                    - Disabled
+                    - Enabled
+                    - Auto
+                  type: string
+                nftablesRefreshInterval:
+                  description:
+                    "NftablesRefreshInterval controls the interval at which
+                    Felix periodically refreshes the nftables rules. [Default: 90s]"
+                  type: string
+                nodeSelector:
+                  description: |-
+                    NodeSelector is an optional label selector that restricts this FelixConfiguration
+                    to apply only to nodes that match the given selector. This field is only valid
+                    on FelixConfiguration resources whose name is not "default" and does not start
+                    with "node.". For resources named "default", the configuration applies globally
+                    to all nodes. For resources named "node.<nodename>", the configuration applies to
+                    the named node only.
+
+                    At most one selector-scoped FelixConfiguration should match any given node.
+                    If multiple selector-scoped resources match, the oldest (by creation
+                    timestamp) is used and a warning is logged. This prevents an accidentally
+                    created conflicting resource from disrupting an existing, working
+                    configuration.
+                  maxLength: 1024
+                  type: string
+                openstackRegion:
+                  description: |-
+                    OpenstackRegion is the name of the region that a particular Felix belongs to. In a multi-region
+                    Calico/OpenStack deployment, this must be configured somehow for each Felix (here in the datamodel,
+                    or in felix.cfg or the environment on each compute node), and must match the [calico]
+                    openstack_region value configured in neutron.conf on each node. [Default: Empty]
+                  type: string
+                policySyncPathPrefix:
+                  description: |-
+                    PolicySyncPathPrefix is used to by Felix to communicate policy changes to external services,
+                    like Application layer policy. [Default: Empty]
+                  type: string
+                programClusterRoutes:
+                  description: |-
+                    ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
+                    when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Disabled,
+                    it is expected that confd and BIRD will program that route. When ProgramClusterRoutes is Enabled, Felix program that route.
+                    Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: Disabled]
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                prometheusGoMetricsEnabled:
+                  description: |-
+                    PrometheusGoMetricsEnabled disables Go runtime metrics collection, which the Prometheus client does by default, when
+                    set to false. This reduces the number of metrics reported, reducing Prometheus load. [Default: true]
+                  type: boolean
+                prometheusMetricsCAFile:
+                  description: |-
+                    PrometheusMetricsCAFile defines the absolute path to the TLS CA certificate file used for securing the /metrics endpoint.
+                    This certificate must be valid and accessible by the calico-node process.
+                  type: string
+                prometheusMetricsCertFile:
+                  description: |-
+                    PrometheusMetricsCertFile defines the absolute path to the TLS certificate file used for securing the /metrics endpoint.
+                    This certificate must be valid and accessible by the calico-node process.
+                  type: string
+                prometheusMetricsClientAuth:
+                  description: |-
+                    PrometheusMetricsClientAuth specifies the client authentication type for the /metrics endpoint.
+                    This determines how the server validates client certificates. Default is "RequireAndVerifyClientCert".
+                  type: string
+                prometheusMetricsEnabled:
+                  description:
+                    "PrometheusMetricsEnabled enables the Prometheus metrics
+                    server in Felix if set to true. [Default: false]"
+                  type: boolean
+                prometheusMetricsHost:
+                  description:
+                    "PrometheusMetricsHost is the host that the Prometheus
+                    metrics server should bind to. [Default: empty]"
+                  type: string
+                prometheusMetricsKeyFile:
+                  description: |-
+                    PrometheusMetricsKeyFile defines the absolute path to the private key file corresponding to the TLS certificate
+                    used for securing the /metrics endpoint. The private key must be valid and accessible by the calico-node process.
+                  type: string
+                prometheusMetricsPort:
+                  description:
+                    "PrometheusMetricsPort is the TCP port that the Prometheus
+                    metrics server should bind to. [Default: 9091]"
+                  type: integer
+                prometheusProcessMetricsEnabled:
+                  description: |-
+                    PrometheusProcessMetricsEnabled disables process metrics collection, which the Prometheus client does by default, when
+                    set to false. This reduces the number of metrics reported, reducing Prometheus load. [Default: true]
+                  type: boolean
+                prometheusWireGuardMetricsEnabled:
+                  description: |-
+                    PrometheusWireGuardMetricsEnabled disables wireguard metrics collection, which the Prometheus client does by default, when
+                    set to false. This reduces the number of metrics reported, reducing Prometheus load. [Default: true]
+                  type: boolean
+                removeExternalRoutes:
+                  description: |-
+                    RemoveExternalRoutes Controls whether Felix will remove unexpected routes to workload interfaces. Felix will
+                    always clean up expected routes that use the configured DeviceRouteProtocol.  To add your own routes, you must
+                    use a distinct protocol (in addition to setting this field to false).
+                  type: boolean
+                reportingInterval:
+                  description: |-
+                    ReportingInterval is the interval at which Felix reports its status into the datastore or 0 to disable.
+                    Must be non-zero in OpenStack deployments. [Default: 30s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                reportingTTL:
+                  description:
+                    "ReportingTTL is the time-to-live setting for process-wide
+                    status reports. [Default: 90s]"
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                requireMTUFile:
+                  description: |-
+                    RequireMTUFile specifies whether mtu file is required to start the felix.
+                    Optional as to keep the same as previous behavior. [Default: false]
+                  type: boolean
+                routeRefreshInterval:
+                  description: |-
+                    RouteRefreshInterval is the period at which Felix re-checks the routes
+                    in the dataplane to ensure that no other process has accidentally broken Calico's rules.
+                    Set to 0 to disable route refresh. [Default: 90s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                routeSource:
+                  description: |-
+                    RouteSource configures where Felix gets its routing information.
+                    - WorkloadIPs: use workload endpoints to construct routes.
+                    - CalicoIPAM: the default - use IPAM data to construct routes.
+                  pattern: ^(?i)(WorkloadIPs|CalicoIPAM)?$
+                  type: string
+                routeSyncDisabled:
+                  description: |-
+                    RouteSyncDisabled will disable all operations performed on the route table. Set to true to
+                    run in network-policy mode only.
+                  type: boolean
+                routeTableRange:
+                  description: |-
+                    Deprecated in favor of RouteTableRanges.
+                    Calico programs additional Linux route tables for various purposes.
+                    RouteTableRange specifies the indices of the route tables that Calico should use.
+                  properties:
+                    max:
+                      type: integer
+                    min:
+                      type: integer
+                  required:
+                    - max
+                    - min
+                  type: object
+                routeTableRanges:
+                  description: |-
+                    Calico programs additional Linux route tables for various purposes.
+                    RouteTableRanges specifies a set of table index ranges that Calico should use.
+                    Deprecates`RouteTableRange`, overrides `RouteTableRange`.
+                  items:
+                    properties:
+                      max:
+                        type: integer
+                      min:
+                        type: integer
+                    required:
+                      - max
+                      - min
+                    type: object
+                  type: array
+                serviceLoopPrevention:
+                  description: |-
+                    When service IP advertisement is enabled, prevent routing loops to service IPs that are
+                    not in use, by dropping or rejecting packets that do not get DNAT'd by kube-proxy.
+                    Unless set to "Disabled", in which case such routing loops continue to be allowed.
+                    [Default: Drop]
+                  pattern: ^(?i)(Drop|Reject|Disabled)?$
+                  type: string
+                sidecarAccelerationEnabled:
+                  description:
+                    "SidecarAccelerationEnabled enables experimental sidecar
+                    acceleration [Default: false]"
+                  type: boolean
+                usageReportingEnabled:
+                  description: |-
+                    UsageReportingEnabled reports anonymous Calico version number and cluster size to projectcalico.org. Logs warnings returned by the usage
+                    server. For example, if a significant security vulnerability has been discovered in the version of Calico being used. [Default: true]
+                  type: boolean
+                usageReportingInitialDelay:
+                  description:
+                    "UsageReportingInitialDelay controls the minimum delay
+                    before Felix makes a report. [Default: 300s]"
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                usageReportingInterval:
+                  description:
+                    "UsageReportingInterval controls the interval at which
+                    Felix makes reports. [Default: 86400s]"
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                useInternalDataplaneDriver:
+                  description: |-
+                    UseInternalDataplaneDriver, if true, Felix will use its internal dataplane programming logic.  If false, it
+                    will launch an external dataplane driver and communicate with it over protobuf.
+                  type: boolean
+                vxlanEnabled:
+                  description: |-
+                    VXLANEnabled overrides whether Felix should create the VXLAN tunnel device for IPv4 VXLAN networking.
+                    Optional as Felix determines this based on the existing IP pools. [Default: nil (unset)]
+                  type: boolean
+                vxlanMTU:
+                  description: |-
+                    VXLANMTU is the MTU to set on the IPv4 VXLAN tunnel device.  Optional as Felix auto-detects the MTU based on the
+                    MTU of the host's interfaces. [Default: 0 (auto-detect)]
+                  type: integer
+                vxlanMTUV6:
+                  description: |-
+                    VXLANMTUV6 is the MTU to set on the IPv6 VXLAN tunnel device. Optional as Felix auto-detects the MTU based on the
+                    MTU of the host's interfaces. [Default: 0 (auto-detect)]
+                  type: integer
+                vxlanPort:
+                  description:
+                    "VXLANPort is the UDP port number to use for VXLAN traffic.
+                    [Default: 4789]"
+                  type: integer
+                vxlanVNI:
+                  description: |-
+                    VXLANVNI is the VXLAN VNI to use for VXLAN traffic.  You may need to change this if the default value is
+                    in use on your system. [Default: 4096]
+                  type: integer
+                windowsManageFirewallRules:
+                  description:
+                    "WindowsManageFirewallRules configures whether or not
+                    Felix will program Windows Firewall rules (to allow inbound access
+                    to its own metrics ports). [Default: Disabled]"
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                wireguardEnabled:
+                  description:
+                    "WireguardEnabled controls whether Wireguard is enabled
+                    for IPv4 (encapsulating IPv4 traffic over an IPv4 underlay network).
+                    [Default: false]"
+                  type: boolean
+                wireguardEnabledV6:
+                  description:
+                    "WireguardEnabledV6 controls whether Wireguard is enabled
+                    for IPv6 (encapsulating IPv6 traffic over an IPv6 underlay network).
+                    [Default: false]"
+                  type: boolean
+                wireguardHostEncryptionEnabled:
+                  description:
+                    "WireguardHostEncryptionEnabled controls whether Wireguard
+                    host-to-host encryption is enabled. [Default: false]"
+                  type: boolean
+                wireguardInterfaceName:
+                  description:
+                    "WireguardInterfaceName specifies the name to use for
+                    the IPv4 Wireguard interface. [Default: wireguard.cali]"
+                  type: string
+                wireguardInterfaceNameV6:
+                  description:
+                    "WireguardInterfaceNameV6 specifies the name to use for
+                    the IPv6 Wireguard interface. [Default: wg-v6.cali]"
+                  type: string
+                wireguardKeepAlive:
+                  description:
+                    "WireguardPersistentKeepAlive controls Wireguard PersistentKeepalive
+                    option. Set 0 to disable. [Default: 0]"
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+                wireguardListeningPort:
+                  description:
+                    "WireguardListeningPort controls the listening port used
+                    by IPv4 Wireguard. [Default: 51820]"
+                  type: integer
+                wireguardListeningPortV6:
+                  description:
+                    "WireguardListeningPortV6 controls the listening port
+                    used by IPv6 Wireguard. [Default: 51821]"
+                  type: integer
+                wireguardMTU:
+                  description:
+                    "WireguardMTU controls the MTU on the IPv4 Wireguard
+                    interface. See Configuring MTU [Default: 1440]"
+                  type: integer
+                wireguardMTUV6:
+                  description:
+                    "WireguardMTUV6 controls the MTU on the IPv6 Wireguard
+                    interface. See Configuring MTU [Default: 1420]"
+                  type: integer
+                wireguardRoutingRulePriority:
+                  description:
+                    "WireguardRoutingRulePriority controls the priority value
+                    to use for the Wireguard routing rule. [Default: 99]"
+                  type: integer
+                wireguardThreadingEnabled:
+                  description: |-
+                    WireguardThreadingEnabled controls whether Wireguard has Threaded NAPI enabled. [Default: false]
+                    This increases the maximum number of packets a Wireguard interface can process.
+                    Consider threaded NAPI only if you have high packets per second workloads that are causing dropping packets due to a saturated `softirq` CPU core.
+                    There is a [known issue](https://lore.kernel.org/netdev/CALrw=nEoT2emQ0OAYCjM1d_6Xe_kNLSZ6dhjb5FxrLFYh4kozA@mail.gmail.com/T/) with this setting
+                    that may cause NAPI to get stuck holding the global `rtnl_mutex` when a peer is removed.
+                    Workaround: Make sure your Linux kernel [includes this patch](https://github.com/torvalds/linux/commit/56364c910691f6d10ba88c964c9041b9ab777bd6) to unwedge NAPI.
+                  type: boolean
+                workloadSourceSpoofing:
+                  description: |-
+                    WorkloadSourceSpoofing controls whether pods can use the allowedSourcePrefixes annotation to send traffic with a source IP
+                    address that is not theirs. This is disabled by default. When set to "Any", pods can request any prefix.
+                  pattern: ^(?i)(Disabled|Any)?$
+                  type: string
+                xdpEnabled:
+                  description:
+                    "XDPEnabled enables XDP acceleration for suitable untracked
+                    incoming deny rules. [Default: true]"
+                  type: boolean
+                xdpRefreshInterval:
+                  description: |-
+                    XDPRefreshInterval is the period at which Felix re-checks all XDP state to ensure that no
+                    other process has accidentally broken Calico's BPF maps or attached programs. Set to 0 to
+                    disable XDP refresh. [Default: 90s]
+                  pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                  type: string
+              type: object
+              x-kubernetes-validations:
+                - message: routeTableRange and routeTableRanges cannot both be set
+                  reason: FieldValueForbidden
+                  rule: "!has(self.routeTableRange) || !has(self.routeTableRanges)"
+          type: object
+          x-kubernetes-validations:
+            - message:
+                nodeSelector must not be set on the 'default' or per-node ('node.*')
+                FelixConfiguration
+              reason: FieldValueForbidden
+              rule:
+                "self.metadata.name == 'default' || self.metadata.name.startsWith('node.')
+                ? !has(self.spec.nodeSelector) : true"
+      served: true
+      storage: true
+---
+# Source: crds/crd.projectcalico.org_globalnetworkpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: globalnetworkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: GlobalNetworkPolicy
+    listKind: GlobalNetworkPolicyList
+    plural: globalnetworkpolicies
+    singular: globalnetworkpolicy
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                applyOnForward:
+                  type: boolean
+                doNotTrack:
+                  type: boolean
+                egress:
+                  items:
+                    properties:
+                      action:
+                        enum:
+                          - Allow
+                          - Deny
+                          - Log
+                          - Pass
+                        type: string
+                      destination:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      http:
+                        properties:
+                          methods:
+                            items:
+                              type: string
+                            maxItems: 20
+                            type: array
+                          paths:
+                            items:
+                              properties:
+                                exact:
+                                  maxLength: 1024
+                                  type: string
+                                prefix:
+                                  maxLength: 1024
+                                  type: string
+                              type: object
+                            maxItems: 20
+                            type: array
+                        type: object
+                      icmp:
+                        properties:
+                          code:
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      ipVersion:
+                        enum:
+                          - 4
+                          - 6
+                        type: integer
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      notICMP:
+                        properties:
+                          code:
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - action
+                    type: object
+                    x-kubernetes-validations:
+                      - message: rules with HTTP match must have protocol TCP or unset
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.http) || !has(self.protocol) || self.protocol
+                          == 'TCP' || self.protocol == 6"
+                      - message: HTTP match is only valid on Allow rules
+                        reason: FieldValueForbidden
+                        rule: self.action == 'Allow' || !has(self.http)
+                      - message: ports and notPorts cannot be specified with services
+                        reason: FieldValueForbidden
+                        rule:
+                          "!has(self.destination) || !has(self.destination.services)
+                          || (!has(self.destination.ports) || size(self.destination.ports)
+                          == 0) && (!has(self.destination.notPorts) || size(self.destination.notPorts)
+                          == 0)"
+                  type: array
+                ingress:
+                  items:
+                    properties:
+                      action:
+                        enum:
+                          - Allow
+                          - Deny
+                          - Log
+                          - Pass
+                        type: string
+                      destination:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      http:
+                        properties:
+                          methods:
+                            items:
+                              type: string
+                            maxItems: 20
+                            type: array
+                          paths:
+                            items:
+                              properties:
+                                exact:
+                                  maxLength: 1024
+                                  type: string
+                                prefix:
+                                  maxLength: 1024
+                                  type: string
+                              type: object
+                            maxItems: 20
+                            type: array
+                        type: object
+                      icmp:
+                        properties:
+                          code:
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      ipVersion:
+                        enum:
+                          - 4
+                          - 6
+                        type: integer
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      notICMP:
+                        properties:
+                          code:
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - action
+                    type: object
+                    x-kubernetes-validations:
+                      - message: rules with HTTP match must have protocol TCP or unset
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.http) || !has(self.protocol) || self.protocol
+                          == 'TCP' || self.protocol == 6"
+                      - message: HTTP match is only valid on Allow rules
+                        reason: FieldValueForbidden
+                        rule: self.action == 'Allow' || !has(self.http)
+                      - message: ports and notPorts cannot be specified with services
+                        reason: FieldValueForbidden
+                        rule:
+                          "!has(self.destination) || !has(self.destination.services)
+                          || (!has(self.destination.ports) || size(self.destination.ports)
+                          == 0) && (!has(self.destination.notPorts) || size(self.destination.notPorts)
+                          == 0)"
+                  type: array
+                namespaceSelector:
+                  type: string
+                order:
+                  type: number
+                performanceHints:
+                  items:
+                    enum:
+                      - AssumeNeededOnEveryNode
+                    type: string
+                  type: array
+                preDNAT:
+                  type: boolean
+                selector:
+                  type: string
+                serviceAccountSelector:
+                  type: string
+                tier:
+                  default: default
+                  type: string
+                types:
+                  items:
+                    enum:
+                      - Ingress
+                      - Egress
+                    type: string
+                  maxItems: 2
+                  minItems: 1
+                  type: array
+                  x-kubernetes-list-type: set
+              type: object
+              x-kubernetes-validations:
+                - message: preDNAT and doNotTrack cannot both be true
+                  reason: FieldValueForbidden
+                  rule:
+                    "!((has(self.doNotTrack) && self.doNotTrack) && (has(self.preDNAT)
+                    && self.preDNAT))"
+                - message: preDNAT policy cannot have any egress rules
+                  reason: FieldValueForbidden
+                  rule:
+                    (!has(self.preDNAT) || !self.preDNAT) || !has(self.egress) ||
+                    size(self.egress) == 0
+                - message: preDNAT policy cannot have 'Egress' type
+                  reason: FieldValueForbidden
+                  rule:
+                    (!has(self.preDNAT) || !self.preDNAT) || !has(self.types) || !self.types.exists(t,
+                    t == 'Egress')
+                - message:
+                    applyOnForward must be true if either preDNAT or doNotTrack
+                    is true
+                  reason: FieldValueInvalid
+                  rule:
+                    (has(self.applyOnForward) && self.applyOnForward) || ((!has(self.doNotTrack)
+                    || !self.doNotTrack) && (!has(self.preDNAT) || !self.preDNAT))
+          type: object
+      served: true
+      storage: true
+---
+# Source: crds/crd.projectcalico.org_globalnetworksets.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: globalnetworksets.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: GlobalNetworkSet
+    listKind: GlobalNetworkSetList
+    plural: globalnetworksets
+    singular: globalnetworkset
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                nets:
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: crds/crd.projectcalico.org_hostendpoints.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: hostendpoints.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: HostEndpoint
+    listKind: HostEndpointList
+    plural: hostendpoints
+    singular: hostendpoint
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                expectedIPs:
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                interfaceName:
+                  maxLength: 15
+                  type: string
+                node:
+                  maxLength: 253
+                  type: string
+                ports:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                      port:
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                    required:
+                      - name
+                      - port
+                      - protocol
+                    type: object
+                  type: array
+                profiles:
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+              type: object
+              x-kubernetes-validations:
+                - message: at least one of interfaceName or expectedIPs must be specified
+                  reason: FieldValueInvalid
+                  rule:
+                    (has(self.interfaceName) && size(self.interfaceName) > 0) || (has(self.expectedIPs)
+                    && size(self.expectedIPs) > 0)
+                - message: node must be specified
+                  reason: FieldValueInvalid
+                  rule: has(self.node) && size(self.node) > 0
+          type: object
+      served: true
+      storage: true
+---
+# Source: crds/crd.projectcalico.org_ipamblocks.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: ipamblocks.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPAMBlock
+    listKind: IPAMBlockList
+    plural: ipamblocks
+    singular: ipamblock
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                affinity:
+                  type: string
+                affinityClaimTime:
+                  format: date-time
+                  type: string
+                allocations:
+                  items:
+                    type: integer
+                    # TODO: This nullable is manually added in. We should update controller-gen
+                    # to handle []*int properly itself.
+                    nullable: true
+                  type: array
+                attributes:
+                  items:
+                    properties:
+                      alternateOwnerAttrs:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      handle_id:
+                        type: string
+                      secondary:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  type: array
+                cidr:
+                  type: string
+                deleted:
+                  type: boolean
+                sequenceNumber:
+                  default: 0
+                  format: int64
+                  type: integer
+                sequenceNumberForAllocation:
+                  additionalProperties:
+                    format: int64
+                    type: integer
+                  type: object
+                strictAffinity:
+                  type: boolean
+                unallocated:
+                  items:
+                    type: integer
+                  type: array
+              required:
+                - allocations
+                - attributes
+                - cidr
+                - strictAffinity
+                - unallocated
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: crds/crd.projectcalico.org_ipamconfigs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: ipamconfigs.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPAMConfig
+    listKind: IPAMConfigList
+    plural: ipamconfigs
+    singular: ipamconfig
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                autoAllocateBlocks:
+                  type: boolean
+                kubeVirtVMAddressPersistence:
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                maxBlocksPerHost:
+                  maximum: 2147483647
+                  minimum: 0
+                  type: integer
+                strictAffinity:
+                  type: boolean
+              required:
+                - autoAllocateBlocks
+                - strictAffinity
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: crds/crd.projectcalico.org_ipamhandles.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: ipamhandles.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPAMHandle
+    listKind: IPAMHandleList
+    plural: ipamhandles
+    singular: ipamhandle
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                block:
+                  additionalProperties:
+                    type: integer
+                  type: object
+                deleted:
+                  type: boolean
+                handleID:
+                  type: string
+              required:
+                - block
+                - handleID
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: crds/crd.projectcalico.org_ippools.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: ippools.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPPool
+    listKind: IPPoolList
+    plural: ippools
+    singular: ippool
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                allowedUses:
+                  items:
+                    enum:
+                      - Workload
+                      - Tunnel
+                      - LoadBalancer
+                    type: string
+                  maxItems: 10
+                  type: array
+                  x-kubernetes-list-type: set
+                assignmentMode:
+                  default: Automatic
+                  enum:
+                    - Automatic
+                    - Manual
+                  type: string
+                blockSize:
+                  maximum: 128
+                  minimum: 0
+                  type: integer
+                  x-kubernetes-validations:
+                    - message:
+                        Block size cannot be changed; follow IP pool migration
+                        guide to avoid corruption.
+                      reason: FieldValueInvalid
+                      rule: self == oldSelf
+                cidr:
+                  format: cidr
+                  maxLength: 48
+                  type: string
+                  x-kubernetes-validations:
+                    - message:
+                        CIDR cannot be changed; follow IP pool migration guide
+                        to avoid corruption.
+                      reason: FieldValueInvalid
+                      rule: self == oldSelf
+                disableBGPExport:
+                  type: boolean
+                disabled:
+                  type: boolean
+                ipipMode:
+                  enum:
+                    - Never
+                    - Always
+                    - CrossSubnet
+                  type: string
+                namespaceSelector:
+                  type: string
+                natOutgoing:
+                  type: boolean
+                nodeSelector:
+                  type: string
+                vxlanMode:
+                  enum:
+                    - Never
+                    - Always
+                    - CrossSubnet
+                  type: string
+              required:
+                - cidr
+              type: object
+              x-kubernetes-validations:
+                - message: ipipMode and vxlanMode cannot both be enabled
+                  reason: FieldValueForbidden
+                  rule:
+                    "!has(self.ipipMode) || !has(self.vxlanMode) || self.ipipMode
+                    == 'Never' || self.vxlanMode == 'Never' || size(self.ipipMode)
+                    == 0 || size(self.vxlanMode) == 0"
+                - message: LoadBalancer IP pool cannot have IPIP or VXLAN enabled
+                  reason: FieldValueForbidden
+                  rule:
+                    "!has(self.allowedUses) || !self.allowedUses.exists(u, u == 'LoadBalancer')
+                    || (!has(self.ipipMode) || size(self.ipipMode) == 0 || self.ipipMode
+                    == 'Never') && (!has(self.vxlanMode) || size(self.vxlanMode) ==
+                    0 || self.vxlanMode == 'Never')"
+                - message:
+                    LoadBalancer cannot be combined with Workload or Tunnel allowed
+                    uses
+                  reason: FieldValueForbidden
+                  rule:
+                    "!has(self.allowedUses) || !self.allowedUses.exists(u, u == 'LoadBalancer')
+                    || !self.allowedUses.exists(u, u == 'Workload' || u == 'Tunnel')"
+                - message: IPIP is not supported on IPv6 pools
+                  reason: FieldValueForbidden
+                  rule:
+                    "!self.cidr.contains(':') || !has(self.ipipMode) || self.ipipMode
+                    == 'Never' || size(self.ipipMode) == 0"
+          type: object
+      served: true
+      storage: true
+---
+# Source: crds/crd.projectcalico.org_ipreservations.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: ipreservations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPReservation
+    listKind: IPReservationList
+    plural: ipreservations
+    singular: ipreservation
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                reservedCIDRs:
+                  format: cidr
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: crds/crd.projectcalico.org_kubecontrollersconfigurations.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: kubecontrollersconfigurations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: KubeControllersConfiguration
+    listKind: KubeControllersConfigurationList
+    plural: kubecontrollersconfigurations
+    singular: kubecontrollersconfiguration
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                controllers:
+                  properties:
+                    loadBalancer:
+                      properties:
+                        assignIPs:
+                          default: AllServices
+                          enum:
+                            - AllServices
+                            - RequestedServicesOnly
+                          type: string
+                      type: object
+                    namespace:
+                      properties:
+                        reconcilerPeriod:
+                          type: string
+                      type: object
+                    node:
+                      properties:
+                        hostEndpoint:
+                          properties:
+                            autoCreate:
+                              enum:
+                                - Enabled
+                                - Disabled
+                              type: string
+                            createDefaultHostEndpoint:
+                              type: string
+                            templates:
+                              items:
+                                properties:
+                                  generateName:
+                                    maxLength: 253
+                                    type: string
+                                  interfaceCIDRs:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                  interfacePattern:
+                                    type: string
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  nodeSelector:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        leakGracePeriod:
+                          type: string
+                        reconcilerPeriod:
+                          type: string
+                        syncLabels:
+                          enum:
+                            - Enabled
+                            - Disabled
+                          type: string
+                      type: object
+                    policy:
+                      properties:
+                        reconcilerPeriod:
+                          type: string
+                      type: object
+                    policyMigration:
+                      properties:
+                        enabled:
+                          default: Enabled
+                          enum:
+                            - Disabled
+                            - Enabled
+                          type: string
+                      type: object
+                    serviceAccount:
+                      properties:
+                        reconcilerPeriod:
+                          type: string
+                      type: object
+                    workloadEndpoint:
+                      properties:
+                        reconcilerPeriod:
+                          type: string
+                      type: object
+                  type: object
+                debugProfilePort:
+                  format: int32
+                  maximum: 65535
+                  minimum: 0
+                  type: integer
+                etcdV3CompactionPeriod:
+                  type: string
+                healthChecks:
+                  default: Enabled
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
+                logSeverityScreen:
+                  enum:
+                    - None
+                    - Debug
+                    - Info
+                    - Warning
+                    - Error
+                    - Fatal
+                    - Panic
+                  type: string
+                prometheusMetricsPort:
+                  maximum: 65535
+                  minimum: 0
+                  type: integer
+              required:
+                - controllers
+              type: object
+            status:
+              properties:
+                environmentVars:
+                  additionalProperties:
+                    type: string
+                  type: object
+                runningConfig:
+                  properties:
+                    controllers:
+                      properties:
+                        loadBalancer:
+                          properties:
+                            assignIPs:
+                              default: AllServices
+                              enum:
+                                - AllServices
+                                - RequestedServicesOnly
+                              type: string
+                          type: object
+                        namespace:
+                          properties:
+                            reconcilerPeriod:
+                              type: string
+                          type: object
+                        node:
+                          properties:
+                            hostEndpoint:
+                              properties:
+                                autoCreate:
+                                  enum:
+                                    - Enabled
+                                    - Disabled
+                                  type: string
+                                createDefaultHostEndpoint:
+                                  type: string
+                                templates:
+                                  items:
+                                    properties:
+                                      generateName:
+                                        maxLength: 253
+                                        type: string
+                                      interfaceCIDRs:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      interfacePattern:
+                                        type: string
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      nodeSelector:
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                            leakGracePeriod:
+                              type: string
+                            reconcilerPeriod:
+                              type: string
+                            syncLabels:
+                              enum:
+                                - Enabled
+                                - Disabled
+                              type: string
+                          type: object
+                        policy:
+                          properties:
+                            reconcilerPeriod:
+                              type: string
+                          type: object
+                        policyMigration:
+                          properties:
+                            enabled:
+                              default: Enabled
+                              enum:
+                                - Disabled
+                                - Enabled
+                              type: string
+                          type: object
+                        serviceAccount:
+                          properties:
+                            reconcilerPeriod:
+                              type: string
+                          type: object
+                        workloadEndpoint:
+                          properties:
+                            reconcilerPeriod:
+                              type: string
+                          type: object
+                      type: object
+                    debugProfilePort:
+                      format: int32
+                      maximum: 65535
+                      minimum: 0
+                      type: integer
+                    etcdV3CompactionPeriod:
+                      type: string
+                    healthChecks:
+                      default: Enabled
+                      enum:
+                        - Enabled
+                        - Disabled
+                      type: string
+                    logSeverityScreen:
+                      enum:
+                        - None
+                        - Debug
+                        - Info
+                        - Warning
+                        - Error
+                        - Fatal
+                        - Panic
+                      type: string
+                    prometheusMetricsPort:
+                      maximum: 65535
+                      minimum: 0
+                      type: integer
+                  required:
+                    - controllers
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: crds/crd.projectcalico.org_networkpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: networkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: NetworkPolicy
+    listKind: NetworkPolicyList
+    plural: networkpolicies
+    singular: networkpolicy
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                egress:
+                  items:
+                    properties:
+                      action:
+                        enum:
+                          - Allow
+                          - Deny
+                          - Log
+                          - Pass
+                        type: string
+                      destination:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      http:
+                        properties:
+                          methods:
+                            items:
+                              type: string
+                            maxItems: 20
+                            type: array
+                          paths:
+                            items:
+                              properties:
+                                exact:
+                                  maxLength: 1024
+                                  type: string
+                                prefix:
+                                  maxLength: 1024
+                                  type: string
+                              type: object
+                            maxItems: 20
+                            type: array
+                        type: object
+                      icmp:
+                        properties:
+                          code:
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      ipVersion:
+                        enum:
+                          - 4
+                          - 6
+                        type: integer
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      notICMP:
+                        properties:
+                          code:
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - action
+                    type: object
+                    x-kubernetes-validations:
+                      - message: rules with HTTP match must have protocol TCP or unset
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.http) || !has(self.protocol) || self.protocol
+                          == 'TCP' || self.protocol == 6"
+                      - message: HTTP match is only valid on Allow rules
+                        reason: FieldValueForbidden
+                        rule: self.action == 'Allow' || !has(self.http)
+                      - message: ports and notPorts cannot be specified with services
+                        reason: FieldValueForbidden
+                        rule:
+                          "!has(self.destination) || !has(self.destination.services)
+                          || (!has(self.destination.ports) || size(self.destination.ports)
+                          == 0) && (!has(self.destination.notPorts) || size(self.destination.notPorts)
+                          == 0)"
+                  type: array
+                ingress:
+                  items:
+                    properties:
+                      action:
+                        enum:
+                          - Allow
+                          - Deny
+                          - Log
+                          - Pass
+                        type: string
+                      destination:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      http:
+                        properties:
+                          methods:
+                            items:
+                              type: string
+                            maxItems: 20
+                            type: array
+                          paths:
+                            items:
+                              properties:
+                                exact:
+                                  maxLength: 1024
+                                  type: string
+                                prefix:
+                                  maxLength: 1024
+                                  type: string
+                              type: object
+                            maxItems: 20
+                            type: array
+                        type: object
+                      icmp:
+                        properties:
+                          code:
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      ipVersion:
+                        enum:
+                          - 4
+                          - 6
+                        type: integer
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      notICMP:
+                        properties:
+                          code:
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - action
+                    type: object
+                    x-kubernetes-validations:
+                      - message: rules with HTTP match must have protocol TCP or unset
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.http) || !has(self.protocol) || self.protocol
+                          == 'TCP' || self.protocol == 6"
+                      - message: HTTP match is only valid on Allow rules
+                        reason: FieldValueForbidden
+                        rule: self.action == 'Allow' || !has(self.http)
+                      - message: ports and notPorts cannot be specified with services
+                        reason: FieldValueForbidden
+                        rule:
+                          "!has(self.destination) || !has(self.destination.services)
+                          || (!has(self.destination.ports) || size(self.destination.ports)
+                          == 0) && (!has(self.destination.notPorts) || size(self.destination.notPorts)
+                          == 0)"
+                  type: array
+                order:
+                  type: number
+                performanceHints:
+                  items:
+                    enum:
+                      - AssumeNeededOnEveryNode
+                    type: string
+                  type: array
+                selector:
+                  type: string
+                serviceAccountSelector:
+                  type: string
+                tier:
+                  default: default
+                  type: string
+                types:
+                  items:
+                    enum:
+                      - Ingress
+                      - Egress
+                    type: string
+                  maxItems: 2
+                  minItems: 1
+                  type: array
+                  x-kubernetes-list-type: set
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: crds/crd.projectcalico.org_networksets.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: networksets.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: NetworkSet
+    listKind: NetworkSetList
+    plural: networksets
+    singular: networkset
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                nets:
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: crds/crd.projectcalico.org_stagedglobalnetworkpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: stagedglobalnetworkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: StagedGlobalNetworkPolicy
+    listKind: StagedGlobalNetworkPolicyList
+    plural: stagedglobalnetworkpolicies
+    singular: stagedglobalnetworkpolicy
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                applyOnForward:
+                  type: boolean
+                doNotTrack:
+                  type: boolean
+                egress:
+                  items:
+                    properties:
+                      action:
+                        enum:
+                          - Allow
+                          - Deny
+                          - Log
+                          - Pass
+                        type: string
+                      destination:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      http:
+                        properties:
+                          methods:
+                            items:
+                              type: string
+                            maxItems: 20
+                            type: array
+                          paths:
+                            items:
+                              properties:
+                                exact:
+                                  maxLength: 1024
+                                  type: string
+                                prefix:
+                                  maxLength: 1024
+                                  type: string
+                              type: object
+                            maxItems: 20
+                            type: array
+                        type: object
+                      icmp:
+                        properties:
+                          code:
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      ipVersion:
+                        enum:
+                          - 4
+                          - 6
+                        type: integer
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      notICMP:
+                        properties:
+                          code:
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - action
+                    type: object
+                    x-kubernetes-validations:
+                      - message: rules with HTTP match must have protocol TCP or unset
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.http) || !has(self.protocol) || self.protocol
+                          == 'TCP' || self.protocol == 6"
+                      - message: HTTP match is only valid on Allow rules
+                        reason: FieldValueForbidden
+                        rule: self.action == 'Allow' || !has(self.http)
+                      - message: ports and notPorts cannot be specified with services
+                        reason: FieldValueForbidden
+                        rule:
+                          "!has(self.destination) || !has(self.destination.services)
+                          || (!has(self.destination.ports) || size(self.destination.ports)
+                          == 0) && (!has(self.destination.notPorts) || size(self.destination.notPorts)
+                          == 0)"
+                  type: array
+                ingress:
+                  items:
+                    properties:
+                      action:
+                        enum:
+                          - Allow
+                          - Deny
+                          - Log
+                          - Pass
+                        type: string
+                      destination:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      http:
+                        properties:
+                          methods:
+                            items:
+                              type: string
+                            maxItems: 20
+                            type: array
+                          paths:
+                            items:
+                              properties:
+                                exact:
+                                  maxLength: 1024
+                                  type: string
+                                prefix:
+                                  maxLength: 1024
+                                  type: string
+                              type: object
+                            maxItems: 20
+                            type: array
+                        type: object
+                      icmp:
+                        properties:
+                          code:
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      ipVersion:
+                        enum:
+                          - 4
+                          - 6
+                        type: integer
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      notICMP:
+                        properties:
+                          code:
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - action
+                    type: object
+                    x-kubernetes-validations:
+                      - message: rules with HTTP match must have protocol TCP or unset
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.http) || !has(self.protocol) || self.protocol
+                          == 'TCP' || self.protocol == 6"
+                      - message: HTTP match is only valid on Allow rules
+                        reason: FieldValueForbidden
+                        rule: self.action == 'Allow' || !has(self.http)
+                      - message: ports and notPorts cannot be specified with services
+                        reason: FieldValueForbidden
+                        rule:
+                          "!has(self.destination) || !has(self.destination.services)
+                          || (!has(self.destination.ports) || size(self.destination.ports)
+                          == 0) && (!has(self.destination.notPorts) || size(self.destination.notPorts)
+                          == 0)"
+                  type: array
+                namespaceSelector:
+                  type: string
+                order:
+                  type: number
+                performanceHints:
+                  items:
+                    enum:
+                      - AssumeNeededOnEveryNode
+                    type: string
+                  type: array
+                preDNAT:
+                  type: boolean
+                selector:
+                  type: string
+                serviceAccountSelector:
+                  type: string
+                stagedAction:
+                  default: Set
+                  enum:
+                    - Set
+                    - Delete
+                    - Learn
+                    - Ignore
+                  type: string
+                tier:
+                  default: default
+                  type: string
+                types:
+                  items:
+                    enum:
+                      - Ingress
+                      - Egress
+                    type: string
+                  maxItems: 2
+                  minItems: 1
+                  type: array
+                  x-kubernetes-list-type: set
+              type: object
+              x-kubernetes-validations:
+                - message: preDNAT and doNotTrack cannot both be true
+                  reason: FieldValueForbidden
+                  rule:
+                    "!((has(self.doNotTrack) && self.doNotTrack) && (has(self.preDNAT)
+                    && self.preDNAT))"
+                - message: preDNAT policy cannot have any egress rules
+                  reason: FieldValueForbidden
+                  rule:
+                    (!has(self.preDNAT) || !self.preDNAT) || !has(self.egress) ||
+                    size(self.egress) == 0
+                - message: preDNAT policy cannot have 'Egress' type
+                  reason: FieldValueForbidden
+                  rule:
+                    (!has(self.preDNAT) || !self.preDNAT) || !has(self.types) || !self.types.exists(t,
+                    t == 'Egress')
+                - message:
+                    applyOnForward must be true if either preDNAT or doNotTrack
+                    is true
+                  reason: FieldValueInvalid
+                  rule:
+                    (has(self.applyOnForward) && self.applyOnForward) || ((!has(self.doNotTrack)
+                    || !self.doNotTrack) && (!has(self.preDNAT) || !self.preDNAT))
+          type: object
+      served: true
+      storage: true
+---
+# Source: crds/crd.projectcalico.org_stagedkubernetesnetworkpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: stagedkubernetesnetworkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: StagedKubernetesNetworkPolicy
+    listKind: StagedKubernetesNetworkPolicyList
+    plural: stagedkubernetesnetworkpolicies
+    singular: stagedkubernetesnetworkpolicy
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                egress:
+                  items:
+                    properties:
+                      ports:
+                        items:
+                          properties:
+                            endPort:
+                              format: int32
+                              type: integer
+                            port:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                            protocol:
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      to:
+                        items:
+                          properties:
+                            ipBlock:
+                              properties:
+                                cidr:
+                                  type: string
+                                except:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - cidr
+                              type: object
+                            namespaceSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            podSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  type: array
+                ingress:
+                  items:
+                    properties:
+                      from:
+                        items:
+                          properties:
+                            ipBlock:
+                              properties:
+                                cidr:
+                                  type: string
+                                except:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - cidr
+                              type: object
+                            namespaceSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            podSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      ports:
+                        items:
+                          properties:
+                            endPort:
+                              format: int32
+                              type: integer
+                            port:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                            protocol:
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  type: array
+                podSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                policyTypes:
+                  items:
+                    type: string
+                  maxItems: 2
+                  minItems: 1
+                  type: array
+                  x-kubernetes-list-type: set
+                stagedAction:
+                  default: Set
+                  enum:
+                    - Set
+                    - Delete
+                    - Learn
+                    - Ignore
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: crds/crd.projectcalico.org_stagednetworkpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: stagednetworkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: StagedNetworkPolicy
+    listKind: StagedNetworkPolicyList
+    plural: stagednetworkpolicies
+    singular: stagednetworkpolicy
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                egress:
+                  items:
+                    properties:
+                      action:
+                        enum:
+                          - Allow
+                          - Deny
+                          - Log
+                          - Pass
+                        type: string
+                      destination:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      http:
+                        properties:
+                          methods:
+                            items:
+                              type: string
+                            maxItems: 20
+                            type: array
+                          paths:
+                            items:
+                              properties:
+                                exact:
+                                  maxLength: 1024
+                                  type: string
+                                prefix:
+                                  maxLength: 1024
+                                  type: string
+                              type: object
+                            maxItems: 20
+                            type: array
+                        type: object
+                      icmp:
+                        properties:
+                          code:
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      ipVersion:
+                        enum:
+                          - 4
+                          - 6
+                        type: integer
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      notICMP:
+                        properties:
+                          code:
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - action
+                    type: object
+                    x-kubernetes-validations:
+                      - message: rules with HTTP match must have protocol TCP or unset
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.http) || !has(self.protocol) || self.protocol
+                          == 'TCP' || self.protocol == 6"
+                      - message: HTTP match is only valid on Allow rules
+                        reason: FieldValueForbidden
+                        rule: self.action == 'Allow' || !has(self.http)
+                      - message: ports and notPorts cannot be specified with services
+                        reason: FieldValueForbidden
+                        rule:
+                          "!has(self.destination) || !has(self.destination.services)
+                          || (!has(self.destination.ports) || size(self.destination.ports)
+                          == 0) && (!has(self.destination.notPorts) || size(self.destination.notPorts)
+                          == 0)"
+                  type: array
+                ingress:
+                  items:
+                    properties:
+                      action:
+                        enum:
+                          - Allow
+                          - Deny
+                          - Log
+                          - Pass
+                        type: string
+                      destination:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                      http:
+                        properties:
+                          methods:
+                            items:
+                              type: string
+                            maxItems: 20
+                            type: array
+                          paths:
+                            items:
+                              properties:
+                                exact:
+                                  maxLength: 1024
+                                  type: string
+                                prefix:
+                                  maxLength: 1024
+                                  type: string
+                              type: object
+                            maxItems: 20
+                            type: array
+                        type: object
+                      icmp:
+                        properties:
+                          code:
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      ipVersion:
+                        enum:
+                          - 4
+                          - 6
+                        type: integer
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      notICMP:
+                        properties:
+                          code:
+                            maximum: 255
+                            minimum: 0
+                            type: integer
+                          type:
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                        x-kubernetes-validations:
+                          - message: ICMP code specified without an ICMP type
+                            reason: FieldValueInvalid
+                            rule: "!has(self.code) || has(self.type)"
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        properties:
+                          namespaceSelector:
+                            type: string
+                          nets:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          notNets:
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            type: string
+                          ports:
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            type: string
+                          serviceAccounts:
+                            properties:
+                              names:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              selector:
+                                type: string
+                            type: object
+                          services:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - action
+                    type: object
+                    x-kubernetes-validations:
+                      - message: rules with HTTP match must have protocol TCP or unset
+                        reason: FieldValueInvalid
+                        rule:
+                          "!has(self.http) || !has(self.protocol) || self.protocol
+                          == 'TCP' || self.protocol == 6"
+                      - message: HTTP match is only valid on Allow rules
+                        reason: FieldValueForbidden
+                        rule: self.action == 'Allow' || !has(self.http)
+                      - message: ports and notPorts cannot be specified with services
+                        reason: FieldValueForbidden
+                        rule:
+                          "!has(self.destination) || !has(self.destination.services)
+                          || (!has(self.destination.ports) || size(self.destination.ports)
+                          == 0) && (!has(self.destination.notPorts) || size(self.destination.notPorts)
+                          == 0)"
+                  type: array
+                order:
+                  type: number
+                performanceHints:
+                  items:
+                    enum:
+                      - AssumeNeededOnEveryNode
+                    type: string
+                  type: array
+                selector:
+                  type: string
+                serviceAccountSelector:
+                  type: string
+                stagedAction:
+                  default: Set
+                  enum:
+                    - Set
+                    - Delete
+                    - Learn
+                    - Ignore
+                  type: string
+                tier:
+                  default: default
+                  type: string
+                types:
+                  items:
+                    enum:
+                      - Ingress
+                      - Egress
+                    type: string
+                  maxItems: 2
+                  minItems: 1
+                  type: array
+                  x-kubernetes-list-type: set
+              type: object
+          type: object
+      served: true
+      storage: true
+---
+# Source: crds/crd.projectcalico.org_tiers.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: tiers.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: Tier
+    listKind: TierList
+    plural: tiers
+    singular: tier
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                defaultAction:
+                  allOf:
+                    - enum:
+                        - Allow
+                        - Deny
+                        - Log
+                        - Pass
+                    - enum:
+                        - Pass
+                        - Deny
+                  default: Deny
+                  type: string
+                order:
+                  type: number
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+          x-kubernetes-validations:
+            - message: The 'kube-admin' tier must have default action 'Pass'
+              rule:
+                "self.metadata.name == 'kube-admin' ? self.spec.defaultAction ==
+                'Pass' : true"
+            - message: The 'kube-baseline' tier must have default action 'Pass'
+              rule:
+                "self.metadata.name == 'kube-baseline' ? self.spec.defaultAction
+                == 'Pass' : true"
+            - message: The 'default' tier must have default action 'Deny'
+              rule:
+                "self.metadata.name == 'default' ? self.spec.defaultAction == 'Deny'
+                : true"
+      served: true
+      storage: true
+---
+# Source: crds/policy.networking.k8s.io_clusternetworkpolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/347
+    policy.networking.k8s.io/bundle-version: v0.2.0
+    policy.networking.k8s.io/channel: standard
+  name: clusternetworkpolicies.policy.networking.k8s.io
+spec:
+  group: policy.networking.k8s.io
+  names:
+    kind: ClusterNetworkPolicy
+    listKind: ClusterNetworkPolicyList
+    plural: clusternetworkpolicies
+    shortNames:
+      - cnp
+    singular: clusternetworkpolicy
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.tier
+          name: Tier
+          type: string
+        - jsonPath: .spec.priority
+          name: Priority
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha2
+      schema:
+        openAPIV3Schema:
+          description: ClusterNetworkPolicy is a cluster-wide network policy resource.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the desired behavior of ClusterNetworkPolicy.
+              properties:
+                egress:
+                  description: |-
+                    Egress is the list of Egress rules to be applied to the selected pods.
+
+                    A maximum of 25 rules is allowed in this block.
+
+                    The relative precedence of egress rules within a single CNP object
+                    (all of which share the priority) will be determined by the order
+                    in which the rule is written.
+                    Thus, a rule that appears at the top of the egress rules
+                    would take the highest precedence.
+                    CNPs with no egress rules do not affect egress traffic.
+                  items:
+                    description: |-
+                      ClusterNetworkPolicyEgressRule describes an action to take on a particular
+                      set of traffic originating from pods selected by a ClusterNetworkPolicy's
+                      Subject field.
+
+                      <network-policy-api:experimental:validation>
+                    properties:
+                      action:
+                        description: |-
+                          Action specifies the effect this rule will have on matching
+                          traffic.  Currently the following actions are supported:
+
+                          - Accept: Accepts the selected traffic, allowing it to
+                            egress. No further ClusterNetworkPolicy or NetworkPolicy
+                            rules will be processed.
+
+                          - Deny: Drops the selected traffic. No further
+                            ClusterNetworkPolicy or NetworkPolicy rules will be
+                            processed.
+
+                          - Pass: Skips all further ClusterNetworkPolicy rules in the
+                            current tier for the selected traffic, and passes
+                            evaluation to the next tier.
+                        enum:
+                          - Accept
+                          - Deny
+                          - Pass
+                        type: string
+                      name:
+                        description: |-
+                          Name is an identifier for this rule, that may be no more than
+                          100 characters in length. This field should be used by the implementation
+                          to help improve observability, readability and error-reporting
+                          for any applied policies.
+                        maxLength: 100
+                        type: string
+                      protocols:
+                        description: |-
+                          Protocols allows for more fine-grain matching of traffic on
+                          protocol-specific attributes such as the port. If
+                          unspecified, protocol-specific attributes will not be used
+                          to match traffic.
+                        items:
+                          description: |-
+                            ClusterNetworkPolicyProtocol describes additional protocol-specific match rules.
+                            Exactly one field must be set.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            destinationNamedPort:
+                              description: |-
+                                DestinationNamedPort selects a destination port on a pod based on the
+                                ContainerPort name. You can't use this in a rule that targets resources
+                                without named ports (e.g. Nodes or Networks).
+                              type: string
+                            sctp:
+                              description: SCTP specific protocol matches.
+                              minProperties: 1
+                              properties:
+                                destinationPort:
+                                  description: DestinationPort for the match.
+                                  maxProperties: 1
+                                  minProperties: 1
+                                  properties:
+                                    number:
+                                      description: Number defines a network port value.
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                    range:
+                                      description:
+                                        Range defines a contiguous range
+                                        of ports.
+                                      properties:
+                                        end:
+                                          description: |-
+                                            end specifies the last port in the range. It must be
+                                            greater than start.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                        start:
+                                          description: |-
+                                            start defines a network port that is the start of a port
+                                            range, the Start value must be less than End.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                        - end
+                                        - start
+                                      type: object
+                                      x-kubernetes-validations:
+                                        - message: Start port must be less than End port
+                                          rule: self.start < self.end
+                                  type: object
+                              type: object
+                            tcp:
+                              description: TCP specific protocol matches.
+                              minProperties: 1
+                              properties:
+                                destinationPort:
+                                  description: DestinationPort for the match.
+                                  maxProperties: 1
+                                  minProperties: 1
+                                  properties:
+                                    number:
+                                      description: Number defines a network port value.
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                    range:
+                                      description:
+                                        Range defines a contiguous range
+                                        of ports.
+                                      properties:
+                                        end:
+                                          description: |-
+                                            end specifies the last port in the range. It must be
+                                            greater than start.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                        start:
+                                          description: |-
+                                            start defines a network port that is the start of a port
+                                            range, the Start value must be less than End.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                        - end
+                                        - start
+                                      type: object
+                                      x-kubernetes-validations:
+                                        - message: Start port must be less than End port
+                                          rule: self.start < self.end
+                                  type: object
+                              type: object
+                            udp:
+                              description: UDP specific protocol matches.
+                              minProperties: 1
+                              properties:
+                                destinationPort:
+                                  description: DestinationPort for the match.
+                                  maxProperties: 1
+                                  minProperties: 1
+                                  properties:
+                                    number:
+                                      description: Number defines a network port value.
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                    range:
+                                      description:
+                                        Range defines a contiguous range
+                                        of ports.
+                                      properties:
+                                        end:
+                                          description: |-
+                                            end specifies the last port in the range. It must be
+                                            greater than start.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                        start:
+                                          description: |-
+                                            start defines a network port that is the start of a port
+                                            range, the Start value must be less than End.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                        - end
+                                        - start
+                                      type: object
+                                      x-kubernetes-validations:
+                                        - message: Start port must be less than End port
+                                          rule: self.start < self.end
+                                  type: object
+                              type: object
+                          type: object
+                        maxItems: 25
+                        minItems: 1
+                        type: array
+                      to:
+                        description: |-
+                          To is the list of destinations whose traffic this rule applies to. If any
+                          element matches the destination of outgoing traffic then the specified
+                          action is applied. This field must be defined and contain at least one
+                          item.
+                        items:
+                          description: |-
+                            ClusterNetworkPolicyEgressPeer defines a peer to allow traffic to.
+
+                            Exactly one of the fields must be set for a given peer and this is enforced
+                            by the validation rules on the CRD. If an implementation sees no fields are
+                            set then it can infer that the deployed CRD is of an incompatible version
+                            with an unknown field.  In that case it should fail closed.
+
+                            For "Accept" rules, "fail closed" means: "treat the rule as matching no
+                            traffic". For "Deny" and "Pass" rules, "fail closed" means: "treat the rule
+                            as a 'Deny all' rule".
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            namespaces:
+                              description: |-
+                                Namespaces defines a way to select all pods within a set of Namespaces.
+                                Note that host-networked pods are not included in this type of peer.
+                              properties:
+                                matchExpressions:
+                                  description:
+                                    matchExpressions is a list of label selector
+                                    requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description:
+                                          key is the label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            networks:
+                              description: |-
+                                Networks defines a way to select peers via CIDR blocks.
+                                This is intended for representing entities that live outside the cluster,
+                                which can't be selected by pods, namespaces and nodes peers, but note
+                                that cluster-internal traffic will be checked against the rule as
+                                well. So if you Accept or Deny traffic to `"0.0.0.0/0"`, that will allow
+                                or deny all IPv4 pod-to-pod traffic as well. If you don't want that,
+                                add a rule that Passes all pod traffic before the Networks rule.
+
+                                Each item in Networks should be provided in the CIDR format and should be
+                                IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+
+                                Networks can have up to 25 CIDRs specified.
+                              items:
+                                description: |-
+                                  CIDR is an IP address range in CIDR notation
+                                  (for example, "10.0.0.0/8" or "fd00::/8").
+                                maxLength: 43
+                                type: string
+                                x-kubernetes-validations:
+                                  - message: Invalid CIDR format provided
+                                    rule: isCIDR(self)
+                              maxItems: 25
+                              minItems: 1
+                              type: array
+                              x-kubernetes-list-type: set
+                            pods:
+                              description: |-
+                                Pods defines a way to select a set of pods in
+                                a set of namespaces. Note that host-networked pods
+                                are not included in this type of peer.
+                              properties:
+                                namespaceSelector:
+                                  description: |-
+                                    NamespaceSelector follows standard label selector
+                                    semantics; if empty, it selects all Namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description:
+                                        matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description:
+                                              key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                podSelector:
+                                  description: |-
+                                    PodSelector is used to explicitly select pods within a namespace;
+                                    if empty, it selects all Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description:
+                                        matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description:
+                                              key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                                - podSelector
+                              type: object
+                          type: object
+                        maxItems: 25
+                        minItems: 1
+                        type: array
+                    required:
+                      - action
+                      - to
+                    type: object
+                  maxItems: 25
+                  type: array
+                ingress:
+                  description: |-
+                    Ingress is the list of Ingress rules to be applied to the selected pods.
+
+                    A maximum of 25 rules is allowed in this block.
+
+                    The relative precedence of ingress rules within a single CNP object
+                    (all of which share the priority) will be determined by the order
+                    in which the rule is written.
+                    Thus, a rule that appears at the top of the ingress rules
+                    would take the highest precedence.
+                    CNPs with no ingress rules do not affect ingress traffic.
+                  items:
+                    description: |-
+                      ClusterNetworkPolicyIngressRule describes an action to take on a particular
+                      set of traffic destined for pods selected by a ClusterNetworkPolicy's
+                      Subject field.
+                    properties:
+                      action:
+                        description: |-
+                          Action specifies the effect this rule will have on matching
+                          traffic. Currently the following actions are supported:
+
+                          - Accept: Accepts the selected traffic, allowing it into
+                            the destination. No further ClusterNetworkPolicy or
+                            NetworkPolicy rules will be processed.
+
+                            Note: while Accept ensures traffic is accepted by
+                            Kubernetes network policy, it is still possible that the
+                            packet is blocked in other ways: custom nftable rules,
+                            high-layers e.g. service mesh.
+
+                          - Deny: Drops the selected traffic. No further
+                            ClusterNetworkPolicy or NetworkPolicy rules will be
+                            processed.
+
+                          - Pass: Skips all further ClusterNetworkPolicy rules in the
+                            current tier for the selected traffic, and passes
+                            evaluation to the next tier.
+                        enum:
+                          - Accept
+                          - Deny
+                          - Pass
+                        type: string
+                      from:
+                        description: |-
+                          From is the list of sources whose traffic this rule applies to.
+                          If any element matches the source of incoming
+                          traffic then the specified action is applied.
+                          This field must be defined and contain at least one item.
+                        items:
+                          description: |-
+                            ClusterNetworkPolicyIngressPeer defines a peer to allow traffic from.
+
+                            Exactly one of the fields must be set for a given peer and this is enforced
+                            by the validation rules on the CRD. If an implementation sees no fields are
+                            set then it can infer that the deployed CRD is of an incompatible version
+                            with an unknown field.  In that case it should fail closed.
+
+                            For "Accept" rules, "fail closed" means: "treat the rule as matching no
+                            traffic". For "Deny" and "Pass" rules, "fail closed" means: "treat the rule
+                            as a 'Deny all' rule".
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            namespaces:
+                              description: |-
+                                Namespaces defines a way to select all pods within a set of Namespaces.
+                                Note that host-networked pods are not included in this type of peer.
+                              properties:
+                                matchExpressions:
+                                  description:
+                                    matchExpressions is a list of label selector
+                                    requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description:
+                                          key is the label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            pods:
+                              description: |-
+                                Pods defines a way to select a set of pods in
+                                a set of namespaces. Note that host-networked pods
+                                are not included in this type of peer.
+                              properties:
+                                namespaceSelector:
+                                  description: |-
+                                    NamespaceSelector follows standard label selector
+                                    semantics; if empty, it selects all Namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description:
+                                        matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description:
+                                              key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                podSelector:
+                                  description: |-
+                                    PodSelector is used to explicitly select pods within a namespace;
+                                    if empty, it selects all Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description:
+                                        matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description:
+                                              key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                                - podSelector
+                              type: object
+                          type: object
+                        maxItems: 25
+                        minItems: 1
+                        type: array
+                      name:
+                        description: |-
+                          Name is an identifier for this rule, that may be no more than
+                          100 characters in length. This field should be used by the implementation
+                          to help improve observability, readability and error-reporting
+                          for any applied policies.
+                        maxLength: 100
+                        type: string
+                      protocols:
+                        description: |-
+                          Protocols allows for more fine-grain matching of traffic on
+                          protocol-specific attributes such as the port. If
+                          unspecified, protocol-specific attributes will not be used
+                          to match traffic.
+                        items:
+                          description: |-
+                            ClusterNetworkPolicyProtocol describes additional protocol-specific match rules.
+                            Exactly one field must be set.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            destinationNamedPort:
+                              description: |-
+                                DestinationNamedPort selects a destination port on a pod based on the
+                                ContainerPort name. You can't use this in a rule that targets resources
+                                without named ports (e.g. Nodes or Networks).
+                              type: string
+                            sctp:
+                              description: SCTP specific protocol matches.
+                              minProperties: 1
+                              properties:
+                                destinationPort:
+                                  description: DestinationPort for the match.
+                                  maxProperties: 1
+                                  minProperties: 1
+                                  properties:
+                                    number:
+                                      description: Number defines a network port value.
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                    range:
+                                      description:
+                                        Range defines a contiguous range
+                                        of ports.
+                                      properties:
+                                        end:
+                                          description: |-
+                                            end specifies the last port in the range. It must be
+                                            greater than start.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                        start:
+                                          description: |-
+                                            start defines a network port that is the start of a port
+                                            range, the Start value must be less than End.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                        - end
+                                        - start
+                                      type: object
+                                      x-kubernetes-validations:
+                                        - message: Start port must be less than End port
+                                          rule: self.start < self.end
+                                  type: object
+                              type: object
+                            tcp:
+                              description: TCP specific protocol matches.
+                              minProperties: 1
+                              properties:
+                                destinationPort:
+                                  description: DestinationPort for the match.
+                                  maxProperties: 1
+                                  minProperties: 1
+                                  properties:
+                                    number:
+                                      description: Number defines a network port value.
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                    range:
+                                      description:
+                                        Range defines a contiguous range
+                                        of ports.
+                                      properties:
+                                        end:
+                                          description: |-
+                                            end specifies the last port in the range. It must be
+                                            greater than start.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                        start:
+                                          description: |-
+                                            start defines a network port that is the start of a port
+                                            range, the Start value must be less than End.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                        - end
+                                        - start
+                                      type: object
+                                      x-kubernetes-validations:
+                                        - message: Start port must be less than End port
+                                          rule: self.start < self.end
+                                  type: object
+                              type: object
+                            udp:
+                              description: UDP specific protocol matches.
+                              minProperties: 1
+                              properties:
+                                destinationPort:
+                                  description: DestinationPort for the match.
+                                  maxProperties: 1
+                                  minProperties: 1
+                                  properties:
+                                    number:
+                                      description: Number defines a network port value.
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                    range:
+                                      description:
+                                        Range defines a contiguous range
+                                        of ports.
+                                      properties:
+                                        end:
+                                          description: |-
+                                            end specifies the last port in the range. It must be
+                                            greater than start.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                        start:
+                                          description: |-
+                                            start defines a network port that is the start of a port
+                                            range, the Start value must be less than End.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                        - end
+                                        - start
+                                      type: object
+                                      x-kubernetes-validations:
+                                        - message: Start port must be less than End port
+                                          rule: self.start < self.end
+                                  type: object
+                              type: object
+                          type: object
+                        maxItems: 25
+                        minItems: 1
+                        type: array
+                    required:
+                      - action
+                      - from
+                    type: object
+                  maxItems: 25
+                  type: array
+                priority:
+                  description: |-
+                    Priority is a value from 0 to 1000 indicating the precedence of
+                    the policy within its tier. Policies with lower priority values have
+                    higher precedence, and are checked before policies with higher priority
+                    values in the same tier. All Admin tier rules have higher precedence than
+                    NetworkPolicy or Baseline tier rules.
+                    If two (or more) policies in the same tier with the same priority
+                    could match a connection, then the implementation can apply any of the
+                    matching policies to the connection, and there is no way for the user to
+                    reliably determine which one it will choose. Administrators must be
+                    careful about assigning the priorities for policies with rules that will
+                    match many connections, and ensure that policies have unique priority
+                    values in cases where ambiguity would be unacceptable.
+                  format: int32
+                  maximum: 1000
+                  minimum: 0
+                  type: integer
+                subject:
+                  description:
+                    Subject defines the pods to which this ClusterNetworkPolicy
+                    applies.
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    namespaces:
+                      description: Namespaces is used to select pods via namespace selectors.
+                      properties:
+                        matchExpressions:
+                          description:
+                            matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description:
+                                  key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    pods:
+                      description:
+                        Pods is used to select pods via namespace AND pod
+                        selectors.
+                      properties:
+                        namespaceSelector:
+                          description: |-
+                            NamespaceSelector follows standard label selector
+                            semantics; if empty, it selects all Namespaces.
+                          properties:
+                            matchExpressions:
+                              description:
+                                matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description:
+                                      key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        podSelector:
+                          description: |-
+                            PodSelector is used to explicitly select pods within a namespace;
+                            if empty, it selects all Pods.
+                          properties:
+                            matchExpressions:
+                              description:
+                                matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description:
+                                      key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                        - podSelector
+                      type: object
+                  type: object
+                tier:
+                  description: |-
+                    Tier is used as the top-level grouping for network policy prioritization.
+
+                    Policy tiers are evaluated in the following order:
+                    * Admin tier
+                    * NetworkPolicy tier
+                    * Baseline tier
+
+                    ClusterNetworkPolicy can use 2 of these tiers: Admin and Baseline.
+
+                    The Admin tier takes precedence over all other policies. Policies
+                    defined in this tier are used to set cluster-wide security rules
+                    that cannot be overridden in the other tiers. If Admin tier has
+                    made a final decision (Accept or Deny) on a connection, then no
+                    further evaluation is done.
+
+                    NetworkPolicy tier is the tier for the namespaced v1.NetworkPolicy.
+                    These policies are intended for the application developer to describe
+                    the security policy associated with their deployments inside their
+                    namespace. v1.NetworkPolicy always makes a final decision for selected
+                    pods. Further evaluation only happens for Pods not selected by a
+                    v1.NetworkPolicy.
+
+                    Baseline tier is a cluster-wide policy that can be overridden by the
+                    v1.NetworkPolicy. If Baseline tier has made a final decision (Accept or
+                    Deny) on a connection, then no further evaluation is done.
+
+                    If a given connection wasn't allowed or denied by any of the tiers,
+                    the default kubernetes policy is applied, which says that
+                    all pods can communicate with each other.
+                  enum:
+                    - Admin
+                    - Baseline
+                  type: string
+              required:
+                - priority
+                - subject
+                - tier
+              type: object
+            status:
+              description: Status is the status to be reported by the implementation.
+              properties:
+                conditions:
+                  items:
+                    description:
+                      Condition contains details for one aspect of the current
+                      state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+              required:
+                - conditions
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/SPECS/calico/calico-v3.32.0-openruyi-riscv64.yaml.in
+++ b/SPECS/calico/calico-v3.32.0-openruyi-riscv64.yaml.in
@@ -1,0 +1,361 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-node
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-cni-plugin
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-kube-controllers
+  namespace: kube-system
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-config
+  namespace: kube-system
+data:
+  typha_service_name: "none"
+  calico_backend: "vxlan"
+  veth_mtu: "0"
+  cni_network_config: |-
+    {
+      "name": "k8s-pod-network",
+      "cniVersion": "0.3.1",
+      "plugins": [
+        {
+          "type": "calico",
+          "log_level": "info",
+          "log_file_path": "/var/log/calico/cni/cni.log",
+          "datastore_type": "kubernetes",
+          "nodename": "__KUBERNETES_NODE_NAME__",
+          "mtu": __CNI_MTU__,
+          "ipam": {"type": "calico-ipam"},
+          "policy": {"type": "k8s"},
+          "kubernetes": {"kubeconfig": "__KUBECONFIG_FILEPATH__"}
+        },
+        {
+          "type": "portmap",
+          "snat": true,
+          "capabilities": {"portMappings": true}
+        }
+      ]
+    }
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: calico-node
+rules:
+- apiGroups: [""]
+  resources: ["pods", "nodes", "nodes/status", "namespaces", "serviceaccounts", "endpoints", "services", "configmaps", "secrets"]
+  verbs: ["get", "list", "watch", "create", "update", "patch"]
+- apiGroups: [""]
+  resources: ["pods/status"]
+  verbs: ["patch"]
+- apiGroups: ["authentication.k8s.io"]
+  resources: ["tokenreviews"]
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources: ["subjectaccessreviews"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["serviceaccounts/token"]
+  verbs: ["create"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "list", "watch", "create", "update", "patch"]
+- apiGroups: ["networking.k8s.io"]
+  resources: ["networkpolicies"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["policy.networking.k8s.io"]
+  resources: ["adminnetworkpolicies", "baselineadminnetworkpolicies", "clusternetworkpolicies"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["kubevirt.io"]
+  resources: ["virtualmachineinstances", "virtualmachineinstancemigrations"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["crd.projectcalico.org"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-node
+subjects:
+- kind: ServiceAccount
+  name: calico-node
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-cni-plugin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-node
+subjects:
+- kind: ServiceAccount
+  name: calico-cni-plugin
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-kube-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-node
+subjects:
+- kind: ServiceAccount
+  name: calico-kube-controllers
+  namespace: kube-system
+---
+apiVersion: crd.projectcalico.org/v1
+kind: IPPool
+metadata:
+  name: default-ipv4-ippool
+spec:
+  allowedUses:
+  - Workload
+  - Tunnel
+  assignmentMode: Automatic
+  blockSize: 26
+  cidr: 10.244.0.0/16
+  ipipMode: Never
+  natOutgoing: true
+  nodeSelector: all()
+  vxlanMode: Always
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: calico-node
+  namespace: kube-system
+  labels:
+    k8s-app: calico-node
+spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-node
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-node
+    spec:
+      hostNetwork: true
+      serviceAccountName: calico-node
+      priorityClassName: system-node-critical
+      terminationGracePeriodSeconds: 0
+      tolerations:
+      - operator: Exists
+      initContainers:
+      - name: install-cni
+        image: localhost/kubernetes/calico:v3.32.0-riscv64
+        imagePullPolicy: Never
+        command: ["/opt/cni/bin/install"]
+        env:
+        - name: CNI_CONF_NAME
+          value: "10-calico.conflist"
+        - name: CNI_NETWORK_CONFIG
+          valueFrom:
+            configMapKeyRef:
+              name: calico-config
+              key: cni_network_config
+        - name: KUBERNETES_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: CNI_MTU
+          valueFrom:
+            configMapKeyRef:
+              name: calico-config
+              key: veth_mtu
+        - name: SLEEP
+          value: "false"
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-bin-dir
+        - mountPath: /host/etc/cni/net.d
+          name: cni-net-dir
+        securityContext:
+          privileged: true
+      containers:
+      - name: calico-node
+        image: localhost/kubernetes/calico:v3.32.0-riscv64
+        imagePullPolicy: Never
+        env:
+        - name: DATASTORE_TYPE
+          value: "kubernetes"
+        - name: WAIT_FOR_DATASTORE
+          value: "true"
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: CALICO_NETWORKING_BACKEND
+          value: "vxlan"
+        - name: CLUSTER_TYPE
+          value: "k8s,openruyi"
+        - name: IP
+          value: "autodetect"
+        - name: IP_AUTODETECTION_METHOD
+          value: "interface=eth1"
+        - name: CALICO_IPV4POOL_CIDR
+          value: "10.244.0.0/16"
+        - name: CALICO_IPV4POOL_IPIP
+          value: "Never"
+        - name: CALICO_IPV4POOL_VXLAN
+          value: "Always"
+        - name: CALICO_IPV4POOL_NAT_OUTGOING
+          value: "true"
+        - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+          value: "ACCEPT"
+        - name: FELIX_IPV6SUPPORT
+          value: "false"
+        - name: FELIX_HEALTHENABLED
+          value: "true"
+        - name: FELIX_IPTABLESBACKEND
+          value: "NFT"
+        - name: FELIX_BPFENABLED
+          value: "false"
+        - name: FELIX_BPFKUBEPROXYIPTABLESCLEANUPENABLED
+          value: "false"
+        - name: FELIX_XDPENABLED
+          value: "false"
+        - name: FELIX_LOGSEVERITYSYS
+          value: "none"
+        - name: CALICO_DISABLE_FILE_LOGGING
+          value: "true"
+        securityContext:
+          privileged: true
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/calico-node", "-shutdown"]
+        livenessProbe:
+          exec:
+            command: ["/bin/calico-node", "-felix-live"]
+          periodSeconds: 10
+          initialDelaySeconds: 20
+          failureThreshold: 6
+          timeoutSeconds: 10
+        readinessProbe:
+          exec:
+            command: ["/bin/calico-node", "-felix-ready"]
+          periodSeconds: 10
+          timeoutSeconds: 10
+        volumeMounts:
+        - mountPath: /host/etc/cni/net.d
+          name: cni-net-dir
+          readOnly: false
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
+          readOnly: false
+        - mountPath: /var/run/calico
+          name: var-run-calico
+          readOnly: false
+        - mountPath: /var/lib/calico
+          name: var-lib-calico
+          readOnly: false
+        - mountPath: /var/run/nodeagent
+          name: policysync
+      volumes:
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      - name: var-run-calico
+        hostPath:
+          path: /var/run/calico
+          type: DirectoryOrCreate
+      - name: var-lib-calico
+        hostPath:
+          path: /var/lib/calico
+          type: DirectoryOrCreate
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+      - name: cni-bin-dir
+        hostPath:
+          path: /opt/cni/bin
+          type: DirectoryOrCreate
+      - name: cni-net-dir
+        hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate
+      - name: policysync
+        hostPath:
+          path: /var/run/nodeagent
+          type: DirectoryOrCreate
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: calico-kube-controllers
+  namespace: kube-system
+  labels:
+    k8s-app: calico-kube-controllers
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: calico-kube-controllers
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-kube-controllers
+    spec:
+      serviceAccountName: calico-kube-controllers
+      priorityClassName: system-cluster-critical
+      tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        effect: NoSchedule
+      - key: CriticalAddonsOnly
+        operator: Exists
+      containers:
+      - name: calico-kube-controllers
+        image: localhost/kubernetes/calico:v3.32.0-riscv64
+        imagePullPolicy: Never
+        command: ["/usr/bin/kube-controllers"]
+        env:
+        - name: ENABLED_CONTROLLERS
+          value: "node,loadbalancer"
+        - name: DATASTORE_TYPE
+          value: "kubernetes"
+        livenessProbe:
+          exec:
+            command: ["/usr/bin/check-status", "-l"]
+          periodSeconds: 10
+          initialDelaySeconds: 10
+          failureThreshold: 6
+          timeoutSeconds: 10
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/check-status", "-r"]
+          periodSeconds: 10
+          timeoutSeconds: 10

--- a/SPECS/calico/calico.spec
+++ b/SPECS/calico/calico.spec
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: wangyf0611 <wangyufeng@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           calico
+Version:        3.32.0
+Release:        %autorelease
+Summary:        Calico manifests for openRuyi RISC-V Kubernetes clusters
+License:        Apache-2.0
+URL:            https://github.com/projectcalico/calico
+BuildArch:      noarch
+#!RemoteAsset:  sha256:55defb4135a7f04942ff596848b4decc5eeed67d0d97f81b57df5395f41354c9
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+# Kubernetes multi-document manifests: upstream CRDs and the validated RISC-V deployment.
+Source1:        calico-v%{version}-crds.yaml.in
+Source2:        calico-v%{version}-openruyi-riscv64.yaml.in
+Source3:        README.openruyi
+
+Recommends:     kubernetes
+
+%description
+Calico provides Kubernetes pod networking and network policy. This package
+installs the Calico v3.32.0 CRD manifest and the openRuyi RISC-V multi-node
+VXLAN manifest used by the validated Kata Containers and Cloud Hypervisor
+Kubernetes environment.
+
+%prep
+%setup -q -n %{name}-%{version}
+
+%build
+# Nothing to build; the package installs Kubernetes manifests.
+
+%install
+install -Dpm0644 %{SOURCE1} \
+    %{buildroot}%{_datadir}/kubernetes/calico/calico-v%{version}-crds.yaml
+install -Dpm0644 %{SOURCE2} \
+    %{buildroot}%{_datadir}/kubernetes/calico/calico-v%{version}-openruyi-riscv64.yaml
+install -Dpm0644 %{SOURCE3} \
+    %{buildroot}%{_datadir}/kubernetes/calico/README.openruyi
+
+%check
+grep -q 'localhost/kubernetes/calico:v%{version}-riscv64' %{SOURCE2}
+grep -q 'vxlanMode: Always' %{SOURCE2}
+grep -q 'interface=eth1' %{SOURCE2}
+
+%files
+%doc README.md
+%license LICENSE.md
+%dir %{_datadir}/kubernetes
+%dir %{_datadir}/kubernetes/calico
+%{_datadir}/kubernetes/calico/calico-v%{version}-crds.yaml
+%{_datadir}/kubernetes/calico/calico-v%{version}-openruyi-riscv64.yaml
+%{_datadir}/kubernetes/calico/README.openruyi
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

add calico for openruyi k8s network

obs validation: home:yufeng:calico

## Related Issue

openruyi 202608 k8s task

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: ChatGPT:GPT-5.5

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
