### PR TITLE
SPECS: Add po4a and dependencies

### DIFF
--- a/SPECS/perl-ExtUtils-CBuilder/perl-ExtUtils-CBuilder.spec
+++ b/SPECS/perl-ExtUtils-CBuilder/perl-ExtUtils-CBuilder.spec
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           perl-ExtUtils-CBuilder
+Version:        0.280236
+Release:        %autorelease
+Summary:        Compile and link C code for Perl modules
+License:        GPL-1.0-or-later OR Artistic-1.0-Perl
+URL:            https://metacpan.org/dist/ExtUtils-CBuilder
+#!RemoteAsset:  sha256:abc21827eb8a513171bf7fdecefce9945132cb76db945036518291f607b1491f
+Source0:        https://www.cpan.org/authors/id/A/AM/AMBS/ExtUtils-CBuilder-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    perlmaker
+
+BuildOption(build):  INSTALLDIRS=vendor
+
+BuildRequires:  make
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-macros
+BuildRequires:  perl(Cwd)
+BuildRequires:  perl(ExtUtils::MakeMaker) >= 6.30
+BuildRequires:  perl(File::Basename)
+BuildRequires:  perl(File::Spec) >= 3.13
+BuildRequires:  perl(File::Temp)
+BuildRequires:  perl(IO::File)
+BuildRequires:  perl(IPC::Cmd)
+BuildRequires:  perl(Perl::OSType) >= 1
+BuildRequires:  perl(Test::More) >= 0.47
+BuildRequires:  perl(Text::ParseWords)
+
+Requires:       perl(ExtUtils::MakeMaker) >= 6.30
+Requires:       perl(File::Spec) >= 3.13
+Requires:       perl(Perl::OSType) >= 1
+
+%description
+This module can build the C portions of Perl modules by invoking the
+appropriate compilers and linkers in a cross-platform manner. It was
+motivated by the Module::Build project, but may be useful for other
+purposes as well. However, it is not intended as a general cross-platform
+interface to all your C building needs. That would have been a much more
+ambitious goal!
+
+%files -f %{name}.files
+%doc CONTRIBUTING Changes NOTAS-Alberto README README.mkdn README.patching README.release
+
+%changelog
+%autochangelog

--- a/SPECS/perl-ExtUtils-CChecker/perl-ExtUtils-CChecker.spec
+++ b/SPECS/perl-ExtUtils-CChecker/perl-ExtUtils-CChecker.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           perl-ExtUtils-CChecker
+Version:        0.12
+Release:        %autorelease
+Summary:        Configure-time utilities for using C headers, libraries, or OS features
+License:        GPL-1.0-or-later OR Artistic-1.0-Perl
+URL:            https://metacpan.org/dist/ExtUtils-CChecker
+#!RemoteAsset:  sha256:8b87d145337dec1ee754d30871d0b105c180ad4c92c7dc0c7fadd76cec8c57d3
+Source0:        https://www.cpan.org/authors/id/P/PE/PEVANS/ExtUtils-CChecker-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    perlbuild
+
+BuildOption(build):  --installdirs=vendor
+BuildOption(install):  --destdir=%{buildroot} --create_packlist=0
+
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-macros
+BuildRequires:  perl >= 5.14.0
+BuildRequires:  perl(ExtUtils::CBuilder)
+BuildRequires:  perl(Module::Build)
+BuildRequires:  perl(Test2::V0)
+
+%description
+Often Perl modules are written to wrap functionality found in existing C
+headers, libraries, or to use OS-specific features. It is useful in the
+Build.PL or Makefile.PL file to check for the existance of these
+requirements before attempting to actually build the module.
+
+%files -f %{name}.files
+%doc Changes README
+
+%changelog
+%autochangelog

--- a/SPECS/perl-MIME-Charset/perl-MIME-Charset.spec
+++ b/SPECS/perl-MIME-Charset/perl-MIME-Charset.spec
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           perl-MIME-Charset
+Version:        1.013.1
+Release:        %autorelease
+Summary:        Charset Information for MIME
+License:        GPL-2.0-only
+URL:            https://metacpan.org/dist/MIME-Charset
+#!RemoteAsset:  sha256:1bb7a6e0c0d251f23d6e60bf84c9adefc5b74eec58475bfee4d39107e60870f0
+Source0:        https://www.cpan.org/authors/id/N/NE/NEZUMI/MIME-Charset-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    perlmaker
+
+BuildOption(build):  INSTALLDIRS=vendor
+
+BuildRequires:  make
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-macros
+BuildRequires:  perl(ExtUtils::MakeMaker)
+
+%description
+MIME::Charset provides information about character sets used for MIME
+messages on Internet.
+
+%files -f %{name}.files
+%doc ARTISTIC Changes README
+
+%changelog
+%autochangelog

