### PR TITLE
SPECS: python-protobuf: update to 7.35.1 [security-fixes]

### DIFF
--- a/SPECS/python-protobuf/python-protobuf.spec
+++ b/SPECS/python-protobuf/python-protobuf.spec
@@ -1,18 +1,19 @@
 # SPDX-FileCopyrightText: (C) 2025 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2025 openRuyi Project Contributors
 # SPDX-FileContributor: yyjeqhc <jialin.oerv@isrc.iscas.ac.cn>
+# SPDX-FileContributor: Zitao Zhou <zitao.oerv@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %global srcname protobuf
 
 Name:           python-%{srcname}
-Version:        6.33.6
+Version:        7.35.1
 Release:        %autorelease
 Summary:        Python bindings for Protocol Buffers
 License:        BSD-3-Clause
 URL:            https://developers.google.com/protocol-buffers/
-#!RemoteAsset:  sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135
+#!RemoteAsset:  sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildSystem:    pyproject
 


### PR DESCRIPTION

## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

| Package         | Version | Manifest  | Status                               | CVE                                                             | GHSA                                                                        |
| --------------- | ------- | --------- | ------------------------------------ | --------------------------------------------------------------- | --------------------------------------------------------------------------- |
| python-protobuf | 6.33.2  | pyproject | affected_by_osv+dependency_reference | [CVE-2026-0994](https://www.cve.org/CVERecord?id=CVE-2026-0994) | [GHSA-7gcm-g887-7qv7](https://github.com/advisories/GHSA-7gcm-g887-7qv7) |

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

no issue.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
