### PR TITLE
SPECS: Add Prometheus v3.13 modules - DAG L8-16

### DIFF
--- a/SPECS/go-github-aliyun-aliyun-log-go-sdk/2000-use-function-callback-with-generic-backoff.patch
+++ b/SPECS/go-github-aliyun-aliyun-log-go-sdk/2000-use-function-callback-with-generic-backoff.patch
@@ -1,0 +1,34 @@
+From 534943315f17c110505d56dd05062c99f20ef270 Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Tue, 18 Aug 2026 16:17:01 +0800
+Subject: [PATCH] retry: accept function callbacks with generic backoff
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ retry.go | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/retry.go b/retry.go
+index e47b062..fa69e54 100644
+--- a/retry.go
++++ b/retry.go
+@@ -21,13 +21,13 @@ import (
+ //  8          8.538                   [4.269, 12.807]
+ //  9         12.807                   [6.403, 19.210]
+ // ...
+-// The signature of backoff.Operation is "func() error".
+-func Retry(ctx context.Context, o backoff.Operation) error {
++// The operation returns an error and is retried with exponential backoff.
++func Retry(ctx context.Context, o func() error) error {
+ 	return RetryWithBackOff(ctx, backoff.NewExponentialBackOff(), o)
+ }
+ 
+ // RetryWithBackOff ...
+-func RetryWithBackOff(ctx context.Context, b backoff.BackOff, o backoff.Operation) error {
++func RetryWithBackOff(ctx context.Context, b backoff.BackOff, o func() error) error {
+ 	ticker := backoff.NewTicker(b)
+ 	defer ticker.Stop()
+ 	var err error
+-- 
+2.43.0
+

--- a/SPECS/go-github-aliyun-aliyun-log-go-sdk/go-github-aliyun-aliyun-log-go-sdk.spec
+++ b/SPECS/go-github-aliyun-aliyun-log-go-sdk/go-github-aliyun-aliyun-log-go-sdk.spec
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           aliyun-log-go-sdk
+%define go_import_path  github.com/aliyun/aliyun-log-go-sdk
+# The root, consumer, and producer suites require live Alibaba Cloud services;
+# two example directories contain multiple standalone main programs.
+%define go_test_exclude %{shrink:
+    %{go_import_path}
+    %{go_import_path}/consumer
+    %{go_import_path}/example/config
+    %{go_import_path}/example/etl
+    %{go_import_path}/producer
+}
+
+Name:           go-github-aliyun-aliyun-log-go-sdk
+Version:        0.1.100
+Release:        %autorelease
+Summary:        Alibaba Cloud Log Service SDK for Go
+License:        MIT
+URL:            https://github.com/aliyun/aliyun-log-go-sdk
+#!RemoteAsset:  sha256:551a836a3b17f55dd443307c224c6783b6d254e6323e675dc5d70936030d7758
+Source0:        https://github.com/aliyun/aliyun-log-go-sdk/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# Keep retry callbacks compatible with the canonical generic backoff package.
+Patch2000:      2000-use-function-callback-with-generic-backoff.patch
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/DataDog/zstd)
+BuildRequires:  go(github.com/Netflix/go-env)
+BuildRequires:  go(github.com/alibabacloud-go/alibabacloud-gateway-spi)
+BuildRequires:  go(github.com/alibabacloud-go/darabonba-openapi/v2)
+BuildRequires:  go(github.com/alibabacloud-go/debug)
+BuildRequires:  go(github.com/alibabacloud-go/endpoint-util)
+BuildRequires:  go(github.com/alibabacloud-go/openapi-util)
+BuildRequires:  go(github.com/alibabacloud-go/sts-20150401/v2)
+BuildRequires:  go(github.com/alibabacloud-go/tea)
+BuildRequires:  go(github.com/alibabacloud-go/tea-utils)
+BuildRequires:  go(github.com/alibabacloud-go/tea-utils/v2)
+BuildRequires:  go(github.com/alibabacloud-go/tea-xml)
+BuildRequires:  go(github.com/aliyun/credentials-go)
+BuildRequires:  go(github.com/cenkalti/backoff)
+BuildRequires:  go(github.com/clbanning/mxj/v2)
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/gogo/protobuf)
+BuildRequires:  go(github.com/go-kit/kit)
+BuildRequires:  go(github.com/golang/protobuf)
+BuildRequires:  go(github.com/json-iterator/go)
+BuildRequires:  go(github.com/klauspost/compress)
+BuildRequires:  go(github.com/modern-go/concurrent)
+BuildRequires:  go(github.com/modern-go/reflect2)
+BuildRequires:  go(github.com/pierrec/lz4/v4)
+BuildRequires:  go(github.com/pkg/errors)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(github.com/tjfoc/gmsm)
+BuildRequires:  go(go.uber.org/atomic)
+BuildRequires:  go(golang.org/x/net)
+BuildRequires:  go(gopkg.in/ini.v1)
+BuildRequires:  go(gopkg.in/natefinch/lumberjack.v2)
+BuildRequires:  go(gopkg.in/yaml.v2)
+BuildRequires:  go(google.golang.org/protobuf)
+
+Provides:       go(%{go_import_path}) = %{version}
+
+Requires:       go(github.com/DataDog/zstd)
+Requires:       go(github.com/Netflix/go-env)
+Requires:       go(github.com/alibabacloud-go/darabonba-openapi/v2)
+Requires:       go(github.com/alibabacloud-go/sts-20150401/v2)
+Requires:       go(github.com/cenkalti/backoff)
+Requires:       go(github.com/go-kit/kit)
+Requires:       go(github.com/gogo/protobuf)
+Requires:       go(github.com/golang/protobuf)
+Requires:       go(github.com/klauspost/compress)
+Requires:       go(github.com/pierrec/lz4/v4)
+Requires:       go(github.com/pkg/errors)
+Requires:       go(go.uber.org/atomic)
+Requires:       go(golang.org/x/net)
+Requires:       go(google.golang.org/protobuf)
+Requires:       go(gopkg.in/natefinch/lumberjack.v2)
+
+%description
+The Alibaba Cloud Log Service SDK for Go provides APIs for sending, querying,
+managing, and consuming logs from Alibaba Cloud Simple Log Service.
+
+%files
+%doc README.md README_EN.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-k8s-apiextensions-apiserver/go-k8s-apiextensions-apiserver.spec
+++ b/SPECS/go-k8s-apiextensions-apiserver/go-k8s-apiextensions-apiserver.spec
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           apiextensions-apiserver
+%define go_import_path  k8s.io/apiextensions-apiserver
+
+Name:           go-k8s-apiextensions-apiserver
+Version:        0.36.2
+Release:        %autorelease
+Summary:        TODO: short description
+License:        TODO
+URL:            https://github.com/kubernetes/apiextensions-apiserver
+#!RemoteAsset:  sha256:f2c49f57a0da3aa37bf5caf6fe735a054cf994c0f44c77b3a2893e9d0340f1f8
+Source0:        https://github.com/kubernetes/apiextensions-apiserver/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/emicklei/go-restful/v3)
+BuildRequires:  go(github.com/fxamacker/cbor/v2)
+BuildRequires:  go(github.com/google/cel-go)
+BuildRequires:  go(github.com/google/gnostic-models)
+BuildRequires:  go(github.com/google/go-cmp)
+BuildRequires:  go(github.com/google/uuid)
+BuildRequires:  go(github.com/spf13/cobra)
+BuildRequires:  go(github.com/spf13/pflag)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(go.etcd.io/etcd/client/v3)
+BuildRequires:  go(go.opentelemetry.io/otel/attribute)
+BuildRequires:  go(go.opentelemetry.io/otel/trace)
+BuildRequires:  go(go.yaml.in/yaml/v2)
+BuildRequires:  go(golang.org/x/sync)
+BuildRequires:  go(golang.org/x/text)
+BuildRequires:  go(google.golang.org/grpc)
+BuildRequires:  go(google.golang.org/protobuf/proto)
+BuildRequires:  go(gopkg.in/evanphx/json-patch.v4)
+BuildRequires:  go(k8s.io/api/apidiscovery/v2)
+BuildRequires:  go(k8s.io/api/autoscaling/v1)
+BuildRequires:  go(k8s.io/api/core/v1)
+BuildRequires:  go(k8s.io/apimachinery/pkg)
+BuildRequires:  go(k8s.io/apimachinery/pkg/version)
+BuildRequires:  go(k8s.io/apiserver/pkg)
+BuildRequires:  go(k8s.io/client-go/applyconfigurations)
+BuildRequires:  go(k8s.io/client-go/discovery)
+BuildRequires:  go(k8s.io/client-go/dynamic)
+BuildRequires:  go(k8s.io/client-go/gentype)
+BuildRequires:  go(k8s.io/client-go/kubernetes)
+BuildRequires:  go(k8s.io/client-go/listers)
+BuildRequires:  go(k8s.io/client-go/openapi3)
+BuildRequires:  go(k8s.io/client-go/rest)
+BuildRequires:  go(k8s.io/client-go/restmapper)
+BuildRequires:  go(k8s.io/client-go/scale)
+BuildRequires:  go(k8s.io/client-go/testing)
+BuildRequires:  go(k8s.io/client-go/tools)
+BuildRequires:  go(k8s.io/client-go/util)
+BuildRequires:  go(k8s.io/component-base/cli)
+BuildRequires:  go(k8s.io/component-base/compatibility)
+BuildRequires:  go(k8s.io/component-base/featuregate)
+BuildRequires:  go(k8s.io/component-base/logs)
+BuildRequires:  go(k8s.io/component-base/metrics)
+BuildRequires:  go(k8s.io/component-base/tracing)
+BuildRequires:  go(k8s.io/klog/v2)
+BuildRequires:  go(k8s.io/kube-openapi/pkg)
+BuildRequires:  go(k8s.io/kube-openapi/pkg/validation)
+BuildRequires:  go(k8s.io/utils/net)
+BuildRequires:  go(k8s.io/utils/ptr)
+BuildRequires:  go(sigs.k8s.io/json)
+BuildRequires:  go(sigs.k8s.io/randfill)
+BuildRequires:  go(sigs.k8s.io/structured-merge-diff/v6)
+BuildRequires:  go(sigs.k8s.io/yaml)
+
+Provides:       go(k8s.io/apiextensions-apiserver) = %{version}
+
+Requires:       go(github.com/emicklei/go-restful/v3)
+Requires:       go(github.com/google/cel-go)
+Requires:       go(github.com/google/uuid)
+Requires:       go(github.com/spf13/cobra)
+Requires:       go(github.com/spf13/pflag)
+Requires:       go(github.com/stretchr/testify)
+Requires:       go(go.etcd.io/etcd/client/v3)
+Requires:       go(go.opentelemetry.io/otel/attribute)
+Requires:       go(go.opentelemetry.io/otel/trace)
+Requires:       go(golang.org/x/sync)
+Requires:       go(golang.org/x/text)
+Requires:       go(google.golang.org/grpc)
+Requires:       go(k8s.io/api/apidiscovery/v2)
+Requires:       go(k8s.io/api/autoscaling/v1)
+Requires:       go(k8s.io/api/core/v1)
+Requires:       go(k8s.io/apimachinery/pkg)
+Requires:       go(k8s.io/apimachinery/pkg/version)
+Requires:       go(k8s.io/apiserver/pkg)
+Requires:       go(k8s.io/client-go/applyconfigurations)
+Requires:       go(k8s.io/client-go/discovery)
+Requires:       go(k8s.io/client-go/dynamic)
+Requires:       go(k8s.io/client-go/gentype)
+Requires:       go(k8s.io/client-go/kubernetes)
+Requires:       go(k8s.io/client-go/listers)
+Requires:       go(k8s.io/client-go/rest)
+Requires:       go(k8s.io/client-go/restmapper)
+Requires:       go(k8s.io/client-go/scale)
+Requires:       go(k8s.io/client-go/testing)
+Requires:       go(k8s.io/client-go/tools)
+Requires:       go(k8s.io/client-go/util)
+Requires:       go(k8s.io/component-base/cli)
+Requires:       go(k8s.io/component-base/compatibility)
+Requires:       go(k8s.io/component-base/featuregate)
+Requires:       go(k8s.io/component-base/logs)
+Requires:       go(k8s.io/component-base/metrics)
+Requires:       go(k8s.io/component-base/tracing)
+Requires:       go(k8s.io/klog/v2)
+Requires:       go(k8s.io/kube-openapi/pkg)
+Requires:       go(k8s.io/kube-openapi/pkg/validation)
+Requires:       go(k8s.io/utils/net)
+Requires:       go(k8s.io/utils/ptr)
+Requires:       go(sigs.k8s.io/json)
+Requires:       go(sigs.k8s.io/randfill)
+Requires:       go(sigs.k8s.io/structured-merge-diff/v6)
+
+
+%description
+TODO: long description
+
+%files
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

This PR contains 2 Go module package changes for Prometheus v3.13 (DAG level 8). The listed PRs provide the direct Go module dependencies required by this batch.

Requires: #1117 #1120 #1121 #1122 #1123 #1124 #1125 #1127 #1128 #1129 #1131

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: ChatGPT:GPT-5.6-sol High

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]: https://openruyi.cn/governance/policy/ai-contribution-policy