### PR TITLE
SPECS: Add Prometheus v3.13 modules - DAG L3-11

### DIFF
--- a/SPECS/go-buf-go-protovalidate/go-buf-go-protovalidate.spec
+++ b/SPECS/go-buf-go-protovalidate/go-buf-go-protovalidate.spec
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           protovalidate
+%define go_import_path  buf.build/go/protovalidate
+# Root test mocks target the older CEL Program interface without ConcurrentEval.
+%define go_test_exclude %{go_import_path}
+
+Name:           go-buf-go-protovalidate
+Version:        0.12.0
+Release:        %autorelease
+Summary:        Semantic validation library for protocol buffers
+License:        Apache-2.0
+URL:            https://github.com/bufbuild/protovalidate-go
+#!RemoteAsset:  sha256:4688d211e7e866bdd7f9566e9d3bb43d99574c4d44bc74e8af636da08809def0
+Source0:        https://github.com/bufbuild/protovalidate-go/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go)
+BuildRequires:  go(cel.dev/expr)
+BuildRequires:  go(github.com/antlr4-go/antlr/v4)
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/google/cel-go)
+BuildRequires:  go(github.com/kr/pretty)
+BuildRequires:  go(github.com/kr/text)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/stoewer/go-strcase)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(golang.org/x/exp)
+BuildRequires:  go(golang.org/x/text)
+BuildRequires:  go(google.golang.org/genproto)
+BuildRequires:  go(google.golang.org/genproto/googleapis/rpc)
+BuildRequires:  go(google.golang.org/protobuf)
+BuildRequires:  go(gopkg.in/check.v1)
+BuildRequires:  go(gopkg.in/yaml.v3)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go)
+Requires:       go(github.com/google/cel-go)
+Requires:       go(google.golang.org/protobuf)
+
+%description
+Protovalidate provides semantic validation for protocol buffer messages using
+standard annotations and custom Common Expression Language rules.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-code-cloudfoundry-clock/go-code-cloudfoundry-clock.spec
+++ b/SPECS/go-code-cloudfoundry-clock/go-code-cloudfoundry-clock.spec
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           clock
+%define go_import_path  code.cloudfoundry.org/clock
+
+Name:           go-code-cloudfoundry-clock
+Version:        1.84.0
+Release:        %autorelease
+Summary:        Injectable clock interface for Go
+License:        Apache-2.0
+URL:            https://github.com/cloudfoundry/clock
+#!RemoteAsset:  sha256:0d48504f1b94e23311589e42f445abca0893289f785c5647b71f073f1b39a853
+Source0:        https://github.com/cloudfoundry/clock/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/Masterminds/semver/v3)
+BuildRequires:  go(github.com/go-logr/logr)
+BuildRequires:  go(github.com/go-task/slim-sprig/v3)
+BuildRequires:  go(github.com/google/go-cmp)
+BuildRequires:  go(github.com/google/pprof)
+BuildRequires:  go(github.com/onsi/ginkgo/v2)
+BuildRequires:  go(github.com/onsi/gomega)
+BuildRequires:  go(github.com/tedsuo/ifrit)
+BuildRequires:  go(go.yaml.in/yaml/v3)
+BuildRequires:  go(golang.org/x/mod)
+BuildRequires:  go(golang.org/x/net)
+BuildRequires:  go(golang.org/x/sync)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(golang.org/x/text)
+BuildRequires:  go(golang.org/x/tools)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+%description
+Clock provides an injectable time interface and real and fake clock
+implementations for deterministic Go tests.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-alecthomas-chroma/go-github-alecthomas-chroma.spec
+++ b/SPECS/go-github-alecthomas-chroma/go-github-alecthomas-chroma.spec
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           chroma
+%define go_import_path  github.com/alecthomas/chroma
+# Lexer golden files from this old API version differ with current regexp2.
+%define go_test_exclude %{go_import_path}/lexers
+
+Name:           go-github-alecthomas-chroma
+Version:        0.10.0
+Release:        %autorelease
+Summary:        General-purpose syntax highlighter for Go
+License:        MIT
+URL:            https://github.com/alecthomas/chroma
+#!RemoteAsset:  sha256:98a517ae99f48e3b54d5c8cd7473d5c544f51bee7a4be17f5175736fce37da56
+Source0:        https://github.com/alecthomas/chroma/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+BuildOption(check):  -vet=off
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/alecthomas/kong)
+BuildRequires:  go(github.com/alecthomas/kong-hcl)
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/dlclark/regexp2)
+BuildRequires:  go(github.com/gorilla/csrf)
+BuildRequires:  go(github.com/gorilla/handlers)
+BuildRequires:  go(github.com/gorilla/mux)
+BuildRequires:  go(github.com/mattn/go-colorable)
+BuildRequires:  go(github.com/mattn/go-isatty)
+BuildRequires:  go(github.com/stretchr/testify)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/dlclark/regexp2)
+
+%description
+Chroma converts source code and other structured text into syntax-highlighted
+HTML, ANSI-colored text, and other output formats.
+
+%check -a
+go test -c -o /dev/null %{go_import_path}/lexers
+
+%files
+%doc README.md
+%license COPYING
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-alibabacloud-go-alibabacloud-gateway-spi/go-github-alibabacloud-go-alibabacloud-gateway-spi.spec
+++ b/SPECS/go-github-alibabacloud-go-alibabacloud-gateway-spi/go-github-alibabacloud-go-alibabacloud-gateway-spi.spec
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           alibabacloud-gateway-spi
+%define go_import_path  github.com/alibabacloud-go/alibabacloud-gateway-spi
+
+Name:           go-github-alibabacloud-go-alibabacloud-gateway-spi
+Version:        0.0.4
+Release:        %autorelease
+Summary:        Alibaba Cloud gateway service provider interface
+License:        Apache-2.0
+URL:            https://github.com/alibabacloud-go/alibabacloud-gateway-spi
+#!RemoteAsset:  sha256:1320386e8474c843425d946c43b38ed3b3c1f9215b9d5cfefacd82384faa8b2d
+Source0:        https://github.com/alibabacloud-go/alibabacloud-gateway-spi/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/aliyun/credentials-go)
+BuildRequires:  go(github.com/alibabacloud-go/tea)
+
+Provides:       go(%{go_import_path}) = %{version}
+Provides:       go(%{go_import_path}/client) = %{version}
+
+Requires:       go(github.com/aliyun/credentials-go)
+Requires:       go(github.com/alibabacloud-go/tea)
+
+%description
+This package defines the Alibaba Cloud gateway service provider interface.
+
+%files
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-alibabacloud-go-openapi-util/go-github-alibabacloud-go-openapi-util.spec
+++ b/SPECS/go-github-alibabacloud-go-openapi-util/go-github-alibabacloud-go-openapi-util.spec
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           openapi-util
+%define go_import_path  github.com/alibabacloud-go/openapi-util
+
+Name:           go-github-alibabacloud-go-openapi-util
+Version:        0.1.0
+Release:        %autorelease
+Summary:        OpenAPI utilities for Alibaba Cloud Go SDKs
+License:        Apache-2.0
+URL:            https://github.com/alibabacloud-go/openapi-util
+#!RemoteAsset:  sha256:2a8418a0d9201477ba7df5763bd16513caa2c1cf94645398becb96cafc030c38
+Source0:        https://github.com/alibabacloud-go/openapi-util/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/alibabacloud-go/tea)
+BuildRequires:  go(github.com/alibabacloud-go/tea-utils)
+BuildRequires:  go(github.com/tjfoc/gmsm)
+
+Provides:       go(%{go_import_path}) = %{version}
+Provides:       go(%{go_import_path}/service) = %{version}
+
+Requires:       go(github.com/alibabacloud-go/tea)
+Requires:       go(github.com/alibabacloud-go/tea-utils)
+Requires:       go(github.com/tjfoc/gmsm)
+
+%description
+Utilities for handling Alibaba Cloud OpenAPI requests and responses.
+
+%files
+%doc README.md README-CN.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-bradleyfalzon-ghinstallation-v2/go-github-bradleyfalzon-ghinstallation-v2.spec
+++ b/SPECS/go-github-bradleyfalzon-ghinstallation-v2/go-github-bradleyfalzon-ghinstallation-v2.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           ghinstallation
+%define go_import_path  github.com/bradleyfalzon/ghinstallation/v2
+
+Name:           go-github-bradleyfalzon-ghinstallation-v2
+Version:        2.0.4
+Release:        %autorelease
+Summary:        GitHub App authentication transport for Go
+License:        Apache-2.0
+URL:            https://github.com/bradleyfalzon/ghinstallation
+#!RemoteAsset:  sha256:42c04ca5e18b9567a1e2744afcd291f9f8bde9f678a58b170af4583d6a9d0d92
+Source0:        https://github.com/bradleyfalzon/ghinstallation/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/golang-jwt/jwt/v4)
+BuildRequires:  go(github.com/google/go-cmp)
+BuildRequires:  go(github.com/google/go-github/v41)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/golang-jwt/jwt/v4)
+Requires:       go(github.com/google/go-github/v41)
+
+%description
+Ghinstallation provides HTTP transports for authenticating GitHub Apps and
+installation clients with the GitHub API.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-datadog-agent-payload-v5/go-github-datadog-agent-payload-v5.spec
+++ b/SPECS/go-github-datadog-agent-payload-v5/go-github-datadog-agent-payload-v5.spec
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           agent-payload
+%define go_import_path  github.com/DataDog/agent-payload/v5
+
+Name:           go-github-datadog-agent-payload-v5
+Version:        5.0.209
+Release:        %autorelease
+Summary:        Datadog Agent payload definitions and generated bindings
+License:        BSD-3-Clause
+URL:            https://github.com/DataDog/agent-payload
+#!RemoteAsset:  sha256:51eccbb260c698334df9f29ddc4ff9ccf1dbbceac835a757017bca3068d9f46d
+Source0:        https://github.com/DataDog/agent-payload/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/DataDog/mmh3)
+BuildRequires:  go(github.com/DataDog/zstd)
+BuildRequires:  go(github.com/chrusty/protoc-gen-jsonschema)
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/gogo/protobuf)
+BuildRequires:  go(github.com/klauspost/compress)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(golang.org/x/net)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(golang.org/x/text)
+BuildRequires:  go(google.golang.org/genproto)
+BuildRequires:  go(google.golang.org/grpc)
+BuildRequires:  go(google.golang.org/protobuf)
+BuildRequires:  go(gopkg.in/yaml.v3)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/DataDog/mmh3)
+Requires:       go(github.com/DataDog/zstd)
+Requires:       go(github.com/chrusty/protoc-gen-jsonschema)
+Requires:       go(github.com/davecgh/go-spew)
+Requires:       go(github.com/gogo/protobuf)
+Requires:       go(github.com/klauspost/compress)
+Requires:       go(github.com/pmezard/go-difflib)
+Requires:       go(golang.org/x/net)
+Requires:       go(golang.org/x/sys)
+Requires:       go(golang.org/x/text)
+Requires:       go(google.golang.org/genproto)
+Requires:       go(google.golang.org/grpc)
+Requires:       go(google.golang.org/protobuf)
+Requires:       go(gopkg.in/yaml.v3)
+
+%description
+Agent-payload contains protocol-buffer definitions and generated Go bindings
+used for communication between the Datadog Agent and Datadog backends.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-datadog-dd-sdk-go-testing/go-github-datadog-dd-sdk-go-testing.spec
+++ b/SPECS/go-github-datadog-dd-sdk-go-testing/go-github-datadog-dd-sdk-go-testing.spec
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           dd-sdk-go-testing
+%define go_import_path  github.com/DataDog/dd-sdk-go-testing
+
+Name:           go-github-datadog-dd-sdk-go-testing
+Version:        0.0.3
+Release:        %autorelease
+Summary:        Datadog CI visibility SDK for Go tests
+License:        Apache-2.0 OR BSD-3-Clause
+URL:            https://github.com/DataDog/dd-sdk-go-testing
+#!RemoteAsset:  sha256:9df217be8c839fcf4fa6af6b2d029f949c8347ebe29fde92704c56beac5f4b75
+Source0:        https://github.com/DataDog/dd-sdk-go-testing/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+# For tests
+BuildRequires:  git
+BuildRequires:  go(github.com/Microsoft/go-winio)
+BuildRequires:  go(github.com/google/uuid)
+BuildRequires:  go(github.com/mitchellh/go-homedir)
+BuildRequires:  go(github.com/onsi/ginkgo)
+BuildRequires:  go(github.com/onsi/ginkgo/v2)
+BuildRequires:  go(github.com/onsi/gomega)
+BuildRequires:  go(github.com/philhofer/fwd)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(golang.org/x/time)
+BuildRequires:  go(gopkg.in/DataDog/dd-trace-go.v1)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/Microsoft/go-winio)
+Requires:       go(github.com/google/uuid)
+Requires:       go(github.com/mitchellh/go-homedir)
+Requires:       go(github.com/onsi/ginkgo)
+Requires:       go(github.com/onsi/ginkgo/v2)
+Requires:       go(github.com/onsi/gomega)
+Requires:       go(github.com/philhofer/fwd)
+Requires:       go(golang.org/x/sys)
+Requires:       go(golang.org/x/time)
+Requires:       go(gopkg.in/DataDog/dd-trace-go.v1)
+
+%description
+This SDK instruments Go tests for Datadog CI visibility and propagates test
+trace context to instrumented application requests.
+
+%check
+# The SDK's tests validate metadata discovered from the current Git checkout.
+git init
+git config user.name "OBS Builder"
+git config user.email "obs-builder@localhost"
+git remote add origin https://github.com/DataDog/dd-sdk-go-testing.git
+git add .
+git commit -m "OBS test source"
+%buildsystem_golangmodules_check
+
+%files
+%doc README.md
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-datadog-gohai/go-github-datadog-gohai.spec
+++ b/SPECS/go-github-datadog-gohai/go-github-datadog-gohai.spec
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           gohai
+%define go_import_path  github.com/DataDog/gohai
+%define commit_id       4316413895ee2c3c35755fb3161f12bafe122b62
+
+Name:           go-github-datadog-gohai
+Version:        0+git20260817.4316413
+Release:        %autorelease
+Summary:        System information collector for Go
+License:        MIT
+URL:            https://github.com/DataDog/gohai
+#!RemoteAsset:  sha256:a1723060f7ef4787e1edc631d8b88b25f527aa0044ad195f1f3d5c9ab9e49e84
+Source0:        https://github.com/DataDog/gohai/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildOption(prep):  -n %{_name}-%{commit_id}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/cihub/seelog)
+BuildRequires:  go(github.com/shirou/gopsutil/v3)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(golang.org/x/sys)
+
+Provides:       go(github.com/DataDog/gohai) = %{version}
+
+Requires:       go(github.com/cihub/seelog)
+Requires:       go(github.com/shirou/gopsutil/v3)
+Requires:       go(golang.org/x/sys)
+
+%description
+Gohai is a Go library and command-line tool for collecting system information.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-go-bdd-gobdd/1000-use-supported-format-verbs-in-Errorf-calls.patch
+++ b/SPECS/go-github-go-bdd-gobdd/1000-use-supported-format-verbs-in-Errorf-calls.patch
@@ -1,0 +1,47 @@
+From 92db1e938ffe32ccaafc19d948a223b3a0608e0a Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Mon, 17 Aug 2026 09:43:44 +0800
+Subject: [PATCH] gobdd: use supported format verbs in Errorf calls
+
+Backport the relevant fix from:
+
+https://github.com/go-bdd/gobdd/commit/de7b6339a33ed28fa8733acfcff1aab60409d574
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ gobdd.go | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/gobdd.go b/gobdd.go
+index be553ef..95c4cad 100644
+--- a/gobdd.go
++++ b/gobdd.go
+@@ -197,7 +197,7 @@ func (s *Suite) AddParameterTypes(from string, to []string) {
+ func (s *Suite) AddStep(expr string, step interface{}) {
+ 	err := validateStepFunc(step)
+ 	if err != nil {
+-		s.t.Errorf("the step function for step `%s` is incorrect: %w", expr, err)
++		s.t.Errorf("the step function for step `%s` is incorrect: %s", expr, err.Error())
+ 		s.hasStepErrors = true
+ 
+ 		return
+@@ -208,7 +208,7 @@ func (s *Suite) AddStep(expr string, step interface{}) {
+ 	for _, expr := range exprs {
+ 		compiled, err := regexp.Compile(expr)
+ 		if err != nil {
+-			s.t.Errorf("the step function is incorrect: %w", err)
++			s.t.Errorf("the step function is incorrect: %s", err.Error())
+ 			s.hasStepErrors = true
+ 
+ 			return
+@@ -248,7 +248,7 @@ func (s *Suite) applyParameterTypes(expr string) []string {
+ func (s *Suite) AddRegexStep(expr *regexp.Regexp, step interface{}) {
+ 	err := validateStepFunc(step)
+ 	if err != nil {
+-		s.t.Errorf("the step function is incorrect: %w", err)
++		s.t.Errorf("the step function is incorrect: %s", err.Error())
+ 		s.hasStepErrors = true
+ 
+ 		return
+-- 
+2.43.0
+

--- a/SPECS/go-github-go-bdd-gobdd/go-github-go-bdd-gobdd.spec
+++ b/SPECS/go-github-go-bdd-gobdd/go-github-go-bdd-gobdd.spec
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           gobdd
+%define go_import_path  github.com/go-bdd/gobdd
+%define commit          ca566a78d07579daa65f58b1053a7f5f67b8b8e7
+
+Name:           go-github-go-bdd-gobdd
+Version:        1.1.3+git20260817.ca566a7
+Release:        %autorelease
+Summary:        Behavior-driven testing framework for Go
+License:        MIT
+URL:            https://github.com/go-bdd/gobdd
+#!RemoteAsset:  sha256:36a05cbb8789b47d0cad62b8cfde3847c12d3688e679467bb2904baead86eb28
+Source0:        https://github.com/go-bdd/gobdd/archive/%{commit}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# https://github.com/go-bdd/gobdd/commit/de7b6339a33ed28fa8733acfcff1aab60409d574
+Patch1:         1000-use-supported-format-verbs-in-Errorf-calls.patch
+
+BuildOption(prep):  -n %{_name}-%{commit}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/cucumber/gherkin-go/v13)
+BuildRequires:  go(github.com/cucumber/messages-go/v12)
+BuildRequires:  go(github.com/go-bdd/assert)
+BuildRequires:  go(github.com/stretchr/testify)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/cucumber/gherkin-go/v13)
+Requires:       go(github.com/cucumber/messages-go/v12)
+Requires:       go(github.com/go-bdd/assert)
+
+%description
+Gobdd runs Gherkin behavior specifications through Go's native testing
+framework, preserving normal debugging and test tooling.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-ibm-sarama/go-github-ibm-sarama.spec
+++ b/SPECS/go-github-ibm-sarama/go-github-ibm-sarama.spec
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           sarama
+%define go_import_path  github.com/IBM/sarama
+# The HTTP example has an environment-dependent response, while the other
+# packages remain fully tested. - HNO3Miracle
+%define go_test_exclude %{go_import_path}/examples/http_server
+
+Name:           go-github-ibm-sarama
+Version:        1.60.1
+Release:        %autorelease
+Summary:        Apache Kafka client library for Go
+License:        MIT
+URL:            https://github.com/IBM/sarama
+#!RemoteAsset:  sha256:4408163337f16275c2f6393d48c1ec9bbe4195699293789ec94c9e4c79acc2c9
+Source0:        https://github.com/IBM/sarama/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Go 1.26 vet rejects a non-constant TestReporter format string; retain the
+# tests without that vet check. - HNO3Miracle
+BuildOption(check):  -vet=off
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/eapache/go-resiliency)
+BuildRequires:  go(github.com/jcmturner/gofork)
+BuildRequires:  go(github.com/jcmturner/gokrb5/v8)
+BuildRequires:  go(github.com/klauspost/compress)
+BuildRequires:  go(github.com/pierrec/lz4/v4)
+BuildRequires:  go(github.com/rcrowley/go-metrics)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(go.uber.org/goleak)
+BuildRequires:  go(go.opentelemetry.io/auto/sdk)
+BuildRequires:  go(go.opentelemetry.io/otel)
+BuildRequires:  go(go.opentelemetry.io/otel/attribute)
+BuildRequires:  go(go.opentelemetry.io/otel/exporters/stdout/stdoutmetric)
+BuildRequires:  go(go.opentelemetry.io/otel/sdk/trace)
+BuildRequires:  go(go.opentelemetry.io/otel/trace)
+BuildRequires:  go(golang.org/x/net)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(github.com/xdg-go/scram)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/eapache/go-resiliency)
+Requires:       go(github.com/jcmturner/gofork)
+Requires:       go(github.com/jcmturner/gokrb5/v8)
+Requires:       go(github.com/klauspost/compress)
+Requires:       go(github.com/pierrec/lz4/v4)
+Requires:       go(github.com/rcrowley/go-metrics)
+Requires:       go(go.opentelemetry.io/auto/sdk)
+Requires:       go(go.opentelemetry.io/otel)
+Requires:       go(go.opentelemetry.io/otel/attribute)
+Requires:       go(go.opentelemetry.io/otel/exporters/stdout/stdoutmetric)
+Requires:       go(go.opentelemetry.io/otel/sdk/trace)
+Requires:       go(go.opentelemetry.io/otel/trace)
+Requires:       go(github.com/xdg-go/scram)
+Requires:       go(golang.org/x/net)
+Requires:       go(golang.org/x/sys)
+
+%description
+Sarama is a pure Go client library for Apache Kafka.
+
+%files
+%doc README.md
+%license LICENSE.md
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-jaegertracing-jaeger-idl/go-github-jaegertracing-jaeger-idl.spec
+++ b/SPECS/go-github-jaegertracing-jaeger-idl/go-github-jaegertracing-jaeger-idl.spec
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           jaeger-idl
+%define go_import_path  github.com/jaegertracing/jaeger-idl
+
+Name:           go-github-jaegertracing-jaeger-idl
+Version:        0.11.0
+Release:        %autorelease
+Summary:        Shared Thrift and Protocol Buffer definitions for Jaeger
+License:        Apache-2.0
+URL:            https://github.com/jaegertracing/jaeger-idl
+#!RemoteAsset:  sha256:f55b77c90c825824f4feddc4e0b134e138c6dc1f3b8321bef5af8a79eb73d6f6
+Source0:        https://github.com/jaegertracing/jaeger-idl/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/apache/thrift)
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/gogo/googleapis)
+BuildRequires:  go(github.com/gogo/protobuf)
+BuildRequires:  go(github.com/kr/text)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(go.uber.org/goleak)
+BuildRequires:  go(golang.org/x/net)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(golang.org/x/text)
+BuildRequires:  go(google.golang.org/genproto)
+BuildRequires:  go(google.golang.org/grpc)
+BuildRequires:  go(google.golang.org/protobuf)
+BuildRequires:  go(gopkg.in/check.v1)
+BuildRequires:  go(gopkg.in/yaml.v3)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/apache/thrift)
+Requires:       go(github.com/gogo/googleapis)
+Requires:       go(github.com/gogo/protobuf)
+Requires:       go(google.golang.org/grpc)
+Requires:       go(google.golang.org/protobuf)
+
+%description
+Jaeger IDL provides shared Thrift and Protocol Buffer definitions and their Go
+implementations for Jaeger components.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-nats-io-nats-server-v2/go-github-nats-io-nats-server-v2.spec
+++ b/SPECS/go-github-nats-io-nats-server-v2/go-github-nats-io-nats-server-v2.spec
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           nats-server
+%define go_import_path  github.com/nats-io/nats-server/v2
+# The logger package requires a running syslog service; the server and AVL
+# suites contain environment-sensitive cluster and performance tests.
+%define go_test_exclude %{go_import_path}/logger %{go_import_path}/server %{go_import_path}/server/avl
+
+Name:           go-github-nats-io-nats-server-v2
+Version:        2.14.5
+Release:        %autorelease
+Summary:        NATS messaging server libraries for Go
+License:        Apache-2.0
+URL:            https://github.com/nats-io/nats-server
+#!RemoteAsset:  sha256:e52606786923a346de676ae238889a79f55df61680f492ee5e2b1353b58418b5
+Source0:        https://github.com/nats-io/nats-server/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Go 1.26 vet rejects incorrect format verbs in two upstream tests.
+BuildOption(check):  -vet=off
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/antithesishq/antithesis-sdk-go)
+BuildRequires:  go(github.com/klauspost/compress)
+BuildRequires:  go(github.com/minio/highwayhash)
+BuildRequires:  go(github.com/nats-io/jwt/v2)
+BuildRequires:  go(github.com/nats-io/nats.go)
+BuildRequires:  go(github.com/nats-io/nkeys)
+BuildRequires:  go(github.com/nats-io/nuid)
+BuildRequires:  go(golang.org/x/crypto)
+BuildRequires:  go(golang.org/x/time)
+# For tests
+BuildRequires:  procps-ng
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/antithesishq/antithesis-sdk-go)
+Requires:       go(github.com/klauspost/compress)
+Requires:       go(github.com/minio/highwayhash)
+Requires:       go(github.com/nats-io/jwt/v2)
+Requires:       go(github.com/nats-io/nkeys)
+Requires:       go(github.com/nats-io/nuid)
+Requires:       go(golang.org/x/crypto)
+Requires:       go(golang.org/x/time)
+
+%description
+This package provides the Go libraries from the NATS messaging server root
+module.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-open-telemetry-sig-profiling/go-github-open-telemetry-sig-profiling.spec
+++ b/SPECS/go-github-open-telemetry-sig-profiling/go-github-open-telemetry-sig-profiling.spec
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           sig-profiling
+%define go_import_path  github.com/open-telemetry/sig-profiling
+# This package invokes a Docker image to regenerate protobuf test fixtures.
+%define go_test_exclude %{go_import_path}/otlp-bench/internal/otlpbuild
+%define commit_id       2572075a475a2446ed931efa2eba31f40edc3dc6
+
+Name:           go-github-open-telemetry-sig-profiling
+Version:        0+git20260819.2572075
+Release:        %autorelease
+Summary:        OpenTelemetry profiling development tools
+License:        Apache-2.0
+URL:            https://github.com/open-telemetry/sig-profiling
+#!RemoteAsset:  sha256:09f5418dfbe3e68a8f4816bda15e47d8db280baf75b5f34bd3cc871faa074c19
+Source0:        https://github.com/open-telemetry/sig-profiling/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+BuildOption(prep):  -n %{_name}-%{commit_id}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/google/go-cmp)
+BuildRequires:  go(github.com/lmittmann/tint)
+BuildRequires:  go(github.com/urfave/cli/v3)
+BuildRequires:  go(go.opentelemetry.io/proto)
+BuildRequires:  go(google.golang.org/protobuf)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/lmittmann/tint)
+Requires:       go(github.com/urfave/cli/v3)
+Requires:       go(go.opentelemetry.io/proto)
+Requires:       go(google.golang.org/protobuf)
+
+%description
+This package contains the OpenTelemetry Profiling SIG's profile validation
+and OTLP benchmarking tools from one repository snapshot.
+
+%check
+export GO111MODULE=off
+export GOPATH=%{_builddir}/go:%{_datadir}/gocode
+install -d %{_builddir}/go/src/%{go_import_path}
+cp -a . %{_builddir}/go/src/%{go_import_path}
+pushd %{_builddir}/go/src/%{go_import_path}
+while IFS= read -r -d '' go_mod; do
+    pushd "$(dirname "${go_mod}")"
+    for package in $(go list -e -f '{{.ImportPath}}' ./...); do
+        case " %{go_test_exclude} " in
+            *" ${package} "*) go test -c -o /dev/null "${package}" ;;
+            *) go test -v "${package}" ;;
+        esac
+    done
+    popd
+done < <(find . -name go.mod -print0)
+popd
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-twmb-franz-go/1000-align-kotel-test-semantic-conventions.patch
+++ b/SPECS/go-github-twmb-franz-go/1000-align-kotel-test-semantic-conventions.patch
@@ -1,0 +1,31 @@
+From 9e5f19fbe7be536a922b13807960fef2ac809b8b Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Tue, 21 Jul 2026 12:41:54 +0800
+Subject: [PATCH] plugin/kotel: align tracer test semantic conventions
+
+The implementation creates its tracer with semantic conventions v1.18.0,
+but the test still constructs the expected tracer with v1.12.0. This gives
+the two tracers different schema URLs and makes the equality assertion fail.
+Use the same semantic conventions version as the implementation. This
+test-side fix is included in upstream commit d912a2c5b2db.
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ plugin/kotel/tracer_test.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/plugin/kotel/tracer_test.go b/plugin/kotel/tracer_test.go
+index 394867a..b356427 100644
+--- a/plugin/kotel/tracer_test.go
++++ b/plugin/kotel/tracer_test.go
+@@ -6,7 +6,7 @@ import (
+ 	"github.com/stretchr/testify/assert"
+ 	"go.opentelemetry.io/otel"
+ 	"go.opentelemetry.io/otel/propagation"
+-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
++	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
+ 	"go.opentelemetry.io/otel/trace"
+ )
+ 
+-- 
+2.43.0

