### PR TITLE
SPECS: Add some containerd 2.3.3 dependencies

### DIFF
--- a/SPECS/go-github-adalogics-go-fuzz-headers/go-github-adalogics-go-fuzz-headers.spec
+++ b/SPECS/go-github-adalogics-go-fuzz-headers/go-github-adalogics-go-fuzz-headers.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-fuzz-headers
+%define go_import_path  github.com/AdaLogics/go-fuzz-headers
+%define commit_id e8a1dd7889d65b8a6f02175e0d79d7c0557db7f9
+
+Name:           go-github-adalogics-go-fuzz-headers
+Version:        0+git20260816.e8a1dd7
+Release:        %autorelease
+Summary:        This repository contains various helper functions for go fuzzing
+License:        Apache-2.0
+URL:            https://github.com/AdaLogics/go-fuzz-headers
+#!RemoteAsset:  sha256:a8dbee5d0e350c46ca319ce75d6cc7ed9a0978d218d8917fb4073022a6c6754f
+Source0:        https://github.com/AdaLogics/go-fuzz-headers/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/AdaLogics/go-fuzz-headers) = %{version}
+
+%description
+This repository contains various helper functions for go fuzzing. It is
+mostly used in combination with go-fuzz but compatibility with fuzzing in
+the standard library will also be supported. Any coverage guided fuzzing
+engine that provides an array or slice of bytes can be used with go-fuzz-headers.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-blang-semver-v4/go-github-blang-semver-v4.spec
+++ b/SPECS/go-github-blang-semver-v4/go-github-blang-semver-v4.spec
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           semver
+%define go_import_path  github.com/blang/semver/v4
+%define go_source_subdir v4
+
+Name:           go-github-blang-semver-v4
+Version:        4.0.0
+Release:        %autorelease
+Summary:        Semantic Versioning library for Go
+License:        MIT
+URL:            https://github.com/blang/semver
+#!RemoteAsset:  sha256:873e979323df6060cb4f843bc920f07fa59c05002359bf5d4a3311c8911f6640
+Source0:        https://github.com/blang/semver/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/blang/semver/v4) = %{version}
+
+%description
+Semantic Versioning library for Go. It implements version 2.0.0 of the
+Semantic Versioning specification.
+
+%install
+pushd %{go_source_subdir}
+%buildsystem_golangmodules_install
+popd
+
+%check
+pushd %{go_source_subdir}
+export GO111MODULE=off
+export GOPATH=%{_builddir}/go:%{_datadir}/gocode
+mkdir -p %{_builddir}/go/src/$(dirname %{go_import_path})
+cp -a . %{_builddir}/go/src/%{go_import_path}
+cd %{_builddir}/go/src/%{go_import_path}
+go test -vet=off -v ./...
+popd
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-cenkalti-backoff-v5/go-github-cenkalti-backoff-v5.spec
+++ b/SPECS/go-github-cenkalti-backoff-v5/go-github-cenkalti-backoff-v5.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           backoff
+%define go_import_path  github.com/cenkalti/backoff/v5
+# The tests need too much time to run
+%define go_test_exclude %{go_import_path}
+
+Name:           go-github-cenkalti-backoff-v5
+Version:        5.0.3
+Release:        %autorelease
+Summary:        Exponential backoff algorithm for Go
+License:        MIT
+URL:            https://github.com/cenkalti/backoff
+#!RemoteAsset:  sha256:e967898e592ef838ca5ccfa68cf407d97adbfa757391f8942be9763646cbe3c5
+Source0:        https://github.com/cenkalti/backoff/archive/refs/tags/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/cenkalti/backoff/v5) = %{version}
+
+%description
+Backoff implements retry operations with configurable exponential delays and
+elapsed-time limits.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-checkpoint-restore-go-criu-v7/go-github-checkpoint-restore-go-criu-v7.spec
+++ b/SPECS/go-github-checkpoint-restore-go-criu-v7/go-github-checkpoint-restore-go-criu-v7.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-criu
+%define go_import_path  github.com/checkpoint-restore/go-criu/v7
+# The upstream source archive omits crit/test-imgs required by its tests.
+%global go_test_ignore_failure 1
+
+Name:           go-github-checkpoint-restore-go-criu-v7
+Version:        7.2.0
+Release:        %autorelease
+Summary:        This repository provides Go bindings for CRIU
+License:        Apache-2.0
+URL:            https://github.com/checkpoint-restore/go-criu
+#!RemoteAsset:  sha256:fe6e0a3747ebed21ef6fc03e93967cafdebeac54d8b17a7469310676a1b03141
+Source0:        https://github.com/checkpoint-restore/go-criu/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/spf13/cobra)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(google.golang.org/protobuf)
+
+Provides:       go(github.com/checkpoint-restore/go-criu/v7) = %{version}
+
+Requires:       go(github.com/spf13/cobra)
+Requires:       go(golang.org/x/sys)
+Requires:       go(google.golang.org/protobuf)
+
+%description
+This repository provides Go bindings for CRIU. The code is based on the
+Go-based PHaul implementation from the CRIU repository and has been moved
+to this repository for easier inclusion in Go projects.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-containerd-btrfs-v2/go-github-containerd-btrfs-v2.spec
+++ b/SPECS/go-github-containerd-btrfs-v2/go-github-containerd-btrfs-v2.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           btrfs
+%define go_import_path  github.com/containerd/btrfs/v2
+
+Name:           go-github-containerd-btrfs-v2
+Version:        2.0.0
+Release:        %autorelease
+Summary:        Provides bindings for working with btrfs partitions from Go
+License:        Apache-2.0
+URL:            https://github.com/containerd/btrfs
+#!RemoteAsset:  sha256:d19f38a7237bfdd318c674b68c109b5fa3dc1392225018bded14076f18cd8856
+Source0:        https://github.com/containerd/btrfs/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(golang.org/x/sys)
+
+Provides:       go(github.com/containerd/btrfs/v2) = %{version}
+
+Requires:       go(golang.org/x/sys)
+
+%description
+Native Go bindings for btrfs.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-go-logr-zapr/go-github-go-logr-zapr.spec
+++ b/SPECS/go-github-go-logr-zapr/go-github-go-logr-zapr.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           zapr
+%define go_import_path  github.com/go-logr/zapr
+
+Name:           go-github-go-logr-zapr
+Version:        1.3.0
+Release:        %autorelease
+Summary:        logr implementation built on Zap
+License:        Apache-2.0
+URL:            https://github.com/go-logr/zapr
+#!RemoteAsset:  sha256:37a516aa30dd42af8be6edd8ab8ba3684b197374f763f0655078bfe9fb2e44cc
+Source0:        https://github.com/go-logr/zapr/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Go 1.26 slogtest rejects empty nested groups
+BuildOption(check):  -skip TestSlogHandler
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/go-logr/logr)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(go.uber.org/zap)
+BuildRequires:  go(go.uber.org/multierr)
+
+Provides:       go(github.com/go-logr/zapr) = %{version}
+
+Requires:       go(github.com/go-logr/logr)
+Requires:       go(go.uber.org/zap)
+
+%description
+A logr implementation using Zap. It can also be used as a slog handler.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-k8s-api/go-k8s-api.spec
+++ b/SPECS/go-k8s-api/go-k8s-api.spec
@@ -7,7 +7,6 @@
 
 %define _name           api
 %define go_import_path  k8s.io/api
