### PR TITLE
SPECS: Add Prometheus v3.13 modules - DAG L10-18

### DIFF
--- a/SPECS/go-github-open-telemetry-opentelemetry-collector-contrib/2000-cmd-telemetrygen-fix-canonical-import-comments.patch
+++ b/SPECS/go-github-open-telemetry-opentelemetry-collector-contrib/2000-cmd-telemetrygen-fix-canonical-import-comments.patch
@@ -1,0 +1,43 @@
+From 35f9797ba86b7016cc4df23f997defd15ee42ebe Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Mon, 17 Aug 2026 03:17:54 +0800
+Subject: [PATCH] cmd/telemetrygen: fix canonical import comments
+
+Go module mode ignores canonical import comments, but GOPATH mode validates
+them. Update two stale comments so telemetrygen can also be built in the
+offline GOPATH layout used by openRuyi.
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ cmd/telemetrygen/config.go            | 2 +-
+ cmd/telemetrygen/pkg/traces/worker.go | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/cmd/telemetrygen/config.go b/cmd/telemetrygen/config.go
+index 20df54dabf..0412b842fa 100644
+--- a/cmd/telemetrygen/config.go
++++ b/cmd/telemetrygen/config.go
+@@ -4,7 +4,7 @@
+ 
+ //go:generate make mdatagen
+ 
+-package main // import "github.com/open-telemetry/opentelemetry-collector-contrib/telemetrygen/internal/telemetrygen"
++package main // import "github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen"
+ 
+ import (
+ 	"os"
+diff --git a/cmd/telemetrygen/pkg/traces/worker.go b/cmd/telemetrygen/pkg/traces/worker.go
+index a5aee180ca..cdd068ce8a 100644
+--- a/cmd/telemetrygen/pkg/traces/worker.go
++++ b/cmd/telemetrygen/pkg/traces/worker.go
+@@ -1,7 +1,7 @@
+ // Copyright The OpenTelemetry Authors
+ // SPDX-License-Identifier: Apache-2.0
+ 
+-package traces // import "github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen/internal/traces"
++package traces // import "github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen/pkg/traces"
+ 
+ import (
+ 	"context"
+-- 
+2.43.0

--- a/SPECS/go-github-open-telemetry-opentelemetry-collector-contrib/2001-exporter-clickhouse-support-clickhouse-go-v2.48-test.patch
+++ b/SPECS/go-github-open-telemetry-opentelemetry-collector-contrib/2001-exporter-clickhouse-support-clickhouse-go-v2.48-test.patch
@@ -1,0 +1,37 @@
+From 497e707f171c1e21715c3ac476965db522d8855c Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Wed, 19 Aug 2026 02:56:06 +0800
+Subject: [PATCH] exporter/clickhouse: support clickhouse-go v2.48 test
+ interface
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ exporter/clickhouseexporter/exporter_bench_test.go | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/exporter/clickhouseexporter/exporter_bench_test.go b/exporter/clickhouseexporter/exporter_bench_test.go
+index 6ca2ed7..124ba0e 100644
+--- a/exporter/clickhouseexporter/exporter_bench_test.go
++++ b/exporter/clickhouseexporter/exporter_bench_test.go
+@@ -6,6 +6,7 @@ package clickhouseexporter
+ import (
+ 	"context"
+ 	"fmt"
++	"io"
+ 	"testing"
+ 	"time"
+ 
+@@ -43,6 +44,10 @@ func (noopConn) ServerVersion() (*driver.ServerVersion, error) {
+ func (noopConn) Select(_ context.Context, _ any, _ string, _ ...any) error        { return nil }
+ func (noopConn) Query(_ context.Context, _ string, _ ...any) (driver.Rows, error) { return nil, nil }
+ func (noopConn) QueryRow(_ context.Context, _ string, _ ...any) driver.Row        { return nil }
++func (noopConn) QueryFormat(_ context.Context, _, _ string, _ ...any) (io.ReadCloser, error) {
++	return nil, nil
++}
++func (noopConn) InsertFormat(_ context.Context, _, _ string, _ io.Reader) error { return nil }
+ func (noopConn) PrepareBatch(_ context.Context, _ string, _ ...driver.PrepareBatchOption) (driver.Batch, error) {
+ 	return noopBatch{}, nil
+ }
+-- 
+2.43.0
+

--- a/SPECS/go-github-open-telemetry-opentelemetry-collector-contrib/2002-exporter-coralogix-avoid-resolver-specific-error-mes.patch
+++ b/SPECS/go-github-open-telemetry-opentelemetry-collector-contrib/2002-exporter-coralogix-avoid-resolver-specific-error-mes.patch
@@ -1,0 +1,108 @@
+From 21a3a03d7b20cb0a0f6685b7899fbe317080b78c Mon Sep 17 00:00:00 2001
+From: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+Date: Wed, 19 Aug 2026 03:11:51 +0800
+Subject: [PATCH] exporter/coralogix: avoid resolver-specific error messages
+
+Signed-off-by: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+---
+ exporter/coralogixexporter/logs_client_test.go     | 4 +++-
+ exporter/coralogixexporter/metrics_client_test.go  | 4 +++-
+ exporter/coralogixexporter/profiles_client_test.go | 4 +++-
+ exporter/coralogixexporter/traces_client_test.go   | 4 +++-
+ 4 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/exporter/coralogixexporter/logs_client_test.go b/exporter/coralogixexporter/logs_client_test.go
+index 6bc73ba..fc462ef 100644
+--- a/exporter/coralogixexporter/logs_client_test.go
++++ b/exporter/coralogixexporter/logs_client_test.go
+@@ -26,7 +26,9 @@ import (
+ 	"go.uber.org/zap/zapcore"
+ 	"go.uber.org/zap/zaptest/observer"
+ 	"google.golang.org/grpc"
++	"google.golang.org/grpc/codes"
+ 	"google.golang.org/grpc/metadata"
++	"google.golang.org/grpc/status"
+ )
+ 
+ func TestNewLogsExporter(t *testing.T) {
+@@ -203,7 +205,7 @@ func TestLogsExporter_PushLogs_WhenCannotSend(t *testing.T) {
+ 			if tt.enabled {
+ 				assert.Contains(t, err.Error(), "rate limit exceeded")
+ 			} else {
+-				assert.Contains(t, err.Error(), "produced zero addresses")
++				assert.Equal(t, codes.Unavailable, status.Code(err))
+ 			}
+ 		})
+ 	}
+diff --git a/exporter/coralogixexporter/metrics_client_test.go b/exporter/coralogixexporter/metrics_client_test.go
+index eff5b7d..0a79b10 100644
+--- a/exporter/coralogixexporter/metrics_client_test.go
++++ b/exporter/coralogixexporter/metrics_client_test.go
+@@ -26,7 +26,9 @@ import (
+ 	"go.uber.org/zap/zapcore"
+ 	"go.uber.org/zap/zaptest/observer"
+ 	"google.golang.org/grpc"
++	"google.golang.org/grpc/codes"
+ 	"google.golang.org/grpc/metadata"
++	"google.golang.org/grpc/status"
+ )
+ 
+ func TestNewMetricsExporter(t *testing.T) {
+@@ -216,7 +218,7 @@ func TestMetricsExporter_PushMetrics_WhenCannotSend(t *testing.T) {
+ 			if tt.enabled {
+ 				assert.Contains(t, err.Error(), "rate limit exceeded")
+ 			} else {
+-				assert.Contains(t, err.Error(), "produced zero addresses")
++				assert.Equal(t, codes.Unavailable, status.Code(err))
+ 			}
+ 		})
+ 	}
+diff --git a/exporter/coralogixexporter/profiles_client_test.go b/exporter/coralogixexporter/profiles_client_test.go
+index 4ff81e2..1fcbb29 100644
+--- a/exporter/coralogixexporter/profiles_client_test.go
++++ b/exporter/coralogixexporter/profiles_client_test.go
+@@ -26,7 +26,9 @@ import (
+ 	"go.uber.org/zap/zapcore"
+ 	"go.uber.org/zap/zaptest/observer"
+ 	"google.golang.org/grpc"
++	"google.golang.org/grpc/codes"
+ 	"google.golang.org/grpc/metadata"
++	"google.golang.org/grpc/status"
+ )
+ 
+ func TestNewProfilesExporter(t *testing.T) {
+@@ -199,7 +201,7 @@ func TestProfilesExporter_PushProfiles_WhenCannotSend(t *testing.T) {
+ 			if tt.enabled {
+ 				assert.Contains(t, err.Error(), "rate limit exceeded")
+ 			} else {
+-				assert.Contains(t, err.Error(), "produced zero addresses")
++				assert.Equal(t, codes.Unavailable, status.Code(err))
+ 			}
+ 		})
+ 	}
+diff --git a/exporter/coralogixexporter/traces_client_test.go b/exporter/coralogixexporter/traces_client_test.go
+index ca563e5..1d5d6b5 100644
+--- a/exporter/coralogixexporter/traces_client_test.go
++++ b/exporter/coralogixexporter/traces_client_test.go
+@@ -26,7 +26,9 @@ import (
+ 	"go.uber.org/zap/zapcore"
+ 	"go.uber.org/zap/zaptest/observer"
+ 	"google.golang.org/grpc"
++	"google.golang.org/grpc/codes"
+ 	"google.golang.org/grpc/metadata"
++	"google.golang.org/grpc/status"
+ 
+ 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter/internal/validation"
+ )
+@@ -205,7 +207,7 @@ func TestTracesExporter_PushTraces_WhenCannotSend(t *testing.T) {
+ 			if tt.configEnabled {
+ 				assert.Contains(t, err.Error(), "rate limit exceeded")
+ 			} else {
+-				assert.Contains(t, err.Error(), "produced zero addresses")
++				assert.Equal(t, codes.Unavailable, status.Code(err))
+ 			}
+ 		})
+ 	}
+-- 
+2.43.0
+