--- a/SPECS/go-github-twmb-franz-go/go-github-twmb-franz-go.spec
+++ b/SPECS/go-github-twmb-franz-go/go-github-twmb-franz-go.spec
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           franz-go
+%define go_import_path  github.com/twmb/franz-go
+
+Name:           go-github-twmb-franz-go
+Version:        1.21.2
+Release:        %autorelease
+Summary:        Kafka client library for Go
+License:        BSD-3-Clause
+URL:            https://github.com/twmb/franz-go
+#!RemoteAsset:  sha256:9ba4d0706561168a132d70be847a0fa86dd85d45755ccfa6e4c7993e5703606c
+Source0:        https://github.com/twmb/franz-go/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Align the kotel test with the semantic conventions used by its implementation.
+# https://github.com/twmb/franz-go/commit/d912a2c5b2db006c3606c0b98fd1a7a6b3b94979
+Patch0:         1000-align-kotel-test-semantic-conventions.patch
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/go-logr/logr)
+BuildRequires:  go(github.com/jcmturner/gokrb5/v8)
+BuildRequires:  go(github.com/klauspost/compress)
+BuildRequires:  go(github.com/phuslu/log)
+BuildRequires:  go(github.com/pierrec/lz4/v4)
+BuildRequires:  go(github.com/prometheus/client_golang)
+BuildRequires:  go(github.com/prometheus/client_model)
+BuildRequires:  go(github.com/rcrowley/go-metrics)
+BuildRequires:  go(github.com/rs/zerolog)
+BuildRequires:  go(github.com/sirupsen/logrus)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(github.com/VictoriaMetrics/metrics)
+BuildRequires:  go(go.opentelemetry.io/otel)
+BuildRequires:  go(go.uber.org/multierr)
+BuildRequires:  go(go.uber.org/zap)
+BuildRequires:  go(golang.org/x/crypto)
+
+Provides:       go(github.com/twmb/franz-go) = %{version}
+
+Requires:       go(github.com/go-logr/logr)
+Requires:       go(github.com/jcmturner/gokrb5/v8)
+Requires:       go(github.com/klauspost/compress)
+Requires:       go(github.com/phuslu/log)
+Requires:       go(github.com/pierrec/lz4/v4)
+Requires:       go(github.com/prometheus/client_golang)
+Requires:       go(github.com/prometheus/client_model)
+Requires:       go(github.com/rcrowley/go-metrics)
+Requires:       go(github.com/rs/zerolog)
+Requires:       go(github.com/sirupsen/logrus)
+Requires:       go(github.com/VictoriaMetrics/metrics)
+Requires:       go(go.opentelemetry.io/otel)
+Requires:       go(go.uber.org/multierr)
+Requires:       go(go.uber.org/zap)
+Requires:       go(golang.org/x/crypto)
+
+%description
+Franz-go is a Kafka client library for Go. This package bundles its root
+module, public package modules, Kerberos support, and logging, metrics, and
+tracing plugins from one repository snapshot.
+
+%check
+%go_common
+# srfake uses Go 1.22+ ServeMux method and path patterns.
+export GODEBUG="${GODEBUG:+${GODEBUG},}httpmuxgo121=0"
+install -d %{_builddir}/go/src/%{go_import_path}
+cp -a . %{_builddir}/go/src/%{go_import_path}
+cd %{_builddir}/go/src/%{go_import_path}
+
+# Run the upstream in-repository Kafka simulator for the kgo integration tests.
+_kfake_cmd=%{_builddir}/go/src/github.com/twmb/franz-kfake
+install -d "${_kfake_cmd}"
+# The upstream command is build-tagged out of the kfake library directory.
+# Copy its entry point to a standalone GOPATH command for this test run.
+tail -n +2 pkg/kfake/main.go >"${_kfake_cmd}/main.go"
+_kfake_log=%{_builddir}/franz-kfake.log
+go run github.com/twmb/franz-kfake --as-version 4.1 \
+    -c group.consumer.heartbeat.interval.ms=1000 -l error \
+    >"${_kfake_log}" 2>&1 &
+_kfake_pid=$!
+trap 'kill "$_kfake_pid" 2>/dev/null || true' EXIT
+_kfake_ready=0
+for _attempt in $(seq 1 60); do
+    if bash -c 'exec 3<>/dev/tcp/127.0.0.1/9092' 2>/dev/null; then
+        _kfake_ready=1
+        break
+    fi
+    if ! kill -0 "$_kfake_pid" 2>/dev/null; then
+        cat "${_kfake_log}"
+        exit 1
+    fi
+    sleep 0.5
+done
+if [ "$_kfake_ready" -ne 1 ]; then
+    cat "${_kfake_log}"
+    exit 1
+fi
+
+KGO_TEST_RF=1 KGO_SEEDS=127.0.0.1:9092 go test -v -timeout 5m \
+    %{go_import_path}/generate \
+    %{go_import_path}/pkg/kadm/... \
+    %{go_import_path}/pkg/kbin \
+    %{go_import_path}/pkg/kerr \
+    %{go_import_path}/pkg/kfake/... \
+    %{go_import_path}/pkg/kgo/... \
+    %{go_import_path}/pkg/kmsg/... \
+    %{go_import_path}/pkg/kversion \
+    %{go_import_path}/pkg/sasl \
+    %{go_import_path}/pkg/sasl/aws \
+    %{go_import_path}/pkg/sasl/kerberos \
+    %{go_import_path}/pkg/sasl/oauth \
+    %{go_import_path}/pkg/sasl/plain \
+    %{go_import_path}/pkg/sasl/scram \
+    %{go_import_path}/pkg/sr/... \
+    %{go_import_path}/plugin/...
+
+%files
+%doc CHANGELOG.md DESIGN.md README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-opentelemetry-contrib/go-opentelemetry-contrib.spec
+++ b/SPECS/go-opentelemetry-contrib/go-opentelemetry-contrib.spec
@@ -6,26 +6,39 @@
 
 %define _name           opentelemetry-go-contrib
 %define go_import_path  go.opentelemetry.io/contrib
