### PR TITLE
.github: Use ghcr image for CI build.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,7 +87,7 @@ jobs:
     needs: build
     runs-on: [ubuntu-latest]
     container:
-      image: git.openruyi.cn/openruyi/creek-x86-64:latest
+      image: ghcr.io/openruyi-project/creek-x86_64:latest
     steps:
     - name: Download All Artifacts
       uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary

Our internal source is currently not functioning for internal reasons. This pull request switches to ghcr to restore our build actions.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
