### PR TITLE
SPECS: python-outlines-core: enable more tests

### DIFF
--- a/SPECS/python-outlines-core/python-outlines-core.spec
+++ b/SPECS/python-outlines-core/python-outlines-core.spec
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
 # SPDX-FileContributor: Li Guan <guanli.oerv@isrc.iscas.ac.cn>
 # SPDX-FileContributor: yyjeqhc <jialin.oerv@isrc.iscas.ac.cn>
+# SPDX-FileContributor: zhangjinqiang <jinqiang.oerv@isrc.iscas.ac.cn>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
@@ -23,8 +24,6 @@ BuildOption(install):  -l %{pypi_name}
 BuildOption(check):  -e outlines_core.kernels.mlx
 # No module named 'numba'
 BuildOption(check):  -e outlines_core.kernels.numpy
-# ImportError: libomp.so: cannot open shared object file: No such file or directory
-BuildOption(check):  -e outlines_core.kernels.torch
 
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  pkgconfig(python3)


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

The workaround that excluded `outlines_core.kernels.torch` from testing is no longer needed since #970 was merged.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