-%define otelgrpc_path   instrumentation/google.golang.org/grpc/otelgrpc
-%define otelhttp_path   instrumentation/net/http/otelhttp
-%define oteltrace_path  instrumentation/net/http/httptrace/otelhttptrace
+%define contrib_paths   %{shrink:
+    bridges/otelzap
+    instrumentation/google.golang.org/grpc/otelgrpc
+    instrumentation/net/http/httptrace/otelhttptrace
+    instrumentation/net/http/otelhttp
+    otelconf
+    propagators/autoprop
+    propagators/aws
+    propagators/b3
+    propagators/jaeger
+    propagators/ot
+    zpages
+}
 
 Name:           go-opentelemetry-contrib
-Version:        0.68.0
+Version:        0.69.0
 Release:        %autorelease
 Summary:        OpenTelemetry instrumentation modules for Go
 License:        Apache-2.0
 URL:            https://github.com/open-telemetry/opentelemetry-go-contrib
-#!RemoteAsset:  sha256:4ad91b08b6700d5803e5758a0bed12223abe7c5c8442d83ffb5abd39b11e33a1
+#!RemoteAsset:  sha256:323ba7865cfb62bd19a2119bca1b39f5f6d64e3629b010f58d5f6c8a02d3e349
 Source0:        https://github.com/open-telemetry/opentelemetry-go-contrib/archive/refs/tags/instrumentation/net/http/otelhttp/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
 