-%define upstream_version  0.35.3
 
 Name:           go-k8s-api
 Version:        0.36.2
@@ -15,8 +14,8 @@ Release:        %autorelease
 Summary:        Canonical Kubernetes API definitions for Go
 License:        Apache-2.0
 URL:            https://github.com/kubernetes/api
-#!RemoteAsset:  sha256:9d1a223f57d874c993e1949983a8c4983c019f3c30456065519604173c109158
-Source0:        https://github.com/kubernetes/api/archive/refs/tags/v%{upstream_version}.tar.gz#/%{_name}-%{upstream_version}.tar.gz
+#!RemoteAsset:  sha256:f2c49f57a0da3aa37bf5caf6fe735a054cf994c0f44c77b3a2893e9d0340f1f8
+Source0:        https://github.com/kubernetes/api/archive/refs/tags/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
 

--- a/SPECS/go-k8s-apimachinery/go-k8s-apimachinery.spec
+++ b/SPECS/go-k8s-apimachinery/go-k8s-apimachinery.spec
@@ -7,7 +7,6 @@
 
 %define _name           apimachinery
 %define go_import_path  k8s.io/apimachinery
-%define upstream_version  0.35.3
 # managedfields tests expect api/openapi-spec/swagger.json from the full
 # kubernetes repository, but the standalone apimachinery archive lacks it. - HNO3Miracle
 %define go_test_exclude %{shrink:
@@ -21,8 +20,8 @@ Release:        %autorelease
 Summary:        Shared Kubernetes API machinery for Go
 License:        Apache-2.0
 URL:            https://github.com/kubernetes/apimachinery
-#!RemoteAsset:  sha256:1543950c9875bfa87b12038c484571d573a8870df495e6f19c53abca53e5616e
-Source0:        https://github.com/kubernetes/apimachinery/archive/refs/tags/v%{upstream_version}.tar.gz#/%{_name}-%{upstream_version}.tar.gz
+#!RemoteAsset:  sha256:10fe89c116f303013cc123ff5b4f4a40c55a4d4c89d39e30da0278bb3284b674
+Source0:        https://github.com/kubernetes/apimachinery/archive/refs/tags/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
 
@@ -60,6 +59,7 @@ BuildRequires:  go(gopkg.in/inf.v0)
 BuildRequires:  go(gopkg.in/yaml.v3)
 BuildRequires:  go(k8s.io/klog/v2)
 BuildRequires:  go(k8s.io/kube-openapi)
+BuildRequires:  go(k8s.io/streaming)
 BuildRequires:  go(k8s.io/utils)
 BuildRequires:  go(sigs.k8s.io/json)
 BuildRequires:  go(sigs.k8s.io/randfill)
@@ -99,6 +99,7 @@ Requires:       go(gopkg.in/inf.v0)
 Requires:       go(gopkg.in/yaml.v3)
 Requires:       go(k8s.io/klog/v2)
 Requires:       go(k8s.io/kube-openapi)
+Requires:       go(k8s.io/streaming)
 Requires:       go(k8s.io/utils)
 Requires:       go(sigs.k8s.io/json)
 Requires:       go(sigs.k8s.io/randfill)

--- a/SPECS/go-k8s-client-go/go-k8s-client-go.spec
+++ b/SPECS/go-k8s-client-go/go-k8s-client-go.spec
@@ -7,7 +7,6 @@
 
 %define _name           client-go
 %define go_import_path  k8s.io/client-go
-%define upstream_version  0.35.3
 # k8s.io/client-go/testing/internal and k8s.io/client-go/tools/cache use
 # testing/synctest; OBS builds run with asynctimerchan!=0, which makes
 # synctest.Run panic with "synctest.Run not supported with asynctimerchan!=0".
@@ -29,8 +28,8 @@ Release:        %autorelease
 Summary:        Kubernetes client libraries for Go
 License:        Apache-2.0
 URL:            https://github.com/kubernetes/client-go
-#!RemoteAsset:  sha256:9a2a9ca3e1922eb966e93d58fc60cb277ac5bee6884b6b4e1ce32b26e43a0b4f
-Source0:        https://github.com/kubernetes/client-go/archive/refs/tags/v%{upstream_version}.tar.gz#/%{_name}-%{upstream_version}.tar.gz
+#!RemoteAsset:  sha256:916216f9cf446f556bf7b74361c2c7a58c2e7eaeecad0d7862220fca965c7b49
+Source0:        https://github.com/kubernetes/client-go/archive/refs/tags/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
 

--- a/SPECS/go-k8s-component-base/go-k8s-component-base.spec
+++ b/SPECS/go-k8s-component-base/go-k8s-component-base.spec
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           component-base
+%define go_import_path  k8s.io/component-base
+
+Name:           go-k8s-component-base
+Version:        0.36.0
+Release:        %autorelease
+Summary:        Common functionality for Kubernetes core components
+License:        Apache-2.0
+URL:            https://github.com/kubernetes/component-base
+#!RemoteAsset:  sha256:6b5fb4602554e3d5564815895428c514dab0df25c7f445780c7092e620b03971
+Source0:        https://github.com/kubernetes/component-base/archive/refs/tags/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/blang/semver/v4)
+BuildRequires:  go(github.com/go-logr/logr)
+BuildRequires:  go(github.com/go-logr/zapr)
+BuildRequires:  go(github.com/google/go-cmp)
+BuildRequires:  go(github.com/moby/term)
+BuildRequires:  go(github.com/prometheus/client_golang)
+BuildRequires:  go(github.com/prometheus/client_model)
+BuildRequires:  go(github.com/prometheus/common)
+BuildRequires:  go(github.com/prometheus/procfs)
+BuildRequires:  go(github.com/spf13/cobra)
+BuildRequires:  go(github.com/spf13/pflag)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp)
+BuildRequires:  go(go.opentelemetry.io/otel/attribute)
+BuildRequires:  go(go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc)
+BuildRequires:  go(go.opentelemetry.io/otel/propagation)
+BuildRequires:  go(go.opentelemetry.io/otel/semconv/v1.17.0)
+BuildRequires:  go(go.opentelemetry.io/otel/sdk)
+BuildRequires:  go(go.opentelemetry.io/otel/trace)
+BuildRequires:  go(go.uber.org/zap)
+BuildRequires:  go(go.uber.org/zap/zapcore)
+BuildRequires:  go(go.yaml.in/yaml/v2)
+BuildRequires:  go(golang.org/x/text)
+BuildRequires:  go(k8s.io/apimachinery)
+BuildRequires:  go(k8s.io/client-go)
+BuildRequires:  go(k8s.io/klog/v2)
+BuildRequires:  go(k8s.io/utils/clock)
+BuildRequires:  go(k8s.io/utils/ptr)
+BuildRequires:  go(k8s.io/utils/trace)
+BuildRequires:  go(sigs.k8s.io/json)
+
+Provides:       go(k8s.io/component-base) = %{version}
+
+Requires:       go(github.com/blang/semver/v4)
+Requires:       go(github.com/go-logr/logr)
+Requires:       go(github.com/go-logr/zapr)
+Requires:       go(github.com/google/go-cmp)
+Requires:       go(github.com/moby/term)
+Requires:       go(github.com/prometheus/client_golang)
+Requires:       go(github.com/prometheus/client_model)
+Requires:       go(github.com/prometheus/common)
+Requires:       go(github.com/prometheus/procfs)
+Requires:       go(github.com/spf13/cobra)
+Requires:       go(github.com/spf13/pflag)
+Requires:       go(go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp)
+Requires:       go(go.opentelemetry.io/otel/attribute)
+Requires:       go(go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc)
+Requires:       go(go.opentelemetry.io/otel/propagation)
+Requires:       go(go.opentelemetry.io/otel/semconv/v1.17.0)
+Requires:       go(go.opentelemetry.io/otel/sdk)
+Requires:       go(go.opentelemetry.io/otel/trace)
+Requires:       go(go.uber.org/zap)
+Requires:       go(go.uber.org/zap/zapcore)
+Requires:       go(go.yaml.in/yaml/v2)
+Requires:       go(golang.org/x/text)
+Requires:       go(k8s.io/apimachinery)
+Requires:       go(k8s.io/client-go)
+Requires:       go(k8s.io/klog/v2)
+Requires:       go(k8s.io/utils/ptr)
+Requires:       go(k8s.io/utils/trace)
+
+%description
+Component-base implements common functionality shared by Kubernetes core
+components, including configuration, flag handling, HTTPS serving,
+authentication, authorization, and logging.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-k8s-streaming/go-k8s-streaming.spec
+++ b/SPECS/go-k8s-streaming/go-k8s-streaming.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           streaming
+%define go_import_path  k8s.io/streaming
+
+Name:           go-k8s-streaming
+Version:        0.36.2
+Release:        %autorelease
+Summary:        Contains the staged module root for Kubernetes transport streaming primitives
+License:        Apache-2.0
+URL:            https://github.com/kubernetes/streaming
+#!RemoteAsset:  sha256:cdcb85a1668aae13e2a373ff5cdc9cbae16e46fca84ccf320e027ff585bfdf76
+Source0:        https://github.com/kubernetes/streaming/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/armon/go-socks5)
+BuildRequires:  go(github.com/moby/spdystream)
+BuildRequires:  go(golang.org/x/net)
+BuildRequires:  go(k8s.io/klog/v2)
+BuildRequires:  go(k8s.io/utils/net)
+
+Provides:       go(k8s.io/streaming) = %{version}
+
+Requires:       go(github.com/moby/spdystream)
+Requires:       go(golang.org/x/net)
+Requires:       go(k8s.io/klog/v2)
+Requires:       go(k8s.io/utils/net)
+
+%description
+Kubernetes transport streaming primitives for Go.
+
+%files
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-k8s-utils/go-k8s-utils.spec
+++ b/SPECS/go-k8s-utils/go-k8s-utils.spec
@@ -29,6 +29,10 @@ BuildRequires:  go-k8s-klog-v2
 BuildRequires:  go(k8s.io/klog/v2)
 
 Provides:       go(k8s.io/utils) = %{version}
