### PR TITLE
SPECS: python-torch: avoid building rvv kernel on rva20

### DIFF
--- a/SPECS/python-torch/2011-gate-rvv-kernel-on-vector-target.patch
+++ b/SPECS/python-torch/2011-gate-rvv-kernel-on-vector-target.patch
@@ -1,0 +1,51 @@
+From b6a381e639068fb91a05077c17925314fc8f4735 Mon Sep 17 00:00:00 2001
+From: CHEN Xuan <chenxuan@iscas.ac.cn>
+Date: Fri, 28 Aug 2026 11:57:27 +0800
+Subject: [PATCH] riscv: gate RVV kernel on vector target
+
+__riscv_v_intrinsic indicates RVV intrinsic API availability and is defined
+even when the selected target(rva20) does not enable V.
+
+---
+ aten/src/ATen/native/Convolution.cpp             | 2 +-
+ aten/src/ATen/native/cpu/DepthwiseConvKernel.cpp | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/aten/src/ATen/native/Convolution.cpp b/aten/src/ATen/native/Convolution.cpp
+index 0354d0d..e407246 100644
+--- a/aten/src/ATen/native/Convolution.cpp
++++ b/aten/src/ATen/native/Convolution.cpp
+@@ -355,7 +355,7 @@ struct ConvParams {
+   }
+ 
+   bool use_cpu_depthwise3x3_winograd(const at::Tensor& input, const at::Tensor& weight, const std::optional<at::Tensor>& bias) const {
+-#if defined(__ARM_NEON__) || (defined(__riscv_v_intrinsic) && __riscv_v_intrinsic>=12000)
++#if defined(__ARM_NEON__) || defined(__riscv_vector)
+     // Currently only 3x3 depthwise convolutions on tensors of float are supported.
+     return (input.ndimension() == 4) &&
+            (at::symint::size<T>(input, 1) == groups) &&
+diff --git a/aten/src/ATen/native/cpu/DepthwiseConvKernel.cpp b/aten/src/ATen/native/cpu/DepthwiseConvKernel.cpp
+index cce4c43..c88a05a 100644
+--- a/aten/src/ATen/native/cpu/DepthwiseConvKernel.cpp
++++ b/aten/src/ATen/native/cpu/DepthwiseConvKernel.cpp
+@@ -13,7 +13,7 @@
+ 
+ #ifdef __ARM_NEON__
+ #include <arm_neon.h>
+-#elif defined(__riscv_v_intrinsic) && __riscv_v_intrinsic>=12000
++#elif defined(__riscv_vector)
+ #include <riscv_vector.h>
+ #endif
+ 
+@@ -246,7 +246,7 @@ void convolution_depthwise3x3_winograd_impl(
+   }
+ }
+ 
+-#elif defined(__riscv_v_intrinsic) && __riscv_v_intrinsic>=12000
++#elif defined(__riscv_vector)
+ 
+ inline void winograd_f2k3_input_transform_inplace__rvv(
+     vfloat32m1x4_t* input_tile_val) {
+-- 
+2.53.0
+

--- a/SPECS/python-torch/python-torch.spec
+++ b/SPECS/python-torch/python-torch.spec
@@ -240,6 +240,8 @@ validation of %{name}. This is not the complete upstream Python test suite.
 2009-skip-benchmark-try-run.patch
 # Install the GLOO test
 2010-install-cpu-gloo-test.patch
+# Avoid compiling and dispatching RVV code for the rva20 baseline.
+2011-gate-rvv-kernel-on-vector-target.patch
 
 %description
 PyTorch is a Python package that provides two high-level features:


### PR DESCRIPTION
## Summary

- Avoid building some rvv kernels on rva20 for python-torch.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.
- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: GPT-5.6-Sol

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy

## Buildlog

https://build.openruyi.cn/package/show/home:Sakura286:ROCm_PyTorch_Submit/python-torch

Because rva20 of openruyi is rebuilding, this package has been blocked. But it has indeed been built:
https://repo.build.openruyi.cn/openruyi/rva20/riscv64/