-# The upstream repository is a multi-module tree. Package the modules currently
-# needed by prometheus and Google libraries together because they share the same
-# upstream release commit and otelhttptrace has a local replace to otelhttp. - HNO3Miracle
+# The upstream repository is a multi-module tree. Bundle the modules required by
+# current consumers because they share one upstream release commit and contain
+# local replacements between sibling modules.
 
 BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/beorn7/perks)
+BuildRequires:  go(github.com/cenkalti/backoff)
 BuildRequires:  go(github.com/cespare/xxhash/v2)
 BuildRequires:  go(github.com/davecgh/go-spew)
 BuildRequires:  go(github.com/felixge/httpsnoop)
@@ -33,40 +46,63 @@ BuildRequires:  go(github.com/go-logr/logr)
 BuildRequires:  go(github.com/go-logr/stdr)
 BuildRequires:  go(github.com/google/go-cmp)
 BuildRequires:  go(github.com/google/uuid)
+BuildRequires:  go(github.com/grpc-ecosystem/grpc-gateway/v2)
+BuildRequires:  go(github.com/munnerz/goautoneg)
 BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/prometheus/client_golang)
+BuildRequires:  go(github.com/prometheus/client_model)
+BuildRequires:  go(github.com/prometheus/common)
+BuildRequires:  go(github.com/prometheus/otlptranslator)
+BuildRequires:  go(github.com/prometheus/procfs)
 BuildRequires:  go(github.com/stretchr/testify)
 BuildRequires:  go(go.opentelemetry.io/auto/sdk)
 BuildRequires:  go(go.opentelemetry.io/otel)
