### PR TITLE
SPECS: clang-wrap: Fix 2 cmake problems

### DIFF
--- a/SPECS/clang-wrap/clang-wrap.spec
+++ b/SPECS/clang-wrap/clang-wrap.spec
@@ -4,8 +4,8 @@
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
-%global git_ver git20260813.61647ae
-%global git_commit 61647ae15a409fef8d1663feae720b5467b0055d
+%global git_ver git20260814.79032e7
+%global git_commit 79032e78a3d76dc46f793cf0b4103278a69da689
 
 Name:           clang-wrap
 Version:        0+%{git_ver}
@@ -13,7 +13,7 @@ Release:        %{autorelease}
 License:        Mulan-2.0
 Summary:        clang-wrap to collect LLVM IR
 URL:            https://github.com/openRuyi-Project/clang-wrap
-#!RemoteAsset:  sha256:41fa9d19b1050db402e358dfb324f7b3abfbb064db15db699375ff06cd1fda29
+#!RemoteAsset:  sha256:6d18256fb93139ba94d30d98b05bfe472dd729ac9014c9a2a14b4a9857c6b3b6
 Source0:        https://github.com/openRuyi-Project/clang-wrap/archive/%{git_commit}.tar.gz
 Source1:        macros.clang-wrap
 BuildSystem:    rust


### PR DESCRIPTION
## Summary

1. strip -ffat-lto-objects option from _cmd file
2. use -l:soname instead of ../soname

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: CLine:GPT-5.6-Terra

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
