### PR TITLE
Ship dpdk usertools and enable the vector paths on RVA23

### DIFF
--- a/SPECS/dpdk/dpdk.spec
+++ b/SPECS/dpdk/dpdk.spec
@@ -98,7 +98,6 @@ Requires:       python3dist(pyelftools)
 %{_libdir}/pkgconfig/libdpdk-libs.pc
 
 %files tools
-%exclude %{_bindir}/dpdk-*.py
 %{_bindir}/dpdk-dumpcap
 %{_bindir}/dpdk-pdump
 %{_bindir}/dpdk-graph

--- a/SPECS/dpdk/dpdk.spec
+++ b/SPECS/dpdk/dpdk.spec
@@ -27,8 +27,15 @@ VCS:            git:https://github.com/DPDK/dpdk
 Source:         https://fast.dpdk.org/rel/dpdk-%{version}.tar.xz
 BuildSystem:    meson
 
+%global dpdk_isa generic
+%ifarch riscv64
+%if "%{openruyi_riscv_arch}" == "-march=rva23u64"
+%global dpdk_isa rva23u64
+%endif
+%endif
+
 BuildOption(prep):  -p1 -n dpdk%{version_suffix}-%{version}
-BuildOption(conf):  -Dmachine=generic
+BuildOption(conf):  -Dcpu_instruction_set=%{dpdk_isa}
 
 BuildRequires:  meson
 BuildRequires:  python3dist(pyelftools)
@@ -74,6 +81,7 @@ Requires:       %{name}%{?_isa} = %{version}-%{release}
 Requires:       kmod
 Requires:       pciutils
 Requires:       iproute2
+Requires:       which
 Requires:       python3dist(pyelftools)
 
 %description    tools


### PR DESCRIPTION
## Summary

Ship the usertools scripts, which were excluded from `dpdk-tools`, and the `which` they need. Build with `-Dcpu_instruction_set=rva23u64` on RVA23 to get the vector paths.

## Related Issue

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy