### PR TITLE
SPECS: python-scipy: Update to 1.17.1 and use lp64 openblas.

### DIFF
--- a/SPECS/python-scipy/python-scipy.spec
+++ b/SPECS/python-scipy/python-scipy.spec
@@ -10,17 +10,17 @@
 %global _pyproject_wheeldir %{_builddir}/%{name}-%{version}-%{release}/pyproject-wheeldir
 
 Name:           python-%{srcname}
-Version:        1.17.0
+Version:        1.17.1
 Release:        %autorelease
 Summary:        Scientific Tools for Python
 License:        BSD-3-Clause AND LGPL-2.0-or-later AND BSL-1.0
 URL:            https://www.scipy.org
-#!RemoteAsset:  sha256:2591060c8e648d8b96439e111ac41fd8342fdeff1876be2e19dea3fe8930454e
+#!RemoteAsset:  sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0
 Source0:        https://files.pythonhosted.org/packages/source/s/%{srcname}/%{srcname}-%{version}.tar.gz
 BuildSystem:    pyproject
 
-BuildOption(build):  -Csetup-args=-Dblas=openblas64
-BuildOption(build):  -Csetup-args=-Dlapack=openblas64
+BuildOption(build):  -Csetup-args=-Dblas=openblas
+BuildOption(build):  -Csetup-args=-Dlapack=openblas
 BuildOption(install):  -l %{srcname} -L
 # We don't have python3dist(pooch)
 BuildOption(check):  -e scipy.datasets.tests.test_data


### PR DESCRIPTION
Openblas64 is ilp64 library which has 64-bit integer size. [Python-scipy 1.17 has only initial support of ilp64 openblas library](https://github.com/scipy/scipy/releases). Falling back to lp64 library can avoid compatible problems.

1.17.1 is a bugfix release of 1.17.
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #992 

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
