### PR TITLE
SPECS: Add Prometheus v3.13 modules - DAG L0-01

### DIFF
--- a/SPECS/go-github-alibabacloud-go-debug/go-github-alibabacloud-go-debug.spec
+++ b/SPECS/go-github-alibabacloud-go-debug/go-github-alibabacloud-go-debug.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           debug
+%define go_import_path  github.com/alibabacloud-go/debug
+
+Name:           go-github-alibabacloud-go-debug
+Version:        1.0.1
+Release:        %autorelease
+Summary:        Debug helpers for Alibaba Cloud Go SDKs
+License:        Apache-2.0
+URL:            https://github.com/alibabacloud-go/debug
+#!RemoteAsset:  sha256:25531ff5dd790db1dcaa004eef78e53c894fcdc161b1493049051e4be6701027
+Source0:        https://github.com/alibabacloud-go/debug/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+Provides:       go(%{go_import_path}/debug) = %{version}
+
+%description
+Debug support used by Alibaba Cloud Go SDKs.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-allegro-bigcache-v3/2000-serialize-stats-index-test.patch
+++ b/SPECS/go-github-allegro-bigcache-v3/2000-serialize-stats-index-test.patch
@@ -1,0 +1,27 @@
+From b908b157b86aad156ededb374b8ea4eb5e8667de Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Tue, 8 Sep 2026 01:28:46 +0800
+Subject: [PATCH] server: serialize stats index test
+
+TestGetStatsIndex shares the package-level cache used by other server tests. Do not run it in parallel, so its entry count and collisions remain deterministic.
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ server/server_test.go | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/server/server_test.go b/server/server_test.go
+index 266afef..471d9d5 100644
+--- a/server/server_test.go
++++ b/server/server_test.go
+@@ -209,7 +209,6 @@ func TestGetStats(t *testing.T) {
+ }
+ 
+ func TestGetStatsIndex(t *testing.T) {
+-	t.Parallel()
+ 	var testStats bigcache.Stats
+ 
+ 	getreq := httptest.NewRequest("GET", testBaseString+"/api/v1/stats", nil)
+-- 
+2.43.0
+

--- a/SPECS/go-github-allegro-bigcache-v3/go-github-allegro-bigcache-v3.spec
+++ b/SPECS/go-github-allegro-bigcache-v3/go-github-allegro-bigcache-v3.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           bigcache
+%define go_import_path  github.com/allegro/bigcache/v3
+
+Name:           go-github-allegro-bigcache-v3
+Version:        3.2.0
+Release:        %autorelease
+Summary:        Efficient cache for large numbers of Go entries
+License:        Apache-2.0
+URL:            https://github.com/allegro/bigcache
+#!RemoteAsset:  sha256:4fc24187d81a530f2f08b34fcc7232a0ad660492a720536b1a5e1ed5557f568f
+Source0:        https://github.com/allegro/bigcache/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# The server stats test uses a shared cache and is not safe to run in parallel.
+Patch2000:      2000-serialize-stats-index-test.patch
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+BigCache is a fast, concurrent, eviction-based in-memory cache designed for
+large numbers of entries while limiting garbage collector overhead.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-andybalholm-cascadia/go-github-andybalholm-cascadia.spec
+++ b/SPECS/go-github-andybalholm-cascadia/go-github-andybalholm-cascadia.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           cascadia
+%define go_import_path  github.com/andybalholm/cascadia
+
+Name:           go-github-andybalholm-cascadia
+Version:        1.3.4
+Release:        %autorelease
+Summary:        CSS selector implementation for Go
+License:        BSD-3-Clause
+URL:            https://github.com/andybalholm/cascadia
+#!RemoteAsset:  sha256:6d646174d19d2400b610d627ff43d4a53a4de91bfc02fad7a70aae73c36930e0
+Source0:        https://codeload.github.com/andybalholm/cascadia/tar.gz/refs/tags/v%{version}#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(golang.org/x/net)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(golang.org/x/net)
+
+%description
+Cascadia implements CSS selectors for use with the Go HTML parser.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-antchfx-xpath/go-github-antchfx-xpath.spec
+++ b/SPECS/go-github-antchfx-xpath/go-github-antchfx-xpath.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           xpath
+%define go_import_path  github.com/antchfx/xpath
+
+Name:           go-github-antchfx-xpath
+Version:        1.3.8
+Release:        %autorelease
+Summary:        XPath expression implementation for Go
+License:        MIT
+URL:            https://github.com/antchfx/xpath
+#!RemoteAsset:  sha256:fa32cbc5c987688c5d9db1dd5842adf45cd2b2867b824ddc70d9cc5aa2b50159
+Source0:        https://codeload.github.com/antchfx/xpath/tar.gz/refs/tags/v%{version}#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Current Go vet rejects legacy non-constant format strings and mismatched
+# formatting verbs; keep running the tests with vet disabled.
+BuildOption(check):  -vet=off
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+This package evaluates XPath expressions against XML, HTML, and other tree
+structured documents.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-antlr4-go-antlr-v4/go-github-antlr4-go-antlr-v4.spec
+++ b/SPECS/go-github-antlr4-go-antlr-v4/go-github-antlr4-go-antlr-v4.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           antlr
+%define go_import_path  github.com/antlr4-go/antlr/v4
+
+Name:           go-github-antlr4-go-antlr-v4
+Version:        4.13.1
+Release:        %autorelease
+Summary:        ANTLR 4 runtime for Go
+License:        BSD-3-Clause
+URL:            https://github.com/antlr4-go/antlr
+#!RemoteAsset:  sha256:2738fa0e68c3a61fea8de7b6c2f55fc1b39c7337a3d9351c2042bf6003e5590a
+Source0:        https://codeload.github.com/antlr4-go/antlr/tar.gz/refs/tags/v%{version}#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(golang.org/x/exp)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(golang.org/x/exp)
+
+%description
+This package provides the official ANTLR 4 runtime implementation for Go.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-aws-aws-lambda-go/go-github-aws-aws-lambda-go.spec
+++ b/SPECS/go-github-aws-aws-lambda-go/go-github-aws-aws-lambda-go.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           aws-lambda-go
+%define go_import_path  github.com/aws/aws-lambda-go
+
+Name:           go-github-aws-aws-lambda-go
+Version:        1.55.0
+Release:        %autorelease
+Summary:        Libraries for building AWS Lambda functions in Go
+License:        Apache-2.0
+URL:            https://github.com/aws/aws-lambda-go
+#!RemoteAsset:  sha256:06c080cf35eb27ba2645bf9ac02c2f2cdb69b065b5b4d161218e1c28d7e746df
+Source0:        https://github.com/aws/aws-lambda-go/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(gopkg.in/yaml.v3)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+AWS Lambda for Go provides libraries, event definitions, and runtime support
+for implementing AWS Lambda functions in Go.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-aws-aws-msk-iam-sasl-signer-go/go-github-aws-aws-msk-iam-sasl-signer-go.spec
+++ b/SPECS/go-github-aws-aws-msk-iam-sasl-signer-go/go-github-aws-aws-msk-iam-sasl-signer-go.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           aws-msk-iam-sasl-signer-go
+%define go_import_path  github.com/aws/aws-msk-iam-sasl-signer-go
+
+Name:           go-github-aws-aws-msk-iam-sasl-signer-go
+Version:        1.0.4
+Release:        %autorelease
+Summary:        AWS MSK IAM SASL signer for Go
+License:        Apache-2.0
+URL:            https://github.com/aws/aws-msk-iam-sasl-signer-go
+#!RemoteAsset:  sha256:e6a52d43315a72af309b80dffac4542841bdbaa61bd2312ffbea3faaa384c81b
+Source0:        https://github.com/aws/aws-msk-iam-sasl-signer-go/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/aws/aws-sdk-go-v2)
+
+%description
+The AWS MSK IAM SASL signer generates authentication tokens for Go Kafka
+clients connecting to Amazon Managed Streaming for Apache Kafka with IAM.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-azure-go-ansiterm/2000-Fix-logging-of-transition-target-state.patch
+++ b/SPECS/go-github-azure-go-ansiterm/2000-Fix-logging-of-transition-target-state.patch
@@ -1,0 +1,26 @@
+From 3db72355ce5d12d0cae3d2a327452a43d56b7237 Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Wed, 19 Aug 2026 00:54:07 +0800
+Subject: [PATCH] Fix logging of transition target state
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ parser.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/parser.go b/parser.go
+index 03cec7a..4013a88 100644
+--- a/parser.go
++++ b/parser.go
+@@ -136,7 +136,7 @@ func (ap *AnsiParser) changeState(newState state) error {
+ 
+ 	// Perform transition action
+ 	if err := ap.currState.Transition(newState); err != nil {
+-		ap.logf("Transition from '%s' to '%s' failed with: '%v'", ap.currState.Name(), newState.Name, err)
++		ap.logf("Transition from '%s' to '%s' failed with: '%v'", ap.currState.Name(), newState.Name(), err)
+ 		return err
+ 	}
+ 
+-- 
+2.43.0
+

--- a/SPECS/go-github-azure-go-ansiterm/go-github-azure-go-ansiterm.spec
+++ b/SPECS/go-github-azure-go-ansiterm/go-github-azure-go-ansiterm.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-ansiterm
+%define go_import_path  github.com/Azure/go-ansiterm
+%define commit_id       faa5f7b0171c46bb398a91b4a0c906324d3664cf
+
+Name:           go-github-azure-go-ansiterm
+Version:        0+git20260818.faa5f7b
+Release:        %autorelease
+Summary:        ANSI terminal emulation library for Go
+License:        MIT
+URL:            https://github.com/Azure/go-ansiterm
+#!RemoteAsset:  sha256:17e7f56d4f981022a7bb5bbf5b2385d73aa57dcbcfb7f3ce3cf80228ec557cbe
+Source0:        https://github.com/Azure/go-ansiterm/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Call the state name method when logging a failed transition.
+Patch2000:      2000-Fix-logging-of-transition-target-state.patch
+
+BuildOption(prep):  -n %{_name}-%{commit_id}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(golang.org/x/sys)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(golang.org/x/sys)
+
+%description
+Go ANSI terminal provides a parser and terminal implementation used to process
+ANSI escape sequences, including Windows console support.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-bazelbuild-rules-go/go-github-bazelbuild-rules-go.spec
+++ b/SPECS/go-github-bazelbuild-rules-go/go-github-bazelbuild-rules-go.spec
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           rules_go
+%define go_import_path  github.com/bazelbuild/rules_go
+# These packages are Bazel actions or integration-test harnesses. They require
+# Bazel-selected source files, generated fixtures, runfiles, or Go internal
+# packages and therefore cannot be tested as ordinary GOPATH packages.
+%define go_test_exclude_glob  %{shrink:
+    %{go_import_path}/go/private
+    %{go_import_path}/go/tools/builders
+    %{go_import_path}/go/tools/bzltestutil/bincov
+    %{go_import_path}/go/tools/gopackagesdriver
+    %{go_import_path}/tests/*
+}
+# These nested command modules intentionally rely on dependencies injected by
+# Bazel rather than declaring them in their go.mod files.
+%define go_test_exclude  %{shrink:
+    %{go_import_path}/examples/basic_gazelle
+    %{go_import_path}/go/tools/fetch_repo
+    %{go_import_path}/go/tools/releaser
+}
+
+Name:           go-github-bazelbuild-rules-go
+Version:        0.62.0
+Release:        %autorelease
+Summary:        Bazel rules for building Go code
+License:        Apache-2.0
+URL:            https://github.com/bazelbuild/rules_go
+#!RemoteAsset:  sha256:988a8856e5cf6ce5bcb1e30919fe87e444af0fe09ae26ae125035c9522bda147
+Source0:        https://github.com/bazelbuild/rules_go/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{_name}-%{version}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+BuildRequires:  go(github.com/aymanbagabas/go-udiff)
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/gogo/protobuf)
+BuildRequires:  go(github.com/golang/mock)
+BuildRequires:  go(github.com/golang/protobuf)
+BuildRequires:  go(github.com/google/go-cmp)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(golang.org/x/crypto)
+BuildRequires:  go(golang.org/x/mod)
+BuildRequires:  go(golang.org/x/net)
+BuildRequires:  go(golang.org/x/oauth2)
+BuildRequires:  go(golang.org/x/sync)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(golang.org/x/text)
+BuildRequires:  go(golang.org/x/tools)
+BuildRequires:  go(google.golang.org/genproto)
+BuildRequires:  go(google.golang.org/grpc)
+BuildRequires:  go(google.golang.org/protobuf)
+BuildRequires:  go(gopkg.in/yaml.v2)
+BuildRequires:  go(gopkg.in/yaml.v3)
+
+Provides:       go(%{go_import_path}) = %{version}
+Provides:       go(%{go_import_path}/go/runfiles) = %{version}
+Provides:       go(github.com/bazel-contrib/rules_go/examples/basic_gazelle) = %{version}
+
+Requires:       go(github.com/aymanbagabas/go-udiff)
+Requires:       go(github.com/gogo/protobuf)
+Requires:       go(github.com/golang/protobuf)
+Requires:       go(golang.org/x/crypto)
+Requires:       go(golang.org/x/mod)
+Requires:       go(golang.org/x/net)
+Requires:       go(golang.org/x/oauth2)
+Requires:       go(golang.org/x/sync)
+Requires:       go(golang.org/x/tools)
+Requires:       go(google.golang.org/genproto)
+Requires:       go(google.golang.org/grpc)
+Requires:       go(google.golang.org/protobuf)
+Requires:       go(gopkg.in/yaml.v2)
+
+%description
+Rules_go provides Bazel rules for building, testing, and managing Go code,
+including toolchain, library, binary, test, and protocol buffer integration.
+
+%install -a
+# basic_gazelle is a nested module whose declared import path uses the
+# bazel-contrib organization, so move it out of the enclosing repository path.
+install -d %{buildroot}%{go_sys_gopath}/github.com/bazel-contrib/rules_go/examples
+mv %{buildroot}%{go_sys_gopath}/%{go_import_path}/examples/basic_gazelle \
+    %{buildroot}%{go_sys_gopath}/github.com/bazel-contrib/rules_go/examples/
+
+%check -p
+# Prepare the differently named nested module at its canonical GOPATH before
+# the default check copies and tests the enclosing rules_go repository.
+%go_common
+install -d %{_builddir}/go/src/github.com/bazel-contrib/rules_go/examples
+cp -a examples/basic_gazelle \
+    %{_builddir}/go/src/github.com/bazel-contrib/rules_go/examples/
+# Bazel normally exports these paths for go/tools/bazel tests. Point them at
+# the GOPATH tree that the default check creates from the same source archive.
+export TEST_SRCDIR=%{_builddir}/go/src
+export TEST_WORKSPACE=%{go_import_path}
+
+%check -a
+# The default ./... check sees basic_gazelle only at the enclosing repository
+# path; test it separately under the import path declared by its go.mod file.
+cd %{_builddir}/go/src/github.com/bazel-contrib/rules_go/examples/basic_gazelle
+go test -v ./...
+
+%files
+%doc README.rst
+%license LICENSE.txt
+%{go_sys_gopath}/%{go_import_path}
+%{go_sys_gopath}/github.com/bazel-contrib/rules_go
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-benbjohnson-clock/go-github-benbjohnson-clock.spec
+++ b/SPECS/go-github-benbjohnson-clock/go-github-benbjohnson-clock.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           clock
+%define go_import_path  github.com/benbjohnson/clock
+
+Name:           go-github-benbjohnson-clock
+Version:        1.3.5
+Release:        %autorelease
+Summary:        Mockable clock library for Go
+License:        MIT
+URL:            https://github.com/benbjohnson/clock
+#!RemoteAsset:  sha256:d26928c5301d8f7feedebeda0506599fa8c9aeb0b724de619b9d468df441a33c
+Source0:        https://github.com/benbjohnson/clock/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Clock wraps Go's time package with interchangeable real and mock clock
+implementations for deterministic testing.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-bitly-go-hostpool/go-github-bitly-go-hostpool.spec
+++ b/SPECS/go-github-bitly-go-hostpool/go-github-bitly-go-hostpool.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-hostpool
+%define go_import_path  github.com/bitly/go-hostpool
+
+Name:           go-github-bitly-go-hostpool
+Version:        0.1.1
+Release:        %autorelease
+Summary:        Host pool library for Go
+License:        MIT
+URL:            https://github.com/bitly/go-hostpool
+#!RemoteAsset:  sha256:7fb8b2ec737a76becf80c0fe586ccb4bce4f0479505e1366a5c59d6f59359c49
+Source0:        https://github.com/bitly/go-hostpool/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(gopkg.in/yaml.v3)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+This package selects hosts using round-robin or epsilon-greedy strategies and
+temporarily avoids unresponsive hosts.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-bmatcuk-doublestar-v4/go-github-bmatcuk-doublestar-v4.spec
+++ b/SPECS/go-github-bmatcuk-doublestar-v4/go-github-bmatcuk-doublestar-v4.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           doublestar
+%define go_import_path  github.com/bmatcuk/doublestar/v4
+# The examples module contains a non-constant fmt.Printf format rejected by
+# the current Go vet; the library package itself remains fully tested.
+%define go_test_exclude_glob  %{go_import_path}/examples*
+
+Name:           go-github-bmatcuk-doublestar-v4
+Version:        4.10.0
+Release:        %autorelease
+Summary:        Path pattern matching and globbing supporting doublestar patterns
+License:        MIT
+URL:            https://github.com/bmatcuk/doublestar
+#!RemoteAsset:  sha256:5d178e61fe67b3ae3ea46f023b2fbfaf0400e6ee74fe5cef1074690305a3f4f6
+Source0:        https://github.com/bmatcuk/doublestar/archive/refs/tags/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/bmatcuk/doublestar/v4) = %{version}
+
+%description
+Doublestar provides path pattern matching and globbing with support for
+doublestar (**) patterns.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-bmizerany-assert/2000-example-use-canonical-assert-import-path.patch
+++ b/SPECS/go-github-bmizerany-assert/2000-example-use-canonical-assert-import-path.patch
@@ -1,0 +1,27 @@
+From a6a9237450deb34c77ed519a3410dda493d26de9 Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Tue, 18 Aug 2026 23:37:44 +0800
+Subject: [PATCH] example: use canonical assert import path
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ example/point_test.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/example/point_test.go b/example/point_test.go
+index 34e791a..0ff7332 100644
+--- a/example/point_test.go
++++ b/example/point_test.go
+@@ -1,8 +1,8 @@
+ package point
+ 
+ import (
++	"github.com/bmizerany/assert"
+ 	"testing"
+-	"assert"
+ )
+ 
+ func TestAsserts(t *testing.T) {
+-- 
+2.43.0
+

--- a/SPECS/go-github-bmizerany-assert/go-github-bmizerany-assert.spec
+++ b/SPECS/go-github-bmizerany-assert/go-github-bmizerany-assert.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           assert
+%define go_import_path  github.com/bmizerany/assert
+%define commit_id       b7ed37b82869576c289d7d97fb2bbd8b64a0cb28
+# The example intentionally compares unequal values to demonstrate failure output.
+%define go_test_exclude  %{go_import_path}/example
+
+Name:           go-github-bmizerany-assert
+Version:        0+git20260818.b7ed37b
+Release:        %autorelease
+Summary:        Assertions for Go tests
+License:        MIT
+URL:            https://github.com/bmizerany/assert
+#!RemoteAsset:  sha256:bcbbd85bb420d7fe6be587cdf524b01faa30a0095a52345c075787616385f503
+Source0:        https://github.com/bmizerany/assert/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Use the canonical module path in the legacy example test.
+Patch2000:      2000-example-use-canonical-assert-import-path.patch
+
+BuildOption(prep):  -n %{_name}-%{commit_id}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/kr/pretty)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/kr/pretty)
+
+%description
+Assert provides simple equality and error assertions for Go tests.
+
+%files
+%doc README.md
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-bombsimon-logrusr-v4/go-github-bombsimon-logrusr-v4.spec
+++ b/SPECS/go-github-bombsimon-logrusr-v4/go-github-bombsimon-logrusr-v4.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           logrusr
+%define go_import_path  github.com/bombsimon/logrusr/v4
+
+Name:           go-github-bombsimon-logrusr-v4
+Version:        4.1.0
+Release:        %autorelease
+Summary:        Logrus backend for the logr interface
+License:        MIT
+URL:            https://github.com/bombsimon/logrusr
+#!RemoteAsset:  sha256:f65a0182512284e7887efc1ace8a126eabf038abbf40ab8fcdf7cc99d1b0f81a
+Source0:        https://github.com/bombsimon/logrusr/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/go-logr/logr)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/sirupsen/logrus)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(gopkg.in/yaml.v3)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/go-logr/logr)
+Requires:       go(github.com/sirupsen/logrus)
+
+%description
+Logrusr adapts Logrus loggers to the structured logging interfaces defined by
+github.com/go-logr/logr.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-cactus-go-statsd-client/go-github-cactus-go-statsd-client.spec
+++ b/SPECS/go-github-cactus-go-statsd-client/go-github-cactus-go-statsd-client.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-statsd-client
+%define go_import_path  github.com/cactus/go-statsd-client
+
+Name:           go-github-cactus-go-statsd-client
+Version:        3.2.1
+Release:        %autorelease
+Summary:        StatsD client for Go
+License:        MIT
+URL:            https://github.com/cactus/go-statsd-client
+#!RemoteAsset:  sha256:8fc4f36ae20ec78721767135f0b23228b6db19ef3c05b101f071e3a1ff4659fb
+Source0:        https://github.com/cactus/go-statsd-client/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go(github.com/jessevdk/go-flags)
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+This package provides a UDP StatsD client for Go.
+
+%files
+%doc README.md
+%license LICENSE.md
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-casbin-govaluate/go-github-casbin-govaluate.spec
+++ b/SPECS/go-github-casbin-govaluate/go-github-casbin-govaluate.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           govaluate
+%define go_import_path  github.com/casbin/govaluate
+
+Name:           go-github-casbin-govaluate
+Version:        1.10.0
+Release:        %autorelease
+Summary:        Expression evaluator for Go
+License:        MIT
+URL:            https://github.com/casbin/govaluate
+#!RemoteAsset:  sha256:a726f9f69964024c399cd67f2e0b7a0ed43d861dd73455ebc0076db98d843e61
+Source0:        https://github.com/casbin/govaluate/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Govaluate evaluates arbitrary C-like expressions in Go.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-cihub-seelog/1000-fix-xml-syntax-error-with-go1.6.patch
+++ b/SPECS/go-github-cihub-seelog/1000-fix-xml-syntax-error-with-go1.6.patch
@@ -1,0 +1,25 @@
+From abfc09715edde0722e239c1c1744c31618d4da5d Mon Sep 17 00:00:00 2001
+From: Yohan Legat <yohan.legat@zenika.com>
+Date: Tue, 5 Apr 2016 16:28:44 +0200
+Subject: [PATCH] Fix XML syntax error with go1.6
+
+---
+ internals_xmlnode_test.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/internals_xmlnode_test.go b/internals_xmlnode_test.go
+index 3a4487c..2655002 100644
+--- a/internals_xmlnode_test.go
++++ b/internals_xmlnode_test.go
+@@ -110,7 +110,7 @@ func getXMLTests() []xmlNodeTest {
+ 		testName = "Comments"
+ 		testXML =
+ 			`<!-- <abcdef/> -->
+-<a> <!-- <!--12345-->
++<a> <!-- 12345-->
+ </a>
+ `
+ 		testExpected = newNode()
+-- 
+2.43.0
+

--- a/SPECS/go-github-cihub-seelog/1001-remove-racy-test.patch
+++ b/SPECS/go-github-cihub-seelog/1001-remove-racy-test.patch
@@ -1,0 +1,39 @@
+From 79cbb3d1b030f15bedefb1470e80b3ba80c93d21 Mon Sep 17 00:00:00 2001
+From: Pavel Korotkov <pkorotkov@gmail.com>
+Date: Mon, 30 Jan 2017 16:45:32 +0300
+Subject: [PATCH] Remove racy test
+
+---
+ writers_bufferedwriter_test.go | 16 ----------------
+ 1 file changed, 16 deletions(-)
+
+diff --git a/writers_bufferedwriter_test.go b/writers_bufferedwriter_test.go
+index 03f74f7..9f8f509 100644
+--- a/writers_bufferedwriter_test.go
++++ b/writers_bufferedwriter_test.go
+@@ -43,22 +43,6 @@ func TestChunkWriteOnFilling(t *testing.T) {
+ 	bufferedWriter.Write(bytes)
+ }
+ 
+-func TestFlushByTimePeriod(t *testing.T) {
+-	writer, _ := newBytesVerifier(t)
+-	bufferedWriter, err := NewBufferedWriter(writer, 1024, 10)
+-
+-	if err != nil {
+-		t.Fatalf("Unexpected buffered writer creation error: %s", err.Error())
+-	}
+-
+-	bytes := []byte("Hello")
+-
+-	for i := 0; i < 2; i++ {
+-		writer.ExpectBytes(bytes)
+-		bufferedWriter.Write(bytes)
+-	}
+-}
+-
+ func TestBigMessageMustPassMemoryBuffer(t *testing.T) {
+ 	writer, _ := newBytesVerifier(t)
+ 	bufferedWriter, err := NewBufferedWriter(writer, 1024, 0)
+-- 
+2.43.0
+

--- a/SPECS/go-github-cihub-seelog/2000-support-current-go-tooling.patch
+++ b/SPECS/go-github-cihub-seelog/2000-support-current-go-tooling.patch
@@ -1,0 +1,126 @@
+From 4cd06cd1bde0fbd00bc426b08c3eae7796a8c709 Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Mon, 17 Aug 2026 13:31:02 +0800
+Subject: [PATCH] tests: support current Go tooling
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ cfg_logconfig_test.go             | 6 +++---
+ common_constraints_test.go        | 4 ++--
+ dispatch_filterdispatcher_test.go | 4 ++--
+ dispatch_splitdispatcher_test.go  | 2 +-
+ internals_byteverifiers_test.go   | 2 +-
+ writers_formattedwriter_test.go   | 2 +-
+ 6 files changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/cfg_logconfig_test.go b/cfg_logconfig_test.go
+index af64a6c..f09477a 100644
+--- a/cfg_logconfig_test.go
++++ b/cfg_logconfig_test.go
+@@ -48,17 +48,17 @@ func TestConfig(t *testing.T) {
+ 
+ 	context, err := currentContext(nil)
+ 	if err != nil {
+-		t.Errorf("cannot get current context:" + err.Error())
++		t.Errorf("cannot get current context: %s", err)
+ 		return
+ 	}
+ 	firstContext, err := getFirstContext()
+ 	if err != nil {
+-		t.Errorf("cannot get current context:" + err.Error())
++		t.Errorf("cannot get current context: %s", err)
+ 		return
+ 	}
+ 	secondContext, err := getSecondContext()
+ 	if err != nil {
+-		t.Errorf("cannot get current context:" + err.Error())
++		t.Errorf("cannot get current context: %s", err)
+ 		return
+ 	}
+ 
+diff --git a/common_constraints_test.go b/common_constraints_test.go
+index bb9918e..0fb60ee 100644
+--- a/common_constraints_test.go
++++ b/common_constraints_test.go
+@@ -60,7 +60,7 @@ func TestInvalidLogLevels(t *testing.T) {
+ 	}
+ }
+ 
+-func TestlistConstraintsWithDuplicates(t *testing.T) {
++func TestListConstraintsWithDuplicates(t *testing.T) {
+ 	duplicateList := []LogLevel{TraceLvl, DebugLvl, InfoLvl,
+ 		WarnLvl, ErrorLvl, CriticalLvl, CriticalLvl, CriticalLvl}
+ 
+@@ -85,7 +85,7 @@ func TestlistConstraintsWithDuplicates(t *testing.T) {
+ 	}
+ }
+ 
+-func TestlistConstraintsWithOffInList(t *testing.T) {
++func TestListConstraintsWithOffInList(t *testing.T) {
+ 	offList := []LogLevel{TraceLvl, DebugLvl, Off}
+ 
+ 	listConstr, errList := NewListConstraints(offList)
+diff --git a/dispatch_filterdispatcher_test.go b/dispatch_filterdispatcher_test.go
+index c1894a7..0d5f0db 100644
+--- a/dispatch_filterdispatcher_test.go
++++ b/dispatch_filterdispatcher_test.go
+@@ -28,7 +28,7 @@ import (
+ 	"testing"
+ )
+ 
+-func TestfilterDispatcher_Pass(t *testing.T) {
++func TestFilterDispatcher_Pass(t *testing.T) {
+ 	writer, _ := newBytesVerifier(t)
+ 	filter, err := NewFilterDispatcher(onlyMessageFormatForTest, []interface{}{writer}, TraceLvl)
+ 	if err != nil {
+@@ -48,7 +48,7 @@ func TestfilterDispatcher_Pass(t *testing.T) {
+ 	writer.MustNotExpect()
+ }
+ 
+-func TestfilterDispatcher_Deny(t *testing.T) {
++func TestFilterDispatcher_Deny(t *testing.T) {
+ 	writer, _ := newBytesVerifier(t)
+ 	filter, err := NewFilterDispatcher(DefaultFormatter, []interface{}{writer})
+ 	if err != nil {
+diff --git a/dispatch_splitdispatcher_test.go b/dispatch_splitdispatcher_test.go
+index fc4651c..781c9d9 100644
+--- a/dispatch_splitdispatcher_test.go
++++ b/dispatch_splitdispatcher_test.go
+@@ -39,7 +39,7 @@ func init() {
+ 	}
+ }
+ 
+-func TestsplitDispatcher(t *testing.T) {
++func TestSplitDispatcher(t *testing.T) {
+ 	writer1, _ := newBytesVerifier(t)
+ 	writer2, _ := newBytesVerifier(t)
+ 	spliter, err := NewSplitDispatcher(onlyMessageFormatForTest, []interface{}{writer1, writer2})
+diff --git a/internals_byteverifiers_test.go b/internals_byteverifiers_test.go
+index 0ab6ebc..26a1024 100644
+--- a/internals_byteverifiers_test.go
++++ b/internals_byteverifiers_test.go
+@@ -97,7 +97,7 @@ func (verifier *bytesVerifier) MustNotExpect() {
+ 			errorText += ". text = " + string(verifier.expectedBytes)
+ 		}
+ 
+-		verifier.testEnv.Errorf(errorText)
++		verifier.testEnv.Error(errorText)
+ 	}
+ }
+ 
+diff --git a/writers_formattedwriter_test.go b/writers_formattedwriter_test.go
+index 351ac4e..c2c5740 100644
+--- a/writers_formattedwriter_test.go
++++ b/writers_formattedwriter_test.go
+@@ -28,7 +28,7 @@ import (
+ 	"testing"
+ )
+ 
+-func TestformattedWriter(t *testing.T) {
++func TestFormattedWriter(t *testing.T) {
+ 	formatStr := "%Level %LEVEL %Msg"
+ 	message := "message"
+ 	var logLevel = LogLevel(TraceLvl)
+-- 
+2.43.0
+

--- a/SPECS/go-github-cihub-seelog/go-github-cihub-seelog.spec
+++ b/SPECS/go-github-cihub-seelog/go-github-cihub-seelog.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           seelog
+%define go_import_path  github.com/cihub/seelog
+
+Name:           go-github-cihub-seelog
+Version:        2.6
+Release:        %autorelease
+Summary:        Logging library for Go
+License:        BSD-3-Clause
+URL:            https://github.com/cihub/seelog
+#!RemoteAsset:  sha256:68ed377a2eba7a1558987bc1e52677295b4e703ecfc3a00708c2f68c4cb28354
+Source0:        https://github.com/cihub/seelog/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Backport the XML fixture fix required by Go 1.6 and later parsers.
+Patch1000:      1000-fix-xml-syntax-error-with-go1.6.patch
+# Backport removal of a timing-dependent buffered writer test.
+Patch1001:      1001-remove-racy-test.patch
+# Update tests for current Go formatting and vet requirements.
+Patch2000:      2000-support-current-go-tooling.patch
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/cihub/seelog) = %{version}
+
+%description
+Seelog is a Go logging library with configurable asynchronous dispatching,
+filtering, and formatting.
+
+%files
+%doc README.markdown
+%license LICENSE.txt
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-clbanning-mxj/go-github-clbanning-mxj.spec
+++ b/SPECS/go-github-clbanning-mxj/go-github-clbanning-mxj.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           mxj
+%define go_import_path  github.com/clbanning/mxj
+# The examples directory contains multiple standalone main packages.
+%define go_test_exclude  %{go_import_path}/examples
+
+Name:           go-github-clbanning-mxj
+Version:        1.8.4
+Release:        %autorelease
+Summary:        XML and JSON map utilities for Go
+License:        (BSD-3-Clause OR MIT)
+URL:            https://github.com/clbanning/mxj
+#!RemoteAsset:  sha256:335fa9d17855c8540eca83fd8ecacc5979570fe15be04f7c1154f0b71f2c39c7
+Source0:        https://github.com/clbanning/mxj/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Go 1.26 vet rejects legacy example names, while the tests themselves remain
+# valid and are still executed.
+BuildOption(check):  -vet=off
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+Provides:       go(%{go_import_path}/x2j-wrapper) = %{version}
+
+%description
+mxj encodes and decodes XML and JSON values as Go maps and supports querying
+and modifying values by key path.
+
+%files
+%doc readme.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-coocood-freecache/go-github-coocood-freecache.spec
+++ b/SPECS/go-github-coocood-freecache/go-github-coocood-freecache.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           freecache
+%define go_import_path  github.com/coocood/freecache
+
+Name:           go-github-coocood-freecache
+Version:        1.2.7
+Release:        %autorelease
+Summary:        Cache library with zero garbage collector overhead
+License:        MIT
+URL:            https://github.com/coocood/freecache
+#!RemoteAsset:  sha256:c8ce60c58e857735b781a4f1560b7fefd45fc84146481ab183ac01c8cfdce2c6
+Source0:        https://github.com/coocood/freecache/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/cespare/xxhash/v2)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/cespare/xxhash/v2)
+
+%description
+FreeCache is an in-memory cache for Go that stores large numbers of entries
+with zero garbage collector overhead.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-cucumber-messages-go-v28/go-github-cucumber-messages-go-v28.spec
+++ b/SPECS/go-github-cucumber-messages-go-v28/go-github-cucumber-messages-go-v28.spec
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           messages
+%define go_import_path  github.com/cucumber/messages/go/v28
+
+Name:           go-github-cucumber-messages-go-v28
+Version:        28.1.0
+Release:        %autorelease
+Summary:        Cucumber message protocol types for Go
+License:        MIT
+URL:            https://github.com/cucumber/messages
+#!RemoteAsset:  sha256:2c2e0b07fffb78e028fb61d1cf1d3678078483b89aa66ab0ae0261b54e3e8eed
+Source0:        https://github.com/cucumber/messages/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/google/uuid)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(gopkg.in/yaml.v3)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/google/uuid)
+
+%description
+This package provides the Go implementation of Cucumber's cross-language
+message protocol from the upstream messages repository.
+
+%install
+pushd go
+%buildsystem_golangmodules_install
+popd
+
+%check
+pushd go
+%buildsystem_golangmodules_check
+popd
+
+%files
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-datadog-datadog-go/go-github-datadog-datadog-go.spec
+++ b/SPECS/go-github-datadog-datadog-go/go-github-datadog-datadog-go.spec
@@ -8,26 +8,28 @@
 %define go_import_path  github.com/DataDog/datadog-go
 
 Name:           go-github-datadog-datadog-go
-Version:        3.2.0
+Version:        4.8.3
 Release:        %autorelease
 Summary:        Go DogStatsD client library for Datadog
 License:        MIT
 URL:            https://github.com/DataDog/datadog-go
-#!RemoteAsset:  sha256:0bcedc94ee42e08997a53753a091ff3465f87cd9c156a59d0516b0f6bfbd2eb1
+#!RemoteAsset:  sha256:0053a6b391abda1f494b858a23575fcbdd218666dd8050249074ad3f0a1dd3b5
 Source0:        https://github.com/DataDog/datadog-go/archive/refs/tags/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
 
 BuildRequires:  go
 BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/Microsoft/go-winio)
 BuildRequires:  go(github.com/stretchr/testify)
 
 Provides:       go(github.com/DataDog/datadog-go) = %{version}
 
+Requires:       go(github.com/Microsoft/go-winio)
+
 %description
 This package provides the legacy, pre-v5 github.com/DataDog/datadog-go
-import path required by packages that depend on
-github.com/DataDog/datadog-go v3.x+incompatible.
+import path required by packages that depend on v3 or v4 releases.
 
 %files
 %doc CHANGELOG.md

--- a/SPECS/go-github-datadog-go-sqllexer/go-github-datadog-go-sqllexer.spec
+++ b/SPECS/go-github-datadog-go-sqllexer/go-github-datadog-go-sqllexer.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-sqllexer
+%define go_import_path  github.com/DataDog/go-sqllexer
+
+Name:           go-github-datadog-go-sqllexer
+Version:        0.2.4
+Release:        %autorelease
+Summary:        SQL lexer for query obfuscation and normalization
+License:        MIT
+URL:            https://github.com/DataDog/go-sqllexer
+#!RemoteAsset:  sha256:c048dba3e8fe14ba02449d72dbca0325cb1888aa2d11ab2f7cd9d966fa3929ce
+Source0:        https://github.com/DataDog/go-sqllexer/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/stretchr/testify)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Go-sqllexer tokenizes SQL queries for obfuscation and normalization without
+implementing a full SQL parser.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-datadog-gostackparse/go-github-datadog-gostackparse.spec
+++ b/SPECS/go-github-datadog-gostackparse/go-github-datadog-gostackparse.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           gostackparse
+%define go_import_path  github.com/DataDog/gostackparse
+
+Name:           go-github-datadog-gostackparse
+Version:        0.7.0
+Release:        %autorelease
+Summary:        Parse Go goroutine stack traces
+License:        Apache-2.0 OR BSD-3-Clause
+URL:            https://github.com/DataDog/gostackparse
+#!RemoteAsset:  sha256:24c35d411f473b9a4ad4889f3c3a13ae44285e039dd748216e20f32e9171eebc
+Source0:        https://github.com/DataDog/gostackparse/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/stretchr/testify)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Gostackparse efficiently parses textual goroutine stack traces emitted by
+panic and runtime/debug.Stack into structured Go values.
+
+%files
+%doc README.md
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-datadog-mmh3/go-github-datadog-mmh3.spec
+++ b/SPECS/go-github-datadog-mmh3/go-github-datadog-mmh3.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           mmh3
+%define go_import_path  github.com/DataDog/mmh3
+%define commit_id       012dc69a9e49ffc8ea75406d83c36b507caeea6b
+
+Name:           go-github-datadog-mmh3
+Version:        0+git20260817.012dc69
+Release:        %autorelease
+Summary:        MurmurHash3 functions implemented in pure Go
+License:        MIT
+URL:            https://github.com/DataDog/mmh3
+#!RemoteAsset:  sha256:114dd4cb316ef1507e8a3cf33a84a9ef8742a08ae94a234688319b70be1aad18
+Source0:        https://github.com/DataDog/mmh3/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/stretchr/testify)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Mmh3 implements the 32-bit and 128-bit variants of MurmurHash3 in pure Go,
+including an optimized little-endian 128-bit function.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-dgryski-go-farm/go-github-dgryski-go-farm.spec
+++ b/SPECS/go-github-dgryski-go-farm/go-github-dgryski-go-farm.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-farm
+%define go_import_path  github.com/dgryski/go-farm
+%define commit_id       3414d57e47dafc94b763b0f8a0470333f5f44051
+
+Name:           go-github-dgryski-go-farm
+Version:        0+git20260817.3414d57
+Release:        %autorelease
+Summary:        FarmHash hash functions implemented in Go
+License:        MIT
+URL:            https://github.com/dgryski/go-farm
+#!RemoteAsset:  sha256:15c84a30ae3984562d9cf071e69d64dfa515b93ab8e69012f4b67ec6f0e7964f
+Source0:        https://github.com/dgryski/go-farm/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Go-farm provides a Go implementation of Google's non-SSE4 and non-AESNI
+FarmHash functions.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-docopt-docopt-go/go-github-docopt-docopt-go.spec
+++ b/SPECS/go-github-docopt-docopt-go/go-github-docopt-docopt-go.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           docopt-go
+%define go_import_path  github.com/docopt/docopt-go
+
+Name:           go-github-docopt-docopt-go
+Version:        0.6.2
+Release:        %autorelease
+Summary:        Command-line argument parser based on help messages
+License:        MIT
+URL:            https://github.com/docopt/docopt-go
+#!RemoteAsset:  sha256:bfd2816c9b1830eff84fc97fdad8fbf88ed56b6fccfe29d40c85c55e676edea9
+Source0:        https://github.com/docopt/docopt-go/archive/%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Docopt-go parses command-line arguments from the usage and option descriptions
+in an application's help message.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-dolthub-maphash/go-github-dolthub-maphash.spec
+++ b/SPECS/go-github-dolthub-maphash/go-github-dolthub-maphash.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           maphash
+%define go_import_path  github.com/dolthub/maphash
+
+Name:           go-github-dolthub-maphash
+Version:        0.1.0
+Release:        %autorelease
+Summary:        Runtime-backed hashing for comparable Go values
+License:        Apache-2.0
+URL:            https://github.com/dolthub/maphash
+#!RemoteAsset:  sha256:e1cc92f97f77f7104708c382fbebd3bdf9bf1b116167ed73c532b24fb4b926b1
+Source0:        https://github.com/dolthub/maphash/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(gopkg.in/yaml.v3)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Maphash exposes Go's optimized runtime hashing for values of any comparable
+type, using hardware acceleration when available.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-eapache-go-resiliency/go-github-eapache-go-resiliency.spec
+++ b/SPECS/go-github-eapache-go-resiliency/go-github-eapache-go-resiliency.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-resiliency
+%define go_import_path  github.com/eapache/go-resiliency
+
+Name:           go-github-eapache-go-resiliency
+Version:        1.7.0
+Release:        %autorelease
+Summary:        Resiliency patterns for Go
+License:        MIT
+URL:            https://github.com/eapache/go-resiliency
+#!RemoteAsset:  sha256:9f84d71fae41cdcd2acedb9fe17ebe7659e1b2cf734be6b2d7135a0aab8f2649
+Source0:        https://github.com/eapache/go-resiliency/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+This package provides retry, breaker, and timeout resiliency patterns for Go.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

This PR contains the level-0 leaf batch of Go modules for Prometheus v3.13. It has no dependency on the other new module PRs and can be built independently.

Requires: None.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: ChatGPT:GPT-5.6-sol High

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]: https://openruyi.cn/governance/policy/ai-contribution-policy