### PR TITLE
SPECS: python-distributed: remove libomp BuildRequires

### DIFF
--- a/SPECS/python-distributed/python-distributed.spec
+++ b/SPECS/python-distributed/python-distributed.spec
@@ -63,11 +63,6 @@ BuildRequires:  python3dist(torch)
 BuildRequires:  python3dist(tornado)
 BuildRequires:  python3dist(urllib3)
 BuildRequires:  python3dist(zict)
-# TODO: remove libomp after PR merged
-# https://github.com/openRuyi-Project/openRuyi/pull/970/
-# Importing distributed.protocol.torch fails with:
-# ImportError: libomp.so: cannot open shared object file: No such file or directory
-BuildRequires:  libomp
 
 Provides:       python3-%{srcname} = %{version}-%{release}
 %python_provide python3-%{srcname}


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

The dependency libomp was introduced as a workaround for missing libomp.so errors. Since the prerequisite fix in https://github.com/openRuyi-Project/openRuyi/pull/970 has been merged, the workaround is no longer needed.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
