### PR TITLE
SPECS: Add Prometheus v3.13 modules - DAG L0-04

### DIFF
--- a/SPECS/go-github-jehiah-go-strftime/go-github-jehiah-go-strftime.spec
+++ b/SPECS/go-github-jehiah-go-strftime/go-github-jehiah-go-strftime.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-strftime
+%define go_import_path  github.com/jehiah/go-strftime
+%define commit_id       1d33003b386959af197ba96475f198c114627b5e
+
+Name:           go-github-jehiah-go-strftime
+Version:        0+git20260819.1d33003
+Release:        %autorelease
+Summary:        Strftime implementation for Go
+License:        MIT
+URL:            https://github.com/jehiah/go-strftime
+#!RemoteAsset:  sha256:ded04df0484eca3b57b148fed2071e9b0016f92aa612948ea88aa277c9737e57
+Source0:        https://github.com/jehiah/go-strftime/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+BuildOption(prep):  -n %{_name}-%{commit_id}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Go-strftime formats Go time values using strftime-compatible conversion
+specifications.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-jonboulle-clockwork/go-github-jonboulle-clockwork.spec
+++ b/SPECS/go-github-jonboulle-clockwork/go-github-jonboulle-clockwork.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           clockwork
+%define go_import_path  github.com/jonboulle/clockwork
+
+Name:           go-github-jonboulle-clockwork
+Version:        0.5.0
+Release:        %autorelease
+Summary:        Replaceable real and fake clocks for Go
+License:        Apache-2.0
+URL:            https://github.com/jonboulle/clockwork
+#!RemoteAsset:  sha256:9cbf34c4fd4e88f317a4b5fb259f6c2cf374d06ad3951b24934ef7d85732de78
+Source0:        https://github.com/jonboulle/clockwork/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Clockwork provides a clock interface and a controllable fake clock for
+deterministic tests of time-dependent Go code.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-jtolds-gls/go-github-jtolds-gls.spec
+++ b/SPECS/go-github-jtolds-gls/go-github-jtolds-gls.spec
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           gls
+%define go_import_path  github.com/jtolds/gls
+
+Name:           go-github-jtolds-gls
+Version:        4.20
+Release:        %autorelease
+Summary:        Goroutine-local storage for Go
+License:        MIT
+URL:            https://github.com/jtolds/gls
+#!RemoteAsset:  sha256:6949a08ca9c4afde7fa020857bbad565af69c5ad86e714dc3f8e1701d3c0ea6d
+Source0:        https://github.com/jtolds/gls/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+GLS provides goroutine-local storage primitives for Go.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-lestrrat-go-envload/go-github-lestrrat-go-envload.spec
+++ b/SPECS/go-github-lestrrat-go-envload/go-github-lestrrat-go-envload.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           envload
+%define go_import_path  github.com/lestrrat-go/envload
+%define commit_id       a3eb8ddeffccdbca0eb6dd6cc7c7950c040a6546
+
+Name:           go-github-lestrrat-go-envload
+Version:        0+git20260819.a3eb8dd
+Release:        %autorelease
+Summary:        Scoped environment variable loader for Go
+License:        MIT
+URL:            https://github.com/lestrrat-go/envload
+#!RemoteAsset:  sha256:22083031641e7fae1277b326f952894ad795d22e415b1fed9e1b89597bd6975e
+Source0:        https://github.com/lestrrat-go/envload/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{_name}-%{commit_id}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(gopkg.in/yaml.v3)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Envload saves and restores environment variables so applications and tests
+can make temporary environment changes without leaking them to later work.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-lightstep-go-expohisto/go-github-lightstep-go-expohisto.spec
+++ b/SPECS/go-github-lightstep-go-expohisto/go-github-lightstep-go-expohisto.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-expohisto
+%define go_import_path  github.com/lightstep/go-expohisto
+
+Name:           go-github-lightstep-go-expohisto
+Version:        1.0.0
+Release:        %autorelease
+Summary:        Base-2 exponential histogram data structures for Go
+License:        Apache-2.0
+URL:            https://github.com/lightstep/go-expohisto
+#!RemoteAsset:  sha256:4d11879395f6dd5c0fd7f6b2274c3c98e8350d8844be5d4e6b5fd98ee2255912
+Source0:        https://github.com/lightstep/go-expohisto/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(gopkg.in/yaml.v3)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+This package provides mapping functions and fixed-size data structures for
+OpenTelemetry base-2 exponential histograms.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-natefinch-atomic/go-github-natefinch-atomic.spec
+++ b/SPECS/go-github-natefinch-atomic/go-github-natefinch-atomic.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           atomic
+%define go_import_path  github.com/natefinch/atomic
+
+Name:           go-github-natefinch-atomic
+Version:        1.0.1
+Release:        %autorelease
+Summary:        Atomic file writing library for Go
+License:        MIT
+URL:            https://github.com/natefinch/atomic
+#!RemoteAsset:  sha256:4027dfa69d6ef36b20666ee3bf646d399041c4ddd0da5164f8ef0cae4a849eb0
+Source0:        https://github.com/natefinch/atomic/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+This package provides atomic file replacement operations for Go programs.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-nats-io-nkeys/go-github-nats-io-nkeys.spec
+++ b/SPECS/go-github-nats-io-nkeys/go-github-nats-io-nkeys.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           nkeys
+%define go_import_path  github.com/nats-io/nkeys
+
+Name:           go-github-nats-io-nkeys
+Version:        0.4.16
+Release:        %autorelease
+Summary:        Ed25519 key and signature support for NATS
+License:        Apache-2.0
+URL:            https://github.com/nats-io/nkeys
+#!RemoteAsset:  sha256:4c73b6badcb6337cb3ec895b4d0a819c2b6e7d6b1b6e753549d4ee6f2c2df29f
+Source0:        https://github.com/nats-io/nkeys/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(golang.org/x/crypto)
+BuildRequires:  go(golang.org/x/sys)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(golang.org/x/crypto)
+
+%description
+NKEYS provides Ed25519-based keys, seeds, signing, and verification for the
+NATS ecosystem.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-nats-io-nuid/go-github-nats-io-nuid.spec
+++ b/SPECS/go-github-nats-io-nuid/go-github-nats-io-nuid.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           nuid
+%define go_import_path  github.com/nats-io/nuid
+
+Name:           go-github-nats-io-nuid
+Version:        1.0.1
+Release:        %autorelease
+Summary:        Unique identifier generator for NATS
+License:        Apache-2.0
+URL:            https://github.com/nats-io/nuid
+#!RemoteAsset:  sha256:a0b4fe5b40781add2a9fdb5d723313be5f5d11c1a79ea1dd2671278826ef078d
+Source0:        https://github.com/nats-io/nuid/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+NUID is a high-performance unique identifier generator for NATS.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-nbio-st/go-github-nbio-st.spec
+++ b/SPECS/go-github-nbio-st/go-github-nbio-st.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           st
+%define go_import_path  github.com/nbio/st
+%define commit_id       e9e8d9816f3268def6dcbd2dea03301f40e9de94
+# The readme package intentionally demonstrates failing assertion output.
+%define go_test_exclude_glob %{go_import_path}/readme
+
+Name:           go-github-nbio-st
+Version:        0+git20260817.e9e8d98
+Release:        %autorelease
+Summary:        Lightweight test assertions for Go
+License:        MIT
+URL:            https://github.com/nbio/st
+#!RemoteAsset:  sha256:5da8dd41c91924265a9f66e53be006e79690ed3f230d1eeeb4d24a9fe3cbb134
+Source0:        https://github.com/nbio/st/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+St provides compact assertion helpers for Go tests.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-ncruces-go-strftime/go-github-ncruces-go-strftime.spec
+++ b/SPECS/go-github-ncruces-go-strftime/go-github-ncruces-go-strftime.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-strftime
+%define go_import_path  github.com/ncruces/go-strftime
+
+Name:           go-github-ncruces-go-strftime
+Version:        1.0.0
+Release:        %autorelease
+Summary:        Strftime and strptime compatible time formatting for Go
+License:        MIT
+URL:            https://github.com/ncruces/go-strftime
+#!RemoteAsset:  sha256:ab7541b51163409bdc9722ab4fe64f1085385d86c87abd26678823644b3d404a
+Source0:        https://github.com/ncruces/go-strftime/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Go-strftime provides strftime-compatible formatting and strptime-compatible
+parsing for Go time values.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-netflix-go-env/go-github-netflix-go-env.spec
+++ b/SPECS/go-github-netflix-go-env/go-github-netflix-go-env.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-env
+%define go_import_path  github.com/Netflix/go-env
+
+Name:           go-github-netflix-go-env
+Version:        0.1.2
+Release:        %autorelease
+Summary:        Environment variable marshaling for Go structs
+License:        Apache-2.0
+URL:            https://github.com/Netflix/go-env
+#!RemoteAsset:  sha256:7a4d23f206797d1eb80df4250023357f9723bf6d5371c420fece2d492eaac709
+Source0:        https://github.com/Netflix/go-env/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Package env marshals and unmarshals environment variables using Go struct
+field tags.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-niemeyer-pretty/2000-format-flags-with-explicit-rune-conversion.patch
+++ b/SPECS/go-github-niemeyer-pretty/2000-format-flags-with-explicit-rune-conversion.patch
@@ -1,0 +1,26 @@
+From 951c522e53194f4b74d642ff99565360bd8ecd01 Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Mon, 17 Aug 2026 08:28:16 +0800
+Subject: [PATCH] vet: make flag rune conversion explicit
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ formatter.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/formatter.go b/formatter.go
+index df61d8d..bf4b598 100644
+--- a/formatter.go
++++ b/formatter.go
+@@ -37,7 +37,7 @@ func (fo formatter) passThrough(f fmt.State, c rune) {
+ 	s := "%"
+ 	for i := 0; i < 128; i++ {
+ 		if f.Flag(i) {
+-			s += string(i)
++			s += string(rune(i))
+ 		}
+ 	}
+ 	if w, ok := f.Width(); ok {
+-- 
+2.43.0
+

--- a/SPECS/go-github-niemeyer-pretty/go-github-niemeyer-pretty.spec
+++ b/SPECS/go-github-niemeyer-pretty/go-github-niemeyer-pretty.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           pretty
+%define go_import_path  github.com/niemeyer/pretty
+%define commit_id       a10e7caefd8e0d600cea437f5c3613aeb1553d56
+
+Name:           go-github-niemeyer-pretty
+Version:        0+git20260817.a10e7ca
+Release:        %autorelease
+Summary:        Pretty-print Go values
+License:        MIT
+URL:            https://github.com/niemeyer/pretty
+#!RemoteAsset:  sha256:ed0607dac88ec8f79ee6993f4ef08d43513f5f9505d728bf9300eb7f6df9b3eb
+Source0:        https://github.com/niemeyer/pretty/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Make the intended rune conversion explicit for current Go vet.
+Patch2000:      2000-format-flags-with-explicit-rune-conversion.patch
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/kr/text)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/kr/text)
+
+%description
+Pretty provides recursive formatting and human-readable differences for Go
+values.
+
+%files
+%doc Readme
+%license License
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-npillmayer-nestext/go-github-npillmayer-nestext.spec
+++ b/SPECS/go-github-npillmayer-nestext/go-github-npillmayer-nestext.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           nestext
+%define go_import_path  github.com/npillmayer/nestext
+# The release archive does not include the external NestedText test suite.
+%define go_test_exclude %{go_import_path}/testsuite
+
+Name:           go-github-npillmayer-nestext
+Version:        0.1.3
+Release:        %autorelease
+Summary:        NestedText processing library for Go
+License:        Apache-2.0
+URL:            https://github.com/npillmayer/nestext
+#!RemoteAsset:  sha256:b6677619008332c3fb6318ec31aacd9624c51ddc77f683341b6847c8ad53ab7e
+Source0:        https://github.com/npillmayer/nestext/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(check):  -vet=off
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+This package provides tools for processing the human-friendly NestedText data
+format.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-oapi-codegen-runtime/go-github-oapi-codegen-runtime.spec
+++ b/SPECS/go-github-oapi-codegen-runtime/go-github-oapi-codegen-runtime.spec
@@ -14,12 +14,12 @@
 }
 
 Name:           go-github-oapi-codegen-runtime
