### PR TITLE
SPECS: python-mcp: update to 2.0.0 [security-fixes]

### DIFF
--- a/SPECS/python-mcp/2000-python-mcp-use-static-version-and-distro-deps.patch
+++ b/SPECS/python-mcp/2000-python-mcp-use-static-version-and-distro-deps.patch
@@ -1,42 +1,73 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
-Date: Thu, 30 Apr 2026 21:00:00 +0800
-Subject: [PATCH] python-mcp: use static version and distro dependency names
+Date: Mon, 24 Aug 2026 00:00:00 +1000
+Subject: [PATCH] python-mcp: use static metadata and distro dependencies
 
 ---
- pyproject.toml | 8 ++++----
- 1 file changed, 4 insertions(+), 4 deletions(-)
+ pyproject.toml | 50 +++++++++++++++++---------------------------------
+ 1 file changed, 18 insertions(+), 32 deletions(-)
 
---- a/pyproject.toml	2026-04-30 20:40:34.672705599 +0800
-+++ b/pyproject.toml	2026-04-30 20:40:34.680705600 +0800
-@@ -1,6 +1,6 @@
- [project]
- name = "mcp"
--dynamic = ["version"]
-+version = "1.26.0"
- description = "Model Context Protocol SDK"
- readme = "README.md"
- requires-python = ">=3.10"
-@@ -31,9 +31,9 @@
-     "sse-starlette>=1.6.1",
-     "pydantic-settings>=2.5.2",
-     "uvicorn>=0.31.1; sys_platform != 'emscripten'",
--    "jsonschema>=4.20.0",
-+    "jsonschema>=4.17.3",
-     "pywin32>=310; sys_platform == 'win32'",
--    "pyjwt[crypto]>=2.10.1",
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -3 +3 @@ name = "mcp"
+-dynamic = ["version", "dependencies"]
++version = "2.0.0"
+@@ -26,0 +27,16 @@ classifiers = [
++dependencies = [
++    "anyio>=4.9",
++    "httpx2>=2.5.0",
++    "pydantic>=2.12.0",
++    "starlette>=0.27",
++    "python-multipart>=0.0.9",
++    "sse-starlette>=3.0.0",
++    "uvicorn>=0.31.1; sys_platform != 'emscripten'",
++    "jsonschema>=4.20.0",
++    "pywin32>=311; sys_platform == 'win32'",
 +    "pyjwt>=2.10.1",
-     "typing-extensions>=4.9.0",
-     "typing-inspection>=0.4.1",
- ]
-@@ -72,7 +72,7 @@
- ]
- 
- [build-system]
++    "typing-extensions>=4.13.0",
++    "typing-inspection>=0.4.1",
++    "opentelemetry-api>=1.28.0",
++]
++
+@@ -109 +125 @@ codegen = ["datamodel-code-generator==0.57.0"]
 -requires = ["hatchling", "uv-dynamic-versioning"]
 +requires = ["hatchling"]
- build-backend = "hatchling.build"
- 
- [tool.hatch.version]
+@@ -111,8 +126,0 @@ build-backend = "hatchling.build"
+-
+-[tool.hatch.version]
+-source = "uv-dynamic-versioning"
+-
+-[tool.uv-dynamic-versioning]
+-vcs = "git"
+-style = "pep440"
+-bump = true
+@@ -120,23 +127,0 @@ bump = true
+-[tool.hatch.metadata.hooks.uv-dynamic-versioning]
+-dependencies = [
+-    # anyio < 4.10 triggers a compile-time SyntaxWarning on Python 3.14 (PEP 765,
+-    # "'return' in a 'finally' block"); for stdio servers it lands on the child's
+-    # stderr (agronholm/anyio#816, fixed in 4.10).
+-    "anyio>=4.10; python_version >= '3.14'",
+-    "anyio>=4.9; python_version < '3.14'",
+-    "httpx2>=2.5.0",
+-    "mcp-types=={{ version }}",
+-    "pydantic>=2.12.0",
+-    "starlette>=0.48.0; python_version >= '3.14'",
+-    "starlette>=0.27; python_version < '3.14'",
+-    "python-multipart>=0.0.9",
+-    "sse-starlette>=3.0.0",
+-    "uvicorn>=0.31.1; sys_platform != 'emscripten'",
+-    "jsonschema>=4.20.0",
+-    "pywin32>=311; sys_platform == 'win32'",
+-    "pyjwt[crypto]>=2.10.1",
+-    "typing-extensions>=4.13.0",
+-    "typing-inspection>=0.4.1",
+-    "opentelemetry-api>=1.28.0",
+-]
+-
+@@ -150,0 +135,3 @@ packages = ["src/mcp"]
++
++[tool.hatch.build.targets.wheel.force-include]
++"src/mcp-types/mcp_types" = "mcp_types"
 -- 
 2.51.0

--- a/SPECS/python-mcp/python-mcp.spec
+++ b/SPECS/python-mcp/python-mcp.spec
@@ -1,18 +1,19 @@
 # SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
 # SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+# SPDX-FileContributor: Zitao Zhou <zitao.oerv@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %global srcname mcp
 
 Name:           python-%{srcname}
-Version:        1.26.0
+Version:        2.0.0
 Release:        %autorelease
 Summary:        Model Context Protocol SDK
 License:        MIT
 URL:            https://github.com/modelcontextprotocol/python-sdk
-#!RemoteAsset:  sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66
+#!RemoteAsset:  sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728
 Source0:        https://files.pythonhosted.org/packages/source/m/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject
@@ -27,10 +28,12 @@ BuildOption(check):  -e 'mcp.cli*' %{srcname}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  python3dist(anyio)
+BuildRequires:  python3dist(cryptography)
 BuildRequires:  python3dist(hatchling)
-BuildRequires:  python3dist(httpx)
+BuildRequires:  python3dist(httpx2)
 BuildRequires:  python3dist(httpx-sse)
 BuildRequires:  python3dist(jsonschema)
+BuildRequires:  python3dist(opentelemetry-api)
 BuildRequires:  python3dist(pydantic)
 BuildRequires:  python3dist(pydantic-settings)
 BuildRequires:  python3dist(pyjwt)
@@ -42,6 +45,7 @@ BuildRequires:  python3dist(typing-inspection)
 BuildRequires:  python3dist(uvicorn)
 
 Provides:       python3-%{srcname} = %{version}-%{release}
+Provides:       python3dist(mcp-types) = %{version}
 %python_provide python3-%{srcname}
 
 %description
@@ -58,6 +62,7 @@ components for MCP-based integrations.
 %doc README.md
 %license LICENSE
 %{_bindir}/mcp
+%{python3_sitelib}/mcp_types/
 
 %changelog
 %autochangelog


### PR DESCRIPTION

## Summary

| Package    | Version | Manifest  | Status                                   | CVE | GHSA                                                                                                                   |
| ---------- | ------- | --------- | ---------------------------------------- | --- | ---------------------------------------------------------------------------------------------------------------------- |
| python-mcp | 1.26.0  | pyproject | external_reference+dependency_reference | -   | [GHSA-hvrp-rf83-w775](https://github.com/modelcontextprotocol/python-sdk/security/advisories/GHSA-hvrp-rf83-w775) |
| python-mcp | 1.26.0  | pyproject | external_reference+dependency_reference | -   | [GHSA-jpw9-pfvf-9f58](https://github.com/modelcontextprotocol/python-sdk/security/advisories/GHSA-jpw9-pfvf-9f58) |

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

no issue.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: Codex-GPT5.6-Sol

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
