### PR TITLE
Fix lxcfs, fuse3 dependency and upgrade

### DIFF
--- a/SPECS/fuse3/fuse3.spec
+++ b/SPECS/fuse3/fuse3.spec
@@ -81,6 +81,9 @@ install -p -m 0644 %{SOURCE2} %{buildroot}%{_sysconfdir}
 # Delete pointless udev rules
 rm -f %{buildroot}%{_udevrulesdir}/99-fuse3.rules
 
+# Provide unversioned fusermount
+ln -sf fusermount3 %{buildroot}%{_bindir}/fusermount
+
 # Seems no check
 %check
 
@@ -89,6 +92,7 @@ rm -f %{buildroot}%{_udevrulesdir}/99-fuse3.rules
 %license LICENSE GPL2.txt
 %{_sbindir}/mount.fuse3
 %attr(4755,root,root) %{_bindir}/fusermount3
+%{_bindir}/fusermount
 %{_mandir}/man1/*
 %{_mandir}/man8/*
 %{_libdir}/libfuse3.so.*
@@ -102,4 +106,4 @@ rm -f %{buildroot}%{_udevrulesdir}/99-fuse3.rules
 %config(noreplace) %{_sysconfdir}/fuse.conf
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/fuse3/fuse3.spec
+++ b/SPECS/fuse3/fuse3.spec
@@ -5,20 +5,15 @@
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
-%global xyz_version 3.17.4
-%global xy_version %(sed 's/\\(.*\\)\\..*/\\1/'<<<%{xyz_version})
-
 Name:           fuse3
-Version:        %{xyz_version}
+Version:        3.18.2
 Release:        %autorelease
 Summary:        File System in Userspace (FUSE) v3 utilities
 License:        GPL-1.0-or-later
 URL:            http://fuse.sf.net
 VCS:            git:https://github.com/libfuse/libfuse
-#!RemoteAsset
+#!RemoteAsset:  sha256:f01de85717e20adf5f98aff324acd85dd73d61a5ca3834d573dcf0bd6e54a298
 Source0:        https://github.com/libfuse/libfuse/releases/download/fuse-%{version}/fuse-%{version}.tar.gz
-#!RemoteAsset
-Source1:        https://github.com/libfuse/libfuse/releases/download/fuse-%{version}/fuse-%{version}.tar.gz.sig
 # Our little stupid config file
 Source2:        fuse.conf
 BuildSystem:    meson

--- a/SPECS/lxc/lxc.spec
+++ b/SPECS/lxc/lxc.spec
@@ -6,13 +6,13 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 Name:           lxc
-Version:        6.0.6
+Version:        7.0.0
 Release:        %autorelease
 Summary:        Linux Resource Containers
 License:        LGPL-2.1-or-later AND GPL-2.0-only
 URL:            https://linuxcontainers.org/lxc
 VCS:            git:https://github.com/lxc/lxc
-#!RemoteAsset:  sha256:b0ba4537258d2b848fd07dedb1044dab132de3fb3f1976d240da40a7dee1b8cf
+#!RemoteAsset:  sha256:ba0c860626efbac6683f351dd718edb062065e919716d787b89e3d547c5d9493
 Source0:        https://linuxcontainers.org/downloads/lxc/lxc-%{version}.tar.gz
 Source1:        lxc-net
 BuildSystem:    meson
@@ -111,4 +111,4 @@ install -m 644 %{SOURCE1} %{buildroot}%{_sysconfdir}/sysconfig/lxc-net
 %{_libdir}/liblxc.so
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/lxcfs/lxcfs.spec
+++ b/SPECS/lxcfs/lxcfs.spec
@@ -6,13 +6,13 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 Name:           lxcfs
-Version:        6.0.6
+Version:        7.0.0
 Release:        %autorelease
 Summary:        FUSE based filesystem for LXC
 License:        Apache-2.0
 URL:            https://linuxcontainers.org/lxcfs
 VCS:            git:https://github.com/lxc/lxcfs
-#!RemoteAsset:  sha256:386339ba4cde289b0f6df4fe7a614caa1e45dd91bc0200b4aff6c51bf9d5ef9e
+#!RemoteAsset:  sha256:89a5ac0e98cfae6aad26d00e0e977affe810865ebccd4c4cf9422f980ade5624
 Source:         https://linuxcontainers.org/downloads/lxcfs/lxcfs-%{version}.tar.gz
 BuildSystem:    meson
 

--- a/SPECS/lxcfs/lxcfs.spec
+++ b/SPECS/lxcfs/lxcfs.spec
@@ -27,6 +27,9 @@ BuildRequires:  systemd-rpm-macros
 BuildRequires:  pkgconfig(systemd)
 
 %{?systemd_requires}
+Requires(post):    /usr/bin/fusermount
+Requires(preun):   /usr/bin/fusermount
+Requires(postun):  /usr/bin/fusermount
 
 %description
 LXCFS is a small FUSE filesystem written with the intention of making
@@ -60,4 +63,4 @@ mkdir -p %{buildroot}%{_sharedstatedir}/%{name}
 %dir %{_sharedstatedir}/lxcfs
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

Please see #1183 for the fix.

lxc and lxcfs upgrade to 7.0.0. There is no packages depend on them.

fuse3 upgrade to 3.18.2 and unused macros removed. The upgrade do have API breakage. I searched the repos, there're altogether 13 packages affetced(bindfs, ceph, composefs, dwarfs, freerdp, go-github-hanwen-go-fuse-v2, grub, libnbd, libvirt, qemu, spdk, squashfuse, xdg-desktop-portal), except go-github-hanwen-go-fuse-v2, all build successfully.


## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #1183 

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
