### PR TITLE
SPECS: python-pydantic-settings: update to 2.15.0 [security-fixes]

### DIFF
--- a/SPECS/python-pydantic-settings/python-pydantic-settings.spec
+++ b/SPECS/python-pydantic-settings/python-pydantic-settings.spec
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
 # SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+# SPDX-FileContributor: Zitao Zhou <zitao.oerv@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
@@ -8,13 +9,13 @@
 %global pypi_name pydantic_settings
 
 Name:           python-%{srcname}
-Version:        2.14.1
+Version:        2.15.0
 Release:        %autorelease
 Summary:        Settings management using Pydantic
 License:        MIT
 URL:            https://github.com/pydantic/pydantic-settings
 VCS:            git:https://github.com/pydantic/pydantic-settings.git
-#!RemoteAsset:  sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa
+#!RemoteAsset:  sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117
 Source:         https://files.pythonhosted.org/packages/source/p/%{srcname}/%{pypi_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject


### PR DESCRIPTION

## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

| Package                  | Version | Manifest  | Status                             | CVE | GHSA                                                                                                        |
| ------------------------ | ------- | --------- | ---------------------------------- | --- | ----------------------------------------------------------------------------------------------------------- |
| python-pydantic-settings | 2.14.1  | pyproject | affected_by_osv+external_reference | -   | [GHSA-4xgf-cpjx-pc3j](https://github.com/pydantic/pydantic-settings/security/advisories/GHSA-4xgf-cpjx-pc3j) |

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

no issue.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
