### PR TITLE
SPECS: Add Prometheus v3.13 modules - DAG L2-10

### DIFF
--- a/SPECS/go-github-victoriametrics-metrics/2000-tests-fix-histogram-label-formatting.patch
+++ b/SPECS/go-github-victoriametrics-metrics/2000-tests-fix-histogram-label-formatting.patch
@@ -1,0 +1,39 @@
+From 499ca774c8cf6a90eb4199784341dcd4f4b64bb3 Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Tue, 21 Jul 2026 13:50:56 +0800
+Subject: [PATCH] tests: fix histogram label formatting
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ histogram_example_test.go            | 2 +-
+ prometheus_histogram_example_test.go | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/histogram_example_test.go b/histogram_example_test.go
+index b168e2c..f9a503b 100644
+--- a/histogram_example_test.go
++++ b/histogram_example_test.go
+@@ -20,7 +20,7 @@ func ExampleHistogram() {
+ func ExampleHistogram_vec() {
+ 	for i := range 3 {
+ 		// Dynamically construct metric name and pass it to GetOrCreateHistogram.
+-		name := fmt.Sprintf(`response_size_bytes{path=%q, code=%q}`, "/foo/bar", 200+i)
++		name := fmt.Sprintf(`response_size_bytes{path=%q, code="%d"}`, "/foo/bar", 200+i)
+ 		response := processRequest()
+ 		metrics.GetOrCreateHistogram(name).Update(float64(len(response)))
+ 	}
+diff --git a/prometheus_histogram_example_test.go b/prometheus_histogram_example_test.go
+index 3aeaca2..8371ff4 100644
+--- a/prometheus_histogram_example_test.go
++++ b/prometheus_histogram_example_test.go
+@@ -20,7 +20,7 @@ func ExamplePrometheusHistogram() {
+ func ExamplePrometheusHistogram_vec() {
+ 	for i := range 3 {
+ 		// Dynamically construct metric name and pass it to GetOrCreatePrometheusHistogram.
+-		name := fmt.Sprintf(`response_size_bytes{path=%q, code=%q}`, "/foo/bar", 200+i)
++		name := fmt.Sprintf(`response_size_bytes{path=%q, code="%d"}`, "/foo/bar", 200+i)
+ 		response := processRequest()
+ 		metrics.GetOrCreatePrometheusHistogram(name).Update(float64(len(response)))
+ 	}
+-- 
+2.43.0

--- a/SPECS/go-github-victoriametrics-metrics/go-github-victoriametrics-metrics.spec
+++ b/SPECS/go-github-victoriametrics-metrics/go-github-victoriametrics-metrics.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           metrics
+%define go_import_path  github.com/VictoriaMetrics/metrics
+
+Name:           go-github-victoriametrics-metrics
+Version:        1.44.0
+Release:        %autorelease
+Summary:        Metrics library for Go applications
+License:        MIT
+URL:            https://github.com/VictoriaMetrics/metrics
+#!RemoteAsset:  sha256:fa739c706a64156f6d56693bb5252312999a15947f97142c629bd97b4f5c4194
+Source0:        https://github.com/VictoriaMetrics/metrics/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Keep Prometheus label values quoted while formatting their integer value.
+# https://github.com/VictoriaMetrics/metrics/pull/132
+Patch0:         2000-tests-fix-histogram-label-formatting.patch
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/valyala/histogram)
+BuildRequires:  go(golang.org/x/sys)
+
+Provides:       go(github.com/VictoriaMetrics/metrics) = %{version}
+
+Requires:       go(github.com/valyala/histogram)
+Requires:       go(golang.org/x/sys)
+
+%description
+VictoriaMetrics metrics provides counters, gauges, histograms, summaries, and
+Prometheus-compatible metric exposition for Go applications.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-gopkg-datadog-dd-trace-go.v1/1000-profiler-support-current-pprof-aggregate-api.patch
+++ b/SPECS/go-gopkg-datadog-dd-trace-go.v1/1000-profiler-support-current-pprof-aggregate-api.patch
@@ -1,0 +1,54 @@
+From 31ce1a167f7265be5ea9672cb88e1dae7b4fe25c Mon Sep 17 00:00:00 2001
+From: Nick Ripley <nick.ripley@datadoghq.com>
+Date: Thu, 18 Jan 2024 07:32:28 -0500
+Subject: [PATCH 1/2] profiler/internal/pprofutils: work around breaking pprof
+ change (#2515)
+
+The Google pprof library introduced a breaking change, adding an extra
+argument to a function we use. We currently have "smoke tests" which
+assert that we can unconditionally upgrade every dependency to the
+latest version and still compile.
+
+This commit is meant to satisify that test. We don't actually *need* a
+newer version of the pprof library. But there is a possibility (however
+unlikely) that a user wants to handle pprofs separately of our library
+using that library. Either we upgrade our dependency, breaking them, or
+they upgrade their dependency, breaking us. To avoid either issue, use
+an interface assertion to support either version of the API.
+
+(cherry picked from commit a83fc8bb30c3337fcd624e24f546913ca0bfb538)
+---
+ profiler/internal/pprofutils/protobuf.go | 17 +++++++++++++++--
+ 1 file changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/profiler/internal/pprofutils/protobuf.go b/profiler/internal/pprofutils/protobuf.go
+index 9aed70915..e49760dda 100644
+--- a/profiler/internal/pprofutils/protobuf.go
++++ b/profiler/internal/pprofutils/protobuf.go
+@@ -33,8 +33,21 @@ func (p Protobuf) Convert(protobuf *profile.Profile, text io.Writer) error {
+ 		}
+ 		w.WriteString(strings.Join(sampleTypes, " ") + "\n")
+ 	}
+-	if err := protobuf.Aggregate(true, true, false, false, false); err != nil {
+-		return err
++	// This is a workaround for a breaking change in the pprof library
++	// when it added columns as an additional attribute for aggregation.
++	if pb, ok := any(protobuf).(interface {
++		Aggregate(bool, bool, bool, bool, bool) error
++	}); ok {
++		if err := pb.Aggregate(true, true, false, false, false); err != nil {
++			return err
++		}
++	}
++	if pb, ok := any(protobuf).(interface {
++		Aggregate(bool, bool, bool, bool, bool, bool) error
++	}); ok {
++		if err := pb.Aggregate(true, true, false, false, false, false); err != nil {
++			return err
++		}
+ 	}
+ 	protobuf = protobuf.Compact()
+ 	sort.Slice(protobuf.Sample, func(i, j int) bool {
+-- 
+2.43.0
+

--- a/SPECS/go-gopkg-datadog-dd-trace-go.v1/1001-internal-log-pass-errors-as-format-arguments.patch
+++ b/SPECS/go-gopkg-datadog-dd-trace-go.v1/1001-internal-log-pass-errors-as-format-arguments.patch
@@ -1,0 +1,41 @@
+From e54487461d659149028b4d7ec9ccdf45199cbdf4 Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Mon, 17 Aug 2026 08:59:26 +0800
+Subject: [PATCH 2/2] internal/log: pass aggregated errors as format arguments
+
+Backport the relevant fix from:
+
+https://github.com/DataDog/dd-trace-go/commit/fbda83b5f
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ internal/log/log.go | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/internal/log/log.go b/internal/log/log.go
+index a887721c2..452285191 100644
+--- a/internal/log/log.go
++++ b/internal/log/log.go
+@@ -150,15 +150,15 @@ func Flush() {
+ 
+ func flushLocked() {
+ 	for _, report := range erragg {
+-		msg := fmt.Sprintf("%v", report.err)
++		var extra string
+ 		if report.count > defaultErrorLimit {
+-			msg += fmt.Sprintf(", %d+ additional messages skipped (first occurrence: %s)", defaultErrorLimit, report.first.Format(time.RFC822))
++			extra = fmt.Sprintf(", %d+ additional messages skipped (first occurrence: %s)", defaultErrorLimit, report.first.Format(time.RFC822))
+ 		} else if report.count > 1 {
+-			msg += fmt.Sprintf(", %d additional messages skipped (first occurrence: %s)", report.count-1, report.first.Format(time.RFC822))
++			extra = fmt.Sprintf(", %d additional messages skipped (first occurrence: %s)", report.count-1, report.first.Format(time.RFC822))
+ 		} else {
+-			msg += fmt.Sprintf(" (occurred: %s)", report.first.Format(time.RFC822))
++			extra = fmt.Sprintf(" (occurred: %s)", report.first.Format(time.RFC822))
+ 		}
+-		printMsg("ERROR", msg)
++		printMsg("ERROR", "%v%s", report.err, extra)
+ 	}
+ 	for k := range erragg {
+ 		// compiler-optimized map-clearing post go1.11 (golang/go#20138)
+-- 
+2.43.0
+

--- a/SPECS/go-gopkg-datadog-dd-trace-go.v1/go-gopkg-datadog-dd-trace-go.v1.spec
+++ b/SPECS/go-gopkg-datadog-dd-trace-go.v1/go-gopkg-datadog-dd-trace-go.v1.spec
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           dd-trace-go
+%define go_import_path  gopkg.in/DataDog/dd-trace-go.v1
+# Optional contrib integrations maintain independent framework dependency matrices.
+%define go_test_exclude_glob %{go_import_path}/contrib*
+
+Name:           go-gopkg-datadog-dd-trace-go.v1
+Version:        1.33.0
+Release:        %autorelease
+Summary:        Datadog tracing and profiling libraries for Go
+License:        Apache-2.0 OR BSD-3-Clause
+URL:            https://github.com/DataDog/dd-trace-go
+#!RemoteAsset:  sha256:0e0ae7ddae2468ae06204db48bd64505c59e33de961f74300385f06c4c1af701
+Source0:        https://github.com/DataDog/dd-trace-go/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# https://github.com/DataDog/dd-trace-go/commit/a83fc8bb30c3337fcd624e24f546913ca0bfb538
+Patch1:         1000-profiler-support-current-pprof-aggregate-api.patch
+# https://github.com/DataDog/dd-trace-go/commit/fbda83b5f
+Patch2:         1001-internal-log-pass-errors-as-format-arguments.patch
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/DataDog/datadog-go)
+BuildRequires:  go(github.com/DataDog/gostackparse)
+BuildRequires:  go(github.com/DataDog/sketches-go)
+BuildRequires:  go(github.com/google/pprof)
+BuildRequires:  go(github.com/google/uuid)
+BuildRequires:  go(github.com/opentracing/opentracing-go)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(github.com/tinylib/msgp)
+BuildRequires:  go(golang.org/x/time)
+BuildRequires:  go(golang.org/x/xerrors)
+BuildRequires:  go(google.golang.org/protobuf)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/DataDog/datadog-go)
+Requires:       go(github.com/DataDog/gostackparse)
+Requires:       go(github.com/DataDog/sketches-go)
+Requires:       go(github.com/google/pprof)
+Requires:       go(github.com/google/uuid)
+Requires:       go(github.com/opentracing/opentracing-go)
+Requires:       go(github.com/tinylib/msgp)
+Requires:       go(golang.org/x/time)
+Requires:       go(golang.org/x/xerrors)
+Requires:       go(google.golang.org/protobuf)
+
+%description
+Dd-trace-go provides Datadog application tracing, continuous profiling, and
+instrumentation libraries for Go applications using the v1 import path.
+
+%files
+%doc README.md
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-k8s-kms/go-k8s-kms.spec
+++ b/SPECS/go-k8s-kms/go-k8s-kms.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           kms
+%define go_import_path  k8s.io/kms
+
+Name:           go-k8s-kms
+Version:        0.36.2
+Release:        %autorelease
+Summary:        Kubernetes Key Management Service API
+License:        Apache-2.0
+URL:            https://github.com/kubernetes/kms
+#!RemoteAsset:  sha256:d5b2d8c42b3993fbb713248e176aab0b703f09d638d358a26163f901b41e90b2
+Source0:        https://github.com/kubernetes/kms/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(google.golang.org/grpc)
+BuildRequires:  go(google.golang.org/grpc/codes)
+BuildRequires:  go(google.golang.org/grpc/credentials)
+BuildRequires:  go(google.golang.org/grpc/status)
+BuildRequires:  go(google.golang.org/protobuf/reflect)
+BuildRequires:  go(google.golang.org/protobuf/runtime)
+
+Provides:       go(k8s.io/kms) = %{version}
+
+Requires:       go(google.golang.org/grpc)
+Requires:       go(google.golang.org/grpc/codes)
+Requires:       go(google.golang.org/grpc/status)
+Requires:       go(google.golang.org/protobuf/reflect)
+Requires:       go(google.golang.org/protobuf/runtime)
+
+%description
+The Kubernetes Key Management Service module provides the API and service
+types used by Kubernetes encryption-at-rest key management plugins.
+
+%files
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-k8s-sigs-apiserver-network-proxy-konnectivity-client/go-k8s-sigs-apiserver-network-proxy-konnectivity-client.spec
+++ b/SPECS/go-k8s-sigs-apiserver-network-proxy-konnectivity-client/go-k8s-sigs-apiserver-network-proxy-konnectivity-client.spec
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           konnectivity-client
+%define go_import_path  sigs.k8s.io/apiserver-network-proxy/konnectivity-client
+
+Name:           go-k8s-sigs-apiserver-network-proxy-konnectivity-client
+Version:        0.34.0
+Release:        %autorelease
+Summary:        Kubernetes API server network proxy client
+License:        Apache-2.0
+URL:            https://github.com/kubernetes-sigs/apiserver-network-proxy
+#!RemoteAsset:  sha256:bf660c8f0f580f8ff1b52eac821bfb233bfd58d32416b133a6d75644288cb05f
+Source0:        https://github.com/kubernetes-sigs/apiserver-network-proxy/archive/konnectivity-client/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/prometheus/client_golang)
+BuildRequires:  go(go.uber.org/goleak)
+BuildRequires:  go(google.golang.org/grpc)
+BuildRequires:  go(google.golang.org/grpc/codes)
+BuildRequires:  go(google.golang.org/grpc/status)
+BuildRequires:  go(google.golang.org/protobuf/reflect)
+BuildRequires:  go(google.golang.org/protobuf/runtime)
+BuildRequires:  go(k8s.io/klog/v2)
+
+Provides:       go(sigs.k8s.io/apiserver-network-proxy/konnectivity-client) = %{version}
+
+Requires:       go(github.com/prometheus/client_golang)
+Requires:       go(google.golang.org/grpc)
+Requires:       go(google.golang.org/grpc/codes)
+Requires:       go(google.golang.org/grpc/status)
+Requires:       go(google.golang.org/protobuf/reflect)
+Requires:       go(google.golang.org/protobuf/runtime)
+Requires:       go(k8s.io/klog/v2)
+
+%description
+This package provides the Go client library used by Kubernetes components to
+connect to an API server network proxy.
+
+%files
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-opencensus/go-opencensus.spec
+++ b/SPECS/go-opencensus/go-opencensus.spec
@@ -8,7 +8,7 @@
 %define go_import_path  go.opencensus.io
 # plugin/ochttp hits https://example.com during TestAgainstSpecs, which fails
 # in the OBS network sandbox. plugin/ocgrpc has a timing-sensitive
-# TestServerSpanDuration failure on riscv64 with "no more spans". - HNO3Miracle
+# TestServerSpanDuration failure on riscv64 with "no more spans".
 %define go_test_exclude %{shrink:
     go.opencensus.io/plugin/ochttp
     go.opencensus.io/plugin/ocgrpc
@@ -26,10 +26,11 @@ BuildArch:      noarch
 BuildSystem:    golangmodules
 
 # Current Go vet rejects mismatched fmt format strings in opencensus tests and
-# one error path. Keep the tests enabled and fix the formats. - HNO3Miracle
+# one error path. Keep the tests enabled and fix the formats.
 Patch2000:      2000-fix-format-strings-for-go-vet.patch
 
 BuildRequires:  go
+BuildRequires:  go-rpm-macros
 BuildRequires:  go(github.com/davecgh/go-spew)
 BuildRequires:  go(github.com/golang/groupcache)
 BuildRequires:  go(github.com/golang/protobuf)
@@ -45,9 +46,11 @@ BuildRequires:  go(google.golang.org/genproto/googleapis/rpc)
 BuildRequires:  go(google.golang.org/grpc)
 BuildRequires:  go(google.golang.org/protobuf)
 BuildRequires:  go(gopkg.in/yaml.v3)
-BuildRequires:  go-rpm-macros
 
 Provides:       go(go.opencensus.io) = %{version}
+Provides:       go(go.opencensus.io/plugin/ochttp) = %{version}
+Provides:       go(go.opencensus.io/trace) = %{version}
+Provides:       go(go.opencensus.io/trace/propagation) = %{version}
 
 Requires:       go(github.com/golang/groupcache)
 Requires:       go(github.com/golang/protobuf)

--- a/SPECS/go-opentelemetry-proto/go-opentelemetry-proto.spec
+++ b/SPECS/go-opentelemetry-proto/go-opentelemetry-proto.spec
@@ -8,31 +8,43 @@
 %define go_import_path  go.opentelemetry.io/proto
 
 Name:           go-opentelemetry-proto
-Version:        1.9.0
+Version:        1.10.0
 Release:        %autorelease
 Summary:        Generated code for OpenTelemetry protobuf data model
 License:        Apache-2.0
 URL:            https://github.com/open-telemetry/opentelemetry-proto-go
-#!RemoteAsset:  sha256:87b9d9dab8f5f4ceae467fe7c277cac4804621d052e39b82c06ff96b54c9961e
+#!RemoteAsset:  sha256:2d39f83c69410c481293b005abfc2c2b259b1281179687099384aa948666d501
 Source0:        https://github.com/open-telemetry/opentelemetry-proto-go/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
 
 BuildRequires:  go
 BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/grpc-ecosystem/grpc-gateway/v2)
+BuildRequires:  go(google.golang.org/genproto/googleapis/rpc)
 BuildRequires:  go(google.golang.org/grpc)
 BuildRequires:  go(google.golang.org/protobuf)
-BuildRequires:  go(google.golang.org/genproto/googleapis/rpc)
-BuildRequires:  go(github.com/grpc-ecosystem/grpc-gateway)
 
 Provides:       go(go.opentelemetry.io/proto) = %{version}
+Provides:       go(go.opentelemetry.io/proto/internal/tools) = %{version}
+Provides:       go(go.opentelemetry.io/proto/otlp) = %{version}
+Provides:       go(go.opentelemetry.io/proto/otlp/collector/profiles/v1development) = %{version}
+Provides:       go(go.opentelemetry.io/proto/otlp/profiles/v1development) = %{version}
+Provides:       go(go.opentelemetry.io/proto/slim/otlp) = %{version}
+Provides:       go(go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development) = %{version}
+Provides:       go(go.opentelemetry.io/proto/slim/otlp/profiles/v1development) = %{version}
+
+Requires:       go(github.com/grpc-ecosystem/grpc-gateway/v2)
+Requires:       go(google.golang.org/genproto/googleapis/rpc)
+Requires:       go(google.golang.org/grpc)
+Requires:       go(google.golang.org/protobuf)
 
 %description
 Generated Go code for the OpenTelemetry protobuf data model.
 
 %files
-%license LICENSE*
 %doc README*
+%license LICENSE*
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog


### PR DESCRIPTION
## Summary

This PR contains 6 Go module package changes for Prometheus v3.13 (DAG level 2). The listed PRs provide the direct Go module dependencies required by this batch.

Requires: #1117 #1121 #1123 #1124

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: ChatGPT:GPT-5.6-sol High

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]: https://openruyi.cn/governance/policy/ai-contribution-policy