### PR TITLE
SPECS: libjpeg-turbo: Ship LLVM IR files

### DIFF
--- a/SPECS/libjpeg-turbo/libjpeg-turbo.spec
+++ b/SPECS/libjpeg-turbo/libjpeg-turbo.spec
@@ -6,23 +6,52 @@
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
+%bcond llvmir 1
+%if %{with llvmir}
+  %ifarch x86_64
+     %global emit_llvmir_flags -march=x86-64-v4
+  %elifarch riscv64
+     %global emit_llvmir_flags -march=rva23u64
+  %else
+     %global emit_llvmir_flags 1
+  %endif
+
+%global ___build_pre \
+        set -x \
+        export CMAKE_EMIT_LLVMIR=%{emit_llvmir_flags} \
+        set +x \
+        %{?___build_pre}
+%global toolchain clang
+%endif
+
 Name:           libjpeg-turbo
 Version:        3.1.2
 Release:        %autorelease
 Summary:        A SIMD-accelerated library for manipulating JPEG image files
 License:        Zlib AND BSD-3-Clause AND MIT AND IJG
 URL:            https://github.com/libjpeg-turbo/libjpeg-turbo
-#!RemoteAsset
+#!RemoteAsset:  sha256:560f6338b547544c4f9721b18d8b87685d433ec78b3c644c70d77adad22c55e6
 Source:         https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/%{version}.tar.gz
 Patch:          0001-libjpeg-turbo-cmake.patch
 BuildSystem:    cmake
 
 BuildOption(conf):  -DENABLE_STATIC:BOOL=NO
 BuildOption(conf):  -DFLOATTEST:STRING="fp-contract"
+%if %{with llvmir}
+BuildOption(conf):  -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES:STRING=%{_libdir}/clang-wrap/cmake/CMakeEmitLLVMIR.cmake
+BuildOption(conf):  -DCMAKE_C_COMPILER:STRING=clang
+BuildOption(conf):  -DCMAKE_CXX_COMPILER:STRING=clang++
+%endif
+
 
 BuildRequires:  gcc
 BuildRequires:  cmake
 BuildRequires:  libtool
+%if %{with llvmir}
+BuildRequires:  clang
+BuildRequires:  llvm
+BuildRequires:  clang-wrap
+%endif
 
 %description
 The libjpeg-turbo package contains a library of functions for manipulating JPEG
@@ -63,11 +92,17 @@ TurboJPEG library.
 
 %install -a
 rm -f %{buildroot}/%{_bindir}/tjbench
+%if %{with llvmir}
+rm -f %{buildroot}/%{clang_wrap_llvmir_bin_dir}/tjbench*
+%endif
 
 %files
 %license LICENSE.md
 %doc README.md README.ijg ChangeLog.md
 %{_libdir}/libjpeg.so.62*
+%if %{with llvmir}
+%{clang_wrap_llvmir_dir}/libjpeg.so.62*
+%endif
 
 %files devel
 %doc doc/coderules.txt src/jconfig.txt doc/libjpeg.txt doc/structure.txt
@@ -88,6 +123,13 @@ rm -f %{buildroot}/%{_bindir}/tjbench
 %{_bindir}/jpegtran
 %{_bindir}/rdjpgcom
 %{_bindir}/wrjpgcom
+%if %{with llvmir}
+%{clang_wrap_llvmir_bin_dir}/cjpeg*
+%{clang_wrap_llvmir_bin_dir}/djpeg*
+%{clang_wrap_llvmir_bin_dir}/jpegtran*
+%{clang_wrap_llvmir_bin_dir}/rdjpgcom*
+%{clang_wrap_llvmir_bin_dir}/wrjpgcom*
+%endif
 %{_mandir}/man1/cjpeg.1*
 %{_mandir}/man1/djpeg.1*
 %{_mandir}/man1/jpegtran.1*
@@ -98,6 +140,9 @@ rm -f %{buildroot}/%{_bindir}/tjbench
 %license LICENSE.md
 %doc README.md README.ijg ChangeLog.md
 %{_libdir}/libturbojpeg.so.0*
+%if %{with llvmir}
+%{clang_wrap_llvmir_dir}/libturbojpeg.so.0*
+%endif
 
 %files -n turbojpeg-devel
 %{_includedir}/turbojpeg.h
@@ -105,4 +150,4 @@ rm -f %{buildroot}/%{_bindir}/tjbench
 %{_libdir}/pkgconfig/libturbojpeg.pc
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
Build libjpeg-turbo with clang and ship the LLVM IR of it.

## Summary

Build libjpeg-turbo with clang and ship the LLVM IR of it.

## Benchmark

Benchmark is run with tjbench on a Intel(R) Xeon(R) CPU E7-8890 v4 @ 2.20GHz server
with `./tjbench testout12_440_islow.ppm 80 -rgb -subsamp 420 -nowrite -quiet -benchtime 10 -warmup 10`
```
For Pure clang-22 build
Pixel     JPEG      JPEG  Image  Image   Comp    Comp    Decomp
Format    Format    Qual  Width  Height  Perf    Ratio   Perf

RGB (TD)  8 /4:2:0  80    227    149     37.14   16.74   73.44
```

```
For Pure gcc-16 build
Pixel     JPEG      JPEG  Image  Image   Comp    Comp    Decomp
Format    Format    Qual  Width  Height  Perf    Ratio   Perf

RGB (TD)  8 /4:2:0  80    227    149     39.28   16.74   72.21
```

```
With shared objects convert from LLVM IR to native E7-8890 v4
Pixel     JPEG      JPEG  Image  Image   Comp    Comp    Decomp
Format    Format    Qual  Width  Height  Perf    Ratio   Perf

RGB (TD)  8 /4:2:0  80    227    149     58.89   16.74   78.56
```

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
