### PR TITLE
SPECS: python-pyspark: remove libomp BuildRequires

### DIFF
--- a/SPECS/python-grpcio-status/python-grpcio-status.spec
+++ b/SPECS/python-grpcio-status/python-grpcio-status.spec
@@ -8,13 +8,13 @@
 %global pypi_name grpcio_status
 
 Name:           python-%{srcname}
-Version:        1.80.0
+Version:        1.82.1
 Release:        %autorelease
 Summary:        Status proto mapping for gRPC
 License:        Apache-2.0
 URL:            https://grpc.io/
 VCS:            git:https://github.com/grpc/grpc.git
-#!RemoteAsset:  sha256:df73802a4c89a3ea88aa2aff971e886fccce162bc2e6511408b3d67a144381cd
+#!RemoteAsset:  sha256:d9de8ac34763cd468130fdd2923294af7c3d28d09426f6c45221d27c25931130
 Source0:        https://files.pythonhosted.org/packages/source/g/%{srcname}/%{pypi_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    pyproject

--- a/SPECS/python-pyspark/python-pyspark.spec
+++ b/SPECS/python-pyspark/python-pyspark.spec
@@ -22,11 +22,6 @@ BuildOption(install):  -l pyspark
 BuildOption(check):  -e 'pyspark.python.pyspark.shell'
 BuildOption(check):  -e 'pyspark.shell'
 
-# TODO: remove libomp after PR merged
-# https://github.com/openRuyi-Project/openRuyi/pull/970/
-# Importing pyspark.ml.torch.data fails with:
-# ImportError: libomp.so: cannot open shared object file: No such file or directory
-BuildRequires:  libomp
 BuildRequires:  pkgconfig(python3)
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  python3dist(grpcio)


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

  - Bump `python-grpcio-status` from 1.80.0 to 1.82.1 to resolve the unsatisfied `protobuf >= 6.31.1, < 7` dependency.
  - Remove the temporary `libomp` build dependency from `python-pyspark`, as the prerequisite fix in #970 has been merged.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
