### PR TITLE
SPECS: ypserv: install missing yppasswdd helper scripts to libexecdir

### DIFF
--- a/SPECS/ypserv/rpc.yppasswdd.env
+++ b/SPECS/ypserv/rpc.yppasswdd.env
@@ -1,0 +1,30 @@
+#!/bin/bash
+# 
+# Author: Honza Horak <hhorak@redhat.com>
+# Date: 2011/11/25
+# Package: ypserv
+#
+# This script is part of ypserv package.
+# We need to pass all environment variables set in /etc/sysconfig/yppasswdd 
+# to rpc.yppasswdd daemon, but only if they are not empty. However, this 
+# simple logic is not supported by systemd. 
+# This script wraps the main binary, prepares YPPASSWDD_ARGS variable 
+# to include all necessary variables (ETCDIR, PASSWDFILE and SHADOWFILE)
+# and passes this variable to daemon. 
+# The script ensures, that the rpc.yppasswdd arguments are not used in case 
+# the appropriate environment variables are empty.
+
+if [ "$ETCDIR" ]; then
+  YPPASSWDD_ARGS="$YPPASSWDD_ARGS -D $ETCDIR"
+fi
+
+if [ "$PASSWDFILE" ]; then
+  YPPASSWDD_ARGS="$YPPASSWDD_ARGS -p $PASSWDFILE"
+fi
+
+if [ "$SHADOWFILE" ]; then
+  YPPASSWDD_ARGS="$YPPASSWDD_ARGS -s $SHADOWFILE"
+fi
+
+exec /usr/sbin/rpc.yppasswdd -f $YPPASSWDD_ARGS
+

--- a/SPECS/ypserv/yppasswdd-pre-setdomain
+++ b/SPECS/ypserv/yppasswdd-pre-setdomain
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# yppasswdd-pre-setdomain
+#
+# description: This is part of former ypserv init script, which is used 
+#              to setup proper domainname before starting yppasswdd daemon
+#              itself. If $NISDOMAIN is not defined, it fails. 
+#
+
+DOMAINNAME=`domainname`
+if [ "$DOMAINNAME" = "(none)" -o "$DOMAINNAME" = "" ]; then
+    echo -n $"Setting NIS domain: "
+    if [ -n "$NISDOMAIN" ]; then
+        domainname $NISDOMAIN
+        echo $"'$NISDOMAIN' (environment variable)"
+    else # no domainname found
+        logger -t yppasswdd $"domain not found"
+        exit 1
+    fi
+fi
+

--- a/SPECS/ypserv/ypserv.spec
+++ b/SPECS/ypserv/ypserv.spec
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: (C) 2025 Institute of Software, Chinese Academy of Sciences (ISCAS)
 # SPDX-FileCopyrightText: (C) 2025 openRuyi Project Contributors
 # SPDX-FileContributor: yyjeqhc <jialin.oerv@isrc.iscas.ac.cn>
+# SPDX-FileContributor: Yafen Fang <yafen@iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
@@ -11,12 +12,14 @@ Summary:        The NIS (Network Information Service) server
 License:        GPL-2.0-only
 URL:            https://www.thkukuk.de/nis/nis/ypserv/
 VCS:            git:https://github.com/thkukuk/ypserv
-#!RemoteAsset
+#!RemoteAsset:  sha256:8c9d72ddd6d38aa48545c4b486932e3f7008354131ae1be27db863dfd7b11aaf
 Source0:        https://github.com/thkukuk/ypserv/archive/refs/tags/v%{version}.tar.gz
 Source1:        ypserv.service
 Source2:        yppasswdd.service
 Source3:        ypxfrd.service
 Source4:        yppasswdd
+Source5:        rpc.yppasswdd.env
+Source6:        yppasswdd-pre-setdomain
 BuildSystem:    autotools
 
 # disable gen docs.
@@ -70,6 +73,9 @@ install -m 644 %{SOURCE3} %{buildroot}%{_unitdir}/ypxfrd.service
 
 install -m 644 %{SOURCE4} %{buildroot}%{_sysconfdir}/sysconfig/
 
+install -m 755 %{SOURCE5} %{buildroot}%{_libexecdir}/rpc.yppasswdd.env
+install -m 755 %{SOURCE6} %{buildroot}%{_libexecdir}/yppasswdd-pre-setdomain
+
 %post
 %systemd_post ypserv.service ypxfrd.service yppasswdd.service
 
@@ -89,7 +95,8 @@ install -m 644 %{SOURCE4} %{buildroot}%{_sysconfdir}/sysconfig/
 %{_unitdir}/*
 %{_libdir}/yp/*
 %{_sbindir}/*
+%{_libexecdir}/*
 %{_includedir}/rpcsvc
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
## Summary

Install the two executables referenced by yppasswdd.service that are currently missing from the package:

- `/usr/libexec/yppasswdd-pre-setdomain`
- `/usr/libexec/rpc.yppasswdd.env`


## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
