### PR TITLE
SPECS: Add Prometheus v3.13 modules - DAG L0-06

### DIFF
--- a/SPECS/go-github-op-go-logging/go-github-op-go-logging.spec
+++ b/SPECS/go-github-op-go-logging/go-github-op-go-logging.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-logging
+%define go_import_path  github.com/op/go-logging
+
+Name:           go-github-op-go-logging
+Version:        1
+Release:        %autorelease
+Summary:        Configurable logging infrastructure for Go
+License:        BSD-3-Clause
+URL:            https://github.com/op/go-logging
+#!RemoteAsset:  sha256:949424f3ca0c1efbcc132bec73cc27b7bb426fad328f65605d7cf5403173d9bc
+Source0:        https://github.com/op/go-logging/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Keep the legacy runtime call-path assertion stable under Go 1.26 by
+# disabling compiler inlining for the test binary.
+BuildOption(check):  -gcflags=all=-l
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+The logging package implements configurable loggers and backends for Go.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-phuslu-log/0001-use-local-udp-listener-for-syslog-tests.patch
+++ b/SPECS/go-github-phuslu-log/0001-use-local-udp-listener-for-syslog-tests.patch
@@ -1,0 +1,46 @@
+From a47d606bc9542d124bc20db0aac6743fe4b2fda9 Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Tue, 21 Jul 2026 13:28:55 +0800
+Subject: [PATCH] tests: use a local UDP listener for syslog
+
+The syslog writer test should not send packets to a fixed external address.
+Bind a loopback UDP listener and direct the writer to it so the test remains
+self-contained in restricted build environments.
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ syslog_test.go | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/syslog_test.go b/syslog_test.go
+index 02ef8fa..81e6b6e 100644
+--- a/syslog_test.go
++++ b/syslog_test.go
+@@ -10,9 +10,15 @@ import (
+ )
+ 
+ func TestSyslogWriterTCP(t *testing.T) {
++	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
++	if err != nil {
++		t.Fatalf("listen UDP: %v", err)
++	}
++	defer conn.Close()
++
+ 	w := &SyslogWriter{
+ 		Network: "udp",
+-		Address: "10.0.0.2:543",
++		Address: conn.LocalAddr().String(),
+ 		Tag:     "",
+ 		Dial:    net.Dial,
+ 	}
+@@ -23,7 +29,7 @@ func TestSyslogWriterTCP(t *testing.T) {
+ 		_, _ = wlprintf(w, ParseLevel(level), `{"ts":1234567890,"level":"%s","caller":"test.go:42","error":"i am test error","foo":"bar","n":42,"message":"hello journal writer"}`+"\n", level)
+ 	}
+ 
+-	_, err := wlprintf(w, InfoLevel, `{"time":"2019-07-10T05:35:54.277Z","level":"error","msg":"a test message\n"}`+"\n")
++	_, err = wlprintf(w, InfoLevel, `{"time":"2019-07-10T05:35:54.277Z","level":"error","msg":"a test message\n"}`+"\n")
+ 	if err != nil {
+ 		t.Errorf("write syslog writer error: %+v", err)
+ 	}
+-- 
+2.43.0

--- a/SPECS/go-github-phuslu-log/2000-select-the-matching-file-writer-output.patch
+++ b/SPECS/go-github-phuslu-log/2000-select-the-matching-file-writer-output.patch
@@ -1,0 +1,53 @@
+From 15ef92acfec839d3380fb90e96673438e18f5e09 Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Fri, 21 Aug 2026 22:29:00 +0800
+Subject: [PATCH] tests: select the matching file writer output
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ file_test.go | 28 +++++++++++++++++-----------
+ 1 file changed, 17 insertions(+), 11 deletions(-)
+
+diff --git a/file_test.go b/file_test.go
+index 4b6c760..6371e1c 100644
+--- a/file_test.go
++++ b/file_test.go
+@@ -31,18 +31,24 @@ func TestFileWriter(t *testing.T) {
+ 		t.Fatal("filepath glob return empty")
+ 	}
+ 
+-	data, err := os.ReadFile(matches[0])
+-	if err != nil {
+-		t.Fatalf("read file error: %+v", err)
+-	}
+-
+-	if string(data) != text {
+-		t.Fatalf("read file content mismath: data=[%s], text=[%s]", data, text)
++	found := false
++	for _, match := range matches {
++		data, readErr := os.ReadFile(match)
++		if readErr != nil {
++			t.Fatalf("read file error: %+v", readErr)
++		}
++		if string(data) != text {
++			continue
++		}
++		found = true
++		err = os.Remove(match)
++		if err != nil {
++			t.Fatalf("os remove %s error: %+v", match, err)
++		}
++		break
+ 	}
+-
+-	err = os.Remove(matches[0])
+-	if err != nil {
+-		t.Fatalf("os remove %s error: %+v", matches[0], err)
++	if !found {
++		t.Fatalf("read file content mismatch: no output matched %q", text)
+ 	}
+ 
+ 	os.Remove(filename)
+-- 
+2.43.0
+

--- a/SPECS/go-github-phuslu-log/go-github-phuslu-log.spec
+++ b/SPECS/go-github-phuslu-log/go-github-phuslu-log.spec
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           log
+%define go_import_path  github.com/phuslu/log
+
+Name:           go-github-phuslu-log
+Version:        1.0.127
+Release:        %autorelease
+Summary:        Structured logging library for Go
+License:        MIT
+URL:            https://github.com/phuslu/log
+#!RemoteAsset:  sha256:061bfece7a424660b15b626635b5abcc3509e879c44e3f0d83fd8a0ba9eb1eca
+Source0:        https://github.com/phuslu/log/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Keep the syslog test self-contained in restricted build environments.
+# https://github.com/phuslu/log/pull/122
+Patch0:         0001-use-local-udp-listener-for-syslog-tests.patch
+# Select the matching output when stale rotated files are present.
+Patch2000:      2000-select-the-matching-file-writer-output.patch
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(go.opentelemetry.io/auto/sdk)
+BuildRequires:  go(go.opentelemetry.io/otel)
+BuildRequires:  go(go.opentelemetry.io/otel/exporters/stdout/stdoutlog)
+BuildRequires:  go(go.opentelemetry.io/otel/sdk/log)
+
+Provides:       go(github.com/phuslu/log) = %{version}
+
+Requires:       go(go.opentelemetry.io/auto/sdk)
+Requires:       go(go.opentelemetry.io/otel)
+Requires:       go(go.opentelemetry.io/otel/exporters/stdout/stdoutlog)
+Requires:       go(go.opentelemetry.io/otel/sdk/log)
+
+%description
+Phuslu log provides high-performance structured logging, console and rotating
+file writers, and standard-library logging integration.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-scalyr-dataset-go/go-github-scalyr-dataset-go.spec
+++ b/SPECS/go-github-scalyr-dataset-go/go-github-scalyr-dataset-go.spec
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           dataset-go
+%define go_import_path  github.com/scalyr/dataset-go
+
+Name:           go-github-scalyr-dataset-go
+Version:        0.21.0
+Release:        %autorelease
+Summary:        Go client for the DataSet API
+License:        Apache-2.0
+URL:            https://github.com/scalyr/dataset-go
+#!RemoteAsset:  sha256:92e3aa3c8a74a8a49dd6558b35baddc8b69c7964c43c9b8b2da2097d81de4b5c
+Source0:        https://github.com/scalyr/dataset-go/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/cenkalti/backoff/v4)
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/go-logr/logr)
+BuildRequires:  go(github.com/go-logr/stdr)
+BuildRequires:  go(github.com/google/uuid)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(go.opentelemetry.io/auto/sdk)
+BuildRequires:  go(go.opentelemetry.io/otel)
+BuildRequires:  go(go.uber.org/multierr)
+BuildRequires:  go(go.uber.org/zap)
+BuildRequires:  go(golang.org/x/exp)
+BuildRequires:  go(gopkg.in/yaml.v3)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/cenkalti/backoff/v4)
+Requires:       go(github.com/google/uuid)
+Requires:       go(go.opentelemetry.io/otel)
+Requires:       go(go.uber.org/zap)
+Requires:       go(golang.org/x/exp)
+
+%description
+DataSet-Go is a Go client for sending structured and unstructured log events
+through the DataSet addEvents API.
+
+%files
+%doc README.md RELEASE_NOTES.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-mvdan-editorconfig/2000-Declare-CMake-compatibility-for-core-tests.patch
+++ b/SPECS/go-mvdan-editorconfig/2000-Declare-CMake-compatibility-for-core-tests.patch
@@ -1,0 +1,26 @@
+From a98f6760fefc115c2dd96e90e5acd622b7c5a921 Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Wed, 19 Aug 2026 01:12:31 +0800
+Subject: [PATCH] Declare CMake compatibility for core tests
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ CMakeLists.txt | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9074719..13d4619 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,5 +1,8 @@
+ # This file is only used as part of 'go test'.
+ 
++cmake_minimum_required(VERSION 3.10)
++project(editorconfig-core-test NONE)
++
+ enable_testing()
+ set(EDITORCONFIG_CMD $ENV{EDITORCONFIG_CMD})
+ add_subdirectory(core-test)
+-- 
+2.43.0
+

--- a/SPECS/go-mvdan-editorconfig/2001-Raise-CMake-policy-baseline-for-CMake-4.patch
+++ b/SPECS/go-mvdan-editorconfig/2001-Raise-CMake-policy-baseline-for-CMake-4.patch
@@ -1,0 +1,95 @@
+From 2f6df202f986eb2297cd9e40c110096bd14b100f Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Wed, 19 Aug 2026 01:26:46 +0800
+Subject: [PATCH] Raise CMake policy baseline for CMake 4
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ cmake/almostcat.cmake   | 2 +-
+ cmake/ec_sort.cmake     | 2 +-
+ cmake/runandsort.cmake  | 2 +-
+ filetree/CMakeLists.txt | 2 +-
+ meta/CMakeLists.txt     | 2 +-
+ meta/sample.cmake       | 2 +-
+ 6 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/cmake/almostcat.cmake b/cmake/almostcat.cmake
+index 8889e3a..ae9eadb 100755
+--- a/cmake/almostcat.cmake
++++ b/cmake/almostcat.cmake
+@@ -27,7 +27,7 @@
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ 
+-cmake_minimum_required(VERSION 3.5)
++cmake_minimum_required(VERSION 3.10)
+ 
+ if("${WHICH}" STREQUAL "")
+     message(FATAL_ERROR "No WHICH parameter specified")
+diff --git a/cmake/ec_sort.cmake b/cmake/ec_sort.cmake
+index b98478b..a7726df 100755
+--- a/cmake/ec_sort.cmake
++++ b/cmake/ec_sort.cmake
+@@ -32,7 +32,7 @@
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ 
+-cmake_minimum_required(VERSION 3.5)
++cmake_minimum_required(VERSION 3.10)
+ 
+ # See documentation links at https://stackoverflow.com/q/12802377/2877364
+ set(tests_cmake_ec_sort_dir "${CMAKE_CURRENT_LIST_DIR}")
+diff --git a/cmake/runandsort.cmake b/cmake/runandsort.cmake
+index 5746fc8..df1b245 100755
+--- a/cmake/runandsort.cmake
++++ b/cmake/runandsort.cmake
+@@ -27,7 +27,7 @@
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ 
+-cmake_minimum_required(VERSION 3.5)
++cmake_minimum_required(VERSION 3.10)
+ 
+ # Conventions:
+ #   - "P_*" are parameters parsed using cmake_parse_arguments
+diff --git a/filetree/CMakeLists.txt b/filetree/CMakeLists.txt
+index 1d214ed..51704a4 100644
+--- a/filetree/CMakeLists.txt
++++ b/filetree/CMakeLists.txt
+@@ -24,7 +24,7 @@
+ # POSSIBILITY OF SUCH DAMAGE.
+ #
+ 
+-cmake_minimum_required(VERSION 3.5)
++cmake_minimum_required(VERSION 3.10)
+ 
+ # Test for EditorConfig file in parent directory
+ new_ec_test(parent_directory parent_directory.in parent_directory/test.a "^key=value[ \t\n\r]*$")
+diff --git a/meta/CMakeLists.txt b/meta/CMakeLists.txt
+index 4115da1..f821e1a 100755
+--- a/meta/CMakeLists.txt
++++ b/meta/CMakeLists.txt
+@@ -25,7 +25,7 @@
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ 
+-cmake_minimum_required(VERSION 3.5)
++cmake_minimum_required(VERSION 3.10)
+ 
+ set(tests_meta_cmakelists_dir "${CMAKE_CURRENT_LIST_DIR}")
+ 
+diff --git a/meta/sample.cmake b/meta/sample.cmake
+index a7e9eae..78bd5e5 100644
+--- a/meta/sample.cmake
++++ b/meta/sample.cmake
+@@ -1,6 +1,6 @@
+ # sample.cmake: Tests run_and_sort to make sure it's working.
+ 
+-cmake_minimum_required(VERSION 3.5)
++cmake_minimum_required(VERSION 3.10)
+ 
+ # See documentation links at https://stackoverflow.com/q/12802377/2877364
+ set( tests_meta_sample_dir "${CMAKE_CURRENT_LIST_DIR}" )
+-- 
+2.43.0
+

--- a/SPECS/go-mvdan-editorconfig/go-mvdan-editorconfig.spec
+++ b/SPECS/go-mvdan-editorconfig/go-mvdan-editorconfig.spec
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           editorconfig
+%define go_import_path  mvdan.cc/editorconfig
+%define core_test_commit 772112adb7aec5fffedf869d0d5a54c8374a0547
+
+Name:           go-mvdan-editorconfig
+Version:        0.3.0
+Release:        %autorelease
+Summary:        EditorConfig parser for Go
+License:        BSD-3-Clause
+URL:            https://github.com/mvdan/editorconfig
+#!RemoteAsset:  sha256:f85e873f891f843c9b3a2a94ce95cc6ed94a9303b7c8fe6d69bf6d529d3b8850
+Source0:        https://github.com/mvdan/editorconfig/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+# Restore the editorconfig-core-test submodule revision pinned by upstream.
+#!RemoteAsset:  sha256:8ed5b62da05455cdd3cc3f0c1cda6628355aa2f5952e6749c11e7a451fd1bd09
+Source1:        https://github.com/editorconfig/editorconfig-core-test/archive/%{core_test_commit}.tar.gz#/%{_name}-core-test-%{core_test_commit}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Declare the CMake policy baseline required by current CMake.
+Patch2000:      2000-Declare-CMake-compatibility-for-core-tests.patch
+# Avoid CMake 4 deprecation output breaking multiline output assertions.
+Patch2001:      2001-Raise-CMake-policy-baseline-for-CMake-4.patch
+
+BuildOption(prep):  -N
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  cmake
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+This package parses EditorConfig files and resolves the properties that apply
+to a path.
+
+%prep -a
+%patch -P 2000 -p1
+rm -rf core-test
+mkdir -p core-test
+tar -xf %{SOURCE1} --strip-components=1 -C core-test
+pushd core-test
+%patch -P 2001 -p1
+popd
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-opentelemetry-collector-semconv/go-opentelemetry-collector-semconv.spec
+++ b/SPECS/go-opentelemetry-collector-semconv/go-opentelemetry-collector-semconv.spec
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           opentelemetry-collector
+%define go_import_path  go.opentelemetry.io/collector/semconv
+
+Name:           go-opentelemetry-collector-semconv
+Version:        0.128.0
+Release:        %autorelease
+Summary:        Deprecated OpenTelemetry Collector semantic conventions
+License:        Apache-2.0
+URL:            https://github.com/open-telemetry/opentelemetry-collector
+#!RemoteAsset:  sha256:6fa273689dd67332591cba868fa7401c30615e24fbf5cd31b5334fa5f661175f
+Source0:        https://github.com/open-telemetry/opentelemetry-collector/archive/refs/tags/semconv/v%{version}.tar.gz#/%{_name}-semconv-v%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/hashicorp/go-version)
+BuildRequires:  go(github.com/kr/pretty)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/rogpeppe/go-internal)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(go.uber.org/goleak)
+BuildRequires:  go(gopkg.in/check.v1)
+BuildRequires:  go(gopkg.in/yaml.v3)
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+This package provides the deprecated OpenTelemetry Collector semantic
+conventions module for software that has not migrated to the OpenTelemetry Go
+semantic conventions.
+
+%install
+pushd semconv
+%buildsystem_golangmodules_install
+popd
+
+%check
+pushd semconv
+%buildsystem_golangmodules_check
+popd
+
+%files
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-opentelemetry-otel/go-opentelemetry-otel.spec
+++ b/SPECS/go-opentelemetry-otel/go-opentelemetry-otel.spec
@@ -48,10 +48,15 @@ Provides:       go(go.opentelemetry.io/otel/propagation) = %{version}
 Provides:       go(go.opentelemetry.io/otel/semconv/v1.17.0) = %{version}
 Provides:       go(go.opentelemetry.io/otel/exporters/stdout/stdoutmetric) = %{version}
 Provides:       go(go.opentelemetry.io/otel/exporters/stdout/stdouttrace) = %{version}
