### PR TITLE
SPECS: python-icalendar: update to 7.2.2 [security-fixes]

### DIFF
--- a/SPECS/python-icalendar/python-icalendar.spec
+++ b/SPECS/python-icalendar/python-icalendar.spec
@@ -1,19 +1,20 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
 # SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
+# SPDX-FileContributor: Zitao Zhou <zitao.oerv@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %global srcname icalendar
 
 Name:           python-%{srcname}
-Version:        7.1.0
+Version:        7.2.2
 Release:        %autorelease
 Summary:        RFC 5545 compatible parser and generator of iCalendar files
 License:        BSD-2-Clause
 URL:            https://icalendar.readthedocs.io
 VCS:            git:https://github.com/collective/icalendar.git
-#!RemoteAsset:  sha256:10cd223c792fcc43bee4c3ebe3149d4cf32406c85cfef146624df5a0d414260f
+#!RemoteAsset:  sha256:6cf904a928881e20c89b682e75bca2eb97e8c5ca629782ed44a519abf4cac1cc
 Source0:        https://files.pythonhosted.org/packages/source/i/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

Fixed advisories:
| Package          | Version | Manifest  | Status             | CVE | GHSA                                                                                                                     |
| ---------------- | ------- | --------- | ------------------ | --- | ------------------------------------------------------------------------------------------------------------------------ |
| python-icalendar | 7.1.0   | pyproject | external_reference | -   | [GHSA-cv84-9p8j-fj68](https://github.com/collective/icalendar/security/advisories/GHSA-cv84-9p8j-fj68) |
## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

no issue.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
