### PR TITLE
SPECS: Add Prometheus v3.13 modules - DAG L5-13

### DIFF
--- a/SPECS/go-etcd-io-etcd/go-etcd-io-etcd.spec
+++ b/SPECS/go-etcd-io-etcd/go-etcd-io-etcd.spec
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           etcd
+%define go_import_path  go.etcd.io/etcd
+
+Name:           go-etcd-io-etcd
+Version:        3.7.1
+Release:        %autorelease
+Summary:        Go API and client modules for etcd
+License:        Apache-2.0
+URL:            https://github.com/etcd-io/etcd
+#!RemoteAsset:  sha256:95352a96ffb1d92df77b5bce2bb239046fa94cd99dc839ff7eecfdc983416637
+Source0:        https://github.com/etcd-io/etcd/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/beorn7/perks)
+BuildRequires:  go(github.com/cespare/xxhash/v2)
+BuildRequires:  go(github.com/coreos/go-semver)
+BuildRequires:  go(github.com/coreos/go-systemd/v22)
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/dustin/go-humanize)
+BuildRequires:  go(github.com/golang/protobuf)
+BuildRequires:  go(github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus)
+BuildRequires:  go(github.com/grpc-ecosystem/go-grpc-middleware/v2)
+BuildRequires:  go(github.com/grpc-ecosystem/grpc-gateway/v2)
+BuildRequires:  go(github.com/kr/pretty)
+BuildRequires:  go(github.com/kr/text)
+BuildRequires:  go(github.com/munnerz/goautoneg)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/prometheus/client_golang)
+BuildRequires:  go(github.com/prometheus/client_model)
+BuildRequires:  go(github.com/prometheus/common)
+BuildRequires:  go(github.com/prometheus/procfs)
+BuildRequires:  go(github.com/rogpeppe/go-internal)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(go.uber.org/multierr)
+BuildRequires:  go(go.uber.org/zap)
+BuildRequires:  go(go.yaml.in/yaml/v2)
+BuildRequires:  go(golang.org/x/net)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(golang.org/x/text)
+BuildRequires:  go(google.golang.org/genproto)
+BuildRequires:  go(google.golang.org/genproto/googleapis/rpc)
+BuildRequires:  go(google.golang.org/grpc)
+BuildRequires:  go(google.golang.org/protobuf)
+BuildRequires:  go(gopkg.in/check.v1)
+BuildRequires:  go(gopkg.in/yaml.v3)
+BuildRequires:  go(sigs.k8s.io/yaml)
+
+Provides:       go(%{go_import_path}/api/v3) = %{version}
+Provides:       go(%{go_import_path}/client/pkg/v3) = %{version}
+Provides:       go(%{go_import_path}/client/v3) = %{version}
+Provides:       go(%{go_import_path}/pkg/v3) = %{version}
+
+Requires:       go(github.com/coreos/go-semver)
+Requires:       go(github.com/coreos/go-systemd/v22)
+Requires:       go(github.com/dustin/go-humanize)
+Requires:       go(github.com/golang/protobuf)
+Requires:       go(github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus)
+Requires:       go(github.com/grpc-ecosystem/go-grpc-middleware/v2)
+Requires:       go(github.com/grpc-ecosystem/grpc-gateway/v2)
+Requires:       go(github.com/prometheus/client_golang)
+Requires:       go(github.com/prometheus/client_model)
+Requires:       go(github.com/prometheus/common)
+Requires:       go(github.com/prometheus/procfs)
+Requires:       go(go.uber.org/multierr)
+Requires:       go(go.uber.org/zap)
+Requires:       go(go.yaml.in/yaml/v2)
+Requires:       go(golang.org/x/net)
+Requires:       go(golang.org/x/sys)
+Requires:       go(golang.org/x/text)
+Requires:       go(google.golang.org/genproto)
+Requires:       go(google.golang.org/genproto/googleapis/rpc)
+Requires:       go(google.golang.org/grpc)
+Requires:       go(google.golang.org/protobuf)
+Requires:       go(sigs.k8s.io/yaml)
+
+%description
+This package bundles the etcd API, shared client utilities, and version 3 Go
+client modules from the etcd repository.
+
+%install
+install -d "%{buildroot}%{go_sys_gopath}/%{go_import_path}/api/v3"
+install -d "%{buildroot}%{go_sys_gopath}/%{go_import_path}/client/pkg/v3"
+install -d "%{buildroot}%{go_sys_gopath}/%{go_import_path}/client/v3"
+cp -aL api/. "%{buildroot}%{go_sys_gopath}/%{go_import_path}/api/v3/"
+cp -aL client/pkg/. "%{buildroot}%{go_sys_gopath}/%{go_import_path}/client/pkg/v3/"
+cp -aL client/v3/. "%{buildroot}%{go_sys_gopath}/%{go_import_path}/client/v3/"
+
+%check
+export GO111MODULE=off
+export GOPATH=%{_builddir}/go:%{_datadir}/gocode
+install -d "%{_builddir}/go/src/%{go_import_path}/api/v3"
+install -d "%{_builddir}/go/src/%{go_import_path}/client/pkg/v3"
+install -d "%{_builddir}/go/src/%{go_import_path}/client/v3"
+install -d "%{_builddir}/go/src/%{go_import_path}/tests"
+cp -aL api/. "%{_builddir}/go/src/%{go_import_path}/api/v3/"
+cp -aL client/pkg/. "%{_builddir}/go/src/%{go_import_path}/client/pkg/v3/"
+cp -aL client/v3/. "%{_builddir}/go/src/%{go_import_path}/client/v3/"
+cp -aL tests/fixtures "%{_builddir}/go/src/%{go_import_path}/tests/"
+for _module in api/v3 client/pkg/v3 client/v3; do
+    pushd "%{_builddir}/go/src/%{go_import_path}/${_module}"
+    go test -v $(go list -e -f '{{.ImportPath}}' ./...)
+    popd
+done
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-alibabacloud-go-sts-20150401-v2/go-github-alibabacloud-go-sts-20150401-v2.spec
+++ b/SPECS/go-github-alibabacloud-go-sts-20150401-v2/go-github-alibabacloud-go-sts-20150401-v2.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           sts-20150401
+%define go_import_path  github.com/alibabacloud-go/sts-20150401/v2
+
+Name:           go-github-alibabacloud-go-sts-20150401-v2
+Version:        2.0.1
+Release:        %autorelease
+Summary:        Alibaba Cloud Security Token Service SDK
+License:        Apache-2.0
+URL:            https://github.com/alibabacloud-go/sts-20150401
+#!RemoteAsset:  sha256:c2ecf286b5c57cc7eb405f4541c53573cf8d87984fbec8f2b20c0640059eb309
+Source0:        https://github.com/alibabacloud-go/sts-20150401/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/alibabacloud-go/darabonba-openapi/v2)
+BuildRequires:  go(github.com/alibabacloud-go/endpoint-util)
+BuildRequires:  go(github.com/alibabacloud-go/openapi-util)
+BuildRequires:  go(github.com/alibabacloud-go/tea)
+BuildRequires:  go(github.com/alibabacloud-go/tea-utils/v2)
+
+Provides:       go(%{go_import_path}) = %{version}
+Provides:       go(%{go_import_path}/client) = %{version}
+
+Requires:       go(github.com/alibabacloud-go/darabonba-openapi/v2)
+Requires:       go(github.com/alibabacloud-go/endpoint-util)
+Requires:       go(github.com/alibabacloud-go/openapi-util)
+Requires:       go(github.com/alibabacloud-go/tea)
+Requires:       go(github.com/alibabacloud-go/tea-utils/v2)
+
+%description
+Go SDK for Alibaba Cloud Security Token Service.
+
+%files
+%doc README.md README-CN.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-clickhouse-ch-go/go-github-clickhouse-ch-go.spec
+++ b/SPECS/go-github-clickhouse-ch-go/go-github-clickhouse-ch-go.spec
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           ch-go
+%define go_import_path  github.com/ClickHouse/ch-go
+
+Name:           go-github-clickhouse-ch-go
+Version:        0.74.0
+Release:        %autorelease
+Summary:        Low-level ClickHouse client for Go
+License:        Apache-2.0
+URL:            https://github.com/ClickHouse/ch-go
+#!RemoteAsset:  sha256:ad9499a11634f1096d4833105d616da7df9c0b8b70dab10058aedff232d77b9f
+Source0:        https://github.com/ClickHouse/ch-go/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/cenkalti/backoff/v4)
+BuildRequires:  go(github.com/cespare/xxhash/v2)
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/dmarkham/enumer)
+BuildRequires:  go(github.com/dustin/go-humanize)
+BuildRequires:  go(github.com/go-faster/city)
+BuildRequires:  go(github.com/go-faster/errors)
+BuildRequires:  go(github.com/go-logr/logr)
+BuildRequires:  go(github.com/go-logr/stdr)
+BuildRequires:  go(github.com/google/go-github/v43)
+BuildRequires:  go(github.com/google/uuid)
+BuildRequires:  go(github.com/hashicorp/go-version)
+BuildRequires:  go(github.com/jackc/puddle/v2)
+BuildRequires:  go(github.com/klauspost/compress)
+BuildRequires:  go(github.com/pascaldekloe/name)
+BuildRequires:  go(github.com/pierrec/lz4/v4)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/segmentio/asm)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(go.opentelemetry.io/auto/sdk)
+BuildRequires:  go(go.opentelemetry.io/otel)
+BuildRequires:  go(go.uber.org/multierr)
+BuildRequires:  go(go.uber.org/zap)
+BuildRequires:  go(golang.org/x/crypto)
+BuildRequires:  go(golang.org/x/mod)
+BuildRequires:  go(golang.org/x/oauth2)
+BuildRequires:  go(golang.org/x/sync)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(golang.org/x/tools)
+BuildRequires:  go(gopkg.in/yaml.v3)
+BuildRequires:  tzdata
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/dustin/go-humanize)
+Requires:       go(github.com/go-faster/city)
+Requires:       go(github.com/go-faster/errors)
+Requires:       go(github.com/google/go-github/v43)
+Requires:       go(github.com/google/uuid)
+Requires:       go(github.com/hashicorp/go-version)
+Requires:       go(github.com/jackc/puddle/v2)
+Requires:       go(github.com/klauspost/compress)
+Requires:       go(github.com/pierrec/lz4/v4)
+Requires:       go(github.com/segmentio/asm)
+Requires:       go(github.com/stretchr/testify)
+Requires:       go(go.opentelemetry.io/otel)
+Requires:       go(go.uber.org/multierr)
+Requires:       go(go.uber.org/zap)
+Requires:       go(golang.org/x/crypto)
+Requires:       go(golang.org/x/oauth2)
+Requires:       go(golang.org/x/sync)
+
+%description
+Ch-go implements the ClickHouse native protocol, typed column encodings,
+compression, connection pooling, tracing, and low-level query APIs.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-datadog-datadog-agent/go-github-datadog-datadog-agent.spec
+++ b/SPECS/go-github-datadog-datadog-agent/go-github-datadog-datadog-agent.spec
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           datadog-agent
+%define go_import_path  github.com/DataDog/datadog-agent
+%define commit          7c02565fb890b34e37ee3aadb9efa6d87fa8aa69
+# The complete agent repository contains platform integrations not used as Go libraries.
+%define go_test_include %{go_import_path}/pkg/util/option
+
+Name:           go-github-datadog-datadog-agent
+Version:        7.78.4+git20260817.7c02565
+Release:        %autorelease
+Summary:        Datadog Agent Go source modules
+License:        Apache-2.0
+URL:            https://github.com/DataDog/datadog-agent
+#!RemoteAsset:  sha256:b2a6db773ac91a9d7a9ff0f3d1034bf44a1c20065a0615295e3706a3488f6556
+Source0:        https://github.com/DataDog/datadog-agent/archive/%{commit}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+BuildOption(prep):  -n %{_name}-%{commit}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/DataDog/agent-payload/v5)
+BuildRequires:  go(github.com/DataDog/datadog-api-client-go/v2)
+BuildRequires:  go(github.com/DataDog/go-sqllexer)
+BuildRequires:  go(github.com/DataDog/go-tuf)
+BuildRequires:  go(github.com/DataDog/sketches-go)
+BuildRequires:  go(github.com/DataDog/viper)
+BuildRequires:  go(github.com/benbjohnson/clock)
+BuildRequires:  go(github.com/gofrs/flock)
+BuildRequires:  go(github.com/mdlayher/vsock)
+BuildRequires:  go(github.com/mohae/deepcopy)
+BuildRequires:  go(github.com/outcaste-io/ristretto)
+BuildRequires:  go(github.com/patrickmn/go-cache)
+BuildRequires:  go(github.com/planetscale/vtprotobuf)
+BuildRequires:  go(github.com/richardartoul/molecule)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(github.com/tinylib/msgp)
+BuildRequires:  go(go.uber.org/atomic)
+BuildRequires:  go(go.uber.org/fx)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/DataDog/agent-payload/v5)
+Requires:       go(github.com/DataDog/datadog-api-client-go/v2)
+Requires:       go(github.com/DataDog/go-sqllexer)
+Requires:       go(github.com/DataDog/go-tuf)
+Requires:       go(github.com/DataDog/sketches-go)
+Requires:       go(github.com/DataDog/viper)
+Requires:       go(github.com/benbjohnson/clock)
+Requires:       go(github.com/gofrs/flock)
+Requires:       go(github.com/mdlayher/vsock)
+Requires:       go(github.com/mohae/deepcopy)
+Requires:       go(github.com/outcaste-io/ristretto)
+Requires:       go(github.com/patrickmn/go-cache)
+Requires:       go(github.com/planetscale/vtprotobuf)
+Requires:       go(github.com/richardartoul/molecule)
+Requires:       go(github.com/tinylib/msgp)
+Requires:       go(go.uber.org/atomic)
+Requires:       go(go.uber.org/fx)
+
+%description
+This source package installs the complete Datadog Agent repository, including
+its component, telemetry mapping, protocol, trace, and utility Go modules.
+
+%install -a
+# Architecture-specific binaries are test fixtures, not Go source artifacts.
+find "%{buildroot}%{go_sys_gopath}/%{go_import_path}" -type f \
+    \( -name '*.so' -o -name '*.dll' -o -name '*.o' -o -name '*.exe' \) \
+    -delete
+rm -f "%{buildroot}%{go_sys_gopath}/%{go_import_path}"/pkg/network/usm/testdata/site-packages/ddtrace/libssl.so.*
+find "%{buildroot}%{go_sys_gopath}/%{go_import_path}" -type f -exec chmod a-x {} +
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-elastic-go-docappender-v2/go-github-elastic-go-docappender-v2.spec
+++ b/SPECS/go-github-elastic-go-docappender-v2/go-github-elastic-go-docappender-v2.spec
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           go-docappender
+%define go_import_path  github.com/elastic/go-docappender/v2
+
+Name:           go-github-elastic-go-docappender-v2
+Version:        2.14.1
+Release:        %autorelease
+Summary:        Append-only bulk document indexing library for Elasticsearch
+License:        Apache-2.0
+URL:            https://github.com/elastic/go-docappender
+#!RemoteAsset:  sha256:db081accfe61086bf29e620b4b7289bcb5cc33e64c4f72c5d498a4ab889684e9
+Source0:        https://github.com/elastic/go-docappender/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/cespare/xxhash/v2)
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/elastic/elastic-transport-go/v8)
+BuildRequires:  go(github.com/elastic/go-elasticsearch/v7)
+BuildRequires:  go(github.com/elastic/go-elasticsearch/v8)
+BuildRequires:  go(github.com/go-logr/logr)
+BuildRequires:  go(github.com/go-logr/stdr)
+BuildRequires:  go(github.com/google/uuid)
+BuildRequires:  go(github.com/json-iterator/go)
+BuildRequires:  go(github.com/klauspost/compress)
+BuildRequires:  go(github.com/modern-go/concurrent)
+BuildRequires:  go(github.com/modern-go/reflect2)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(go.elastic.co/fastjson)
+BuildRequires:  go(go.opentelemetry.io/auto/sdk)
+BuildRequires:  go(go.opentelemetry.io/otel)
+BuildRequires:  go(go.uber.org/multierr)
+BuildRequires:  go(go.uber.org/zap)
+BuildRequires:  go(golang.org/x/sync)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(gopkg.in/yaml.v3)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/elastic/elastic-transport-go/v8)
+Requires:       go(github.com/json-iterator/go)
+Requires:       go(github.com/klauspost/compress)
+Requires:       go(github.com/stretchr/testify)
+Requires:       go(go.elastic.co/fastjson)
+Requires:       go(go.opentelemetry.io/otel)
+Requires:       go(go.uber.org/zap)
+Requires:       go(golang.org/x/sync)
+
+%description
+Go-docappender provides an asynchronous Go API for append-only bulk document
+indexing into Elasticsearch.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-googlecloudplatform-opentelemetry-operations-go-exporter-collector/go-github-googlecloudplatform-opentelemetry-operations-go-exporter-collector.spec
+++ b/SPECS/go-github-googlecloudplatform-opentelemetry-operations-go-exporter-collector/go-github-googlecloudplatform-opentelemetry-operations-go-exporter-collector.spec
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           opentelemetry-operations-go
+%define go_import_path  github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector
+
+Name:           go-github-googlecloudplatform-opentelemetry-operations-go-exporter-collector
+Version:        0.57.0
+Release:        %autorelease
+Summary:        Google Cloud exporters for OpenTelemetry Collector data
+License:        Apache-2.0
+URL:            https://github.com/GoogleCloudPlatform/opentelemetry-operations-go
+#!RemoteAsset:  sha256:b48b83c968c53c192b88ec7886a420efbd8f0d71dfcad8685cc39be6848661f0
+Source0:        https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/archive/refs/tags/exporter/collector/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go(cloud.google.com/go/auth)
+BuildRequires:  go(cloud.google.com/go/compute/metadata)
+BuildRequires:  go(cloud.google.com/go/logging)
+BuildRequires:  go(cloud.google.com/go/monitoring)
+BuildRequires:  go(cloud.google.com/go/trace)
+BuildRequires:  go(github.com/cespare/xxhash/v2)
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/felixge/httpsnoop)
+BuildRequires:  go(github.com/fsnotify/fsnotify)
+BuildRequires:  go(github.com/go-logr/logr)
+BuildRequires:  go(github.com/go-logr/stdr)
+BuildRequires:  go(github.com/go-viper/mapstructure/v2)
+BuildRequires:  go(github.com/gobwas/glob)
+BuildRequires:  go(github.com/google/go-cmp)
+BuildRequires:  go(github.com/google/s2a-go)
+BuildRequires:  go(github.com/google/uuid)
+BuildRequires:  go(github.com/googleapis/enterprise-certificate-proxy)
+BuildRequires:  go(github.com/googleapis/gax-go/v2)
+BuildRequires:  go(github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric)
+BuildRequires:  go(github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace)
+BuildRequires:  go(github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping)
+BuildRequires:  go(github.com/hashicorp/go-version)
+BuildRequires:  go(github.com/json-iterator/go)
+BuildRequires:  go(github.com/knadh/koanf/maps)
+BuildRequires:  go(github.com/knadh/koanf/providers/confmap)
+BuildRequires:  go(github.com/knadh/koanf/v2)
+BuildRequires:  go(github.com/mitchellh/copystructure)
+BuildRequires:  go(github.com/mitchellh/reflectwalk)
+BuildRequires:  go(github.com/modern-go/concurrent)
+BuildRequires:  go(github.com/modern-go/reflect2)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/prometheus/otlptranslator)
+BuildRequires:  go(github.com/shirou/gopsutil/v4)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(github.com/tidwall/gjson)
+BuildRequires:  go(github.com/tidwall/match)
+BuildRequires:  go(github.com/tidwall/pretty)
+BuildRequires:  go(github.com/tidwall/tinylru)
+BuildRequires:  go(github.com/tidwall/wal)
+BuildRequires:  go(go.opentelemetry.io/auto/sdk)
+BuildRequires:  go(go.opentelemetry.io/collector)
+BuildRequires:  go(go.opentelemetry.io/contrib)
+BuildRequires:  go(go.opentelemetry.io/otel)
+BuildRequires:  go(go.uber.org/atomic)
+BuildRequires:  go(go.uber.org/multierr)
+BuildRequires:  go(go.uber.org/zap)
+BuildRequires:  go(go.yaml.in/yaml/v3)
+BuildRequires:  go(golang.org/x/crypto)
+BuildRequires:  go(golang.org/x/net)
+BuildRequires:  go(golang.org/x/oauth2)
+BuildRequires:  go(golang.org/x/sync)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(golang.org/x/text)
+BuildRequires:  go(golang.org/x/time)
+BuildRequires:  go(google.golang.org/api)
+BuildRequires:  go(google.golang.org/genproto)
+BuildRequires:  go(google.golang.org/grpc)
+BuildRequires:  go(google.golang.org/protobuf)
+BuildRequires:  go(gopkg.in/yaml.v3)
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(cloud.google.com/go/logging)
+Requires:       go(cloud.google.com/go/monitoring)
+Requires:       go(cloud.google.com/go/trace)
+Requires:       go(github.com/fsnotify/fsnotify)
+Requires:       go(github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace)
+Requires:       go(github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping)
+Requires:       go(github.com/tidwall/wal)
+Requires:       go(go.opentelemetry.io/collector)
+Requires:       go(go.opentelemetry.io/otel)
+Requires:       go(go.uber.org/atomic)
+Requires:       go(go.uber.org/zap)
+Requires:       go(golang.org/x/oauth2)
+Requires:       go(google.golang.org/api)
+Requires:       go(google.golang.org/genproto)
+Requires:       go(google.golang.org/grpc)
+Requires:       go(google.golang.org/protobuf)
+Requires:       go(gopkg.in/yaml.v3)
+
+%description
+This package converts OpenTelemetry Collector metrics, logs, and traces for
+export to Google Cloud services.
+
+%install
+pushd exporter/collector
+%buildsystem_golangmodules_install
+popd
+
+%check
+pushd exporter/collector
+export GO111MODULE=off
+export GOPATH=%{_builddir}/go:%{_datadir}/gocode
+rm -rf "%{_builddir}/go/src/github.com/GoogleCloudPlatform/opentelemetry-operations-go"
+mkdir -p "%{_builddir}/go/src/github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter"
+cp -a . "%{_builddir}/go/src/%{go_import_path}"
+cp -a ../metric "%{_builddir}/go/src/github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/"
+cp -a ../trace "%{_builddir}/go/src/github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/"
+mkdir -p "%{_builddir}/go/src/github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal"
+cp -a ../../internal/cloudmock "%{_builddir}/go/src/github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/"
+cp -a ../../internal/resourcemapping "%{_builddir}/go/src/github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/"
+cd "%{_builddir}/go/src/%{go_import_path}"
+go test -v ./...
+popd
+
+%files
+%doc exporter/collector/README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-grafana-faro-pkg-go/go-github-grafana-faro-pkg-go.spec
+++ b/SPECS/go-github-grafana-faro-pkg-go/go-github-grafana-faro-pkg-go.spec
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           faro
+%define go_import_path  github.com/grafana/faro/pkg/go
+%define commit_id       bb5f9417df83f79eb88449cff5ab1b7ca65531f4
+
+Name:           go-github-grafana-faro-pkg-go
+Version:        0+git20260819.bb5f941
+Release:        %autorelease
+Summary:        Go models for Grafana Faro telemetry
+License:        Apache-2.0
+URL:            https://github.com/grafana/faro
+#!RemoteAsset:  sha256:b6e76f4aa0fef747e393bc8430fc9f2912f354e7161244ac1a959ee3206d2a82
+Source0:        https://github.com/grafana/faro/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+BuildOption(prep):  -n %{_name}-%{commit_id}
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/apapsch/go-jsonmerge/v2)
+BuildRequires:  go(github.com/gogo/protobuf)
+BuildRequires:  go(github.com/google/uuid)
+BuildRequires:  go(github.com/json-iterator/go)
+BuildRequires:  go(github.com/modern-go/concurrent)
+BuildRequires:  go(github.com/modern-go/reflect2)
+BuildRequires:  go(github.com/oapi-codegen/runtime)
+BuildRequires:  go(go.opentelemetry.io/collector)
+BuildRequires:  go(go.uber.org/multierr)
+BuildRequires:  go(golang.org/x/net)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(golang.org/x/text)
+BuildRequires:  go(google.golang.org/genproto)
+BuildRequires:  go(google.golang.org/grpc)
+BuildRequires:  go(google.golang.org/protobuf)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/oapi-codegen/runtime)
+Requires:       go(go.opentelemetry.io/collector)
+
+%description
+This package provides generated Go models and OpenTelemetry conversion code
+for Grafana Faro frontend telemetry.
+
+%install
+pushd pkg/go
+%buildsystem_golangmodules_install
+popd
+
+%check
+pushd pkg/go
+%buildsystem_golangmodules_check
+popd
+
+%files
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-influxdata-influxdb-observability/2000-influx2otel-avoid-runtime-dependency-on-pdatautil.patch
+++ b/SPECS/go-github-influxdata-influxdb-observability/2000-influx2otel-avoid-runtime-dependency-on-pdatautil.patch
@@ -1,0 +1,168 @@
+From e6f2f218a66a2860489c6add597cb711a1a8fa8f Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Wed, 19 Aug 2026 05:52:19 +0800
+Subject: [PATCH] influx2otel: Avoid runtime dependency on pdatautil
+
+Collector contrib imports influx2otel from its InfluxDB receiver, while influx2otel imports pdatautil from Collector contrib. This forms a package-level dependency cycle when the repositories are packaged as complete source trees.
+
+Use a deterministic, length-delimited attribute key for the two internal lookup maps instead. Keep pdatautil as an indirect test dependency through pdatatest.
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ influx2otel/attribute_map_key_test.go         | 26 +++++++++++++++
+ influx2otel/go.mod                            |  2 +-
+ influx2otel/metrics.go                        | 33 ++++++++++++++-----
+ influx2otel/metrics_telegraf_prometheus_v2.go |  3 +-
+ 4 files changed, 53 insertions(+), 11 deletions(-)
+ create mode 100644 influx2otel/attribute_map_key_test.go
+
+diff --git a/influx2otel/attribute_map_key_test.go b/influx2otel/attribute_map_key_test.go
+new file mode 100644
+index 0000000..b45c783
+--- /dev/null
++++ b/influx2otel/attribute_map_key_test.go
+@@ -0,0 +1,26 @@
++package influx2otel
++
++import (
++	"testing"
++
++	"github.com/stretchr/testify/require"
++	"go.opentelemetry.io/collector/pdata/pcommon"
++)
++
++func TestAttributeMapKey(t *testing.T) {
++	first := pcommon.NewMap()
++	first.PutStr("service.name", "api")
++	first.PutStr("region", "west")
++
++	second := pcommon.NewMap()
++	second.PutStr("region", "west")
++	second.PutStr("service.name", "api")
++
++	require.Equal(t, attributeMapKey(first), attributeMapKey(second))
++
++	boundaryA := pcommon.NewMap()
++	boundaryA.PutStr("a", "bc")
++	boundaryB := pcommon.NewMap()
++	boundaryB.PutStr("ab", "c")
++	require.NotEqual(t, attributeMapKey(boundaryA), attributeMapKey(boundaryB))
++}
+diff --git a/influx2otel/go.mod b/influx2otel/go.mod
+index 6cec14c..c6cf336 100644
+--- a/influx2otel/go.mod
++++ b/influx2otel/go.mod
+@@ -7,7 +7,6 @@ toolchain go1.21.10
+ require (
+ 	github.com/influxdata/influxdb-observability/common v0.5.8
+ 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.101.0
+-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.101.0
+ 	github.com/stretchr/testify v1.9.0
+ 	go.opentelemetry.io/collector/pdata v1.8.0
+ 	go.opentelemetry.io/collector/semconv v0.101.0
+@@ -20,6 +19,7 @@ require (
+ 	github.com/json-iterator/go v1.1.12 // indirect
+ 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+ 	github.com/modern-go/reflect2 v1.0.2 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.101.0 // indirect
+ 	github.com/pmezard/go-difflib v1.0.0 // indirect
+ 	go.uber.org/multierr v1.11.0 // indirect
+ 	golang.org/x/net v0.23.0 // indirect
+diff --git a/influx2otel/metrics.go b/influx2otel/metrics.go
+index 7c37cf9..6a51fcd 100644
+--- a/influx2otel/metrics.go
++++ b/influx2otel/metrics.go
+@@ -5,9 +5,9 @@ import (
+ 	"fmt"
+ 	"math"
+ 	"sort"
++	"strings"
+ 	"time"
+ 
+-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil"
+ 	"go.opentelemetry.io/collector/pdata/pcommon"
+ 	"go.opentelemetry.io/collector/pdata/pmetric"
+ 	semconv "go.opentelemetry.io/collector/semconv/v1.16.0"
+@@ -27,9 +27,9 @@ func NewLineProtocolToOtelMetrics(logger common.Logger) (*LineProtocolToOtelMetr
+ 
+ func (c *LineProtocolToOtelMetrics) NewBatch() *MetricsBatch {
+ 	return &MetricsBatch{
+-		rmByAttributes:            make(map[[16]byte]pmetric.ResourceMetrics),
+-		ilmByRMAttributesAndIL:    make(map[[16]byte]map[string]pmetric.ScopeMetrics),
+-		metricByRMIL:              make(map[[16]byte]map[string]map[string]pmetric.Metric),
++		rmByAttributes:            make(map[string]pmetric.ResourceMetrics),
++		ilmByRMAttributesAndIL:    make(map[string]map[string]pmetric.ScopeMetrics),
++		metricByRMIL:              make(map[string]map[string]map[string]pmetric.Metric),
+ 		histogramDataPointsByMDPK: make(map[pmetric.Metric]map[dataPointKey]pmetric.HistogramDataPoint),
+ 		summaryDataPointsByMDPK:   make(map[pmetric.Metric]map[dataPointKey]pmetric.SummaryDataPoint),
+ 
+@@ -38,9 +38,9 @@ func (c *LineProtocolToOtelMetrics) NewBatch() *MetricsBatch {
+ }
+ 
+ type MetricsBatch struct {
+-	rmByAttributes            map[[16]byte]pmetric.ResourceMetrics
+-	ilmByRMAttributesAndIL    map[[16]byte]map[string]pmetric.ScopeMetrics
+-	metricByRMIL              map[[16]byte]map[string]map[string]pmetric.Metric
++	rmByAttributes            map[string]pmetric.ResourceMetrics
++	ilmByRMAttributesAndIL    map[string]map[string]pmetric.ScopeMetrics
++	metricByRMIL              map[string]map[string]map[string]pmetric.Metric
+ 	histogramDataPointsByMDPK map[pmetric.Metric]map[dataPointKey]pmetric.HistogramDataPoint
+ 	summaryDataPointsByMDPK   map[pmetric.Metric]map[dataPointKey]pmetric.SummaryDataPoint
+ 
+@@ -74,6 +74,23 @@ func (b *MetricsBatch) AddPoint(measurement string, tags map[string]string, fiel
+ 
+ var errValueTypeUnknown = errors.New("value type unknown")
+ 
++func attributeMapKey(attributes pcommon.Map) string {
++	keys := make([]string, 0, attributes.Len())
++	attributes.Range(func(key string, _ pcommon.Value) bool {
++		keys = append(keys, key)
++		return true
++	})
++	sort.Strings(keys)
++
++	var key strings.Builder
++	for _, name := range keys {
++		value, _ := attributes.Get(name)
++		valueText := value.AsString()
++		fmt.Fprintf(&key, "%d:%s:%d:%d:%s", len(name), name, value.Type(), len(valueText), valueText)
++	}
++	return key.String()
++}
++
+ func (b *MetricsBatch) lookupMetric(metricName string, tags map[string]string, vType common.InfluxMetricValueType) (pmetric.Metric, pcommon.Map, error) {
+ 	var ilName, ilVersion string
+ 	rAttributes := pcommon.NewMap()
+@@ -98,7 +115,7 @@ func (b *MetricsBatch) lookupMetric(metricName string, tags map[string]string, v
+ 		}
+ 	}
+ 
+-	rKey := pdatautil.MapHash(rAttributes)
++	rKey := attributeMapKey(rAttributes)
+ 	var resourceMetrics pmetric.ResourceMetrics
+ 	if rm, found := b.rmByAttributes[rKey]; found {
+ 		resourceMetrics = rm
+diff --git a/influx2otel/metrics_telegraf_prometheus_v2.go b/influx2otel/metrics_telegraf_prometheus_v2.go
+index ce32c9a..c9a1e34 100644
+--- a/influx2otel/metrics_telegraf_prometheus_v2.go
++++ b/influx2otel/metrics_telegraf_prometheus_v2.go
+@@ -7,7 +7,6 @@ import (
+ 	"strings"
+ 	"time"
+ 
+-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil"
+ 	"go.opentelemetry.io/collector/pdata/pcommon"
+ 
+ 	"github.com/influxdata/influxdb-observability/common"
+@@ -64,7 +63,7 @@ func (b *MetricsBatch) inferMetricValueTypeV2(vType common.InfluxMetricValueType
+ type dataPointKey string
+ 
+ func newDataPointKey(ts time.Time, attributes pcommon.Map) dataPointKey {
+-	return dataPointKey(fmt.Sprintf("%d:%s", ts.UnixNano(), pdatautil.MapHash(attributes)))
++	return dataPointKey(fmt.Sprintf("%d:%s", ts.UnixNano(), attributeMapKey(attributes)))
+ }
+ 
+ func (b *MetricsBatch) convertGaugeV2(tags map[string]string, fields map[string]interface{}, ts time.Time) error {
+-- 
+2.43.0
+

--- a/SPECS/go-github-influxdata-influxdb-observability/go-github-influxdata-influxdb-observability.spec
+++ b/SPECS/go-github-influxdata-influxdb-observability/go-github-influxdata-influxdb-observability.spec
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           influxdb-observability
+%define go_import_path  github.com/influxdata/influxdb-observability
+# Tests use collector-contrib pdatatest, which would create a clean-build cycle.
+%define go_test_exclude %{go_import_path}/influx2otel
+
+Name:           go-github-influxdata-influxdb-observability
+Version:        0.5.12
+Release:        %autorelease
+Summary:        OpenTelemetry conversion libraries for InfluxDB
+License:        MIT
+URL:            https://github.com/influxdata/influxdb-observability
+#!RemoteAsset:  sha256:90c5682b6d7609c04e2751d61579017439c56c112ca19787b4389d5c6aca1ad4
+Source0:        https://github.com/influxdata/influxdb-observability/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Break the runtime dependency cycle with Collector contrib.
+# https://github.com/influxdata/influxdb-observability/pull/353
+Patch2000:      2000-influx2otel-avoid-runtime-dependency-on-pdatautil.patch
+
+BuildRequires:  go
+BuildRequires:  go(github.com/cespare/xxhash/v2)
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/gogo/protobuf)
+BuildRequires:  go(github.com/json-iterator/go)
+BuildRequires:  go(github.com/modern-go/concurrent)
+BuildRequires:  go(github.com/modern-go/reflect2)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(go.opentelemetry.io/collector)
+BuildRequires:  go(go.opentelemetry.io/collector/semconv)
+BuildRequires:  go(go.uber.org/multierr)
+BuildRequires:  go(golang.org/x/exp)
+BuildRequires:  go(golang.org/x/net)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(golang.org/x/text)
+BuildRequires:  go(google.golang.org/genproto)
+BuildRequires:  go(google.golang.org/grpc)
+BuildRequires:  go(google.golang.org/protobuf)
+BuildRequires:  go(gopkg.in/yaml.v3)
+BuildRequires:  go-rpm-macros
+
+Provides:       go(%{go_import_path}/common) = %{version}
+Provides:       go(%{go_import_path}/influx2otel) = %{version}
+Provides:       go(%{go_import_path}/otel2influx) = %{version}
+
+Requires:       go(github.com/gogo/protobuf)
+Requires:       go(github.com/json-iterator/go)
+Requires:       go(go.opentelemetry.io/collector)
+Requires:       go(go.opentelemetry.io/collector/semconv)
+Requires:       go(go.uber.org/multierr)
+Requires:       go(golang.org/x/exp)
+Requires:       go(google.golang.org/genproto)
+Requires:       go(google.golang.org/grpc)
+Requires:       go(google.golang.org/protobuf)
+
+%description
+This package provides the common, influx2otel, and otel2influx modules from
+the InfluxDB observability repository.
+
+%install
+install -d "%{buildroot}%{go_sys_gopath}/%{go_import_path}"
+for module in common influx2otel otel2influx; do
+    cp -a "${module}" "%{buildroot}%{go_sys_gopath}/%{go_import_path}/"
+done
+
+%check
+export GO111MODULE=off
+export GOPATH=%{_builddir}/go:%{_datadir}/gocode
+mkdir -p "%{_builddir}/go/src/%{go_import_path}"
+for module in common influx2otel otel2influx; do
+    cp -a "${module}" "%{_builddir}/go/src/%{go_import_path}/"
+done
+for module in common otel2influx; do
+    pushd "%{_builddir}/go/src/%{go_import_path}/${module}"
+    go test -v ./...
+    popd
+done
+go build %{go_test_exclude}/...
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-mongodb-mongo-driver-v2/1000-Fix-non-constant-test-format-strings.patch
+++ b/SPECS/go-mongodb-mongo-driver-v2/1000-Fix-non-constant-test-format-strings.patch
@@ -1,0 +1,49 @@
+From 87d7e2d65798e05b9610d931c3f57f9eafd8f50a Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Wed, 19 Aug 2026 02:26:32 +0800
+Subject: [PATCH] Fix non-constant test format strings
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ internal/assert/assertion_compare_test.go | 4 ++--
+ internal/rand/rand_test.go                | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/internal/assert/assertion_compare_test.go b/internal/assert/assertion_compare_test.go
+index 35568e7..5defee1 100644
+--- a/internal/assert/assertion_compare_test.go
++++ b/internal/assert/assertion_compare_test.go
+@@ -75,7 +75,7 @@ func TestCompare(t *testing.T) {
+ 		}
+ 
+ 		if resGreater != compareGreater {
+-			t.Errorf("object greater should be greater than less for type " + currCase.cType)
++			t.Errorf("object greater should be greater than less for type %s", currCase.cType)
+ 		}
+ 
+ 		resEqual, isComparable := compare(currCase.less, currCase.less, reflect.ValueOf(currCase.less).Kind())
+@@ -84,7 +84,7 @@ func TestCompare(t *testing.T) {
+ 		}
+ 
+ 		if resEqual != 0 {
+-			t.Errorf("objects should be equal for type " + currCase.cType)
++			t.Errorf("objects should be equal for type %s", currCase.cType)
+ 		}
+ 	}
+ }
+diff --git a/internal/rand/rand_test.go b/internal/rand/rand_test.go
+index 73146d5..cb72c47 100644
+--- a/internal/rand/rand_test.go
++++ b/internal/rand/rand_test.go
+@@ -80,7 +80,7 @@ func checkSampleDistribution(t *testing.T, samples []float64, expected *statsRes
+ 	actual := getStatsResults(samples)
+ 	err := actual.checkSimilarDistribution(expected)
+ 	if err != nil {
+-		t.Errorf(err.Error())
++		t.Error(err)
+ 	}
+ }
+ 
+-- 
+2.43.0
+

--- a/SPECS/go-mongodb-mongo-driver-v2/go-mongodb-mongo-driver-v2.spec
+++ b/SPECS/go-mongodb-mongo-driver-v2/go-mongodb-mongo-driver-v2.spec
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           mongo-driver
+%define go_import_path  go.mongodb.org/mongo-driver/v2
+# These tests require MongoDB, a container runtime, or external network access.
+%define go_test_exclude %{shrink:
+    %{go_import_path}/internal/cmd/benchmark
+    %{go_import_path}/internal/docexamples
+    %{go_import_path}/internal/integration
+    %{go_import_path}/internal/integration/unified
+    %{go_import_path}/internal/test/compilecheck
+    %{go_import_path}/internal/test/goleak
+    %{go_import_path}/mongo
+    %{go_import_path}/mongo/options
+    %{go_import_path}/x/mongo/driver/connstring
+    %{go_import_path}/x/mongo/driver/integration
+    %{go_import_path}/x/mongo/driver/topology
+}
+%define specifications_commit ea6be202feb255242077cbc53527559e79e5cd00
+
+Name:           go-mongodb-mongo-driver-v2
+Version:        2.8.0
+Release:        %autorelease
+Summary:        MongoDB driver for Go
+License:        Apache-2.0
+URL:            https://github.com/mongodb/mongo-go-driver
+#!RemoteAsset:  sha256:9c8297e35821dd8277c968ceefcb4971bcb8e875d4bed4417d127ee5a968bcbb
+Source0:        https://github.com/mongodb/mongo-go-driver/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+# Restore the specifications submodule revision pinned by upstream.
+#!RemoteAsset:  sha256:4011f4ebf0e25b6d477be87a1cb03b86dad13d0adb5f7e558ae53e5a13877900
+Source1:        https://github.com/mongodb/specifications/archive/%{specifications_commit}.tar.gz#/%{_name}-specifications-%{specifications_commit}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Backport the test format fixes from upstream.
+# https://github.com/mongodb/mongo-go-driver/commit/d20c5dbbd8288f43ed462c8aa74edac2d76a3cb7
+Patch1000:      1000-Fix-non-constant-test-format-strings.patch
+
+BuildOption(prep):  -N
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  tzdata
+BuildRequires:  go(github.com/aws/aws-lambda-go)
+BuildRequires:  go(github.com/bitfield/script)
+BuildRequires:  go(github.com/bombsimon/logrusr/v4)
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/go-logr/zapr)
+BuildRequires:  go(github.com/go-logr/zerologr)
+BuildRequires:  go(github.com/google/go-cmp)
+BuildRequires:  go(github.com/klauspost/compress)
+BuildRequires:  go(github.com/miekg/dns)
+BuildRequires:  go(github.com/rs/zerolog)
+BuildRequires:  go(github.com/sirupsen/logrus)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(github.com/testcontainers/testcontainers-go)
+BuildRequires:  go(github.com/xdg-go/pbkdf2)
+BuildRequires:  go(github.com/xdg-go/scram)
+BuildRequires:  go(github.com/xdg-go/stringprep)
+BuildRequires:  go(github.com/youmark/pkcs8)
+BuildRequires:  go(go.uber.org/zap)
+BuildRequires:  go(go.uber.org/goleak)
+BuildRequires:  go(go.uber.org/multierr)
+BuildRequires:  go(golang.org/x/crypto)
+BuildRequires:  go(golang.org/x/sync)
+BuildRequires:  go(golang.org/x/text)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/bitfield/script)
+Requires:       go(github.com/bombsimon/logrusr/v4)
+Requires:       go(github.com/davecgh/go-spew)
+Requires:       go(github.com/go-logr/zapr)
+Requires:       go(github.com/go-logr/zerologr)
+Requires:       go(github.com/klauspost/compress)
+Requires:       go(github.com/miekg/dns)
+Requires:       go(github.com/rs/zerolog)
+Requires:       go(github.com/sirupsen/logrus)
+Requires:       go(github.com/xdg-go/scram)
+Requires:       go(github.com/xdg-go/stringprep)
+Requires:       go(github.com/youmark/pkcs8)
+Requires:       go(go.uber.org/zap)
+Requires:       go(golang.org/x/crypto)
+Requires:       go(golang.org/x/sync)
+
+%description
+The official MongoDB Go driver provides BSON handling, connection pooling,
+authentication, sessions, transactions, change streams, and client APIs.
+
+%prep -a
+%patch -P 1000 -p1
+rm -rf testdata/specifications
+mkdir -p testdata/specifications
+tar -xf %{SOURCE1} --strip-components=1 -C testdata/specifications
+
+%check
+export TZ=America/New_York
+%buildsystem_golangmodules_check
+for pkg in %{go_test_exclude}; do
+    go test -c -o /dev/null "$pkg"
+done
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-opentelemetry-ebpf-profiler/go-opentelemetry-ebpf-profiler.spec
+++ b/SPECS/go-opentelemetry-ebpf-profiler/go-opentelemetry-ebpf-profiler.spec
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           ebpf-profiler
+%define go_import_path  go.opentelemetry.io/ebpf-profiler
+# Coredump tests download external fixtures. Two ELF test packages need
+# generated binaries absent from release archives. internal/tools is a nested
+# tool module that retains the repository's former GitHub import path.
+%define go_test_exclude %{shrink:
+    %{go_import_path}/internal/tools
+    %{go_import_path}/libpf/pfelf
+    %{go_import_path}/nativeunwind/elfunwindinfo
+    %{go_import_path}/tools/coredump
+}
+
+Name:           go-opentelemetry-ebpf-profiler
+Version:        0.0.202622
+Release:        %autorelease
+Summary:        Whole-system eBPF profiler for OpenTelemetry
+License:        Apache-2.0
+URL:            https://github.com/open-telemetry/opentelemetry-ebpf-profiler
+#!RemoteAsset:  sha256:9549be5adedc35485da04314a46ff9e24e59284ba8e19499bd19b1df8a7bd466
+Source0:        https://github.com/open-telemetry/opentelemetry-ebpf-profiler/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/aws/aws-sdk-go-v2)
+BuildRequires:  go(github.com/cespare/xxhash/v2)
+BuildRequires:  go(github.com/cilium/ebpf)
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/elastic/go-freelru)
+BuildRequires:  go(github.com/elastic/go-perf)
+BuildRequires:  go(github.com/go-logr/logr)
+BuildRequires:  go(github.com/go-logr/stdr)
+BuildRequires:  go(github.com/go-viper/mapstructure/v2)
+BuildRequires:  go(github.com/gobwas/glob)
+BuildRequires:  go(github.com/google/go-cmp)
+BuildRequires:  go(github.com/google/uuid)
+BuildRequires:  go(github.com/hashicorp/go-version)
+BuildRequires:  go(github.com/json-iterator/go)
+BuildRequires:  go(github.com/klauspost/compress)
+BuildRequires:  go(github.com/klauspost/cpuid/v2)
+BuildRequires:  go(github.com/knadh/koanf/maps)
+BuildRequires:  go(github.com/knadh/koanf/providers/confmap)
+BuildRequires:  go(github.com/knadh/koanf/v2)
+BuildRequires:  go(github.com/mdlayher/kobject)
+BuildRequires:  go(github.com/mdlayher/netlink)
+BuildRequires:  go(github.com/mdlayher/socket)
+BuildRequires:  go(github.com/minio/sha256-simd)
+BuildRequires:  go(github.com/mitchellh/copystructure)
+BuildRequires:  go(github.com/mitchellh/reflectwalk)
+BuildRequires:  go(github.com/modern-go/concurrent)
+BuildRequires:  go(github.com/modern-go/reflect2)
+BuildRequires:  go(github.com/open-telemetry/sig-profiling)
+BuildRequires:  go(github.com/peterbourgon/ff/v3)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(github.com/zeebo/xxh3)
+BuildRequires:  go(go.opentelemetry.io/auto/sdk)
+BuildRequires:  go(go.opentelemetry.io/collector)
+BuildRequires:  go(go.opentelemetry.io/otel)
+BuildRequires:  go(go.opentelemetry.io/proto)
+BuildRequires:  go(go.uber.org/multierr)
+BuildRequires:  go(go.uber.org/zap)
+BuildRequires:  go(go.yaml.in/yaml/v3)
+BuildRequires:  go(golang.org/x/arch)
+BuildRequires:  go(golang.org/x/exp)
+BuildRequires:  go(golang.org/x/mod)
+BuildRequires:  go(golang.org/x/net)
+BuildRequires:  go(golang.org/x/sync)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(golang.org/x/text)
+BuildRequires:  go(google.golang.org/genproto)
+BuildRequires:  go(google.golang.org/grpc)
+BuildRequires:  go(google.golang.org/protobuf)
+BuildRequires:  go(gopkg.in/yaml.v3)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/aws/aws-sdk-go-v2)
+Requires:       go(github.com/cilium/ebpf)
+Requires:       go(github.com/elastic/go-freelru)
+Requires:       go(github.com/elastic/go-perf)
+Requires:       go(github.com/google/uuid)
+Requires:       go(github.com/klauspost/compress)
+Requires:       go(github.com/mdlayher/kobject)
+Requires:       go(github.com/minio/sha256-simd)
+Requires:       go(github.com/open-telemetry/sig-profiling)
+Requires:       go(github.com/peterbourgon/ff/v3)
+Requires:       go(github.com/zeebo/xxh3)
+Requires:       go(go.opentelemetry.io/collector)
+Requires:       go(go.opentelemetry.io/otel)
+Requires:       go(go.opentelemetry.io/proto)
+Requires:       go(go.uber.org/zap)
+Requires:       go(golang.org/x/arch)
+Requires:       go(golang.org/x/exp)
+Requires:       go(golang.org/x/mod)
+Requires:       go(golang.org/x/sys)
+Requires:       go(google.golang.org/grpc)
+Requires:       go(google.golang.org/protobuf)
+
+%description
+The OpenTelemetry eBPF profiler provides low-overhead, whole-system profiling
+for native and managed-language workloads on Linux.
+
+%check -a
+for pkg in \
+    %{go_import_path}/libpf/pfelf \
+    %{go_import_path}/nativeunwind/elfunwindinfo \
+    %{go_import_path}/tools/coredump; do
+    go test -c -o /dev/null "${pkg}"
+done
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

This PR contains 10 Go module package changes for Prometheus v3.13 (DAG level 5). The listed PRs provide the direct Go module dependencies required by this batch.

Requires: #1117 #1118 #1119 #1120 #1121 #1122 #1123 #1124 #1125 #1126 #1127 #1128

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: ChatGPT:GPT-5.6-sol High

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]: https://openruyi.cn/governance/policy/ai-contribution-policy