### PR TITLE
SPECS: add go-k8s-cri-streaming

### DIFF
--- a/SPECS/go-google-grpc/go-google-grpc.spec
+++ b/SPECS/go-google-grpc/go-google-grpc.spec
@@ -58,6 +58,8 @@ BuildRequires:  go(google.golang.org/genproto)
 BuildRequires:  go(google.golang.org/protobuf)
 
 Provides:       go(google.golang.org/grpc) = %{version}
+Provides:       go(google.golang.org/grpc/codes) = %{version}
+Provides:       go(google.golang.org/grpc/status) = %{version}
 
 Requires:       go(github.com/cespare/xxhash/v2)
 Requires:       go(github.com/cncf/xds/go)

--- a/SPECS/go-google-protobuf/go-google-protobuf.spec
+++ b/SPECS/go-google-protobuf/go-google-protobuf.spec
@@ -24,6 +24,9 @@ BuildRequires:  go-rpm-macros
 BuildRequires:  go(github.com/google/go-cmp)
 
 Provides:       go(google.golang.org/protobuf) = %{version}
+Provides:       go(google.golang.org/protobuf/proto) = %{version}
+Provides:       go(google.golang.org/protobuf/reflect) = %{version}
+Provides:       go(google.golang.org/protobuf/runtime) = %{version}
 
 Requires:       pkgconfig(protobuf)
 

--- a/SPECS/go-k8s-cri-api/go-k8s-cri-api.spec
+++ b/SPECS/go-k8s-cri-api/go-k8s-cri-api.spec
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           cri-api
+%define go_import_path  k8s.io/cri-api
+
+Name:           go-k8s-cri-api
+Version:        0.36.3
+Release:        %autorelease
+Summary:        Kubernetes Container Runtime Interface API definitions
+License:        Apache-2.0
+URL:            https://github.com/kubernetes/cri-api
+#!RemoteAsset:  sha256:1d1aca395dd67dd3f40ab250dba3ec5cd2eb19b1ab934ac6ec6201ad73acc4a1
+Source0:        https://github.com/kubernetes/cri-api/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(google.golang.org/genproto/googleapis/rpc)
+BuildRequires:  go(google.golang.org/grpc)
+BuildRequires:  go(google.golang.org/grpc/codes)
+BuildRequires:  go(google.golang.org/grpc/status)
+BuildRequires:  go(google.golang.org/protobuf/proto)
+BuildRequires:  go(google.golang.org/protobuf/reflect)
+BuildRequires:  go(google.golang.org/protobuf/runtime)
+
+Provides:       go(k8s.io/cri-api) = %{version}
+Provides:       go(k8s.io/cri-api/pkg) = %{version}
+
+Requires:       go(github.com/stretchr/testify)
+Requires:       go(google.golang.org/genproto/googleapis/rpc)
+Requires:       go(google.golang.org/grpc)
+Requires:       go(google.golang.org/grpc/codes)
+Requires:       go(google.golang.org/grpc/status)
+Requires:       go(google.golang.org/protobuf/proto)
+Requires:       go(google.golang.org/protobuf/reflect)
+Requires:       go(google.golang.org/protobuf/runtime)
+
+%description
+This package provides the Kubernetes Container Runtime Interface API
+definitions used by kubelet and container runtime implementations.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-k8s-cri-streaming/go-k8s-cri-streaming.spec
+++ b/SPECS/go-k8s-cri-streaming/go-k8s-cri-streaming.spec
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           cri-streaming
+%define go_import_path  k8s.io/cri-streaming
+
+Name:           go-k8s-cri-streaming
+Version:        0.36.3
+Release:        %autorelease
+Summary:        Kubernetes CRI streaming server implementation
+License:        Apache-2.0
+URL:            https://github.com/kubernetes/cri-streaming
+#!RemoteAsset:  sha256:3b516875a5e9b7020ea969a7b6f06abae889e1a0d92036283ff76158ea34d10d
+Source0:        https://github.com/kubernetes/cri-streaming/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/emicklei/go-restful/v3)
+BuildRequires:  go(github.com/gorilla/websocket)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(go.uber.org/goleak)
+BuildRequires:  go(google.golang.org/grpc/codes)
+BuildRequires:  go(google.golang.org/grpc/status)
+BuildRequires:  go(k8s.io/cri-api/pkg)
+BuildRequires:  go(k8s.io/klog/v2)
+BuildRequires:  go(k8s.io/streaming/pkg)
+BuildRequires:  go(k8s.io/utils/clock)
+BuildRequires:  go(k8s.io/utils/exec)
+
+Provides:       go(k8s.io/cri-streaming) = %{version}
+
+Requires:       go(github.com/emicklei/go-restful/v3)
+Requires:       go(google.golang.org/grpc/codes)
+Requires:       go(google.golang.org/grpc/status)
+Requires:       go(k8s.io/cri-api/pkg)
+Requires:       go(k8s.io/klog/v2)
+Requires:       go(k8s.io/streaming/pkg)
+Requires:       go(k8s.io/utils/clock)
+Requires:       go(k8s.io/utils/exec)
+
+%description
+This package provides the Kubernetes CRI streaming server implementation for
+exec, attach, and port forwarding without depending on the full kubelet module.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-k8s-streaming/go-k8s-streaming.spec
+++ b/SPECS/go-k8s-streaming/go-k8s-streaming.spec
@@ -7,12 +7,12 @@
 %define go_import_path  k8s.io/streaming
 
 Name:           go-k8s-streaming
