### PR TITLE
SPECS: Add Prometheus v3.13 modules - DAG L0-05

### DIFF
--- a/SPECS/go-github-sony-gobreaker/go-github-sony-gobreaker.spec
+++ b/SPECS/go-github-sony-gobreaker/go-github-sony-gobreaker.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           gobreaker
+%define go_import_path  github.com/sony/gobreaker
+
+Name:           go-github-sony-gobreaker
+Version:        1.0.0
+Release:        %autorelease
+Summary:        Circuit breaker implementation for Go
+License:        MIT
+URL:            https://github.com/sony/gobreaker
+#!RemoteAsset:  sha256:3c86c1eabb0b5c95776f9fa04bb856d4cdd021a0a0674bc6b27a1de6d98e7deb
+Source0:        https://github.com/sony/gobreaker/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Go 1.26 vet rejects a non-constant format string in an upstream test;
+# continue running the test without that vet check.
+BuildOption(check):  -vet=off
+
+BuildRequires:  go
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Package gobreaker implements the circuit breaker pattern for Go services.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-spf13-jwalterweatherman/go-github-spf13-jwalterweatherman.spec
+++ b/SPECS/go-github-spf13-jwalterweatherman/go-github-spf13-jwalterweatherman.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           jwalterweatherman
+%define go_import_path  github.com/spf13/jwalterweatherman
+
+Name:           go-github-spf13-jwalterweatherman
+Version:        1.1.0
+Release:        %autorelease
+Summary:        Seamless printing to terminal and logging to files for Go
+License:        MIT
+URL:            https://github.com/spf13/jwalterweatherman
+#!RemoteAsset:  sha256:4fd850a792c5738954c4801cf549d8d0bf53edd17139cd39d179aa5abf7ec68d
+Source0:        https://github.com/spf13/jwalterweatherman/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/stretchr/testify)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Jwalterweatherman provides leveled terminal output and log-file handling for
+Go command-line applications.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-stoewer-go-strcase/go-github-stoewer-go-strcase.spec
+++ b/SPECS/go-github-stoewer-go-strcase/go-github-stoewer-go-strcase.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-strcase
+%define go_import_path  github.com/stoewer/go-strcase
+
+Name:           go-github-stoewer-go-strcase
+Version:        1.3.1
+Release:        %autorelease
+Summary:        String case conversion library for Go
+License:        MIT
+URL:            https://github.com/stoewer/go-strcase
+#!RemoteAsset:  sha256:b9a70676f82b27a6b4de8e5eeae77dbd2e68afb3d9610b88be56fb68cadb612a
+Source0:        https://github.com/stoewer/go-strcase/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/stretchr/testify)
+
+Provides:       go(github.com/stoewer/go-strcase) = %{version}
+
+%description
+Go-strcase converts strings between camel case, snake case, kebab case, and
+other naming formats.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-streadway-handy/go-github-streadway-handy.spec
+++ b/SPECS/go-github-streadway-handy/go-github-streadway-handy.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           handy
+%define go_import_path  github.com/streadway/handy
+%define commit_id       0f66f006fb2ebde51f4ce769641df75d602989e7
+# These historical tests depend on tight wall-clock timing and old retry
+# semantics; keep the other package tests enabled.
+%define go_test_exclude  %{go_import_path}/report %{go_import_path}/retry
+
+Name:           go-github-streadway-handy
+Version:        0+git20260818.0f66f00
+Release:        %autorelease
+Summary:        Reusable HTTP server handlers for Go
+License:        BSD-2-Clause
+URL:            https://github.com/streadway/handy
+#!RemoteAsset:  sha256:979424115de9e3b70ee91fc3839f77bbe54699a9e32b98be6936eea7e80a213f
+Source0:        https://github.com/streadway/handy/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Handy provides reusable HTTP server handlers and filters for Go.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-tebeka-strftime/go-github-tebeka-strftime.spec
+++ b/SPECS/go-github-tebeka-strftime/go-github-tebeka-strftime.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           strftime
+%define go_import_path  github.com/tebeka/strftime
+
+Name:           go-github-tebeka-strftime
+Version:        0.1.5
+Release:        %autorelease
+Summary:        Python-compatible strftime implementation for Go
+License:        MIT
+URL:            https://github.com/tebeka/strftime
+#!RemoteAsset:  sha256:0a0a22c57389e3c27585de9018a6d44198ee512ffe2fc1e7ab9c4ca876844659
+Source0:        https://github.com/tebeka/strftime/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Strftime implements Python-style strftime time formatting directives for Go.
+
+%files
+%doc README.md
+%license LICENSE.txt
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-tidwall-tinylru/go-github-tidwall-tinylru.spec
+++ b/SPECS/go-github-tidwall-tinylru/go-github-tidwall-tinylru.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           tinylru
+%define go_import_path  github.com/tidwall/tinylru
+
+Name:           go-github-tidwall-tinylru
+Version:        1.2.1
+Release:        %autorelease
+Summary:        Tiny LRU cache for Go
+License:        MIT
+URL:            https://github.com/tidwall/tinylru
+#!RemoteAsset:  sha256:05edd231678979e29870788cc550ab17eeaca5cb0adc647a2617dcc7f03b110f
+Source0:        https://github.com/tidwall/tinylru/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Tinylru provides small fixed-capacity and generic LRU caches for Go.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-tilinna-clock/go-github-tilinna-clock.spec
+++ b/SPECS/go-github-tilinna-clock/go-github-tilinna-clock.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           clock
+%define go_import_path  github.com/tilinna/clock
+
+Name:           go-github-tilinna-clock
+Version:        1.1.0
+Release:        %autorelease
+Summary:        Time mocking library for Go
+License:        MIT
+URL:            https://github.com/tilinna/clock
+#!RemoteAsset:  sha256:e7c6f28341386ea4a8431564c64b7ba21ff99de0b14633f426f824fd9e7f5503
+Source0:        https://github.com/tilinna/clock/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Clock provides real-time and mock clock implementations for testing Go code,
+including context-aware deadlines and timers.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-tinylib-msgp/go-github-tinylib-msgp.spec
+++ b/SPECS/go-github-tinylib-msgp/go-github-tinylib-msgp.spec
@@ -6,11 +6,9 @@
 
 %define _name           msgp
 %define go_import_path  github.com/tinylib/msgp
-# TODO: Test need too much dependencies, add it later - Julian
-%define go_test_exclude %{shrink:
-    github.com/tinylib/msgp/msgp
-    github.com/tinylib/msgp/tinygotest
-}
+# TinyGo integration tests compile for embedded targets using a separate
+# compiler and target runtimes that are not packaged in openRuyi.
+%define go_test_exclude  %{go_import_path}/tinygotest
 
 Name:           go-github-tinylib-msgp
 Version:        1.6.4
@@ -29,16 +27,35 @@ BuildRequires:  go
 BuildRequires:  go-rpm-macros
 
 BuildRequires:  go(github.com/philhofer/fwd)
