### PR TITLE
SPECS: python-gradio-client: update to 2.6.0 [security-fixes]

### DIFF
--- a/SPECS/python-gradio-client/python-gradio-client.spec
+++ b/SPECS/python-gradio-client/python-gradio-client.spec
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
 # SPDX-FileContributor: Li Guan <guanli.oerv@isrc.iscas.ac.cn>
+# SPDX-FileContributor: Zitao Zhou <zitao.oerv@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
@@ -8,12 +9,12 @@
 %global pypi_name gradio_client
 
 Name:           python-%{srcname}
-Version:        2.5.0
+Version:        2.6.0
 Release:        %autorelease
 Summary:        Python library for easily interacting with trained machine learning models
 License:        Apache-2.0
 URL:            https://github.com/gradio-app/gradio
-#!RemoteAsset:  sha256:4cde99bad62149595c30c90876ca2e405e3a13687ecf895474f3412cb476673d
+#!RemoteAsset:  sha256:e648110efa31347bb8b1abda150a7a975b40a9658fdd8562803e2ad6a300d033
 Source0:        https://files.pythonhosted.org/packages/source/g/%{srcname}/%{pypi_name}-%{version}.tar.gz
 #!RemoteAsset:  sha256:c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
 Source1:        https://raw.githubusercontent.com/gradio-app/gradio/refs/tags/@gradio/client@2.2.0/LICENSE


### PR DESCRIPTION

## Summary


