### PR TITLE
SPECS: rocthrust & rocrand: disable building test

### DIFF
--- a/SPECS/rocrand/rocrand.spec
+++ b/SPECS/rocrand/rocrand.spec
@@ -27,7 +27,9 @@ BuildSystem:    cmake
 
 BuildOption(conf):  -G Ninja
 BuildOption(conf):  -DAMDGPU_TARGETS=%{rocm_gpu_list_default}
+%if %{with test}
 BuildOption(conf):  -DBUILD_TEST=ON
+%endif
 BuildOption(conf):  -DCMAKE_C_COMPILER=%{rocmllvm_bindir}/clang
 BuildOption(conf):  -DCMAKE_CXX_COMPILER=%{rocmllvm_bindir}/clang++
 
@@ -65,12 +67,14 @@ Requires:       %{name}%{?_isa} = %{version}-%{release}
 %description    devel
 The rocRAND development package.
 
+%if %{with test}
 %package        test
 Summary:        Tests for %{name}
 Requires:       %{name}%{?_isa} = %{version}-%{release}
 
 %description    test
 %{_description}
+%endif
 
 %conf -p
 export PATH=%{rocmllvm_bindir}:$PATH
@@ -93,9 +97,11 @@ rm -f %{buildroot}%{_datadir}/doc/rocrand/LICENSE.md
 %{_libdir}/cmake/rocrand/
 %{_libdir}/librocrand.so
 
+%if %{with test}
 %files test
 %{_bindir}/rocRAND/
 %{_bindir}/test_*
+%endif
 
 %changelog
 %autochangelog

--- a/SPECS/rocthrust/rocthrust.spec
+++ b/SPECS/rocthrust/rocthrust.spec
@@ -34,7 +34,9 @@ BuildSystem:    cmake
 
 BuildOption(conf):  -G Ninja
 BuildOption(conf):  -DAMDGPU_TARGETS=%{rocm_gpu_list_default}
+%if %{with test}
 BuildOption(conf):  -DBUILD_TEST=ON
+%endif
 BuildOption(conf):  -DSQLITE_USE_SYSTEM_PACKAGE=ON
 BuildOption(conf):  -DCMAKE_C_COMPILER=%{rocmllvm_bindir}/clang
 BuildOption(conf):  -DCMAKE_CXX_COMPILER=%{rocmllvm_bindir}/clang++
@@ -69,12 +71,14 @@ Requires:       %{name}%{?_isa} = %{version}-%{release}
 %description    devel
 %{_description}
 
+%if %{with test}
 %package        test
 Summary:        Tests for %{name}
 Requires:       %{name}%{?_isa} = %{version}-%{release}
 
 %description    test
 %{_description}
+%endif
 
 %prep -a
 sed -i -e 's/ROCM_INSTALL_LIBDIR lib/ROCM_INSTALL_LIBDIR %{_lib}/' cmake/ROCMExportTargetsHeaderOnly.cmake
@@ -99,10 +103,12 @@ rm -f %{buildroot}%{_docdir}/rocthrust/LICENSE
 %{_includedir}/thrust/
 %{_libdir}/cmake/rocthrust/
 
+%if %{with test}
 %files test
 %{_bindir}/*.hip
 %{_bindir}/test_*
 %{_bindir}/rocthrust/
+%endif
 
 %changelog
 %autochangelog


### PR DESCRIPTION
## Summary

Disable building test of rocthrust and rocrand to save obs worker resources.

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