+Provides:       go(k8s.io/utils/trace) = %{version}
+Provides:       go(k8s.io/utils/ptr) = %{version}
+Provides:       go(k8s.io/utils/clock) = %{version}
+Provides:       go(k8s.io/utils/net) = %{version}
 
 Requires:       go(github.com/davecgh/go-spew)
 Requires:       go(github.com/go-logr/logr)

--- a/SPECS/go-opentelemetry-otel-exporters-otlp-otlptrace/go-opentelemetry-otel-exporters-otlp-otlptrace.spec
+++ b/SPECS/go-opentelemetry-otel-exporters-otlp-otlptrace/go-opentelemetry-otel-exporters-otlp-otlptrace.spec
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           otlptrace
+%define go_import_path  go.opentelemetry.io/otel/exporters/otlp/otlptrace
+
+Name:           go-opentelemetry-otel-exporters-otlp-otlptrace
+Version:        1.43.0
+Release:        %autorelease
+Summary:        OTLP trace exporter abstractions for OpenTelemetry Go
+License:        Apache-2.0
+URL:            https://github.com/open-telemetry/opentelemetry-go
+#!RemoteAsset:  sha256:971b31afdf0b97356433390927df0ac7f16220a625468b9259d3762e87084899
+Source0:        https://github.com/open-telemetry/opentelemetry-go/archive/refs/tags/exporters/otlp/otlptrace/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/cenkalti/backoff/v5)
+BuildRequires:  go(github.com/go-logr/logr)
+BuildRequires:  go(github.com/google/go-cmp)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(go.opentelemetry.io/otel)
+BuildRequires:  go(go.opentelemetry.io/otel/metric)
+BuildRequires:  go(go.opentelemetry.io/otel/sdk)
+BuildRequires:  go(go.opentelemetry.io/otel/sdk/metric)
+BuildRequires:  go(go.opentelemetry.io/otel/trace)
+BuildRequires:  go(go.opentelemetry.io/proto)
+BuildRequires:  go(go.uber.org/goleak)
+BuildRequires:  go(google.golang.org/genproto/googleapis/rpc)
+BuildRequires:  go(google.golang.org/grpc)
+BuildRequires:  go(google.golang.org/protobuf)
+BuildRequires:  go(go.opentelemetry.io/auto/sdk)
+BuildRequires:  go(github.com/grpc-ecosystem/grpc-gateway/v2)
+
+Provides:       go(go.opentelemetry.io/otel/exporters/otlp/otlptrace) = %{version}
+Provides:       go(go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc) = %{version}
+Provides:       go(go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp) = %{version}
+
+Requires:       go(github.com/cenkalti/backoff/v5)
+Requires:       go(github.com/go-logr/logr)
+Requires:       go(github.com/grpc-ecosystem/grpc-gateway/v2)
+Requires:       go(go.opentelemetry.io/auto/sdk)
+Requires:       go(go.opentelemetry.io/otel)
+Requires:       go(go.opentelemetry.io/otel/metric)
+Requires:       go(go.opentelemetry.io/otel/sdk)
+Requires:       go(go.opentelemetry.io/otel/sdk/metric)
+Requires:       go(go.opentelemetry.io/otel/trace)
+Requires:       go(go.opentelemetry.io/proto)
+Requires:       go(google.golang.org/genproto/googleapis/rpc)
+Requires:       go(google.golang.org/grpc)
+Requires:       go(google.golang.org/protobuf)
+
+%description
+OTLP trace exporter abstractions and gRPC and HTTP exporters for OpenTelemetry Go.
+
+%install
+# The parent source directory contains all three nested modules.
+install -d %{buildroot}%{go_sys_gopath}/%{go_import_path}
+cp -a exporters/otlp/otlptrace/. %{buildroot}%{go_sys_gopath}/%{go_import_path}/
+
+%check
+export GO111MODULE=off
+export GOPATH=%{_builddir}/go:%{_datadir}/gocode
+mkdir -p %{_builddir}/go/src/go.opentelemetry.io
+cp -a . %{_builddir}/go/src/go.opentelemetry.io/otel
+cd %{_builddir}/go/src/%{go_import_path}
+go test -v ./...
+
+%files
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-opentelemetry-otel/go-opentelemetry-otel.spec
+++ b/SPECS/go-opentelemetry-otel/go-opentelemetry-otel.spec
@@ -43,6 +43,9 @@ BuildRequires:  go(gopkg.in/yaml.v3)
 BuildRequires:  go-rpm-macros
 
 Provides:       go(go.opentelemetry.io/otel) = %{version}
