### PR TITLE
SPECS: python-numpy: Fix wrong LAPACK lib selection.

### DIFF
--- a/SPECS/python-numpy/python-numpy.spec
+++ b/SPECS/python-numpy/python-numpy.spec
@@ -17,7 +17,7 @@ Source:         https://files.pythonhosted.org/packages/source/n/%{srcname}/%{sr
 BuildSystem:    pyproject
 
 BuildOption(build):  -Csetup-args=-Dblas=openblas
-BuildOption(build):  -Csetup-args=-Dlapack=lapack
+BuildOption(build):  -Csetup-args=-Dlapack=openblas
 BuildOption(install):  -l %{srcname} -L
 
 BuildRequires:  pyproject-rpm-macros


### PR DESCRIPTION
We have no seperate lapack package for now. At least, when building it complained:
```
[   19s]   Run-time dependency lapack found: NO (tried pkgconfig and system)
```

 Use openblas library instead.

## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