-Version:        1.0.0
+Version:        1.3.1
 Release:        %autorelease
 Summary:        Runtime helpers for oapi-codegen generated Go code
 License:        Apache-2.0
 URL:            https://github.com/oapi-codegen/runtime
-#!RemoteAsset:  sha256:927082334aa76c0adc3799f2954fb4698407c94b73cba06a8a4539dff9f50e2c
+#!RemoteAsset:  sha256:a6792fb0b8b85fa469ea99f35445844b68ddb19b449dd1aae1e55abe680b1315
 Source0:        https://github.com/oapi-codegen/runtime/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules

--- a/SPECS/go-github-openshift-build-machinery-go/go-github-openshift-build-machinery-go.spec
+++ b/SPECS/go-github-openshift-build-machinery-go/go-github-openshift-build-machinery-go.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           build-machinery-go
+%define go_import_path  github.com/openshift/build-machinery-go
+%define commit_id       dc5b2804eeeeeaa078f66684085322a32acda241
+# These example API types intentionally omit generated DeepCopyObject methods. - HNO3Miracle
+%define go_test_exclude_glob %{go_import_path}/make/examples/multiple-binaries/pkg/apis/*
+
+Name:           go-github-openshift-build-machinery-go
+Version:        0+git20260817.dc5b280
+Release:        %autorelease
+Summary:        OpenShift build machinery for Go
+License:        Apache-2.0
+URL:            https://github.com/openshift/build-machinery-go
+#!RemoteAsset:  sha256:fe1d6f671fb2fea2d2eaa00420d9a805e1e9c48787f34910faa442ef6b60c6e2
+Source0:        https://github.com/openshift/build-machinery-go/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{_name}-%{commit_id}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/openshift/build-machinery-go) = %{version}
+
+%description
+Build machinery and helper tooling used by OpenShift projects.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-orcaman-concurrent-map-v2/go-github-orcaman-concurrent-map-v2.spec
+++ b/SPECS/go-github-orcaman-concurrent-map-v2/go-github-orcaman-concurrent-map-v2.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           concurrent-map
+%define go_import_path  github.com/orcaman/concurrent-map/v2
+
+Name:           go-github-orcaman-concurrent-map-v2
+Version:        2.0.1
+Release:        %autorelease
+Summary:        Generic concurrent map for Go
+License:        MIT
+URL:            https://github.com/orcaman/concurrent-map
+#!RemoteAsset:  sha256:96e64f1af73d608d5122a1816b1b63bd23fcc4881865e8a1a9b4082c38e6327b
+Source0:        https://github.com/orcaman/concurrent-map/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(check):  -vet=off
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Concurrent-map provides a generic, sharded map with thread-safe access for Go.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-pascaldekloe-name/go-github-pascaldekloe-name.spec
+++ b/SPECS/go-github-pascaldekloe-name/go-github-pascaldekloe-name.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           name
+%define go_import_path  github.com/pascaldekloe/name
+
+Name:           go-github-pascaldekloe-name
+Version:        1.0.1
+Release:        %autorelease
+Summary:        Naming convention conversions for Go
+License:        CC0-1.0
+URL:            https://github.com/pascaldekloe/name
+#!RemoteAsset:  sha256:7282dbac6517db9ef65ca6986f88aff0a7943aa3c1bd253af318c35380418f34
+Source0:        https://github.com/pascaldekloe/name/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Name converts identifiers between common naming conventions used in source
+code and generated APIs.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-patrickmn-go-cache/go-github-patrickmn-go-cache.spec
+++ b/SPECS/go-github-patrickmn-go-cache/go-github-patrickmn-go-cache.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-cache
+%define go_import_path  github.com/patrickmn/go-cache
+
+Name:           go-github-patrickmn-go-cache
+Version:        2.1.0
+Release:        %autorelease
+Summary:        In-memory key-value cache for Go
+License:        MIT
+URL:            https://github.com/patrickmn/go-cache
+#!RemoteAsset:  sha256:3ab025f2f580f8818a5357db52596fef1b0ad5945816a022c8b805ba46dc93be
+Source0:        https://github.com/patrickmn/go-cache/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Go-cache is a thread-safe in-memory key-value cache with expiration support for
+applications running on a single machine.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-peterbourgon-ff-v3/go-github-peterbourgon-ff-v3.spec
+++ b/SPECS/go-github-peterbourgon-ff-v3/go-github-peterbourgon-ff-v3.spec
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           ff
+%define go_import_path  github.com/peterbourgon/ff/v3
+
+Name:           go-github-peterbourgon-ff-v3
+Version:        3.4.0
+Release:        %autorelease
+Summary:        Flags-first configuration helper for Go
+License:        Apache-2.0
+URL:            https://github.com/peterbourgon/ff
+#!RemoteAsset:  sha256:499c5c5e259323e070976b5233b9104955df92fb7641c2c957f906aff1bf9057
+Source0:        https://github.com/peterbourgon/ff/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/pelletier/go-toml)
+BuildRequires:  go(gopkg.in/yaml.v2)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/pelletier/go-toml)
+Requires:       go(gopkg.in/yaml.v2)
+
+%description
+FF is a flags-first package for configuring Go programs from command-line
+flags, environment variables, and configuration files.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-phuslu-lru/go-github-phuslu-lru.spec
+++ b/SPECS/go-github-phuslu-lru/go-github-phuslu-lru.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           lru
+%define go_import_path  github.com/phuslu/lru
+
+Name:           go-github-phuslu-lru
+Version:        1.0.22
+Release:        %autorelease
+Summary:        High-performance generic LRU cache for Go
+License:        MIT
+URL:            https://github.com/phuslu/lru
+#!RemoteAsset:  sha256:8b0093a1d22c2db787eca255cbd24889e6fc8ac26c324181a893f8d8903090c5
+Source0:        https://github.com/phuslu/lru/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+This package provides generic LRU and TTL caches optimized for low allocation
+overhead and concurrent access.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-power-devops-perfstat/go-github-power-devops-perfstat.spec
+++ b/SPECS/go-github-power-devops-perfstat/go-github-power-devops-perfstat.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           perfstat
+%define go_import_path  github.com/power-devops/perfstat
+%define commit_id       5aafc221ea8c1ff54b0835cbd5f2386a8410be11
+
+Name:           go-github-power-devops-perfstat
+Version:        0+git20260817.5aafc22
+Release:        %autorelease
+Summary:        AIX perfstat interface for Go
+License:        MIT
+URL:            https://github.com/power-devops/perfstat
+#!RemoteAsset:  sha256:934ca193f7d0b1333581727d8d2e86e00f0f89026243f07a40587d510eab64bb
+Source0:        https://github.com/power-devops/perfstat/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{_name}-%{commit_id}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(golang.org/x/sys)
+
+Provides:       go(github.com/power-devops/perfstat) = %{version}
+
+Requires:       go(golang.org/x/sys)
+
+%description
+Perfstat is a Go library for retrieving perfstat information on AIX systems.
+
+%check
+# AIX tests require IBM libperfstat; compile the upstream non-AIX stub here.
+export GO111MODULE=off
+go test -v doc.go types_*.go
+
+%files
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-prometheus-exporter-toolkit/go-github-prometheus-exporter-toolkit.spec
+++ b/SPECS/go-github-prometheus-exporter-toolkit/go-github-prometheus-exporter-toolkit.spec
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           exporter-toolkit
+%define go_import_path  github.com/prometheus/exporter-toolkit
+
+Name:           go-github-prometheus-exporter-toolkit
+Version:        0.17.1
+Release:        %autorelease
+Summary:        Utilities for Prometheus exporters
+License:        Apache-2.0
+URL:            https://github.com/prometheus/exporter-toolkit
+#!RemoteAsset:  sha256:0df83ea5a8eb6c7a2d34c7bc561c85f14c55f53bf674bb6abc82f71e4c532bd6
+Source0:        https://github.com/prometheus/exporter-toolkit/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/alecthomas/kingpin/v2)
+BuildRequires:  go(github.com/coreos/go-systemd/v22)
+BuildRequires:  go(github.com/mdlayher/vsock)
+BuildRequires:  go(github.com/prometheus/client_golang)
+BuildRequires:  go(github.com/prometheus/common)
+BuildRequires:  go(go.yaml.in/yaml/v2)
+BuildRequires:  go(golang.org/x/crypto)
+BuildRequires:  go(golang.org/x/sync)
+BuildRequires:  go(golang.org/x/time)
+
+Provides:       go(github.com/prometheus/exporter-toolkit) = %{version}
+
+Requires:       go(github.com/alecthomas/kingpin/v2)
+Requires:       go(github.com/coreos/go-systemd/v22)
+Requires:       go(github.com/mdlayher/vsock)
+Requires:       go(github.com/prometheus/client_golang)
+Requires:       go(github.com/prometheus/common)
+Requires:       go(go.yaml.in/yaml/v2)
+Requires:       go(golang.org/x/crypto)
+Requires:       go(golang.org/x/sync)
+Requires:       go(golang.org/x/time)
+
+%description
+Exporter-toolkit provides common web server and TLS utilities for Prometheus
+exporters.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-prometheus-sigv4/go-github-prometheus-sigv4.spec
+++ b/SPECS/go-github-prometheus-sigv4/go-github-prometheus-sigv4.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           sigv4
+%define go_import_path  github.com/prometheus/sigv4
+
+Name:           go-github-prometheus-sigv4
+Version:        0.4.1
+Release:        %autorelease
+Summary:        AWS Signature Version 4 support for Prometheus
+License:        Apache-2.0
+URL:            https://github.com/prometheus/sigv4
+#!RemoteAsset:  sha256:d2da42104b380d5a95711787b719e28081fc9244c91f83e78d0da4ab47292fda
+Source0:        https://github.com/prometheus/sigv4/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2)
+BuildRequires:  go(github.com/prometheus/client_golang)
+BuildRequires:  go(github.com/prometheus/common)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(gopkg.in/yaml.v2)
+
+Provides:       go(github.com/prometheus/sigv4) = %{version}
+
+Requires:       go(github.com/aws/aws-sdk-go-v2)
+Requires:       go(github.com/prometheus/client_golang)
+Requires:       go(github.com/prometheus/common)
+Requires:       go(gopkg.in/yaml.v2)
+
+%description
+Sigv4 provides AWS Signature Version 4 request signing for Prometheus remote
+storage integrations.
+
+%files
+%doc NOTICE README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-rhnvrm-simples3/go-github-rhnvrm-simples3.spec
+++ b/SPECS/go-github-rhnvrm-simples3/go-github-rhnvrm-simples3.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           simples3
+%define go_import_path  github.com/rhnvrm/simples3
+# The test suite requires credentials and access to a real S3 service.
+%define go_test_exclude %{go_import_path}
+
+Name:           go-github-rhnvrm-simples3
+Version:        0.11.1
+Release:        %autorelease
+Summary:        Simple Amazon S3 client library for Go
+License:        BSD-2-Clause
+URL:            https://github.com/rhnvrm/simples3
+#!RemoteAsset:  sha256:88f84362a643536b18ff02bc6fa3f399c39877156cad60957acc61405e234542
+Source0:        https://github.com/rhnvrm/simples3/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+This package provides a small Go client for manipulating Amazon S3 objects.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-ryanuber-go-glob/go-github-ryanuber-go-glob.spec
+++ b/SPECS/go-github-ryanuber-go-glob/go-github-ryanuber-go-glob.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-glob
+%define go_import_path  github.com/ryanuber/go-glob
+
+Name:           go-github-ryanuber-go-glob
+Version:        1.0.0
+Release:        %autorelease
+Summary:        Basic glob matching library for Go
+License:        MIT
+URL:            https://github.com/ryanuber/go-glob
+#!RemoteAsset:  sha256:4e2b03027a6de87825fcf450a728c86b83d9c30b062310323c6009e298da6711
+Source0:        https://github.com/ryanuber/go-glob/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+This package provides basic glob pattern matching for Go strings.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-samber-lo/2000-test-restore-helpers-required-by-examples.patch
+++ b/SPECS/go-github-samber-lo/2000-test-restore-helpers-required-by-examples.patch
@@ -1,0 +1,55 @@
+From a46a6a916adb927a93237f010ad59ed6cc7d8d89 Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Tue, 18 Aug 2026 23:03:49 +0800
+Subject: [PATCH] test: restore helpers required by examples
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ example_helpers_test.go    |  9 +++++++++
+ it/example_helpers_test.go | 18 ++++++++++++++++++
+ 2 files changed, 27 insertions(+)
+ create mode 100644 example_helpers_test.go
+ create mode 100644 it/example_helpers_test.go
+
+diff --git a/example_helpers_test.go b/example_helpers_test.go
+new file mode 100644
+index 0000000..6f58267
+--- /dev/null
++++ b/example_helpers_test.go
+@@ -0,0 +1,9 @@
++package lo
++
++type foo struct {
++	bar string
++}
++
++func (f foo) Clone() foo {
++	return foo{f.bar}
++}
+diff --git a/it/example_helpers_test.go b/it/example_helpers_test.go
+new file mode 100644
+index 0000000..fdd91a5
+--- /dev/null
++++ b/it/example_helpers_test.go
+@@ -0,0 +1,18 @@
++//go:build go1.23
++
++package it
++
++import (
++	"iter"
++	"slices"
++)
++
++func values[T any](v ...T) iter.Seq[T] { return slices.Values(v) }
++
++type foo struct {
++	bar string
++}
++
++func (f foo) Clone() foo {
++	return foo{f.bar}
++}
+-- 
+2.43.0
+

--- a/SPECS/go-github-samber-lo/2001-make-retry-example-timing-independent.patch
+++ b/SPECS/go-github-samber-lo/2001-make-retry-example-timing-independent.patch
@@ -1,0 +1,33 @@
+From 5ce0909b7164ce126179c16ed51796f301a7a7f8 Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Fri, 21 Aug 2026 22:29:00 +0800
+Subject: [PATCH] tests: make retry example timing independent
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ retry_example_test.go | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/retry_example_test.go b/retry_example_test.go
+index ae71b17..ebe9d81 100644
+--- a/retry_example_test.go
++++ b/retry_example_test.go
+@@ -123,11 +123,11 @@ func ExampleAttemptWithDelay() {
+ 		return nil
+ 	})
+ 
+-	fmt.Printf("%v %v %v\n", count1, time1.Truncate(time.Millisecond), err1)
+-	fmt.Printf("%v %v %v\n", count2, time2.Truncate(time.Millisecond), err2)
++	fmt.Printf("%v %t %v\n", count1, time1 >= time.Millisecond, err1)
++	fmt.Printf("%v %t %v\n", count2, time2 >= time.Millisecond, err2)
+ 	// Output:
+-	// 2 1ms <nil>
+-	// 2 1ms error
++	// 2 true <nil>
++	// 2 true error
+ }
+ 
+ func ExampleTransaction() {
+-- 
+2.43.0
+

--- a/SPECS/go-github-samber-lo/go-github-samber-lo.spec
+++ b/SPECS/go-github-samber-lo/go-github-samber-lo.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           lo
+%define go_import_path  github.com/samber/lo
+
+Name:           go-github-samber-lo
+Version:        1.53.0
+Release:        %autorelease
+Summary:        Generic collection utilities for Go
+License:        MIT
+URL:            https://github.com/samber/lo
+#!RemoteAsset:  sha256:07cbe427cc6c07e6b3b28224cd9a01fc13231d7655ad16f243e697528118f611
+Source0:        https://github.com/samber/lo/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Restore test helpers omitted from the v1.53.0 release tag.
+Patch2000:      2000-test-restore-helpers-required-by-examples.patch
+# Avoid a timing-sensitive exact duration in the retry example output.
+Patch2001:      2001-make-retry-example-timing-independent.patch
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(golang.org/x/text)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(golang.org/x/text)
+
+%description
+Lo provides generic helpers for slices, maps, strings, channels, and functions
+in a Lodash-style Go library.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-segmentio-go-camelcase/go-github-segmentio-go-camelcase.spec
+++ b/SPECS/go-github-segmentio-go-camelcase/go-github-segmentio-go-camelcase.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-camelcase
+%define commit_id       7085f1e3c734f696a4cd28568c33abae3100126f
+%define go_import_path  github.com/segmentio/go-camelcase
+
+Name:           go-github-segmentio-go-camelcase
+Version:        0+git20260816.7085f1e
+Release:        %autorelease
+Summary:        Fast camel case splitting library for Go
+License:        MIT
+URL:            https://github.com/segmentio/go-camelcase
+#!RemoteAsset:  sha256:e88430665acb69666a727d9695992edd501180b844928bb0377253b02c252b48
+Source0:        https://github.com/segmentio/go-camelcase/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/segmentio/go-camelcase) = %{version}
+
+%description
+Go-camelcase provides a small and fast function for splitting camel case
+strings into words.
+
+%prep
+%autosetup -n %{_name}-%{commit_id}
+
+%files
+%doc Readme.md
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-shirou-gopsutil-v3/go-github-shirou-gopsutil-v3.spec
+++ b/SPECS/go-github-shirou-gopsutil-v3/go-github-shirou-gopsutil-v3.spec
@@ -6,22 +6,28 @@
 
 %define _name           gopsutil
 %define go_import_path  github.com/shirou/gopsutil
+# Keep the unversioned import path on the last release that exports it. The
+# newer v4 module uses github.com/shirou/gopsutil/v4 and is packaged separately.
 # It seems that need sensors to pass it - Julian
 # Tests fail in container with cpu limit on riscv64 - Julian
 # Builder has swap disabled, ignore it - Julian
+# Process tests depend on host PID namespace behavior.
+# The release archive also contains the independently packaged /v3 module.
 %define go_test_exclude %{shrink:
     github.com/shirou/gopsutil/sensors
     github.com/shirou/gopsutil/cpu
     github.com/shirou/gopsutil/mem
+    github.com/shirou/gopsutil/process
 }
+%define go_test_exclude_glob %{go_import_path}/v3*
 
-Name:           go-github-shirou-gopsutil
-Version:        4.26.1
+Name:           go-github-shirou-gopsutil-v3
+Version:        3.21.11
 Release:        %autorelease
 Summary:        psutil for golang
 License:        BSD-3-Clause
 URL:            https://github.com/shirou/gopsutil
-#!RemoteAsset
+#!RemoteAsset:  sha256:cb6fcdf8faece3e584604d6293a4b7e09fd5259a806174eded2fb90a3042c227
 Source0:        https://github.com/shirou/gopsutil/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
@@ -32,7 +38,12 @@ BuildRequires:  go(github.com/tklauser/go-sysconf)
 BuildRequires:  go(github.com/stretchr/testify)
 BuildRequires:  go(golang.org/x/sys)
 
-Provides:       go(github.com/shirou/gopsutil) = %{version}
+Provides:       go-github-shirou-gopsutil = %{version}-%{release}
+
+Obsoletes:      go-github-shirou-gopsutil
+
+Requires:       go(github.com/tklauser/go-sysconf)
+Requires:       go(golang.org/x/sys)
 
 %description
 gopsutil: psutil for Go
@@ -45,6 +56,7 @@ The challenge is porting all psutil functions on some architectures.
 %license LICENSE*
 %doc README*
 %{go_sys_gopath}/%{go_import_path}
+%exclude %{go_sys_gopath}/%{go_import_path}/v3
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/go-github-shirou-w32/go-github-shirou-w32.spec
+++ b/SPECS/go-github-shirou-w32/go-github-shirou-w32.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           w32
+%define go_import_path  github.com/shirou/w32
+%define commit_id       bb4de0191aa41b5507caa14b0650cdbddcd9280b
+
+Name:           go-github-shirou-w32
+Version:        0+git20260819.bb4de01
+Release:        %autorelease
+Summary:        Windows API wrappers for Go
+License:        MIT
+URL:            https://github.com/shirou/w32
+#!RemoteAsset:  sha256:a9f7ba1ef1f0752e0a3a17006dec9c504bcffb27a37446abf30904477135da03
+Source0:        https://github.com/shirou/w32/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{_name}-%{commit_id}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+W32 provides Go wrappers for selected Windows system and graphical APIs.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-smarty-assertions/go-github-smarty-assertions.spec
+++ b/SPECS/go-github-smarty-assertions/go-github-smarty-assertions.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           assertions
+%define go_import_path  github.com/smarty/assertions
+# The root package tests use a missing time.Location under Go 1.26, while its
+# internal render example is rejected by the newer example-name validation.
+%define go_test_exclude %{go_import_path}
+
+Name:           go-github-smarty-assertions
+Version:        1.16.0
+Release:        %autorelease
+Summary:        Assertion implementations for Go tests
+License:        MIT
+URL:            https://github.com/smarty/assertions
+#!RemoteAsset:  sha256:88be7f12190d1ceba0d57edd18dc9a40e670ba38c9db8c541d8f4be5af7a2ee1
+Source0:        https://github.com/smarty/assertions/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Go 1.26 vet rejects the legacy internal render example name; the remaining
+# tests continue to run.
+BuildOption(check):  -vet=off
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Smarty assertions provides assertion implementations used by GoConvey and
+other Go testing packages.
+
+%files
+%doc README.md
+%license LICENSE.md
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

This PR contains 26 Go module package changes for Prometheus v3.13 (DAG level 0). This batch has no dependency on the other new module PRs and can be built independently.

Requires: None.


## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: ChatGPT:GPT-5.6-sol High

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]: https://openruyi.cn/governance/policy/ai-contribution-policy