### PR TITLE
SPECS: python-python-multipart: update to 0.0.32 [security-fixes]

### DIFF
--- a/SPECS/python-python-multipart/python-python-multipart.spec
+++ b/SPECS/python-python-multipart/python-python-multipart.spec
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
 # SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+# SPDX-FileContributor: Zitao Zhou <zitao.oerv@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
@@ -8,13 +9,13 @@
 %global pypi_name python_multipart
 
 Name:           python-%{srcname}
-Version:        0.0.28
+Version:        0.0.32
 Release:        %autorelease
 Summary:        Streaming multipart parser for Python
 License:        Apache-2.0
 URL:            https://github.com/Kludex/python-multipart
 VCS:            git:https://github.com/Kludex/python-multipart.git
-#!RemoteAsset:  sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8
+#!RemoteAsset:  sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e
 Source0:        https://files.pythonhosted.org/packages/source/p/%{srcname}/%{pypi_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->
| Package                 | Version | Manifest  | Status                             | CVE                                                               | GHSA                                                                                                         |
| ----------------------- | ------- | --------- | ---------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
| python-python-multipart | 0.0.28  | pyproject | affected_by_osv+external_reference | [CVE-2026-53539](https://www.cve.org/CVERecord?id=CVE-2026-53539) | [GHSA-5rvq-cxj2-64vf](https://github.com/Kludex/python-multipart/security/advisories/GHSA-5rvq-cxj2-64vf) |
| python-python-multipart | 0.0.28  | pyproject | affected_by_osv+external_reference | [CVE-2026-53538](https://www.cve.org/CVERecord?id=CVE-2026-53538) | [GHSA-6jv3-5f52-599m](https://github.com/Kludex/python-multipart/security/advisories/GHSA-6jv3-5f52-599m) |
| python-python-multipart | 0.0.28  | pyproject | affected_by_osv+external_reference | [CVE-2026-53540](https://www.cve.org/CVERecord?id=CVE-2026-53540) | [GHSA-v9pg-7xvm-68hf](https://github.com/Kludex/python-multipart/security/advisories/GHSA-v9pg-7xvm-68hf) |
| python-python-multipart | 0.0.28  | pyproject | affected_by_osv+external_reference | [CVE-2026-53537](https://www.cve.org/CVERecord?id=CVE-2026-53537) | [GHSA-vffw-93wf-4j4q](https://github.com/Kludex/python-multipart/security/advisories/GHSA-vffw-93wf-4j4q) |

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

no issue.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
