### PR TITLE
SPECS: clang-wrap: Support rename when install

### DIFF
--- a/SPECS/clang-wrap/clang-wrap.spec
+++ b/SPECS/clang-wrap/clang-wrap.spec
@@ -4,8 +4,8 @@
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
-%global git_ver git20260817.d668fd0
-%global git_commit d668fd0e79c76f69cabf64659d7f9af6d516e1b5
+%global git_ver git20260825.83227ac
+%global git_commit 83227ac2bb0b80c560ae899d68b745b6a665df94
 
 Name:           clang-wrap
 Version:        0+%{git_ver}
@@ -13,7 +13,7 @@ Release:        %{autorelease}
 License:        Mulan-2.0
 Summary:        clang-wrap to collect LLVM IR
 URL:            https://github.com/openRuyi-Project/clang-wrap
-#!RemoteAsset:  sha256:28d684902ce5dee0c338507acb900b80eff9a9647c6c0f7e19ad00844ed3a3fd
+#!RemoteAsset:  sha256:18ccb38a6d28569321f167ace61893cc4ccfd1674117b57a8b9de829f0ce9b3c
 Source0:        https://github.com/openRuyi-Project/clang-wrap/archive/%{git_commit}.tar.gz
 Source1:        macros.clang-wrap
 BuildSystem:    rust


### PR DESCRIPTION

## Summary

`install A B` can rename IR files and _cmd files etc.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: CLine:GPT-5.6-Terra

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
