### PR TITLE
SPECS: glibc: add back symlink /usr/lib64/lp64d -> /usr/lib64

### DIFF
--- a/SPECS/glibc/glibc.spec
+++ b/SPECS/glibc/glibc.spec
@@ -272,7 +272,10 @@ ln -s %{buildroot}%{_sbindir} %{buildroot}/sbin
 ln -s bin %{buildroot}/%{_prefix}/sbin
 %endif
 
+%ifarch riscv64
 mkdir -p %{buildroot}%{_libdir}
+ln -s . %{buildroot}%{_libdir}/lp64d
+%endif
 mkdir -p %{buildroot}%{_prefix}/lib
 mkdir -p %{buildroot}%{_prefix}/lib/locale
 
@@ -410,6 +413,9 @@ rpm.spawn({"%{_sbindir}/ldconfig"})
 %attr(755,root,root) %{rtlddir}/%{rtld_name}
 %if 0%{?rtld_oldname:1}
 %attr(755,root,root) %{rtlddir}/%{rtld_oldname}
+%endif
+%ifarch riscv64
+%{_libdir}/lp64d
 %endif
 %{_libdir}/libBrokenLocale.so.1
 %{_libdir}/libanl.so.1


### PR DESCRIPTION
## Summary

Transition for making compiler work. GCC does not search lib64 by default.

Fixes: d7eda85ebd5623c95225e5f7e57e7f049dadc71c

## Related Issue

Resolves #

- Resolves #1046 
- Fixes #1034

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
