### PR TITLE
SPECS: llvmir-converter: Add llvmir_pgo_rebuild.py

### DIFF
--- a/SPECS/llvmir-converter/llvmir-converter.spec
+++ b/SPECS/llvmir-converter/llvmir-converter.spec
@@ -4,8 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-%global git_ver git20260717.bdb85ba
-%global git_commit bdb85ba7978db3bfeffcbd9505c43cc354e4ad6a
+%global git_ver git20260817.0e4f64c
+%global git_commit 0e4f64ccf0bdd028416f98425be75ae7da6b2b75
 %global llvmir_bindir /usr/lib/llvmir-convert/bin
 %global llvmir_statedir /var/lib/llvmir-converter
 
@@ -15,7 +15,7 @@ Release:        %{autorelease}
 Summary:        Convert LLVM IR bitcode command files to ELF outputs
 License:        Apache-2.0
 URL:            https://github.com/openRuyi-Project/llvmir-converter.git
-#!RemoteAsset:  sha256:e39a08bd5e8d4bff8ffbbe8673a47ab953703c7a38e4675613d5014f43bf464f
+#!RemoteAsset:  sha256:aafa011172b1c8ae662fed542a48b8da12a6bc2ba4ea8699877f15f561f2ae78
 Source0:        https://github.com/openRuyi-Project/llvmir-converter/archive/%{git_commit}.tar.gz
 
 BuildRequires:  clang22
@@ -80,6 +80,7 @@ install -d -m 1777 %{buildroot}%{llvmir_statedir}/pgo-profraw
 
 install -m 0755 llvmir-converter-[0-9]* %{buildroot}%{llvmir_bindir}/
 install -m 0755 llvmir_batch_runner.py %{buildroot}%{llvmir_bindir}/
+install -m 0755 llvmir_pgo_rebuild.py %{buildroot}%{llvmir_bindir}/
 install -m 0644 llvmir-converter.service %{buildroot}%{_unitdir}/llvmir-converter.service
 install -m 0644 llvmir-converter.default %{buildroot}%{_sysconfdir}/default/llvmir-converter
 
@@ -102,6 +103,7 @@ install -m 0644 llvmir-converter.tmpfile %{buildroot}%{_tmpfilesdir}/%{name}.con
 %dir %{llvmir_bindir}
 %{llvmir_bindir}/llvmir-converter-*
 %{llvmir_bindir}/llvmir_batch_runner.py
+%{llvmir_bindir}/llvmir_pgo_rebuild.py
 %{_unitdir}/llvmir-converter.service
 %{_tmpfilesdir}/%{name}.conf
 %config(noreplace) %{_sysconfdir}/default/llvmir-converter


### PR DESCRIPTION
## Summary

This tool can convert new binaries with original binary and PGO sample files

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: CLine:GPT-5.6-Terra

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
