### PR TITLE
SPECS: python-lxml: update to 6.1.1 [security-fixes]

### DIFF
--- a/SPECS/python-lxml/python-lxml.spec
+++ b/SPECS/python-lxml/python-lxml.spec
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: (C) 2025 openRuyi Project Contributors
 # SPDX-FileContributor: Zheng Junjie <zhengjunjie@iscas.ac.cn>
 # SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
+# SPDX-FileContributor: Zitao Zhou <zitao.oerv@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
@@ -12,14 +13,14 @@
 %bcond extras 0
 
 Name:           python-%{srcname}
-Version:        6.0.1
+Version:        6.1.1
 Release:        %autorelease
 Summary:        XML processing library combining libxml2/libxslt with the ElementTree API
 License:        BSD-3-Clause AND GPL-2.0-or-later
 URL:            https://github.com/lxml/lxml
 # TODO: Use %%{pypi_source %%{srcname} %%{version}} in the future - 251
 #       Otherwise https://files.pythonhosted.org/packages/source/a/abc/%%{srcname}-%%{version}.tar.gz
-#!RemoteAsset:  sha256:2b3a882ebf27dd026df3801a87cf49ff791336e0f94b0fad195db77e01240690
+#!RemoteAsset:  sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40
 Source0:        https://files.pythonhosted.org/packages/source/l/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildSystem:    pyproject
 


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

| Package     | Version | Manifest  | Status                             | CVE                                                               | GHSA                                                                                           |
| ----------- | ------- | --------- | ---------------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| python-lxml | 6.0.1   | pyproject | affected_by_osv+external_reference | [CVE-2026-41066](https://www.cve.org/CVERecord?id=CVE-2026-41066) | [GHSA-vfmq-68hx-4jfw](https://github.com/lxml/lxml/security/advisories/GHSA-vfmq-68hx-4jfw) |

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

no issue.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
