### PR TITLE
SPECS: mold: Fix test failure on riscv64.

### DIFF
--- a/SPECS/mold/0001-Fix-test-for-some-targets.patch
+++ b/SPECS/mold/0001-Fix-test-for-some-targets.patch
@@ -1,0 +1,21 @@
+From f716fb62def04d7e0d8d266a33ba4bb88476b210 Mon Sep 17 00:00:00 2001
+From: Rui Ueyama <ruiu@cs.stanford.edu>
+Date: Sun, 23 Aug 2026 21:20:56 +0900
+Subject: [PATCH] Fix test for some targets
+
+Fixes https://github.com/rui314/mold/issues/1638
+---
+ test/separate-debug-file-sort.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/separate-debug-file-sort.sh b/test/separate-debug-file-sort.sh
+index 3fb5ec6b18..abfda730ae 100755
+--- a/test/separate-debug-file-sort.sh
++++ b/test/separate-debug-file-sort.sh
+@@ -23,5 +23,5 @@ flock $t/exe.dbg true
+ readelf -p .debug_line_str $t/exe.dbg > $t/str
+ 
+ if grep -Fw a.c $t/str; then
+-  grep -A10 -Fw a.c $t/str | grep -Fw b.c
++  sed -n '/a\.c/,$p' $t/str | grep -Fw b.c
+ fi

--- a/SPECS/mold/mold.spec
+++ b/SPECS/mold/mold.spec
@@ -27,11 +27,16 @@ BuildRequires:  pkgconfig(libxxhash)
 BuildRequires:  pkgconfig(zlib)
 BuildRequires:  pkgconfig(libzstd)
 BuildRequires:  pkgconfig(tbb)
+%ifarch riscv64
+# For riscv64-arch-riscv64-emit-relocs-relax test.
+BuildRequires:  glibc-static
+%endif
 
 Requires(post): update-alternatives
 Requires(preun): update-alternatives
 
 %patchlist
+0001-Fix-test-for-some-targets.patch
 # Allow building against the system-provided `xxhash.h`
 1000-Use-system-compatible-include-path-for-xxhash.h.patch
 


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->
Currently, there are two tests failure on riscv64:
```
[ 4503s] The following tests FAILED:
[ 4503s] 	  3 - riscv64-arch-riscv64-emit-relocs-relax (Failed)
[ 4503s] 	276 - riscv64-separate-debug-file-sort (Failed)
[ 4503s] Errors while running CTest
```
## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