+BuildRequires:  go(golang.org/x/mod)
+BuildRequires:  go(golang.org/x/sync)
 BuildRequires:  go(golang.org/x/tools)
 
 Provides:       go(github.com/tinylib/msgp) = %{version}
 
+Requires:       go(github.com/philhofer/fwd)
+Requires:       go(golang.org/x/tools)
+
 %description
-This is a code generation tool and serialization library for MessagePack. You can read more about MessagePack in the wiki, or at msgpack.org.
+Msgp is a code generation tool and serialization library for MessagePack.
+
+%check -p
+# Upstream's prepare target builds msgp before generating its unit and
+# integration fixtures. Put the generator on PATH for go:generate directives.
+%go_common
+%go_prep
+go build -o %{_builddir}/msgp-test-bin/msgp .
+export PATH=%{_builddir}/msgp-test-bin:${PATH}
+go generate ./msgp ./_generated
+
+%check -a
+# Go's ./... pattern omits underscore-prefixed directories; test the generated
+# integration suite explicitly after the default package checks.
+go test -v ./_generated
 
 %files
-%license LICENSE*
 %doc README*
+%license LICENSE*
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog

--- a/SPECS/go-github-tj-assert/go-github-tj-assert.spec
+++ b/SPECS/go-github-tj-assert/go-github-tj-assert.spec
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           assert
+%define go_import_path  github.com/tj/assert
+
+Name:           go-github-tj-assert
+Version:        0.0.3
+Release:        %autorelease
+Summary:        Immediate-failure assertions for Go tests
+License:        MIT
+URL:            https://github.com/tj/assert
+#!RemoteAsset:  sha256:1596d9e6f2ba75f1b5e4b9b8f4a86ac4834723f1abaff4a717ba8c6896387f05
+Source0:        https://github.com/tj/assert/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(gopkg.in/yaml.v3)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/stretchr/testify)
+
+%description
+Assert provides the same assertions as testify's assert package while stopping
+test execution immediately when an assertion fails.
+
+%files
+%doc Readme.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-tmc-grpc-websocket-proxy/go-github-tmc-grpc-websocket-proxy.spec
+++ b/SPECS/go-github-tmc-grpc-websocket-proxy/go-github-tmc-grpc-websocket-proxy.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           grpc-websocket-proxy
+%define go_import_path  github.com/tmc/grpc-websocket-proxy
+%define commit_id       673ab2c3ae75cc01952b84b88590e30e75dcf395
+
+Name:           go-github-tmc-grpc-websocket-proxy
+Version:        0+git20260821.673ab2c
+Release:        %autorelease
+Summary:        WebSocket proxy for gRPC streams
+License:        MIT
+URL:            https://github.com/tmc/grpc-websocket-proxy
+#!RemoteAsset:  sha256:d61b8d40e899184d5b7a988a959b1f6fb5de64c3c4d5fb3435c9c0246aceb84f
+Source0:        https://github.com/tmc/grpc-websocket-proxy/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/gorilla/websocket)
+BuildRequires:  go(github.com/sirupsen/logrus)
+BuildRequires:  go(golang.org/x/net)
+
+Provides:       go(github.com/tmc/grpc-websocket-proxy) = %{version}
+
+Requires:       go(github.com/gorilla/websocket)
+Requires:       go(github.com/sirupsen/logrus)
+Requires:       go(golang.org/x/net)
+
+%description
+This package adapts gRPC streams to WebSocket connections for clients that
+cannot connect to a native gRPC endpoint.
+
+%files
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-trivago-tgo/go-github-trivago-tgo.spec
+++ b/SPECS/go-github-trivago-tgo/go-github-trivago-tgo.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           tgo
+%define go_import_path  github.com/trivago/tgo
+
+Name:           go-github-trivago-tgo
+Version:        1.0.7
+Release:        %autorelease
+Summary:        Utility packages for Go applications
+License:        Apache-2.0
+URL:            https://github.com/trivago/tgo
+#!RemoteAsset:  sha256:02d48e81089d0bd30d53be5c6acb0f97d7249e0e53bb79e2cf05d147c6dda020
+Source0:        https://github.com/trivago/tgo/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Current Go vet rejects non-constant response bodies passed to fmt.Fprintf
+# in the health-check server tests; keep running all tests with vet disabled.
+BuildOption(check):  -vet=off
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Tgo provides reusable containers, formatting, logging, synchronization, and
+testing helpers for Go applications.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-twmb-murmur3/go-github-twmb-murmur3.spec
+++ b/SPECS/go-github-twmb-murmur3/go-github-twmb-murmur3.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           murmur3
+%define go_import_path  github.com/twmb/murmur3
+
+Name:           go-github-twmb-murmur3
+Version:        1.1.8
+Release:        %autorelease
+Summary:        MurmurHash3 implementation for Go
+License:        BSD-3-Clause
+URL:            https://github.com/twmb/murmur3
+#!RemoteAsset:  sha256:afa51249308db62b5a2d4610b7c30cd41dc4906777211d8d8b09250875a668aa
+Source0:        https://github.com/twmb/murmur3/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+This package implements streaming 32-bit, 64-bit, and 128-bit MurmurHash3
+functions with portable Go and optimized amd64 assembly.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-urfave-cli-v3/go-github-urfave-cli-v3.spec
+++ b/SPECS/go-github-urfave-cli-v3/go-github-urfave-cli-v3.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           cli
+%define go_import_path  github.com/urfave/cli/v3
+# The docs package imports cli-altsrc, which itself requires this module.
+%define go_test_exclude  %{go_import_path}/docs
+
+Name:           go-github-urfave-cli-v3
+Version:        3.11.0
+Release:        %autorelease
+Summary:        Command-line application framework for Go
+License:        MIT
+URL:            https://github.com/urfave/cli
+#!RemoteAsset:  sha256:95351a5fdf8da5ed550521712134abc64dccce81d4f9249eb4ac509504c1ce1a
+Source0:        https://github.com/urfave/cli/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Current Go vet rejects non-constant format strings in command tests; keep
+# running the tests with vet disabled.
+BuildOption(check):  -vet=off
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(gopkg.in/yaml.v3)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Urfave CLI is a minimal framework for building and organizing command-line
+applications in Go.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-valyala-fastrand/go-github-valyala-fastrand.spec
+++ b/SPECS/go-github-valyala-fastrand/go-github-valyala-fastrand.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           fastrand
+%define go_import_path  github.com/valyala/fastrand
+
+Name:           go-github-valyala-fastrand
+Version:        1.1.0
+Release:        %autorelease
+Summary:        Fast pseudorandom number generator for Go
+License:        MIT
+URL:            https://github.com/valyala/fastrand
+#!RemoteAsset:  sha256:04b51f8e3f3ddbc940e01a92f34376709a6722f43918bcf3b3369b302ee68d1d
+Source0:        https://github.com/valyala/fastrand/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(github.com/valyala/fastrand) = %{version}
+
+%description
+Fastrand provides fast pseudorandom number generators that scale across
+multiple CPUs.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-vividcortex-gohistogram/go-github-vividcortex-gohistogram.spec
+++ b/SPECS/go-github-vividcortex-gohistogram/go-github-vividcortex-gohistogram.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           gohistogram
+%define go_import_path  github.com/VividCortex/gohistogram
+
+Name:           go-github-vividcortex-gohistogram
+Version:        1.0.0
+Release:        %autorelease
+Summary:        Weighted and exponential histograms for Go
+License:        MIT
+URL:            https://github.com/VividCortex/gohistogram
+#!RemoteAsset:  sha256:830abe53f98e7a46ccbd829114998e1d7bbe9edfeb669011e7970d684493809e
+Source0:        https://github.com/VividCortex/gohistogram/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Package gohistogram provides weighted and exponential histogram
+implementations for Go.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-vjeantet-grok/go-github-vjeantet-grok.spec
+++ b/SPECS/go-github-vjeantet-grok/go-github-vjeantet-grok.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           grok
+%define go_import_path  github.com/vjeantet/grok
+
+Name:           go-github-vjeantet-grok
+Version:        1.0.1
+Release:        %autorelease
+Summary:        Grok pattern parser for Go
+License:        Apache-2.0
+URL:            https://github.com/vjeantet/grok
+#!RemoteAsset:  sha256:f36b851686fc61b58dee9e15e24b2fe5eb3c75d4cfba98b27e443ddd51101806
+Source0:        https://github.com/vjeantet/grok/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+This package extracts structured fields from text using reusable Grok
+patterns and Go regular expressions.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-wk8-go-ordered-map-v2/go-github-wk8-go-ordered-map-v2.spec
+++ b/SPECS/go-github-wk8-go-ordered-map-v2/go-github-wk8-go-ordered-map-v2.spec
@@ -9,7 +9,7 @@
 Name:           go-github-wk8-go-ordered-map-v2
 Version:        2.1.8
 Release:        %autorelease