+Provides:       go(go.opentelemetry.io/otel/exporters/stdout/stdoutlog) = %{version}
+Provides:       go(go.opentelemetry.io/otel/log) = %{version}
+Provides:       go(go.opentelemetry.io/otel/log/logtest) = %{version}
 Provides:       go(go.opentelemetry.io/otel/metric) = %{version}
 Provides:       go(go.opentelemetry.io/otel/sdk) = %{version}
 Provides:       go(go.opentelemetry.io/otel/sdk/metric) = %{version}
 Provides:       go(go.opentelemetry.io/otel/sdk/metric/metricdata) = %{version}
+Provides:       go(go.opentelemetry.io/otel/sdk/log) = %{version}
+Provides:       go(go.opentelemetry.io/otel/sdk/log/logtest) = %{version}
 Provides:       go(go.opentelemetry.io/otel/trace) = %{version}
 
 Requires:       go(github.com/cespare/xxhash/v2)
@@ -85,14 +90,9 @@ This package provides the core OpenTelemetry API module for Go.
 %exclude %{go_sys_gopath}/%{go_import_path}/exporters/otlp/otlptrace/otlptracegrpc
 %exclude %{go_sys_gopath}/%{go_import_path}/exporters/otlp/otlptrace/otlptracehttp
 %exclude %{go_sys_gopath}/%{go_import_path}/exporters/prometheus