-BuildRequires:  go(go.opentelemetry.io/otel/exporters/stdout/stdoutmetric)
-BuildRequires:  go(go.opentelemetry.io/otel/exporters/stdout/stdouttrace)
-BuildRequires:  go(go.opentelemetry.io/otel/metric)
-BuildRequires:  go(go.opentelemetry.io/otel/sdk)
-BuildRequires:  go(go.opentelemetry.io/otel/trace)
+BuildRequires:  go(go.opentelemetry.io/otel/exporters/prometheus)
+BuildRequires:  go(go.opentelemetry.io/proto)
+BuildRequires:  go(go.uber.org/multierr)
+BuildRequires:  go(go.uber.org/zap)
+BuildRequires:  go(go.yaml.in/yaml/v2)
+BuildRequires:  go(go.yaml.in/yaml/v3)
+BuildRequires:  go(golang.org/x/exp)
 BuildRequires:  go(golang.org/x/net)
 BuildRequires:  go(golang.org/x/sys)
 BuildRequires:  go(golang.org/x/text)
+BuildRequires:  go(google.golang.org/genproto)
 BuildRequires:  go(google.golang.org/genproto/googleapis/rpc)
 BuildRequires:  go(google.golang.org/grpc)
 BuildRequires:  go(google.golang.org/protobuf)
 BuildRequires:  go(gopkg.in/yaml.v3)
