### PR TITLE
SPECS: python-distributed/python-pyspark: remove libomp

### DIFF
--- a/SPECS/python-distributed/python-distributed.spec
+++ b/SPECS/python-distributed/python-distributed.spec
@@ -63,11 +63,6 @@ BuildRequires:  python3dist(torch)
 BuildRequires:  python3dist(tornado)
 BuildRequires:  python3dist(urllib3)
 BuildRequires:  python3dist(zict)
-# TODO: remove libomp after PR merged
-# https://github.com/openRuyi-Project/openRuyi/pull/970/
-# Importing distributed.protocol.torch fails with:
-# ImportError: libomp.so: cannot open shared object file: No such file or directory
-BuildRequires:  libomp
 
 Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}

--- a/SPECS/python-pyspark/python-pyspark.spec
+++ b/SPECS/python-pyspark/python-pyspark.spec
@@ -22,11 +22,6 @@ BuildOption(install):  -l pyspark
 BuildOption(check):  -e 'pyspark.python.pyspark.shell'
 BuildOption(check):  -e 'pyspark.shell'
 
-# TODO: remove libomp after PR merged
-# https://github.com/openRuyi-Project/openRuyi/pull/970/
-# Importing pyspark.ml.torch.data fails with:
-# ImportError: libomp.so: cannot open shared object file: No such file or directory
-BuildRequires:  libomp
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  python3dist(grpcio)


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->


The dependency `libomp` was introduced as a workaround for missing `libomp.so` errors. Since the prerequisite fix in #970 has been merged, the workaround is no longer needed.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