--- a/SPECS/go-github-open-telemetry-opentelemetry-collector-contrib/go-github-open-telemetry-opentelemetry-collector-contrib.spec
+++ b/SPECS/go-github-open-telemetry-opentelemetry-collector-contrib/go-github-open-telemetry-opentelemetry-collector-contrib.spec
@@ -1,0 +1,230 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: HNO3Miracle <xiangao.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           opentelemetry-collector-contrib
+%define go_import_path  github.com/open-telemetry/opentelemetry-collector-contrib
+# Schemagen path assertions require Go module mode rather than the offline GOPATH layout.
+# Failover recovery tests use a fixed timeout that flakes on loaded OBS workers.
+# AWS X-Ray telemetry assertions depend on the external request failure type.
+%define go_test_exclude %{go_import_path}/cmd/schemagen/internal %{go_import_path}/connector/failoverconnector %{go_import_path}/exporter/awsxrayexporter
+
+Name:           go-github-open-telemetry-opentelemetry-collector-contrib
+Version:        0.154.0
+Release:        %autorelease
+Summary:        OpenTelemetry Collector contrib modules
+License:        Apache-2.0
+URL:            https://github.com/open-telemetry/opentelemetry-collector-contrib
+#!RemoteAsset:  sha256:72c3365cf0f1a879a753e97cea902c2c09ce48ac5e28df5246cd048d7786edc1
+Source0:        https://github.com/open-telemetry/opentelemetry-collector-contrib/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+Patch2000:      2000-cmd-telemetrygen-fix-canonical-import-comments.patch
+# Keep the benchmark test connection compatible with packaged clickhouse-go.
+Patch2001:      2001-exporter-clickhouse-support-clickhouse-go-v2.48-test.patch
+# Avoid depending on resolver-specific gRPC error text in Coralogix tests.
+Patch2002:      2002-exporter-coralogix-avoid-resolver-specific-error-mes.patch
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(cloud.google.com/go/secretmanager)
+BuildRequires:  go(cloud.google.com/go/storage)
+BuildRequires:  go(github.com/alecthomas/participle/v2)
+BuildRequires:  go(github.com/aliyun/aliyun-log-go-sdk)
+BuildRequires:  go(github.com/apache/cassandra-gocql-driver/v2)
+BuildRequires:  go(github.com/antchfx/xmlquery)
+BuildRequires:  go(github.com/antchfx/xpath)
+BuildRequires:  go(github.com/Azure/azure-kusto-go)
+BuildRequires:  go(github.com/Azure/azure-sdk-for-go/sdk/storage/azblob)
+BuildRequires:  go(github.com/aws/aws-msk-iam-sasl-signer-go)
+BuildRequires:  go(github.com/bmatcuk/doublestar/v4)
+BuildRequires:  go(github.com/cespare/xxhash/v2)
+BuildRequires:  go(github.com/ClickHouse/clickhouse-go/v2)
+BuildRequires:  go(github.com/containerd/cgroups/v3)
+BuildRequires:  go(github.com/davecgh/go-spew)
+BuildRequires:  go(github.com/DataDog/agent-payload/v5)
+BuildRequires:  go(github.com/DataDog/datadog-agent)
+BuildRequires:  go(github.com/DataDog/datadog-go/v5)
+BuildRequires:  go(github.com/DataDog/gohai)
+BuildRequires:  go(github.com/DeRuina/timberjack)
+BuildRequires:  go(github.com/elastic/elastic-transport-go/v8)
+BuildRequires:  go(github.com/elastic/go-docappender/v2)
+BuildRequires:  go(github.com/elastic/go-freelru)
+BuildRequires:  go(github.com/fortytw2/leaktest)
+BuildRequires:  go(github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp)
+BuildRequires:  go(github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector)
+BuildRequires:  go(github.com/elastic/go-grok)
+BuildRequires:  go(github.com/elastic/go-structform)
+BuildRequires:  go(github.com/openshift/client-go)
+BuildRequires:  go(github.com/elastic/lunes)
+BuildRequires:  go(github.com/go-logr/logr)
+BuildRequires:  go(github.com/go-logr/stdr)
+BuildRequires:  go(github.com/go-viper/mapstructure/v2)
+BuildRequires:  go(github.com/gobwas/glob)
+BuildRequires:  go(github.com/goccy/go-json)
+BuildRequires:  go(github.com/go-sql-driver/mysql)
+BuildRequires:  go(github.com/grafana/faro/pkg/go)
+BuildRequires:  go(github.com/google/go-cmp)
+BuildRequires:  go(github.com/google/uuid)
+BuildRequires:  go(github.com/gorilla/mux)
+BuildRequires:  go(github.com/hashicorp/go-version)
+BuildRequires:  go(github.com/influxdata/influxdb-observability/common)
+BuildRequires:  go(github.com/itchyny/timefmt-go)
+BuildRequires:  go(github.com/jaegertracing/jaeger-idl)
+BuildRequires:  go(github.com/json-iterator/go)
+BuildRequires:  go(github.com/jonboulle/clockwork)
+BuildRequires:  go(github.com/knadh/koanf/maps)
+BuildRequires:  go(github.com/knadh/koanf/providers/confmap)
+BuildRequires:  go(github.com/knadh/koanf/providers/rawbytes)
+BuildRequires:  go(github.com/knadh/koanf/v2)
+BuildRequires:  go(github.com/kr/text)
+BuildRequires:  go(github.com/lestrrat-go/strftime)
+BuildRequires:  go(github.com/lightstep/go-expohisto)
+BuildRequires:  go(github.com/microsoft/ApplicationInsights-Go)
+BuildRequires:  go(github.com/mitchellh/copystructure)
+BuildRequires:  go(github.com/mitchellh/reflectwalk)
+BuildRequires:  go(github.com/modern-go/concurrent)
+BuildRequires:  go(github.com/modern-go/reflect2)
+BuildRequires:  go(github.com/moby/moby/api)
+BuildRequires:  go(github.com/moby/moby/client)
+BuildRequires:  go(github.com/open-telemetry/opamp-go)
+BuildRequires:  go(github.com/orcaman/concurrent-map/v2)
+BuildRequires:  go(github.com/pmezard/go-difflib)
+BuildRequires:  go(github.com/puzpuzpuz/xsync)
+BuildRequires:  go(github.com/rogpeppe/go-internal)
+BuildRequires:  go(github.com/scalyr/dataset-go)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(github.com/tg123/go-htpasswd)
+BuildRequires:  go(github.com/tilinna/clock)
+BuildRequires:  go(github.com/tj/assert)
+BuildRequires:  go(github.com/tidwall/wal)
+BuildRequires:  go(github.com/twmb/murmur3)
+BuildRequires:  go(github.com/ua-parser/uap-go)
+BuildRequires:  go(github.com/wk8/go-ordered-map/v2)
+BuildRequires:  go(github.com/zeebo/xxh3)
+BuildRequires:  go(go.etcd.io/bbolt)
+BuildRequires:  go(go.opentelemetry.io/auto/sdk)
+BuildRequires:  go(go.opentelemetry.io/collector)
+BuildRequires:  go(go.opentelemetry.io/collector/semconv)
+BuildRequires:  go(go.opentelemetry.io/ebpf-profiler)
+BuildRequires:  go(go.opentelemetry.io/otel)
+BuildRequires:  go(go.uber.org/goleak)
+BuildRequires:  go(go.uber.org/multierr)
+BuildRequires:  go(go.uber.org/zap)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(golang.org/x/tools)
+BuildRequires:  go(gopkg.in/yaml.v3)
+BuildRequires:  go(gotest.tools/assert)
+BuildRequires:  go(sigs.k8s.io/controller-runtime)
+BuildRequires:  tzdata
+
+Provides:       go(github.com/open-telemetry/opentelemetry-collector-contrib) = %{version}
+
+Requires:       go(cloud.google.com/go/secretmanager)
+Requires:       go(cloud.google.com/go/storage)
+Requires:       go(github.com/alecthomas/participle/v2)
+Requires:       go(github.com/aliyun/aliyun-log-go-sdk)
+Requires:       go(github.com/apache/cassandra-gocql-driver/v2)
+Requires:       go(github.com/antchfx/xmlquery)
+Requires:       go(github.com/antchfx/xpath)
+Requires:       go(github.com/Azure/azure-kusto-go)
+Requires:       go(github.com/Azure/azure-sdk-for-go/sdk/storage/azblob)
+Requires:       go(github.com/aws/aws-msk-iam-sasl-signer-go)
+Requires:       go(github.com/bmatcuk/doublestar/v4)
+Requires:       go(github.com/cespare/xxhash/v2)
+Requires:       go(github.com/ClickHouse/clickhouse-go/v2)
+Requires:       go(github.com/containerd/cgroups/v3)
+Requires:       go(github.com/DataDog/agent-payload/v5)
+Requires:       go(github.com/DataDog/datadog-agent)
+Requires:       go(github.com/DataDog/datadog-go/v5)
+Requires:       go(github.com/DataDog/gohai)
+Requires:       go(github.com/DeRuina/timberjack)
+Requires:       go(github.com/elastic/elastic-transport-go/v8)
+Requires:       go(github.com/elastic/go-docappender/v2)
+Requires:       go(github.com/elastic/go-freelru)
+Requires:       go(github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp)
+Requires:       go(github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector)
+Requires:       go(github.com/elastic/go-grok)
+Requires:       go(github.com/elastic/go-structform)
+Requires:       go(github.com/openshift/client-go)
+Requires:       go(github.com/elastic/lunes)
+Requires:       go(github.com/goccy/go-json)
+Requires:       go(github.com/go-sql-driver/mysql)
+Requires:       go(github.com/grafana/faro/pkg/go)
+Requires:       go(github.com/google/go-cmp)
+Requires:       go(github.com/gorilla/mux)
+Requires:       go(github.com/influxdata/influxdb-observability/common)
+Requires:       go(github.com/itchyny/timefmt-go)
+Requires:       go(github.com/jaegertracing/jaeger-idl)
+Requires:       go(github.com/jonboulle/clockwork)
+Requires:       go(github.com/knadh/koanf/providers/rawbytes)
+Requires:       go(github.com/lestrrat-go/strftime)
+Requires:       go(github.com/lightstep/go-expohisto)
+Requires:       go(github.com/microsoft/ApplicationInsights-Go)
+Requires:       go(github.com/moby/moby/api)
+Requires:       go(github.com/moby/moby/client)
+Requires:       go(github.com/open-telemetry/opamp-go)
+Requires:       go(github.com/orcaman/concurrent-map/v2)
+Requires:       go(github.com/puzpuzpuz/xsync)
+Requires:       go(github.com/scalyr/dataset-go)
+Requires:       go(github.com/stretchr/testify)
+Requires:       go(github.com/tg123/go-htpasswd)
+Requires:       go(github.com/tilinna/clock)
+Requires:       go(github.com/tidwall/wal)
+Requires:       go(github.com/twmb/murmur3)
+Requires:       go(github.com/ua-parser/uap-go)
+Requires:       go(github.com/wk8/go-ordered-map/v2)
+Requires:       go(github.com/zeebo/xxh3)
+Requires:       go(go.etcd.io/bbolt)
+Requires:       go(go.opentelemetry.io/auto/sdk)
+Requires:       go(go.opentelemetry.io/collector)
+Requires:       go(go.opentelemetry.io/collector/semconv)
+Requires:       go(go.opentelemetry.io/ebpf-profiler)
+Requires:       go(go.opentelemetry.io/otel)
+Requires:       go(golang.org/x/tools)
+Requires:       go(gopkg.in/yaml.v3)
+Requires:       go(sigs.k8s.io/controller-runtime)
+
+%description
+This package bundles the Collector contrib metrics utilities and delta-to-
+cumulative processor from one upstream repository snapshot. Additional modules
+from this repository should be added here instead of split into source packages.
+
+%install
+install -d "%{buildroot}%{go_sys_gopath}/%{go_import_path}"
+cp -a ./. "%{buildroot}%{go_sys_gopath}/%{go_import_path}/"
+
+%check
+export GO111MODULE=off
+export GOPATH=%{_builddir}/go:%{_datadir}/gocode
+install -d "%{_builddir}/go/src/%{go_import_path}"
+cp -a ./. "%{_builddir}/go/src/%{go_import_path}/"
+pushd "%{_builddir}/go/src/%{go_import_path}"
+while IFS= read -r -d '' _go_mod; do
+    _module_dir=${_go_mod%/go.mod}
+    pushd "${_module_dir}"
+    _go_pkgs=$(go list -e -f '{{.ImportPath}}' ./...)
+    _go_test_pkgs=
+    for _go_pkg in ${_go_pkgs}; do
+        case " %{go_test_exclude} " in
+            *" ${_go_pkg} "*) go test -run '^$' "${_go_pkg}" ;;
+            *) _go_test_pkgs="${_go_test_pkgs} ${_go_pkg}" ;;
+        esac
+    done
+    if [ -n "${_go_test_pkgs}" ]; then
+        go test -v ${_go_test_pkgs}
+    fi
+    popd
+done < <(find . -name go.mod -print0 | sort -z)
+popd
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

This PR contains 1 Go module package changes for Prometheus v3.13 (DAG level 10). The listed PRs provide the direct Go module dependencies required by this batch.

Requires: #1117 #1118 #1119 #1120 #1121 #1122 #1123 #1124 #1125 #1127 #1128 #1129 #1131 #1132 #1133

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: ChatGPT:GPT-5.6-sol High

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]: https://openruyi.cn/governance/policy/ai-contribution-policy