### PR TITLE
SPECS: python-pyjwt: update to 2.13.0 [security-fixes]

### DIFF
--- a/SPECS/python-pyjwt/python-pyjwt.spec
+++ b/SPECS/python-pyjwt/python-pyjwt.spec
@@ -1,18 +1,19 @@
 # SPDX-FileCopyrightText: (C) 2025 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2025 openRuyi Project Contributors
 # SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
+# SPDX-FileContributor: Zitao Zhou <zitao.oerv@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %global srcname pyjwt
 
 Name:           python-%{srcname}
-Version:        2.12.1
+Version:        2.13.0
 Release:        %autorelease
 Summary:        Implementation of JSON Web Token validation for Python
 License:        MIT
 URL:            https://github.com/jpadilla/pyjwt
-#!RemoteAsset:  sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b
+#!RemoteAsset:  sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject


### PR DESCRIPTION

## Summary

| Package      | Version | Manifest  | Status                             | CVE                                                               | GHSA                                                                                              |
| ------------ | ------- | --------- | ---------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| python-pyjwt | 2.12.1  | pyproject | affected_by_osv+external_reference | [CVE-2026-48522](https://www.cve.org/CVERecord?id=CVE-2026-48522) | [GHSA-993g-76c3-p5m4](https://github.com/jpadilla/pyjwt/security/advisories/GHSA-993g-76c3-p5m4) |
| python-pyjwt | 2.12.1  | pyproject | affected_by_osv+external_reference | [CVE-2026-48524](https://www.cve.org/CVERecord?id=CVE-2026-48524) | [GHSA-fhv5-28vv-h8m8](https://github.com/jpadilla/pyjwt/security/advisories/GHSA-fhv5-28vv-h8m8) |
| python-pyjwt | 2.12.1  | pyproject | affected_by_osv+external_reference | [CVE-2026-48523](https://www.cve.org/CVERecord?id=CVE-2026-48523) | [GHSA-jq35-7prp-9v3f](https://github.com/jpadilla/pyjwt/security/advisories/GHSA-jq35-7prp-9v3f) |
| python-pyjwt | 2.12.1  | pyproject | affected_by_osv+external_reference | [CVE-2026-48525](https://www.cve.org/CVERecord?id=CVE-2026-48525) | [GHSA-w7vc-732c-9m39](https://github.com/jpadilla/pyjwt/security/advisories/GHSA-w7vc-732c-9m39) |
| python-pyjwt | 2.12.1  | pyproject | affected_by_osv+external_reference | [CVE-2026-48526](https://www.cve.org/CVERecord?id=CVE-2026-48526) | [GHSA-xgmm-8j9v-c9wx](https://github.com/advisories/GHSA-xgmm-8j9v-c9wx) |

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

no issue.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
