### PR TITLE
SPECS: rpm-config-openruyi: reduce compress level to save CPU time

### DIFF
--- a/SPECS/rpm-config-openruyi/macros
+++ b/SPECS/rpm-config-openruyi/macros
@@ -125,7 +125,7 @@
 %_binary_filedigest_algorithm 8
 
 # Use zstd for binary payloads
-%_binary_payload w19T0.zstdio
+%_binary_payload w3T0.zstdio
 
 # Expands to shell code to set the compiler/linker environment
 # variables CFLAGS, CXXFLAGS, FFLAGS, FCFLAGS, LDFLAGS if they have


### PR DESCRIPTION
## Summary

According to:

https://fedoraproject.org/wiki/Changes/Switch_RPMs_to_zstd_compression#Comparison_of_compression_algorithms_and_levels

This will save huge amount CPU time in the cost of slightly larger package size, speeding up package building.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
