### PR TITLE
[openruyi k8s]: add sonobuoy

### DIFF
--- a/SPECS/sonobuoy/0001-config-format-advertise-ip-with-net.JoinHostPort.patch
+++ b/SPECS/sonobuoy/0001-config-format-advertise-ip-with-net.JoinHostPort.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Masashi Honma <1505016+masap@users.noreply.github.com>
+Date: Tue, 11 Aug 2026 16:00:00 +0800
+Subject: [PATCH] config: format advertise IP with net.JoinHostPort
+
+SONOBUOY_ADVERTISE_IP is populated from the aggregator pod IP.  Formatting
+every value as an IPv6 literal produces invalid IPv4 URLs such as
+https://[10.244.0.1]:8080.  Use net.JoinHostPort so IPv4 addresses remain
+host:port while IPv6 addresses are still bracketed.
+
+Signed-off-by: wangyf0611 <wangyufeng@iscas.ac.cn>
+---
+ pkg/config/loader.go | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/pkg/config/loader.go b/pkg/config/loader.go
+index 4e4ff3a..f1b27de 100644
+--- a/pkg/config/loader.go
++++ b/pkg/config/loader.go
+@@ -20,7 +20,9 @@ import (
+ 	"encoding/json"
+ 	"fmt"
+ 	"io"
++	"net"
+ 	"os"
++	"strconv"
+ 	"strings"
+ 
+ 	"github.com/sirupsen/logrus"
+@@ -90,7 +92,7 @@ func (cfg *Config) Resolve() {
+ 	// Figure out what address we will tell pods to dial for aggregation
+ 	if cfg.Aggregation.AdvertiseAddress == "" {
+ 		if ip := os.Getenv("SONOBUOY_ADVERTISE_IP"); ip != "" {
+-			cfg.Aggregation.AdvertiseAddress = fmt.Sprintf("[%v]:%d", ip, cfg.Aggregation.BindPort)
++			cfg.Aggregation.AdvertiseAddress = net.JoinHostPort(ip, strconv.Itoa(cfg.Aggregation.BindPort))
+ 		} else {
+ 			hostname, _ := os.Hostname()
+ 			if hostname != "" {
+-- 
+2.51.0

--- a/SPECS/sonobuoy/openruyi-riscv-sonobuoy-smoke.yaml
+++ b/SPECS/sonobuoy/openruyi-riscv-sonobuoy-smoke.yaml
@@ -1,0 +1,31 @@
+sonobuoy-config:
+  driver: Job
+  plugin-name: openruyi-riscv-smoke
+  result-format: raw
+spec:
+  command:
+  - /bin/sh
+  - -c
+  - |
+    set -eu
+    results_dir="${RESULTS_DIR:-/tmp/sonobuoy/results}"
+    mkdir -p "${results_dir}"
+    {
+     echo "openRuyi RISC-V Sonobuoy smoke"
+     printf "node=%s\n" "${NODE_NAME:-unknown}"
+     uname -m
+     if [ -r /etc/os-release ]; then
+       sed -n '1,3p' /etc/os-release
+     else
+       echo "image=busybox"
+     fi
+     nslookup kubernetes.default.svc.cluster.local || true
+    } > "${results_dir}/smoke.txt"
+    printf "%s" "${results_dir}" > "${results_dir}/done"
+  image: docker.io/library/busybox:1.36.1
+  imagePullPolicy: IfNotPresent
+  name: plugin
+  resources: {}
+  volumeMounts:
+  - mountPath: /tmp/results
+    name: results

--- a/SPECS/sonobuoy/sonobuoy.spec
+++ b/SPECS/sonobuoy/sonobuoy.spec
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: wangyf0611 <wangyufeng@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           sonobuoy
+Version:        0.57.3
+Release:        %autorelease
+Summary:        Kubernetes cluster conformance and diagnostics tool
+License:        Apache-2.0
+URL:            https://github.com/vmware-tanzu/sonobuoy
+#!RemoteAsset:  sha256:d581032898c17f1df6db90e85aae8dae6429e8cd2a1b54e1728ddeaa7d9a989c
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+#!RemoteAsset:  sha256:a4e1f88aed223e6c52344b708a467ec83ea8783a8532b66bb0c28f5e6024cc93
+Source1:        https://github.com/software-vendor/go-sonobuoy-vendor/releases/download/v%{version}/%{name}-%{version}-vendor.tar.gz
+# RISC-V smoke-test manifest installed with the package.
+Source2:        openruyi-riscv-sonobuoy-smoke.yaml
+
+# Adapt the upstream IPv4 aggregator address fix for v%{version}.
+# https://github.com/vmware-tanzu/sonobuoy/commit/08e4ff4475e5e30c596dc6f8ff94708b3750f9d4
+Patch0:         0001-config-format-advertise-ip-with-net.JoinHostPort.patch
+
+BuildRequires:  go >= 1.23
+BuildRequires:  go-rpm-macros
+
+Recommends:     kubernetes
+
+%description
+Sonobuoy is a diagnostic tool that makes it easier to understand the state of a
+Kubernetes cluster by running plugins, collecting results, and producing a
+portable result bundle.
+
+%prep
+%autosetup -n %{name}-%{version} -p1
+tar -xzf %{SOURCE1}
+
+%build
+export GOCACHE=%{_builddir}/go-build-cache
+export GOFLAGS="-mod=vendor -trimpath -modcacherw"
+export GOTOOLCHAIN=local
+
+%__go build %{go_build_flags_default} -o %{name} .
+
+%install
+install -Dpm0755 %{name} %{buildroot}%{_bindir}/%{name}
+install -Dpm0644 %{SOURCE2} %{buildroot}%{_datadir}/%{name}/openruyi-riscv-sonobuoy-smoke.yaml
+
+%check
+%{buildroot}%{_bindir}/%{name} version
+%{buildroot}%{_bindir}/%{name} gen plugin --help >/dev/null
+
+%files
+%doc README.md CONTRIBUTING.md SECURITY.md vendor/modules.txt
+%license LICENSE
+%{_bindir}/%{name}
+%{_datadir}/%{name}/openruyi-riscv-sonobuoy-smoke.yaml
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

add sonobuoy as an openruyi k8s cluster test tool.
obs validation: home:yufeng:sonobuoy

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

openruyi 202608 k8s task

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: ChatGPT:GPT-5.5

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
