### PR TITLE
shadow: fix newgidmap/newuidmap cap

### DIFF
--- a/SPECS/shadow/shadow.spec
+++ b/SPECS/shadow/shadow.spec
@@ -151,8 +151,8 @@ install -Dm644 %{SOURCE4} %{buildroot}%{_unitdir}/shadow.service
 %{_bindir}/sg
 %attr(4755,root,root) %{_bindir}/chage
 %attr(4755,root,root) %{_bindir}/gpasswd
-%attr(0755,root,root) %caps(cap_setgid=ep) %{_bindir}/newgidmap
-%attr(0755,root,root) %caps(cap_setuid=ep) %{_bindir}/newuidmap
+%attr(0755,root,root) %caps(cap_setgid,cap_setpcap=ep) %{_bindir}/newgidmap
+%attr(0755,root,root) %caps(cap_setuid,cap_setpcap=ep) %{_bindir}/newuidmap
 %attr(4755,root,root) %{_bindir}/passwd
 %{_bindir}/chgpasswd
 %{_bindir}/chpasswd


### PR DESCRIPTION
## Summary
After this change, make "pbuild --vm-type podman" work on rootless
<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy

<!-- Message of single commit: -->

<!-- Message of single commit: -->