### PR TITLE
SPECS: pcre2: Fix test failure on rva23 project.

### DIFF
--- a/SPECS/pcre2/0001-pcre2test-allow-using-dynamically-allocated-buffers-and.patch
+++ b/SPECS/pcre2/0001-pcre2test-allow-using-dynamically-allocated-buffers-and.patch
@@ -1,0 +1,134 @@
+From 32b303f8f2c00b7b53902dda742ac308281c7349 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Carlo=20Marcelo=20Arenas=20Bel=C3=B3n?= <carenas@gmail.com>
+Date: Tue, 28 Oct 2025 12:11:06 -0700
+Subject: [PATCH 1/2] pcre2test: allow using dynamically allocated buffers and
+ migrate JITTARGET
+
+Always ask `pcre2_config()` for the expected size of buffers and abort if
+it is too small, effectively avoiding to do the validation after it was
+written.
+
+In preparation for deprecating the use of static buffers, increase
+the documented max size for JITTARGET to the next power of 2.
+---
+ doc/pcre2api.3      |  4 ++--
+ src/pcre2test.c     | 12 ++++++------
+ src/pcre2test_inc.h | 35 ++++++++++++++++++++++++++---------
+ 3 files changed, 34 insertions(+), 17 deletions(-)
+
+diff --git a/doc/pcre2api.3 b/doc/pcre2api.3
+index 1100e59af..67d9034b8 100644
+--- a/doc/pcre2api.3
++++ b/doc/pcre2api.3
+@@ -1296,8 +1296,8 @@ documentation for more details.
+ .sp
+   PCRE2_CONFIG_JITTARGET
+ .sp
+-The \fIwhere\fP argument should point to a buffer that is at least 64 code
+-units long. (The exact length required can be found by calling
++The \fIwhere\fP argument should point to a buffer that is suitably aligned and
++at least 128 code units long. (The exact length required can be found by calling
+ \fBpcre2_config()\fP with \fBwhere\fP set to NULL.) The buffer is filled with a
+ string that contains the name of the architecture for which the JIT compiler is
+ configured, for example "x86 32bit (little endian + unaligned)". If JIT support
+diff --git a/src/pcre2test.c b/src/pcre2test.c
+index 3242b5ce7..81e93741e 100644
+--- a/src/pcre2test.c
++++ b/src/pcre2test.c
+@@ -2942,9 +2942,9 @@ static int pcre2_config(uint32_t what, void *where)
+ DISPATCH(return, pcre2_config_, (what, where));
+ }
+ 
+-static void config_str(uint32_t what, char *where)
++static char *config_str(uint32_t what, char *where, int size)
+ {
+-DISPATCH(, config_str_, (what, where));
++DISPATCH(return, config_str_, (what, where, size));
+ }
+ 
+ static BOOL decode_modifiers(uint8_t *p, int ctx, patctl *pctl, datctl *dctl)
+@@ -3014,7 +3014,7 @@ static void
+ print_version(FILE *f, BOOL include_mode)
+ {
+ char buf[VERSION_SIZE];
+-config_str(PCRE2_CONFIG_VERSION, buf);
++config_str(PCRE2_CONFIG_VERSION, buf, sizeof(buf));
+ fprintf(f, "PCRE2 version %s", buf);
+ if (include_mode)
+   {
+@@ -3033,7 +3033,7 @@ static void
+ print_unicode_version(FILE *f)
+ {
+ char buf[VERSION_SIZE];
+-config_str(PCRE2_CONFIG_UNICODE_VERSION, buf);
++config_str(PCRE2_CONFIG_UNICODE_VERSION, buf, sizeof(buf));
+ fprintf(f, "Unicode version %s", buf);
+ }
+ 
+@@ -3046,9 +3046,9 @@ fprintf(f, "Unicode version %s", buf);
+ static void
+ print_jit_target(FILE *f)
+ {
+-char buf[VERSION_SIZE];
+-config_str(PCRE2_CONFIG_JITTARGET, buf);
++char *buf = config_str(PCRE2_CONFIG_JITTARGET, NULL, 0);
+ fputs(buf, f);
++free(buf);
+ }
+ 
+ 
+diff --git a/src/pcre2test_inc.h b/src/pcre2test_inc.h
+index c47074171..ce808a82f 100644
+--- a/src/pcre2test_inc.h
++++ b/src/pcre2test_inc.h
+@@ -558,24 +558,41 @@ return 0;
+ 
+ Arguments:
+   what       the item to read
+-  where      the 8-bit buffer to receive the string
++  where      the 8-bit buffer to receive the string (NULLABLE)
++  size       sizeof(where) or 0 to ask for the buffer to be allocated
++
++Returns:     the string where the data was written
+ */
+ 
+-static void
+-config_str(uint32_t what, char *where)
++static char *
++config_str(uint32_t what, char *where, int size)
+ {
+-int r1, r2;
+-PCRE2_UCHAR buf[VERSION_SIZE];
++int r2;
++PCRE2_UCHAR *buf;
++int needed_len;
+ 
+-r1 = pcre2_config(what, NULL);
+-r2 = pcre2_config(what, buf);
+-if (r1 < 0 || r1 != r2 || r1 >= VERSION_SIZE)
++needed_len = pcre2_config(what, NULL);
++if (needed_len <= 0)
+   {
+   cfprintf(clr_test_error, stderr, "pcre2test: Error in pcre2_config(%d)\n", what);
+   exit(1);
+   }
++else if (size != 0 && needed_len > size)
++  {
++  cfprintf(clr_test_error, stderr,
++    "pcre2test: Static buffer provided to pcre2_config(%d) too small\n", what);
++  exit(1);
++  }
++
++buf = malloc(needed_len * sizeof(PCRE2_UCHAR));
++r2 = pcre2_config(what, buf);
++PCRE2_ASSERT(r2 == needed_len);
++
++if (where == NULL) where = malloc(needed_len);
++while (r2-- > 0) where[r2] = (char)buf[r2];
++free(buf);
+ 
+-while (r1-- > 0) where[r1] = (char)buf[r1];
++return where;
+ }
+ 
+ 

--- a/SPECS/pcre2/pcre2.spec
+++ b/SPECS/pcre2/pcre2.spec
@@ -17,6 +17,8 @@ VCS:            git:https://github.com/PCRE2Project/pcre2.git
 Source0:        https://github.com/PCRE2Project/pcre2/releases/download/pcre2-%{version}/pcre2-%{version}.tar.bz2
 BuildSystem:    autotools
 
+Patch0:         0001-pcre2test-allow-using-dynamically-allocated-buffers-and.patch
+
 BuildOption(conf):  --enable-jit
 BuildOption(conf):  --enable-pcre2-16
 BuildOption(conf):  --enable-pcre2-32


### PR DESCRIPTION
The patch is the 1st commit of
https://github.com/PCRE2Project/pcre2/pull/835
(The 2nd commit is dropped as it's all about doc changes for the 10.48 version)

## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->
Currently, there is an error on rva23 tests:
```
[  756s] ** pcre2test -8 -C failed - check testSoutput
```
The reason is really about pcre2_config() function failure due to buffer size overflow.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
