### PR TITLE
SPECS: python-langsmith: update to 0.11.0 [security-fixes]

### DIFF
--- a/SPECS/python-langsmith/python-langsmith.spec
+++ b/SPECS/python-langsmith/python-langsmith.spec
@@ -1,26 +1,27 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
 # SPDX-FileContributor: Kimmy <yucheng.or@isrc.iscas.ac.cn>
+# SPDX-FileContributor: Zitao Zhou <zitao.oerv@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %global srcname langsmith
 
 Name:           python-%{srcname}
-Version:        0.8.8
+Version:        0.11.0
 Release:        %autorelease
 Summary:        Client library for the LangSmith platform
 License:        MIT
 URL:            https://smith.langchain.com/
 VCS:            git:https://github.com/langchain-ai/langsmith-sdk.git
-#!RemoteAsset:  sha256:9d00e54f54d833c1914003527ff03ad0364741034330da72f0adbeaba852b6cf
+#!RemoteAsset:  sha256:7339f90e6fd9a1a009445b5084a7a0e56a8b6f17305ee5d7e8c5e7582217854f
 Source0:        https://files.pythonhosted.org/packages/source/l/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
 
 BuildOption(install):  %{srcname}
-# Skip optional Strands integration: No module named 'strands_agents'.
-BuildOption(check):  -e 'langsmith.integrations.strands_agents*'
+# Skip optional integrations that need extra dependencies.
+BuildOption(check):  -e 'langsmith.integrations.livekit*' -e 'langsmith.integrations.pipecat*' -e 'langsmith.integrations.strands_agents*'
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)


### PR DESCRIPTION

## Summary

| Package          | Version | Manifest  | Status                             | CVE | GHSA                                                                                                              |
| ---------------- | ------- | --------- | ---------------------------------- | --- | ----------------------------------------------------------------------------------------------------------------- |
| python-langsmith | 0.8.8   | pyproject | affected_by_osv+external_reference | -   | [GHSA-f4xh-w4cj-qxq8](https://github.com/langchain-ai/langsmith-sdk/security/advisories/GHSA-f4xh-w4cj-qxq8) |

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

no issue.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