+Provides:       go(go.opentelemetry.io/otel/attribute) = %{version}
+Provides:       go(go.opentelemetry.io/otel/propagation) = %{version}
+Provides:       go(go.opentelemetry.io/otel/semconv/v1.17.0) = %{version}
 Provides:       go(go.opentelemetry.io/otel/exporters/stdout/stdoutmetric) = %{version}
 Provides:       go(go.opentelemetry.io/otel/exporters/stdout/stdouttrace) = %{version}
 Provides:       go(go.opentelemetry.io/otel/metric) = %{version}

--- a/SPECS/go-uber-zap/go-uber-zap.spec
+++ b/SPECS/go-uber-zap/go-uber-zap.spec
@@ -29,6 +29,9 @@ BuildRequires:  go(go.uber.org/multierr)
 BuildRequires:  go(go.yaml.in/yaml/v3)
 
 Provides:       go(go.uber.org/zap) = %{version}
+Provides:       go(go.uber.org/zap/zapcore) = %{version}
+
+Requires:       go(go.uber.org/multierr)
 
 %description
 Package zap provides fast, structured, leveled logging.


### PR DESCRIPTION
## Summary

This PR fixed bug in #776, added packages `go-k8s-component-base` and its dependencies, and includes some dependencies needed to upgrade containerd to 2.3.3.

## Related Issue
Internal issue

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: Codex: GPT-5.6-terra medium

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