-Summary:        Optimal implementation of ordered maps for Golang - ie maps that remember the order in which keys were inserted.
+Summary:        Generic insertion-ordered map for Go
 License:        Apache-2.0
 URL:            https://github.com/wk8/go-ordered-map
 #!RemoteAsset:  sha256:de9c9c67b7907d7a0714b4773585144aa0b4fdf7f36ab42d103cd2edc500eb20
@@ -21,24 +21,26 @@ BuildRequires:  go
 BuildRequires:  go-rpm-macros
 BuildRequires:  go(github.com/bahlo/generic-list-go)
 BuildRequires:  go(github.com/buger/jsonparser)
+BuildRequires:  go(github.com/davecgh/go-spew)
 BuildRequires:  go(github.com/mailru/easyjson)
+BuildRequires:  go(github.com/pmezard/go-difflib)
 BuildRequires:  go(github.com/stretchr/testify)
 BuildRequires:  go(gopkg.in/yaml.v3)
 
-Provides:       go(github.com/wk8/go-ordered-map/v2) = %{version}
+Provides:       go(%{go_import_path}) = %{version}
 
 Requires:       go(github.com/bahlo/generic-list-go)
 Requires:       go(github.com/buger/jsonparser)
 Requires:       go(github.com/mailru/easyjson)
-Requires:       go(github.com/stretchr/testify)
 Requires:       go(gopkg.in/yaml.v3)
 
 %description
-go-ordered-map is a generic ordered map for Go that preserves insertion order.
+Go-ordered-map provides a generic map that preserves insertion order and
+supports JSON and YAML serialization.
 
 %files
-%doc README*
-%license LICENSE*
+%doc README.md
+%license LICENSE
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog

--- a/SPECS/go-github-xdg-go-pbkdf2/go-github-xdg-go-pbkdf2.spec
+++ b/SPECS/go-github-xdg-go-pbkdf2/go-github-xdg-go-pbkdf2.spec
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           pbkdf2
+%define go_import_path  github.com/xdg-go/pbkdf2
+
+Name:           go-github-xdg-go-pbkdf2
+Version:        1.0.0
+Release:        %autorelease
+Summary:        PBKDF2 implementation for Go
+License:        Apache-2.0
+URL:            https://github.com/xdg-go/pbkdf2
+#!RemoteAsset:  sha256:2eec55146447215eb58190e04c546c93cad7f369ac9b5aacd9dc11330d756757
+Source0:        https://github.com/xdg-go/pbkdf2/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+This package implements password-based key derivation using PBKDF2 as defined
+by RFC 2898 and RFC 8018.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-xdg-go-stringprep/go-github-xdg-go-stringprep.spec
+++ b/SPECS/go-github-xdg-go-stringprep/go-github-xdg-go-stringprep.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           stringprep
+%define go_import_path  github.com/xdg-go/stringprep
+
+Name:           go-github-xdg-go-stringprep
+Version:        1.0.4
+Release:        %autorelease
+Summary:        RFC 3454 stringprep implementation for Go
+License:        Apache-2.0
+URL:            https://github.com/xdg-go/stringprep
+#!RemoteAsset:  sha256:dc2abbf4f868d71e035d96986bc5c25921046d0e34c7675b6c1d555589611cf0
+Source0:        https://github.com/xdg-go/stringprep/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(golang.org/x/text)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(golang.org/x/text)
+
+%description
+Stringprep implements RFC 3454 and SASLprep from RFC 4013 for Go.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-xlzd-gotp/go-github-xlzd-gotp.spec
+++ b/SPECS/go-github-xlzd-gotp/go-github-xlzd-gotp.spec
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           gotp
+%define go_import_path  github.com/xlzd/gotp
+
+Name:           go-github-xlzd-gotp
+Version:        0.1.0
+Release:        %autorelease
+Summary:        One-time password library for Go
+License:        MIT
+URL:            https://github.com/xlzd/gotp
+#!RemoteAsset:  sha256:f40b63ae731d140158baad46df1a4c35f2aacff033633278a0dba7e61d23eb72
+Source0:        https://github.com/xlzd/gotp/archive/refs/tags/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Gotp implements time-based and counter-based one-time passwords in Go.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-youmark-pkcs8/go-github-youmark-pkcs8.spec
+++ b/SPECS/go-github-youmark-pkcs8/go-github-youmark-pkcs8.spec
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           pkcs8
+%define go_import_path  github.com/youmark/pkcs8
+
+Name:           go-github-youmark-pkcs8
+Version:        1.3
+Release:        %autorelease
+Summary:        PKCS#8 private key support for Go
+License:        MIT
+URL:            https://github.com/youmark/pkcs8
+#!RemoteAsset:  sha256:cefad79e9fe925449f33861fcb770b46084cdc6f3400f9d99db7e90a268aad5d
+Source0:        https://github.com/youmark/pkcs8/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(golang.org/x/crypto)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(golang.org/x/crypto)
+
+%description
+PKCS8 parses and marshals encrypted and unencrypted PKCS#8 private keys in Go.
+
+%files
+%doc README README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-zclconf-go-cty-debug/go-github-zclconf-go-cty-debug.spec
+++ b/SPECS/go-github-zclconf-go-cty-debug/go-github-zclconf-go-cty-debug.spec
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-cty-debug
+%define go_import_path  github.com/zclconf/go-cty-debug
+%define commit_id       0d6042c539401a57fc0cca85ded2861d4a5173c4
+
+Name:           go-github-zclconf-go-cty-debug
+Version:        0+git20260819.0d6042c
+Release:        %autorelease
+Summary:        Debugging and inspection utilities for cty
+License:        MIT
+URL:            https://github.com/zclconf/go-cty-debug
+#!RemoteAsset:  sha256:dc98b5561061754fdae18374e7a596ea473d3bda11e27bfb1f2011b32ba37732
+Source0:        https://github.com/zclconf/go-cty-debug/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{_name}-%{commit_id}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/google/go-cmp)
+BuildRequires:  go(github.com/zclconf/go-cty)
+BuildRequires:  go(golang.org/x/text)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/google/go-cmp)
+Requires:       go(github.com/zclconf/go-cty)
+Requires:       go(golang.org/x/text)
+
+%description
+Go-cty-debug provides debugging and inspection helpers for cty values and
+types.
+
+%files
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-go.elastic-fastjson/2000-tolerate-go1.27-json-error-type.patch
+++ b/SPECS/go-go.elastic-fastjson/2000-tolerate-go1.27-json-error-type.patch
@@ -1,0 +1,43 @@
+From 776bb5e57838b74dc49abfde9825aba5256efe6e Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Wed, 2 Sep 2026 22:46:30 +0800
+Subject: [PATCH] test: tolerate Go 1.27 JSON error type formatting
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ marshaler_test.go | 12 ++++++++----
+ 1 file changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/marshaler_test.go b/marshaler_test.go
+index b52d832..071f467 100644
+--- a/marshaler_test.go
++++ b/marshaler_test.go
+@@ -5,6 +5,7 @@ import (
+ 	"errors"
+ 	"math"
+ 	"reflect"
++	"strings"
+ 	"testing"
+ )
+ 
+@@ -122,11 +123,14 @@ func TestMarshalStdlibMarshalerError(t *testing.T) {
+ 	err := Marshal(&w, stdlibMarshalerFunc(func() ([]byte, error) {
+ 		return nil, errors.New("boom")
+ 	}))
+-	assertEncoded(t, &w, `{"__ERROR__":"json: error calling MarshalJSON for type fastjson.stdlibMarshalerFunc: boom"}`)
+-	expectedErr := `json: error calling MarshalJSON for type fastjson.stdlibMarshalerFunc: boom`
+-	if err == nil || err.Error() != expectedErr {
+-		t.Fatalf("expected %q, got %q", expectedErr, err)
++	if err == nil || !strings.HasPrefix(err.Error(), "json: error calling MarshalJSON for type ") || !strings.HasSuffix(err.Error(), ": boom") {
++		t.Fatalf("unexpected error: %v", err)
++	}
++	expected, marshalErr := json.Marshal(map[string]string{"__ERROR__": err.Error()})
++	if marshalErr != nil {
++		t.Fatal(marshalErr)
+ 	}
++	assertEncoded(t, &w, string(expected))
+ }
+ 
+ func TestMarshalMapValueError(t *testing.T) {
+-- 
+2.43.0

--- a/SPECS/go-go.elastic-fastjson/go-go.elastic-fastjson.spec
+++ b/SPECS/go-go.elastic-fastjson/go-go.elastic-fastjson.spec
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           fastjson
+%define go_import_path  go.elastic.co/fastjson
+
+Name:           go-go.elastic-fastjson
+Version:        1.5.1
+Release:        %autorelease
+Summary:        Fast JSON encoder and code generator for Go
+License:        Apache-2.0 AND MIT
+URL:            https://github.com/elastic/go-fastjson
+#!RemoteAsset:  sha256:932b5327252f092ffe36a639115971e4a2e2067686b6d6aecaea2f2ae94935ec
+Source0:        https://github.com/elastic/go-fastjson/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Go 1.27 formats the Marshaler type in encoding/json errors as a pointer.
+Patch2000:      2000-tolerate-go1.27-json-error-type.patch
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(golang.org/x/mod)
+BuildRequires:  go(golang.org/x/sync)
+BuildRequires:  go(golang.org/x/tools)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(golang.org/x/tools)
+
+%description
+Fastjson provides a fast JSON encoding library and a generator for producing
+marshalling methods for exported Go types.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-google-protobuf/go-google-protobuf.spec
+++ b/SPECS/go-google-protobuf/go-google-protobuf.spec
@@ -27,6 +27,7 @@ Provides:       go(google.golang.org/protobuf) = %{version}
 Provides:       go(google.golang.org/protobuf/proto) = %{version}
 Provides:       go(google.golang.org/protobuf/reflect) = %{version}
 Provides:       go(google.golang.org/protobuf/runtime) = %{version}
+Provides:       go(google.golang.org/protobuf/types) = %{version}
 
 Requires:       pkgconfig(protobuf)
 

--- a/SPECS/go-gopkg-dnaeon-go-vcr.v3/2000-fix-integer-status-format-verbs.patch
+++ b/SPECS/go-gopkg-dnaeon-go-vcr.v3/2000-fix-integer-status-format-verbs.patch
@@ -1,0 +1,35 @@
+From d45d0e418c568b6ad42dafbf18c4a1ff47e9f4a1 Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Mon, 17 Aug 2026 08:28:16 +0800
+Subject: [PATCH] test: use integer verbs for HTTP status codes
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ recorder/recorder_test.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/recorder/recorder_test.go b/recorder/recorder_test.go
+index 0340c91..7d848d6 100644
+--- a/recorder/recorder_test.go
++++ b/recorder/recorder_test.go
+@@ -75,7 +75,7 @@ func (tc testCase) run(client *http.Client, ctx context.Context, serverUrl strin
+ 	}
+ 
+ 	if resp.StatusCode != tc.wantStatus {
+-		return fmt.Errorf("want status: %q, got status: %q", resp.StatusCode, tc.wantStatus)
++		return fmt.Errorf("want status: %d, got status: %d", resp.StatusCode, tc.wantStatus)
+ 	}
+ 
+ 	if resp.ContentLength != int64(tc.wantContentLength) {
+@@ -209,7 +209,7 @@ func TestRecordOnceMode(t *testing.T) {
+ 
+ 		recordedStatus := c.Interactions[i].Response.Code
+ 		if test.wantStatus != recordedStatus {
+-			t.Fatalf("got recorded status: %q, want recorded status: %q", test.wantStatus, recordedStatus)
++			t.Fatalf("got recorded status: %d, want recorded status: %d", test.wantStatus, recordedStatus)
+ 
+ 		}
+ 	}
+-- 
+2.43.0
+

--- a/SPECS/go-gopkg-dnaeon-go-vcr.v3/go-gopkg-dnaeon-go-vcr.v3.spec
+++ b/SPECS/go-gopkg-dnaeon-go-vcr.v3/go-gopkg-dnaeon-go-vcr.v3.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-vcr
+%define go_import_path  gopkg.in/dnaeon/go-vcr.v3
+
+Name:           go-gopkg-dnaeon-go-vcr.v3
+Version:        3.2.0
+Release:        %autorelease
+Summary:        Record and replay HTTP interactions in Go tests
+License:        BSD-2-Clause
+URL:            https://github.com/dnaeon/go-vcr
+#!RemoteAsset:  sha256:831a1d236669511fbbd217478ae0927043bf738bc72fc32d9104b5df3d76934c
+Source0:        https://github.com/dnaeon/go-vcr/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Use integer format verbs for HTTP status codes in tests.
+Patch2000:      2000-fix-integer-status-format-verbs.patch
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(gopkg.in/yaml.v3)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(gopkg.in/yaml.v3)
+
+%description
+Go-vcr records HTTP interactions and replays them to make tests deterministic
+without repeatedly contacting external services.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-gopkg-gcfg.v1/go-gopkg-gcfg.v1.spec
+++ b/SPECS/go-gopkg-gcfg.v1/go-gopkg-gcfg.v1.spec
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           gcfg.v1
+%define go_import_path  gopkg.in/gcfg.v1
+# The types tests assert legacy strconv behavior that changed in Go 1.26.
+%define go_test_exclude  %{go_import_path}/types
+
+Name:           go-gopkg-gcfg.v1
+Version:        1.2.3
+Release:        %autorelease
+Summary:        INI-style configuration reader for Go
+License:        BSD-3-Clause
+URL:            https://github.com/go-gcfg/gcfg
+#!RemoteAsset:  sha256:3d60ba7a07e7d7d831a756f565c7fdc75895f294b2b69185674bb0ed70622645
+Source0:        https://github.com/go-gcfg/gcfg/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(gopkg.in/warnings.v0)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(gopkg.in/warnings.v0)
+
+%description
+Gcfg reads INI-style configuration files into Go structs with support for
+sections, subsections, and user-defined types.
+
+%files
+%doc README
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-gopkg-go-jose-go-jose.v2/2000-fix-non-constant-format-strings-in-examples.patch
+++ b/SPECS/go-gopkg-go-jose-go-jose.v2/2000-fix-non-constant-format-strings-in-examples.patch
@@ -1,0 +1,35 @@
+From 34d75794685fdebdf956a6f761ac1d3f0a0c46d3 Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Fri, 21 Aug 2026 19:32:33 +0800
+Subject: [PATCH] Fix non-constant format strings in examples
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ doc_test.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/doc_test.go b/doc_test.go
+index 8a7b605..c796aa9 100644
+--- a/doc_test.go
++++ b/doc_test.go
+@@ -70,7 +70,7 @@ func Example_jWE() {
+ 		panic(err)
+ 	}
+ 
+-	fmt.Printf(string(decrypted))
++	fmt.Printf("%s", decrypted)
+ 	// output: Lorem ipsum dolor sit amet
+ }
+ 
+@@ -116,7 +116,7 @@ func Example_jWS() {
+ 		panic(err)
+ 	}
+ 
+-	fmt.Printf(string(output))
++	fmt.Printf("%s", output)
+ 	// output: Lorem ipsum dolor sit amet
+ }
+ 
+-- 
+2.43.0
+

--- a/SPECS/go-gopkg-go-jose-go-jose.v2/2001-use-packaged-kingpin-module.patch
+++ b/SPECS/go-gopkg-go-jose-go-jose.v2/2001-use-packaged-kingpin-module.patch
@@ -1,0 +1,42 @@
+From 13ee61e67070507fc7f72f8176becb56637e700b Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Tue, 8 Sep 2026 23:07:24 +0800
+Subject: [PATCH] cmd: use the packaged kingpin v2 module
+
+openRuyi provides kingpin under github.com/alecthomas/kingpin/v2. Update both command imports so the complete source package can be checked against this dependency.
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ jose-util/main.go  | 2 +-
+ jwk-keygen/main.go | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/jose-util/main.go b/jose-util/main.go
+index 1b1c11e..b5df32f 100644
+--- a/jose-util/main.go
++++ b/jose-util/main.go
+@@ -21,7 +21,7 @@ import (
+ 	"io/ioutil"
+ 	"os"
+ 
+-	"gopkg.in/alecthomas/kingpin.v2"
++	"github.com/alecthomas/kingpin/v2"
+ 	"gopkg.in/go-jose/go-jose.v2"
+ )
+ 
+diff --git a/jwk-keygen/main.go b/jwk-keygen/main.go
+index 3270cb4..649ef31 100644
+--- a/jwk-keygen/main.go
++++ b/jwk-keygen/main.go
+@@ -30,7 +30,7 @@ import (
+ 
+ 	"golang.org/x/crypto/ed25519"
+ 
+-	"gopkg.in/alecthomas/kingpin.v2"
++	"github.com/alecthomas/kingpin/v2"
+ 	"gopkg.in/go-jose/go-jose.v2"
+ )
+ 
+-- 
+2.43.0
+

--- a/SPECS/go-gopkg-go-jose-go-jose.v2/go-gopkg-go-jose-go-jose.v2.spec
+++ b/SPECS/go-gopkg-go-jose-go-jose.v2/go-gopkg-go-jose-go-jose.v2.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-jose.v2
+%define go_import_path  gopkg.in/go-jose/go-jose.v2
+
+Name:           go-gopkg-go-jose-go-jose.v2
+Version:        2.6.3
+Release:        %autorelease
+Summary:        Go implementation of JSON Web Signature and Encryption standards
+License:        Apache-2.0
+URL:            https://github.com/go-jose/go-jose
+#!RemoteAsset:  sha256:a0244a93fbea8621f242cc6cbc0342763961eadf16558e8dee127a141105ee55
+Source0:        https://github.com/go-jose/go-jose/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Fix Go 1.26 vet errors in the package examples.
+Patch2000:      2000-fix-non-constant-format-strings-in-examples.patch
+# Use the packaged kingpin v2 module in both command packages.
+Patch2001:      2001-use-packaged-kingpin-module.patch
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/alecthomas/kingpin/v2)
+BuildRequires:  go(github.com/google/go-cmp)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(golang.org/x/crypto)
+
+Provides:       go(gopkg.in/go-jose/go-jose.v2) = %{version}
+
+Requires:       go(github.com/alecthomas/kingpin/v2)
+Requires:       go(golang.org/x/crypto)
+
+%description
+go-jose provides a Go implementation of JSON Web Signature, JSON Web
+Encryption, and JSON Web Key standards.
+
+%files
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-gopkg-natefinch-lumberjack.v2/go-gopkg-natefinch-lumberjack.v2.spec
+++ b/SPECS/go-gopkg-natefinch-lumberjack.v2/go-gopkg-natefinch-lumberjack.v2.spec
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           lumberjack
+%define go_import_path  gopkg.in/natefinch/lumberjack.v2
+
+Name:           go-gopkg-natefinch-lumberjack.v2
+Version:        2.2.1
+Release:        %autorelease
+Summary:        Rolling log file writer for Go
+License:        MIT
+URL:            https://github.com/natefinch/lumberjack
+#!RemoteAsset:  sha256:935582f3f3377f09604bce4ab0488092d71c0d9ff3e9359a397f00ab6caed658
+Source0:        https://github.com/natefinch/lumberjack/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Lumberjack provides a Go log writer that rotates files according to size, age,
+and backup count limits.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-gopkg-telebot.v3/go-gopkg-telebot.v3.spec
+++ b/SPECS/go-gopkg-telebot.v3/go-gopkg-telebot.v3.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           telebot
+%define go_import_path  gopkg.in/telebot.v3
+
+Name:           go-gopkg-telebot.v3
+Version:        3.3.8
+Release:        %autorelease
+Summary:        Telegram Bot API framework for Go
+License:        MIT
+URL:            https://github.com/tucnak/telebot
+#!RemoteAsset:  sha256:cddace7f57ab607eb4273ec0eb1357f983d6dd2b299e4f04afaa508581ae6743
+Source0:        https://github.com/tucnak/telebot/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/goccy/go-yaml)
+BuildRequires:  go(github.com/spf13/viper)
+BuildRequires:  go(github.com/stretchr/testify)
+
+Provides:       go(gopkg.in/telebot.v3) = %{version}
+
+Requires:       go(github.com/goccy/go-yaml)
+Requires:       go(github.com/spf13/viper)
+
+%description
+Telebot is a framework for building Telegram bots in Go.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-gotest-tools/1000-update-tests-for-latest-google-go-cmp.patch
+++ b/SPECS/go-gotest-tools/1000-update-tests-for-latest-google-go-cmp.patch
@@ -1,0 +1,140 @@
+From c452da86ea73d04b66a75e841c87e95e24d5ecb3 Mon Sep 17 00:00:00 2001
+From: Daniel Nephin <dnephin@gmail.com>
+Date: Mon, 24 Jun 2019 20:10:32 -0400
+Subject: [PATCH] Update tests for latest google/go-cmp
+
+Change the expected value for a couple of them to be less strict
+
+Backport to v2.3.0.
+https://github.com/gotestyourself/gotest.tools/commit/85ad333
+---
+ assert/assert_test.go      | 10 +++-------
+ assert/cmp/compare_test.go | 37 +++++++++++++++++++------------------
+ assert/opt/opt_test.go     | 23 +++++++++++++++++++++--
+ 3 files changed, 43 insertions(+), 27 deletions(-)
+
+diff --git a/assert/assert_test.go b/assert/assert_test.go
+index 61d2853..4d117ea 100644
+--- a/assert/assert_test.go
++++ b/assert/assert_test.go
+@@ -302,13 +302,9 @@ func TestDeepEqualFailure(t *testing.T) {
+ 
+ 	fakeT := &fakeTestingT{}
+ 	DeepEqual(fakeT, actual, expected, gocmp.AllowUnexported(stub{}))
+-	expectFailNowed(t, fakeT, "assertion failed: "+`
+---- actual
+-+++ expected
+-{assert.stub}.b:
+-	-: 1
+-	+: 2
+-`)
++	if !fakeT.failNowed {
++		t.Fatal("should have failNowed")
++	}
+ }
+ 
+ func TestErrorFailure(t *testing.T) {
+diff --git a/assert/cmp/compare_test.go b/assert/cmp/compare_test.go
+index f99ce88..7878b0b 100644
+--- a/assert/cmp/compare_test.go
++++ b/assert/cmp/compare_test.go
+@@ -14,32 +14,33 @@ import (
+ )
+ 
+ func TestDeepEqual(t *testing.T) {
+-	actual := DeepEqual([]string{"a", "b"}, []string{"b", "a"})()
+-	expected := `
+---- result
+-+++ exp
+-{[]string}[0]:
+-	-: "a"
+-	+: "b"
+-{[]string}[1]:
+-	-: "b"
+-	+: "a"
+-`
+-	args := []ast.Expr{&ast.Ident{Name: "result"}, &ast.Ident{Name: "exp"}}
+-	assertFailureTemplate(t, actual, args, expected)
++	t.Run("failure", func(t *testing.T) {
++		result := DeepEqual([]string{"a", "b"}, []string{"b", "a"})()
++		if result.Success() {
++			t.Errorf("expected failure")
++		}
++
++		args := []ast.Expr{&ast.Ident{Name: "result"}, &ast.Ident{Name: "exp"}}
++		message := result.(templatedResult).FailureMessage(args)
++		expected := "\n--- result\n+++ exp\n"
++		if !strings.HasPrefix(message, expected) {
++			t.Errorf("expected prefix \n%q\ngot\n%q\n", expected, message)
++		}
++	})
+ 
+-	actual = DeepEqual([]string{"a"}, []string{"a"})()
+-	assertSuccess(t, actual)
++	t.Run("success", func(t *testing.T) {
++		actual := DeepEqual([]string{"a"}, []string{"a"})()
++		assertSuccess(t, actual)
++	})
+ }
+ 
+ type Stub struct {
+ 	unx int
+ }
+ 
+-func TestDeepEqualeWithUnexported(t *testing.T) {
++func TestDeepEqualWithUnexported(t *testing.T) {
+ 	result := DeepEqual(Stub{}, Stub{unx: 1})()
+-	assertFailure(t, result, `cannot handle unexported field: {cmp.Stub}.unx
+-consider using AllowUnexported or cmpopts.IgnoreUnexported`)
++	assertFailureHasPrefix(t, result, `cannot handle unexported field: {cmp.Stub}.unx`)
+ }
+ 
+ func TestRegexp(t *testing.T) {
+diff --git a/assert/opt/opt_test.go b/assert/opt/opt_test.go
+index 734ab71..b5bfb77 100644
+--- a/assert/opt/opt_test.go
++++ b/assert/opt/opt_test.go
+@@ -186,7 +186,12 @@ func TestPathStringFromStruct(t *testing.T) {
+ 
+ 	spec := "Ref.Children.Labels.Value"
+ 	matches := matchPaths(fixture, PathString(spec))
+-	expected := []string{`{opt.node}.Ref.Children[1].Labels["first"].Value`}
++	expected := []string{
++		`{opt.node}.Ref.Children[1].Labels["first"].Value`,
++		// as of google/go-cmp 0.3.0 PathFilter seems to traverse some parts
++		// of the tree more than once.
++		`{opt.node}.Ref.Children[1].Labels["first"].Value`,
++	}
+ 	assert.DeepEqual(t, matches, expected)
+ }
+ 
+@@ -211,7 +216,14 @@ func TestPathStringFromSlice(t *testing.T) {
+ 
+ 	spec := "Ref.Children.Labels.Ref.Value"
+ 	matches := matchPaths(fixture, PathString(spec))
+-	expected := []string{`{[]opt.node}[0].Ref.Children[1].Labels["second"].Ref.Value`}
++	expected := []string{
++		`{[]opt.node}[0].Ref.Children[1].Labels["second"].Ref.Value`,
++		// as of google/go-cmp 0.3.0 PathFilter seems to traverse some parts
++		// of the tree more than once.
++		`{[]opt.node}[0].Ref.Children[1].Labels["second"].Ref.Value`,
++		`{[]opt.node}[0].Ref.Children[1].Labels["second"].Ref.Value`,
++		`{[]opt.node}[0].Ref.Children[1].Labels["second"].Ref.Value`,
++	}
+ 	assert.DeepEqual(t, matches, expected)
+ }
+ 
+@@ -233,6 +245,13 @@ func TestPathField(t *testing.T) {
+ 		"{opt.node}.Children[1].Value.Value",
+ 		"{opt.node}.Children[2].Value.Value",
+ 		"{opt.node}.Children[2].Ref.Value.Value",
++
++		// as of google/go-cmp 0.3.0 PathFilter seems to traverse some parts
++		// of the tree twice.
++		"{opt.node}.Children[0].Value.Value",
++		"{opt.node}.Children[1].Value.Value",
++		"{opt.node}.Children[2].Value.Value",
++		"{opt.node}.Children[2].Ref.Value.Value",
+ 	}
+ 	assert.DeepEqual(t, matches, expected)
+ }

--- a/SPECS/go-gotest-tools/1001-unexport-testcase-cleanup-for-go1.14.patch
+++ b/SPECS/go-gotest-tools/1001-unexport-testcase-cleanup-for-go1.14.patch
@@ -1,0 +1,36 @@
+From a33bc8f11d04ed4ea4a68f5640e984c568d2fe7f Mon Sep 17 00:00:00 2001
+From: zikaeroh <48577114+zikaeroh@users.noreply.github.com>
+Date: Thu, 7 Nov 2019 11:18:01 -0800
+Subject: [PATCH] Unexport testcase.Cleanup to fix Go 1.14
+
+Backport to v2.3.0.
+https://github.com/gotestyourself/gotest.tools/commit/6bc35c2
+---
+ x/subtest/context.go | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/x/subtest/context.go b/x/subtest/context.go
+index 878bdeb..bcf13ee 100644
+--- a/x/subtest/context.go
++++ b/x/subtest/context.go
+@@ -27,9 +27,9 @@ func (tc *testcase) Ctx() context.Context {
+ 	return tc.ctx
+ }
+ 
+-// Cleanup runs all cleanup functions. Functions are run in the opposite order
++// cleanup runs all cleanup functions. Functions are run in the opposite order
+ // in which they were added. Cleanup is called automatically before Run exits.
+-func (tc *testcase) Cleanup() {
++func (tc *testcase) cleanup() {
+ 	for _, f := range tc.cleanupFuncs {
+ 		// Defer all cleanup functions so they all run even if one calls
+ 		// t.FailNow() or panics. Deferring them also runs them in reverse order.
+@@ -59,7 +59,7 @@ type parallel interface {
+ func Run(t *testing.T, name string, subtest func(t TestContext)) bool {
+ 	return t.Run(name, func(t *testing.T) {
+ 		tc := &testcase{TB: t}
+-		defer tc.Cleanup()
++		defer tc.cleanup()
+ 		subtest(tc)
+ 	})
+ }

--- a/SPECS/go-gotest-tools/1002-adapt-to-go-cmp-0.4-diagnostics.patch
+++ b/SPECS/go-gotest-tools/1002-adapt-to-go-cmp-0.4-diagnostics.patch
@@ -1,0 +1,30 @@
+From caac80d44c2f888260b8a655f889463d6a9da468 Mon Sep 17 00:00:00 2001
+From: Anthony Fok <foka@debian.org>
+Date: Wed, 19 Feb 2020 23:57:41 -0700
+Subject: [PATCH] Upgrade to go-cmp v0.4.0
+
+and adjust assert/cmp/compare_test.go accordingly.
+
+In go-cmp v0.4.0, for user convenience, full name of the type
+is printed in the panic message when accessing an unexported field,
+see google/go-cmp#171
+
+Backport only the test changes to v2.3.0; keep its module metadata.
+https://github.com/gotestyourself/gotest.tools/commit/e7180e8
+---
+ assert/cmp/compare_test.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/assert/cmp/compare_test.go b/assert/cmp/compare_test.go
+index 7878b0b..0bbcdce 100644
+--- a/assert/cmp/compare_test.go
++++ b/assert/cmp/compare_test.go
+@@ -40,7 +40,7 @@ type Stub struct {
+ 
+ func TestDeepEqualWithUnexported(t *testing.T) {
+ 	result := DeepEqual(Stub{}, Stub{unx: 1})()
+-	assertFailureHasPrefix(t, result, `cannot handle unexported field: {cmp.Stub}.unx`)
++	assertFailureHasPrefix(t, result, `cannot handle unexported field at {cmp.Stub}.unx:`)
+ }
+ 
+ func TestRegexp(t *testing.T) {

--- a/SPECS/go-gotest-tools/1003-sort-go-cmp-path-results.patch
+++ b/SPECS/go-gotest-tools/1003-sort-go-cmp-path-results.patch
@@ -1,0 +1,69 @@
+From 3d2ec8229448eba6a0ae9239a6463df0bee90b65 Mon Sep 17 00:00:00 2001
+From: Sebastiaan van Stijn <github@gone.nl>
+Date: Sun, 14 Mar 2021 12:10:28 +0100
+Subject: [PATCH] go.mod: github.com/google/go-cmp v0.5.5
+
+Version v0.5.x provides various improvements to  the reporter output;
+https://github.com/google/go-cmp/releases
+
+full diff: https://github.com/google/go-cmp/compare/v0.4.0...v0.5.5
+
+Looks like go-cmp filter now may result in results to be returned in
+random random order; this sorts the results before comparing, but I'm
+not sure if order is important (in which case this could actually be
+a bug)
+
+Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
+(cherry picked from commit 65c6ba672eefe084b1fb97e9b8aab9870345b644)
+Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
+
+Backport only the test changes to v2.3.0; keep its module metadata.
+https://github.com/gotestyourself/gotest.tools/commit/77bb3d3
+---
+ assert/opt/opt_test.go | 15 +++++++--------
+ 1 file changed, 7 insertions(+), 8 deletions(-)
+
+diff --git a/assert/opt/opt_test.go b/assert/opt/opt_test.go
+index b5bfb77..6760e99 100644
+--- a/assert/opt/opt_test.go
++++ b/assert/opt/opt_test.go
+@@ -1,6 +1,7 @@
+ package opt
+ 
+ import (
++	"sort"
+ 	"testing"
+ 	"time"
+ 
+@@ -167,6 +168,7 @@ func (p *pathRecorder) record(path gocmp.Path) bool {
+ func matchPaths(fixture interface{}, filter func(gocmp.Path) bool) []string {
+ 	rec := &pathRecorder{filter: filter}
+ 	gocmp.Equal(fixture, fixture, gocmp.FilterPath(rec.record, gocmp.Ignore()))
++	sort.Strings(rec.matches)
+ 	return rec.matches
+ }
+ 
+@@ -240,18 +242,15 @@ func TestPathField(t *testing.T) {
+ 	filter := PathField(nodeValue{}, "Value")
+ 	matches := matchPaths(fixture, filter)
+ 	expected := []string{
+-		"{opt.node}.Value.Value",
+ 		"{opt.node}.Children[0].Value.Value",
+-		"{opt.node}.Children[1].Value.Value",
+-		"{opt.node}.Children[2].Value.Value",
+-		"{opt.node}.Children[2].Ref.Value.Value",
+-
+-		// as of google/go-cmp 0.3.0 PathFilter seems to traverse some parts
+-		// of the tree twice.
+ 		"{opt.node}.Children[0].Value.Value",
+ 		"{opt.node}.Children[1].Value.Value",
+-		"{opt.node}.Children[2].Value.Value",
++		"{opt.node}.Children[1].Value.Value",
++		"{opt.node}.Children[2].Ref.Value.Value",
+ 		"{opt.node}.Children[2].Ref.Value.Value",
++		"{opt.node}.Children[2].Value.Value",
++		"{opt.node}.Children[2].Value.Value",
++		"{opt.node}.Value.Value",
+ 	}
+ 	assert.DeepEqual(t, matches, expected)
+ }

--- a/SPECS/go-gotest-tools/1004-fix-non-constant-format-string.patch
+++ b/SPECS/go-gotest-tools/1004-fix-non-constant-format-string.patch
@@ -1,0 +1,38 @@
+From 26dced0d017b7fc94c3c5a10bfdc288fb61b6737 Mon Sep 17 00:00:00 2001
+From: Sebastiaan van Stijn <github@gone.nl>
+Date: Thu, 22 Aug 2024 12:21:35 +0200
+Subject: [PATCH] fs: fix printf: non-constant format string in call (govet)
+
+Current versions of govet check for printf functions called with a format
+string, but no arguments. This results in linting errors:
+
+    fs/report.go:107:46: printf: non-constant format string in call to gotest.tools/v3/fs.existenceProblem (govet)
+                p = append(p, existenceProblem("content", r.FailureMessage()))
+                                                          ^
+
+This patch changes existenceProblem to use format.Message, which is used
+elsewhere for similar situations.
+
+Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
+
+Backport to v2.3.0.
+https://github.com/gotestyourself/gotest.tools/commit/89b3401
+---
+ fs/report.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/fs/report.go b/fs/report.go
+index adc5a5f..1822b3b 100644
+--- a/fs/report.go
++++ b/fs/report.go
+@@ -50,8 +50,8 @@ func errProblem(reason string, err error) problem {
+ 	return problem(fmt.Sprintf("%s: %s", reason, err))
+ }
+ 
+-func existenceProblem(filename, reason string, args ...interface{}) problem {
+-	return problem(filename + ": " + fmt.Sprintf(reason, args...))
++func existenceProblem(filename string, msgAndArgs ...interface{}) problem {
++	return problem(filename + ": " + format.Message(msgAndArgs...))
+ }
+ 
+ func eqResource(x, y resource) []problem {

--- a/SPECS/go-gotest-tools/2000-poll-use-a-local-listener-in-connection-test.patch
+++ b/SPECS/go-gotest-tools/2000-poll-use-a-local-listener-in-connection-test.patch
@@ -1,0 +1,42 @@
+From 9ce2bb9e7a5b48402aee7a5e78ec8a118558a235 Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Mon, 17 Aug 2026 08:48:11 +0800
+Subject: [PATCH] poll: use a local listener in connection test
+
+OBS builds do not have external network access, so checking google.com makes the test environment-dependent. A local TCP listener exercises the same successful connection path deterministically.
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ poll/check_test.go | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/poll/check_test.go b/poll/check_test.go
+index a9277d4..2d2f31e 100644
+--- a/poll/check_test.go
++++ b/poll/check_test.go
+@@ -2,6 +2,7 @@ package poll
+ 
+ import (
+ 	"fmt"
++	"net"
+ 	"os"
+ 	"testing"
+ 
+@@ -35,8 +36,12 @@ func TestWaitOnSocketWithTimeout(t *testing.T) {
+ 		assert.Equal(t, r.Message(), "socket tcp://foo.bar:55555 not available")
+ 	})
+ 
+-	t.Run("connection to ", func(t *testing.T) {
+-		check := Connection("tcp", "google.com:80")
++	t.Run("connection to available address", func(t *testing.T) {
++		listener, err := net.Listen("tcp", "127.0.0.1:0")
++		assert.NilError(t, err)
++		defer listener.Close()
++
++		check := Connection("tcp", listener.Addr().String())
+ 		assert.Assert(t, check(t).Done())
+ 	})
+ }
+-- 
+2.43.0
+

--- a/SPECS/go-gotest-tools/go-gotest-tools.spec
+++ b/SPECS/go-gotest-tools/go-gotest-tools.spec
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           gotest.tools
+%define go_import_path  gotest.tools
+
+Name:           go-gotest-tools
+Version:        2.3.0
+Release:        %autorelease
+Summary:        Go packages supporting common test patterns
+License:        Apache-2.0
+URL:            https://github.com/gotestyourself/gotest.tools
+#!RemoteAsset:  sha256:4127bdf4ecd371783f87bf3c229b0b3b15965eb69f965c698311e69b30250649
+Source0:        https://github.com/gotestyourself/gotest.tools/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/google/go-cmp)
+BuildRequires:  go(github.com/pkg/errors)
+BuildRequires:  go(github.com/spf13/pflag)
+BuildRequires:  go(golang.org/x/tools)
+
+Provides:       go(%{go_import_path}) = %{version}
+Provides:       go(gotest.tools/assert) = %{version}
+
+Requires:       go(github.com/google/go-cmp)
+Requires:       go(github.com/pkg/errors)
+Requires:       go(github.com/spf13/pflag)
+Requires:       go(golang.org/x/tools)
+
+%patchlist
+# https://github.com/gotestyourself/gotest.tools/commit/85ad333
+1000-update-tests-for-latest-google-go-cmp.patch
+# https://github.com/gotestyourself/gotest.tools/commit/6bc35c2
+1001-unexport-testcase-cleanup-for-go1.14.patch
+# https://github.com/gotestyourself/gotest.tools/commit/e7180e8
+1002-adapt-to-go-cmp-0.4-diagnostics.patch
+# https://github.com/gotestyourself/gotest.tools/commit/77bb3d3
+1003-sort-go-cmp-path-results.patch
+# https://github.com/gotestyourself/gotest.tools/commit/89b3401
+1004-fix-non-constant-format-string.patch
+# Use a local listener because OBS builds have no external network access.
+2000-poll-use-a-local-listener-in-connection-test.patch
+
+%description
+Gotest.tools provides assertions, polling, filesystem fixtures, command
+execution helpers, and other utilities for Go tests.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

This PR contains 30 Go module package changes for Prometheus v3.13 (DAG level 0). This batch has no dependency on the other new module PRs and can be built independently.

Requires: None.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: ChatGPT:GPT-5.6-sol High

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]: https://openruyi.cn/governance/policy/ai-contribution-policy