### PR TITLE
SPECS: python-starlette: update to 1.6.0 [security-fixes]

### DIFF
--- a/SPECS/python-starlette/python-starlette.spec
+++ b/SPECS/python-starlette/python-starlette.spec
@@ -1,19 +1,20 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
 # SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+# SPDX-FileContributor: Zitao Zhou <zitao.oerv@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %global srcname starlette
 
 Name:           python-%{srcname}
-Version:        1.0.0
+Version:        1.6.0
 Release:        %autorelease
 Summary:        The little ASGI library that shines
 License:        BSD-3-Clause
 URL:            https://github.com/Kludex/starlette
 VCS:            git:https://github.com/Kludex/starlette.git
-#!RemoteAsset:  sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149
+#!RemoteAsset:  sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b
 Source:         https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject


### PR DESCRIPTION

## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

| Package          | Version | Manifest  | Status                             | CVE                                                               | GHSA                                                                                                    |
| ---------------- | ------- | --------- | ---------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
| python-starlette | 1.0.0   | pyproject | affected_by_osv+external_reference | [CVE-2026-54283](https://www.cve.org/CVERecord?id=CVE-2026-54283) | [GHSA-82w8-qh3p-5jfq](https://github.com/Kludex/starlette/security/advisories/GHSA-82w8-qh3p-5jfq) |
| python-starlette | 1.0.0   | pyproject | affected_by_osv+external_reference | [CVE-2026-48710](https://www.cve.org/CVERecord?id=CVE-2026-48710) | [GHSA-86qp-5c8j-p5mr](https://github.com/Kludex/starlette/security/advisories/GHSA-86qp-5c8j-p5mr) |
| python-starlette | 1.0.0   | pyproject | affected_by_osv+external_reference | [CVE-2026-54282](https://www.cve.org/CVERecord?id=CVE-2026-54282) | [GHSA-jp82-jpqv-5vv3](https://github.com/Kludex/starlette/security/advisories/GHSA-jp82-jpqv-5vv3) |
| python-starlette | 1.0.0   | pyproject | affected_by_osv+external_reference | [CVE-2026-48818](https://www.cve.org/CVERecord?id=CVE-2026-48818) | [GHSA-wqp7-x3pw-xc5r](https://github.com/Kludex/starlette/security/advisories/GHSA-wqp7-x3pw-xc5r) |
| python-starlette | 1.0.0   | pyproject | affected_by_osv+external_reference | [CVE-2026-48817](https://www.cve.org/CVERecord?id=CVE-2026-48817) | [GHSA-x746-7m8f-x49c](https://github.com/Kludex/starlette/security/advisories/GHSA-x746-7m8f-x49c) |

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

no issue.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