| Package              | Version | Manifest  | Status             | CVE                                                               | GHSA                                                                                                      |
| -------------------- | ------- | --------- | ------------------ | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
| python-gradio-client | 2.5.0   | pyproject | external_reference | -                                                                 | [GHSA-26jh-r8g2-6fpr](https://github.com/gradio-app/gradio/security/advisories/GHSA-26jh-r8g2-6fpr) |
| python-gradio-client | 2.5.0   | pyproject | external_reference | [CVE-2024-47871](https://www.cve.org/CVERecord?id=CVE-2024-47871) | [GHSA-279j-x4gx-hfrh](https://github.com/gradio-app/gradio/security/advisories/GHSA-279j-x4gx-hfrh) |
| python-gradio-client | 2.5.0   | pyproject | external_reference | [CVE-2024-47166](https://www.cve.org/CVERecord?id=CVE-2024-47166) | [GHSA-37qc-qgx6-9xjv](https://github.com/gradio-app/gradio/security/advisories/GHSA-37qc-qgx6-9xjv) |
| python-gradio-client | 2.5.0   | pyproject | external_reference | [CVE-2026-28414](https://www.cve.org/CVERecord?id=CVE-2026-28414) | [GHSA-39mp-8hj3-5c49](https://github.com/gradio-app/gradio/security/advisories/GHSA-39mp-8hj3-5c49) |
| python-gradio-client | 2.5.0   | pyproject | external_reference | [CVE-2024-47084](https://www.cve.org/CVERecord?id=CVE-2024-47084) | [GHSA-3c67-5hwx-f6wx](https://github.com/gradio-app/gradio/security/advisories/GHSA-3c67-5hwx-f6wx) |
| python-gradio-client | 2.5.0   | pyproject | external_reference | [CVE-2023-34239](https://www.cve.org/CVERecord?id=CVE-2023-34239) | [GHSA-3qqg-pgqq-3695](https://github.com/gradio-app/gradio/security/advisories/GHSA-3qqg-pgqq-3695) |
| python-gradio-client | 2.5.0   | pyproject | external_reference | [CVE-2023-25823](https://www.cve.org/CVERecord?id=CVE-2023-25823) | [GHSA-3x5j-9vwr-8rr5](https://github.com/gradio-app/gradio/security/advisories/GHSA-3x5j-9vwr-8rr5) |
| python-gradio-client | 2.5.0   | pyproject | external_reference | -                                                                 | [GHSA-48cq-79qq-6f7x](https://github.com/gradio-app/gradio/security/advisories/GHSA-48cq-79qq-6f7x) |
| python-gradio-client | 2.5.0   | pyproject | external_reference | [CVE-2024-47868](https://www.cve.org/CVERecord?id=CVE-2024-47868) | [GHSA-4q3c-cj7g-jcwf](https://github.com/gradio-app/gradio/security/advisories/GHSA-4q3c-cj7g-jcwf) |
| python-gradio-client | 2.5.0   | pyproject | external_reference | [CVE-2024-47167](https://www.cve.org/CVERecord?id=CVE-2024-47167) | [GHSA-576c-3j53-r9jj](https://github.com/gradio-app/gradio/security/advisories/GHSA-576c-3j53-r9jj) |
| python-gradio-client | 2.5.0   | pyproject | external_reference | [CVE-2023-51449](https://www.cve.org/CVERecord?id=CVE-2023-51449) | [GHSA-6qm2-wpxq-7qh2](https://github.com/gradio-app/gradio/security/advisories/GHSA-6qm2-wpxq-7qh2) |
| python-gradio-client | 2.5.0   | pyproject | external_reference | [CVE-2024-47164](https://www.cve.org/CVERecord?id=CVE-2024-47164) | [GHSA-77xq-6g77-h274](https://github.com/gradio-app/gradio/security/advisories/GHSA-77xq-6g77-h274) |
| python-gradio-client | 2.5.0   | pyproject | external_reference | [CVE-2024-47165](https://www.cve.org/CVERecord?id=CVE-2024-47165) | [GHSA-89v2-pqfv-c5r9](https://github.com/gradio-app/gradio/security/advisories/GHSA-89v2-pqfv-c5r9) |
| python-gradio-client | 2.5.0   | pyproject | external_reference | [CVE-2024-47867](https://www.cve.org/CVERecord?id=CVE-2024-47867) | [GHSA-8c87-gvhj-xm8m](https://github.com/gradio-app/gradio/security/advisories/GHSA-8c87-gvhj-xm8m) |
| python-gradio-client | 2.5.0   | pyproject | external_reference | [CVE-2022-24770](https://www.cve.org/CVERecord?id=CVE-2022-24770) | [GHSA-f8xq-q7px-wg8c](https://github.com/gradio-app/gradio/security/advisories/GHSA-f8xq-q7px-wg8c) |
| python-gradio-client | 2.5.0   | pyproject | external_reference | [CVE-2024-47872](https://www.cve.org/CVERecord?id=CVE-2024-47872) | [GHSA-gvv6-33j7-884g](https://github.com/gradio-app/gradio/security/advisories/GHSA-gvv6-33j7-884g) |
| python-gradio-client | 2.5.0   | pyproject | external_reference | [CVE-2024-47168](https://www.cve.org/CVERecord?id=CVE-2024-47168) | [GHSA-hm3c-93pg-4cxw](https://github.com/gradio-app/gradio/security/advisories/GHSA-hm3c-93pg-4cxw) |
| python-gradio-client | 2.5.0   | pyproject | external_reference | -                                                                 | [GHSA-hmx6-r76c-85g9](https://github.com/gradio-app/gradio/security/advisories/GHSA-hmx6-r76c-85g9) |
| python-gradio-client | 2.5.0   | pyproject | external_reference | [CVE-2025-23042](https://www.cve.org/CVERecord?id=CVE-2025-23042) | [GHSA-j2jg-fq62-7c3h](https://github.com/gradio-app/gradio/security/advisories/GHSA-j2jg-fq62-7c3h) |
| python-gradio-client | 2.5.0   | pyproject | external_reference | [CVE-2024-47869](https://www.cve.org/CVERecord?id=CVE-2024-47869) | [GHSA-j757-pf57-f8r4](https://github.com/gradio-app/gradio/security/advisories/GHSA-j757-pf57-f8r4) |
| python-gradio-client | 2.5.0   | pyproject | external_reference | [CVE-2026-28416](https://www.cve.org/CVERecord?id=CVE-2026-28416) | [GHSA-jmh7-g254-2cq9](https://github.com/gradio-app/gradio/security/advisories/GHSA-jmh7-g254-2cq9) |
| python-gradio-client | 2.5.0   | pyproject | external_reference | -                                                                 | [GHSA-m842-4qm8-7gpq](https://github.com/gradio-app/gradio/security/advisories/GHSA-m842-4qm8-7gpq) |
| python-gradio-client | 2.5.0   | pyproject | external_reference | [CVE-2026-28415](https://www.cve.org/CVERecord?id=CVE-2026-28415) | [GHSA-pfjf-5gxr-995x](https://github.com/gradio-app/gradio/security/advisories/GHSA-pfjf-5gxr-995x) |
| python-gradio-client | 2.5.0   | pyproject | external_reference | [CVE-2024-47870](https://www.cve.org/CVERecord?id=CVE-2024-47870) | [GHSA-xh2x-3mrm-fwqm](https://github.com/gradio-app/gradio/security/advisories/GHSA-xh2x-3mrm-fwqm) |

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

no issue.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
