### PR TITLE
SPECS: llvm22: Fix VPlan phi recipe ordering.

### DIFF
--- a/SPECS/llvm22/2002-fix-VPlan-phi-recipe-ordering.patch
+++ b/SPECS/llvm22/2002-fix-VPlan-phi-recipe-ordering.patch
@@ -1,0 +1,32 @@
+From: LiYong Tai <liyongtai@iscas.ac.cn>
+Date: Fri, 14 Aug 2026 22:21:05 +0800
+Subject: llvm22: fix VPlan phi recipe ordering
+
+Insert recipes generated while scalarizing pointer inductions after all
+phi-like recipes in the vector loop header. This preserves VPlan recipe
+ordering and fixes a LoopVectorize crash on RISC-V vector targets.
+
+Signed-off-by: misaka00251 <liuxin@iscas.ac.cn>
+---
+diff --git a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+index b41e04cff6d8..011d5894a267 100644
+--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
++++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+@@ -3829,7 +3829,13 @@ void VPlanTransforms::convertToConcreteRecipes(VPlan &Plan) {
+         // If the recipe only generates scalars, scalarize it instead of
+         // expanding it.
+         if (WidenIVR->onlyScalarsGenerated(Plan.hasScalableVF())) {
+-          VPBuilder Builder(WidenIVR);
++          // Insert the scalarizing recipes after all phi-like recipes in the
++          // header, not before WidenIVR: WidenIVR may be followed by further
++          // phi-like recipes, and inserting non-phi recipes before it would
++          // leave phi-like recipes after non-phi ones.
++          VPBasicBlock *HeaderVPBB =
++              Plan.getVectorLoopRegion()->getEntryBasicBlock();
++          VPBuilder Builder(HeaderVPBB, HeaderVPBB->getFirstNonPhi());
+           VPValue *PtrAdd =
+               scalarizeVPWidenPointerInduction(WidenIVR, Plan, Builder);
+           WidenIVR->replaceAllUsesWith(PtrAdd);
+-- 
+2.55.0
+

--- a/SPECS/llvm22/llvm22.spec
+++ b/SPECS/llvm22/llvm22.spec
@@ -86,6 +86,9 @@ Source0:        https://github.com/llvm/llvm-project/releases/download/llvmorg-%
 Patch2000:         2000-Add-riscv64-openruyi-linux-triple-and-set-it-to-rva2.patch
 %endif
 Patch2001:         2001-Add-openruyi-linux-to-X86_64Triples-and-RISCV64Tripl.patch
+# Keep scalarized pointer-induction recipes after all phi-like recipes in the
+# VPlan header, fixing an LLVM LoopVectorize crash on RISC-V vector targets.
+Patch2002:         2002-fix-VPlan-phi-recipe-ordering.patch
 
 # clang patches
 


### PR DESCRIPTION
## Summary

Fix the LLVM LoopVectorize crash triggered when building Rust packages with RISC-V vector support at higher optimization levels. The issue was reproducible with both RVA23 and `riscv64gc` with the V extension enabled, and caused `image-webp` (and packages depending on it) to fail to build. This change restores successful compilation under the affected configurations.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #938
-->

- Resolves #938

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
