### PR TITLE
SPECS: python-tornado: update to 6.5.8 [security-fixes]

### DIFF
--- a/SPECS/python-tornado/python-tornado.spec
+++ b/SPECS/python-tornado/python-tornado.spec
@@ -1,18 +1,19 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
 # SPDX-FileContributor: yyjeqhc <jialin.oerv@isrc.iscas.ac.cn>
+# SPDX-FileContributor: Zitao Zhou <zitao.oerv@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %global srcname tornado
 
 Name:           python-%{srcname}
-Version:        6.5.4
+Version:        6.5.8
 Release:        %autorelease
 Summary:        Scalable, non-blocking web server and tools
 License:        Apache-2.0
 URL:            https://github.com/tornadoweb/tornado
-#!RemoteAsset:  sha256:a22fa9047405d03260b483980635f0b041989d8bcc9a313f8fe18b411d84b1d7
+#!RemoteAsset:  sha256:9452e1b208a8bd771e2cb1f2ff564985b9b214bdebbe622793e1799e0a6bd23f
 Source0:        https://files.pythonhosted.org/packages/source/t/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildSystem:    pyproject
 


### PR DESCRIPTION

## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

| Package        | Version | Manifest  | Status                                                     | CVE                                                               | GHSA                                                                                                      |
| -------------- | ------- | --------- | ---------------------------------------------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
| python-tornado | 6.5.4   | pyproject | affected_by_osv+external_reference+dependency_reference    | -                                                                 | [GHSA-3x9g-8vmp-wqvf](https://github.com/tornadoweb/tornado/security/advisories/GHSA-3x9g-8vmp-wqvf) |
| python-tornado | 6.5.4   | pyproject | affected_by_osv+external_reference+dependency_reference    | -                                                                 | [GHSA-78cv-mqj4-43f7](https://github.com/tornadoweb/tornado/security/advisories/GHSA-78cv-mqj4-43f7) |
| python-tornado | 6.5.4   | pyproject | affected_by_osv+external_reference+dependency_reference    | -                                                                 | [GHSA-cx3h-4qpv-8hc9](https://github.com/advisories/GHSA-cx3h-4qpv-8hc9) |
| python-tornado | 6.5.4   | pyproject | affected_by_osv+external_reference+dependency_reference    | [CVE-2026-35536](https://www.cve.org/CVERecord?id=CVE-2026-35536) | [GHSA-fqwm-6jpj-5wxc](https://github.com/advisories/GHSA-fqwm-6jpj-5wxc) |
| python-tornado | 6.5.4   | pyproject | affected_by_osv+external_reference+dependency_reference    | -                                                                 | [GHSA-mgf9-4vpg-hj56](https://github.com/tornadoweb/tornado/security/advisories/GHSA-mgf9-4vpg-hj56) |
| python-tornado | 6.5.4   | pyproject | affected_by_osv+external_reference+dependency_reference    | -                                                                 | [GHSA-pw6j-qg29-8w7f](https://github.com/tornadoweb/tornado/security/advisories/GHSA-pw6j-qg29-8w7f) |
| python-tornado | 6.5.4   | pyproject | affected_by_osv+external_reference+dependency_reference    | [CVE-2026-31958](https://www.cve.org/CVERecord?id=CVE-2026-31958) | [GHSA-qjxf-f2mg-c6mc](https://github.com/tornadoweb/tornado/security/advisories/GHSA-qjxf-f2mg-c6mc) |

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

no issue.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