--- a/SPECS/perl-Syntax-Keyword-Try/perl-Syntax-Keyword-Try.spec
+++ b/SPECS/perl-Syntax-Keyword-Try/perl-Syntax-Keyword-Try.spec
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           perl-Syntax-Keyword-Try
+Version:        0.31
+Release:        %autorelease
+Summary:        Try/catch/finally syntax for perl
+License:        GPL-1.0-or-later OR Artistic-1.0-Perl
+URL:            https://metacpan.org/dist/Syntax-Keyword-Try
+#!RemoteAsset:  sha256:7bc6242d746378982a599b34de35f07d3decc9e09d5646f8fa3b87f459414a4a
+Source0:        https://www.cpan.org/authors/id/P/PE/PEVANS/Syntax-Keyword-Try-%{version}.tar.gz
+BuildSystem:    perlbuild
+
+BuildOption(build):  --installdirs=vendor optimize="%{optflags}"
+BuildOption(install):  --destdir=%{buildroot} --create_packlist=0
+
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-macros
+BuildRequires:  perl >= 5.14.0
+BuildRequires:  perl(ExtUtils::CBuilder)
+BuildRequires:  perl(Module::Build)
+BuildRequires:  perl(Test2::V0)
+BuildRequires:  perl(XS::Parse::Keyword) >= 0.35
+
+Requires:       perl(XS::Parse::Keyword) >= 0.35
+
+%description
+This module provides a syntax plugin that implements exception-handling
+semantics in a form familiar to users of other languages, being built on a
+block labeled with the try keyword, followed by at least one of a catch or
+finally block.
+
+%files -f %{name}.files
+%doc Changes README hax
+
+%changelog
+%autochangelog

--- a/SPECS/perl-Text-CharWidth/perl-Text-CharWidth.spec
+++ b/SPECS/perl-Text-CharWidth/perl-Text-CharWidth.spec
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           perl-Text-CharWidth
+Version:        0.04
+Release:        %autorelease
+Summary:        Get number of occupied columns of a string on terminal
+License:        GPL-1.0-or-later OR Artistic-1.0-Perl
+URL:            https://metacpan.org/dist/Text-CharWidth
+#!RemoteAsset:  sha256:abded5f4fdd9338e89fd2f1d8271c44989dae5bf50aece41b6179d8e230704f8
+Source0:        https://www.cpan.org/authors/id/K/KU/KUBOTA/Text-CharWidth-%{version}.tar.gz
+BuildSystem:    perlmaker
+
+BuildOption(build):  INSTALLDIRS=vendor OPTIMIZE="%{optflags}"
+
+BuildRequires:  make
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-macros
+BuildRequires:  perl(ExtUtils::MakeMaker)
+
+%description
+This module supplies features similar as wcwidth(3) and wcswidth(3) in
+C language.
+
+%files -f %{name}.files
+%doc Changes README
+
+%changelog
+%autochangelog

--- a/SPECS/perl-Text-WrapI18N/perl-Text-WrapI18N.spec
+++ b/SPECS/perl-Text-WrapI18N/perl-Text-WrapI18N.spec
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           perl-Text-WrapI18N
+Version:        0.06
+Release:        %autorelease
+Summary:        Line wrapping module with support for multibyte, fullwidth, and combining characters and languages without whitespaces between words
+License:        GPL-1.0-or-later OR Artistic-1.0-Perl
+URL:            https://metacpan.org/dist/Text-WrapI18N
+#!RemoteAsset:  sha256:4bd29a17f0c2c792d12c1005b3c276f2ab0fae39c00859ae1741d7941846a488
+Source0:        https://www.cpan.org/authors/id/K/KU/KUBOTA/Text-WrapI18N-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    perlmaker
+
+BuildOption(build):  INSTALLDIRS=vendor
+
+BuildRequires:  make
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-macros
+BuildRequires:  perl(ExtUtils::MakeMaker)
+BuildRequires:  perl(Text::CharWidth) >= 0.02
+
+%description
+This module intends to be a better Text::Wrap module. This module is needed
+to support multibyte character encodings such as UTF-8, EUC-JP, EUC-KR,
+GB2312, and Big5. This module also supports characters with irregular
+widths, such as combining characters (which occupy zero columns on
+terminal, like diacritical marks in UTF-8) and fullwidth characters (which
+occupy two columns on terminal, like most of east Asian characters). Also,
+minimal handling of languages which doesn't use whitespaces between words
+(like Chinese and Japanese) is supported.
+
+%files -f %{name}.files
+%doc Changes README
+
+%changelog
+%autochangelog