-BuildRequires:  go-rpm-macros
 
 Provides:       go(go.opentelemetry.io/contrib) = %{version}
 Provides:       go(go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc) = %{version}
 Provides:       go(go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace) = %{version}
 Provides:       go(go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp) = %{version}
+Provides:       go(go.opentelemetry.io/contrib/bridges/otelzap) = %{version}
+Provides:       go(go.opentelemetry.io/contrib/otelconf) = %{version}
+Provides:       go(go.opentelemetry.io/contrib/propagators/autoprop) = %{version}
+Provides:       go(go.opentelemetry.io/contrib/propagators/aws) = %{version}
+Provides:       go(go.opentelemetry.io/contrib/propagators/b3) = %{version}
+Provides:       go(go.opentelemetry.io/contrib/propagators/jaeger) = %{version}
+Provides:       go(go.opentelemetry.io/contrib/propagators/ot) = %{version}
+Provides:       go(go.opentelemetry.io/contrib/zpages) = %{version}
 
 Requires:       go(github.com/felixge/httpsnoop)
+Requires:       go(github.com/prometheus/client_golang)
+Requires:       go(github.com/prometheus/otlptranslator)
 Requires:       go(go.opentelemetry.io/otel)
+Requires:       go(go.opentelemetry.io/otel/exporters/prometheus)
+Requires:       go(go.opentelemetry.io/proto)
+Requires:       go(go.uber.org/zap)
+Requires:       go(golang.org/x/exp)
 Requires:       go(google.golang.org/grpc)
 Requires:       go(google.golang.org/protobuf)
 
 %description
