### PR TITLE
SPECS: python-joserfc: update to 1.7.4 [security-fixes]

### DIFF
--- a/SPECS/python-joserfc/python-joserfc.spec
+++ b/SPECS/python-joserfc/python-joserfc.spec
@@ -1,18 +1,19 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
 # SPDX-FileContributor: Xuhai Chang <xuhai.oerv@isrc.iscas.ac.cn>
+# SPDX-FileContributor: Zitao Zhou <zitao.oerv@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %global srcname joserfc
 
 Name:           python-%{srcname}
-Version:        1.6.4
+Version:        1.7.4
 Release:        %autorelease
 Summary:        The ultimate Python library for JOSE RFCs (JWS, JWE, JWK, JWA, JWT)
 License:        BSD-3-Clause
 URL:            https://github.com/authlib/joserfc
-#!RemoteAsset:  sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c
+#!RemoteAsset:  sha256:b3bc561672ae541b17a9237053b48a03dacddd92d68047b3ecdfb4b5714a88ed
 Source0:        https://files.pythonhosted.org/packages/source/j/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject


### PR DESCRIPTION
## Summary

| Package        | Version | Manifest  | Status             | CVE                                                               | GHSA                                                                                              |
| -------------- | ------- | --------- | ------------------ | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| python-joserfc | 1.6.4   | pyproject | external_reference | -                                                                 | [GHSA-gg9x-qcx2-xmrh](https://github.com/authlib/joserfc/security/advisories/GHSA-gg9x-qcx2-xmrh) |
| python-joserfc | 1.6.4   | pyproject | external_reference | [CVE-2026-48990](https://www.cve.org/CVERecord?id=CVE-2026-48990) | [GHSA-wphv-vfrh-23q5](https://github.com/authlib/joserfc/security/advisories/GHSA-wphv-vfrh-23q5) |

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

no issue.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