--- a/SPECS/perl-Unicode-LineBreak/perl-Unicode-LineBreak.spec
+++ b/SPECS/perl-Unicode-LineBreak/perl-Unicode-LineBreak.spec
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           perl-Unicode-LineBreak
+Version:        2019.001
+Release:        %autorelease
+Summary:        UAX #14 Unicode Line Breaking Algorithm
+License:        GPL-1.0-or-later OR Artistic-1.0-Perl
+URL:            https://metacpan.org/dist/Unicode-LineBreak
+#!RemoteAsset:  sha256:486762e4cacddcc77b13989f979a029f84630b8175e7fef17989e157d4b6318a
+Source0:        https://www.cpan.org/authors/id/N/NE/NEZUMI/Unicode-LineBreak-%{version}.tar.gz
+BuildSystem:    perlmaker
+
+BuildOption(build):  INSTALLDIRS=vendor OPTIMIZE="%{optflags}"
+
+BuildRequires:  make
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-macros
+BuildRequires:  perl >= 5.8.0
+BuildRequires:  perl(Encode) >= 1.98
+BuildRequires:  perl(ExtUtils::MakeMaker)
+BuildRequires:  perl(MIME::Charset) >= 1.6.2
+BuildRequires:  perl(Test::More) >= 0.45
+
+Requires:       perl(Encode) >= 1.98
+Requires:       perl(MIME::Charset) >= 1.6.2
+
+%description
+Unicode::LineBreak performs Line Breaking Algorithm described in Unicode
+Standard Annex #14 [UAX #14]. East_Asian_Width informative property defined
+by Annex #11 [UAX #11] will be concerned to determine breaking positions.
+
+%files -f %{name}.files
+%doc ARTISTIC Changes Changes.REL1 Makefile.PL.sombok README Todo.REL1 perl-Unicode-LineBreak.spec
+
+%changelog
+%autochangelog

--- a/SPECS/perl-XS-Parse-Keyword/perl-XS-Parse-Keyword.spec
+++ b/SPECS/perl-XS-Parse-Keyword/perl-XS-Parse-Keyword.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           perl-XS-Parse-Keyword
+Version:        0.49
+Release:        %autorelease
+Summary:        XS functions to assist in parsing keyword syntax
+License:        GPL-1.0-or-later OR Artistic-1.0-Perl
+URL:            https://metacpan.org/dist/XS-Parse-Keyword
+#!RemoteAsset:  sha256:76c5ed142abba1f1df2335849681c83d83cc0842fe854af71081d2c411efb0bb
+Source0:        https://www.cpan.org/authors/id/P/PE/PEVANS/XS-Parse-Keyword-%{version}.tar.gz
+BuildSystem:    perlbuild
+
+BuildOption(build):  --installdirs=vendor optimize="%{optflags}"
+BuildOption(install):  --destdir=%{buildroot} --create_packlist=0
+
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-macros
+BuildRequires:  perl >= 5.14.0
+BuildRequires:  perl(ExtUtils::CBuilder)
+BuildRequires:  perl(ExtUtils::CChecker)
+BuildRequires:  perl(ExtUtils::ParseXS) >= 3.16
+BuildRequires:  perl(File::ShareDir) >= 1.00
+BuildRequires:  perl(Module::Build)
+BuildRequires:  perl(Test2::V0)
+
+Requires:       perl(File::ShareDir) >= 1.00
+
+%description
+This module provides some XS functions to assist in writing syntax modules
+that provide new perl-visible syntax, primarily for authors of keyword
+plugins using the PL_keyword_plugin hook mechanism. It is unlikely to be of
+much use to anyone else; and highly unlikely to be any use when writing
+perl code using these. Unless you are writing a keyword plugin using XS,
+this module is not for you.
+
+%files -f %{name}.files
+%doc Changes README hax share-infix share-keyword src
+
+%changelog
+%autochangelog