-%exclude %{go_sys_gopath}/%{go_import_path}/exporters/stdout/stdoutlog
 %exclude %{go_sys_gopath}/%{go_import_path}/exporters/zipkin
 %exclude %{go_sys_gopath}/%{go_import_path}/internal/tools
-%exclude %{go_sys_gopath}/%{go_import_path}/log
-%exclude %{go_sys_gopath}/%{go_import_path}/log/logtest
 %exclude %{go_sys_gopath}/%{go_import_path}/schema
-%exclude %{go_sys_gopath}/%{go_import_path}/sdk/log
-%exclude %{go_sys_gopath}/%{go_import_path}/sdk/log/logtest
 %exclude %{go_sys_gopath}/%{go_import_path}/trace/internal/telemetry/test
 
 %changelog

--- a/SPECS/go-uber-dig/go-uber-dig.spec
+++ b/SPECS/go-uber-dig/go-uber-dig.spec
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           dig
+%define go_import_path  go.uber.org/dig
+
+Name:           go-uber-dig
+Version:        1.19.0
+Release:        %autorelease
+Summary:        Reflection-based dependency injection toolkit for Go
+License:        MIT
+URL:            https://github.com/uber-go/dig
+#!RemoteAsset:  sha256:9ca333ca78dcf8aeb87a8a3fb118a505b56d86f00f0f3fbbef96d31e691dec56
+Source0:        https://github.com/uber-go/dig/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/stretchr/testify)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/stretchr/testify)
+
+%description
+Dig is a reflection-based dependency injection toolkit for constructing and
+resolving Go object graphs.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

This PR contains 7 Go module package changes for Prometheus v3.13 (DAG level 0). This batch has no dependency on the other new module PRs and can be built independently.

Requires: None.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: ChatGPT:GPT-5.6-sol High

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]: https://openruyi.cn/governance/policy/ai-contribution-policy