-Version:        0.36.2
+Version:        0.36.3
 Release:        %autorelease
 Summary:        Contains the staged module root for Kubernetes transport streaming primitives
 License:        Apache-2.0
 URL:            https://github.com/kubernetes/streaming
-#!RemoteAsset:  sha256:cdcb85a1668aae13e2a373ff5cdc9cbae16e46fca84ccf320e027ff585bfdf76
+#!RemoteAsset:  sha256:6a6869bba30980648555f776a7efebeed76c75bd8353be058a2595b4177e1211
 Source0:        https://github.com/kubernetes/streaming/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
@@ -26,6 +26,7 @@ BuildRequires:  go(k8s.io/klog/v2)
 BuildRequires:  go(k8s.io/utils/net)
 
 Provides:       go(k8s.io/streaming) = %{version}
+Provides:       go(k8s.io/streaming/pkg) = %{version}
 
 Requires:       go(github.com/moby/spdystream)
 Requires:       go(golang.org/x/net)
@@ -36,6 +37,8 @@ Requires:       go(k8s.io/utils/net)
 Kubernetes transport streaming primitives for Go.
 
 %files
+%doc README.md
+%license LICENSE
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog

--- a/SPECS/go-k8s-utils/go-k8s-utils.spec
+++ b/SPECS/go-k8s-utils/go-k8s-utils.spec
@@ -32,6 +32,7 @@ Provides:       go(k8s.io/utils) = %{version}
 Provides:       go(k8s.io/utils/trace) = %{version}
 Provides:       go(k8s.io/utils/ptr) = %{version}
 Provides:       go(k8s.io/utils/clock) = %{version}
+Provides:       go(k8s.io/utils/exec) = %{version}
 Provides:       go(k8s.io/utils/net) = %{version}
 
 Requires:       go(github.com/davecgh/go-spew)


### PR DESCRIPTION
## Summary

`go-k8s-cri-streaming` provides the Kubernetes CRI streaming server implementation for container exec, attach, and port-forward operations. It offers a dedicated import path without requiring container runtimes to depend on the full `k8s.io/kubelet` module. This package is required because containerd 2.3.4 directly depends on `k8s.io/cri-streaming` v0.36.3 to build its CRI integration.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves No.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.


[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