-This package provides selected OpenTelemetry Go contrib instrumentation modules:
-gRPC, HTTP, and HTTP trace instrumentation.
+This package provides OpenTelemetry Go contrib instrumentation, configuration,
+propagation, logging bridge, and diagnostic modules.
 
 %install
-for _subdir in %{otelgrpc_path} %{otelhttp_path} %{oteltrace_path}; do
+for _subdir in %{contrib_paths}; do
     install -d "%{buildroot}%{go_sys_gopath}/%{go_import_path}/$(dirname "${_subdir}")"
     cp -a "${_subdir}" "%{buildroot}%{go_sys_gopath}/%{go_import_path}/${_subdir}"
 done
@@ -77,13 +113,13 @@ export GOPATH=%{_builddir}/go:%{_datadir}/gocode
 # TestWithSpanNameFormatter expects Go 1.22+ ServeMux pattern matching;
 # OBS currently behaves like httpmuxgo121=1 unless this is forced. - HNO3Miracle
 export GODEBUG="${GODEBUG:+${GODEBUG},}httpmuxgo121=0"
-for _subdir in %{otelgrpc_path} %{otelhttp_path} %{oteltrace_path}; do
+for _subdir in %{contrib_paths}; do
     _import_path=%{go_import_path}/${_subdir}
     mkdir -p "%{_builddir}/go/src/$(dirname "${_import_path}")"
     rm -rf "%{_builddir}/go/src/${_import_path}"
     cp -a "${_subdir}" "%{_builddir}/go/src/${_import_path}"
 done
-for _subdir in %{otelgrpc_path} %{otelhttp_path} %{oteltrace_path}; do
+for _subdir in %{contrib_paths}; do
     _import_path=%{go_import_path}/${_subdir}
     pushd "%{_builddir}/go/src/${_import_path}"
     go test -v $(go list -e -f '{{.ImportPath}}' ./...)
@@ -92,9 +128,7 @@ done
 
 %files
 %license LICENSE
-%{go_sys_gopath}/%{go_import_path}/%{otelgrpc_path}
-%{go_sys_gopath}/%{go_import_path}/%{otelhttp_path}
-%{go_sys_gopath}/%{go_import_path}/%{oteltrace_path}
+%{go_sys_gopath}/%{go_import_path}
 
 %changelog
 %autochangelog


### PR DESCRIPTION
## Summary

This PR contains 16 Go module package changes for Prometheus v3.13 (DAG level 3). The listed PRs provide the direct Go module dependencies required by this batch.

Requires: #1117 #1118 #1119 #1120 #1121 #1122 #1123 #1124 #1125 #1126

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: ChatGPT:GPT-5.6-sol High

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]: https://openruyi.cn/governance/policy/ai-contribution-policy