--- a/SPECS/po4a/0001-Fix-msginit-compatibility-with-gettext-1.0.patch
+++ b/SPECS/po4a/0001-Fix-msginit-compatibility-with-gettext-1.0.patch
@@ -1,0 +1,39 @@
+From 4cf9c5b90fe8bba7fca48d51ef3885bd411b08ef Mon Sep 17 00:00:00 2001
+From: Philip Taron <philip.taron@gmail.com>
+Date: Sat, 21 Mar 2026 10:14:26 -0700
+Subject: [PATCH] Fix msginit compatibility with gettext >= 1.0.
+
+gettext 1.0 changed msginit behavior: when the output PO file already
+exists, msginit now merges into it like msgmerge instead of failing
+with an error.  This breaks po4a because it passes an empty PO file as
+the output target; msginit merges into the empty file and produces a PO
+with stripped headers and corrupted content.
+
+Remove the output file before calling msginit when it exists and is
+empty, so that msginit always creates a fresh PO file with proper
+headers.
+
+* po4a: Before calling msginit, unlink the output file if it exists
+and is empty.
+
+See: https://github.com/mquinson/po4a/issues/636
+See: https://savannah.gnu.org/news/?id=10853
+---
+ po4a | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/po4a b/po4a
+index 09edb9a13..c55b74b70 100755
+--- a/po4a
++++ b/po4a
+@@ -1875,6 +1875,10 @@ if ( not $po4a_opts{"no-update"} ) {
+                 }
+ 
+                 my $read_pot_filename = find_input_file($pot_filename);
++                # Remove the output file if it exists (e.g. as an empty file),
++                # because gettext >= 1.0's msginit merges into existing files
++                # instead of overwriting, producing broken PO headers.
++                unlink $outfile if ( -e $outfile && -z $outfile );
+                 my $cmd =
+                   "msginit$Config{_exe} -i \"$read_pot_filename\" --locale $lang -o \"$outfile\" --no-translator >$devnull";
+                 run_cmd($cmd);

--- a/SPECS/po4a/po4a.spec
+++ b/SPECS/po4a/po4a.spec
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Suyun <ziyu.oerv@isrc.iscas.ac.cn>
+# SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           po4a
+Version:        0.74
+Release:        %autorelease
+Summary:        Tools for helping translation of documentation
+License:        GPL-2.0-or-later
+URL:            https://po4a.org/
+VCS:            git:https://github.com/mquinson/po4a.git
+#!RemoteAsset:  sha256:25fc323f2ba37bbd48c3af0ebf49952644b0e468261f98633e91219a838fe7c2
+Source0:        https://github.com/mquinson/po4a/releases/download/v%{version}/po4a-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    perlbuild
+
+# https://github.com/mquinson/po4a/issues/636
+Patch0:         0001-Fix-msginit-compatibility-with-gettext-1.0.patch
+
+BuildOption(build):  --installdirs=vendor
+BuildOption(install):  --destdir=%{buildroot} --create_packlist=0
+
+BuildRequires:  make
+BuildRequires:  perl-macros
+BuildRequires:  perl-rpm-macros
+BuildRequires:  perl-rpm-packaging
+BuildRequires:  perl >= 5.8.1
+BuildRequires:  perl(Locale::gettext) >= 1.01
+BuildRequires:  perl(Module::Build) >= 0.42
+BuildRequires:  perl(Pod::Parser)
+BuildRequires:  perl(SGMLS)
+BuildRequires:  perl(Term::ReadKey)
+BuildRequires:  perl(Text::WrapI18N)
+BuildRequires:  perl(Unicode::GCString)
+BuildRequires:  perl(Unicode::LineBreak)
+BuildRequires:  perl(YAML::Tiny)
+BuildRequires:  docbook-xsl
+BuildRequires:  libxslt
+# For tests
+BuildRequires:  perl(Syntax::Keyword::Try)
+BuildRequires:  opensp
+BuildRequires:  docbook-dtds
+# We need kpsewhich
+BuildRequires:  texlive-latex
+
+%description
+po4a (PO for anything) eases the translation of documentation and other
+textual content. It converts documentation to PO files for translation,
+and then back to the original format from translated PO files.
+
+%build -p
+# Replace online docbook.xsl URL with local path for offline build
+sed -i 's|http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl|file://%{_datadir}/sgml/docbook/xsl-stylesheets-1.79.2/manpages/docbook.xsl|' Po4aBuilder.pm
+
+%files -f %{name}.files
+%doc README* TODO changelog
+%{_mandir}/*/man1/po4a*.1*
+%{_mandir}/*/man1/msguntypot.1*
+%{_mandir}/*/man3/Locale::Po4a::*.3*
+%{_mandir}/*/man7/po4a.7*
+%{_datadir}/locale/
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

po4a (PO for anything) eases the translation of documentation and other textual content using gettext PO files, supporting formats like man, pod, tex, xml, asciidoc, markdown, and more.

Original PR: #284

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
