### PR TITLE
rpm-config-openruyi: Add some buildsystem stubs

### DIFF
--- a/SPECS/rpm-config-openruyi/macros.aaa-buildsystem.cmake
+++ b/SPECS/rpm-config-openruyi/macros.aaa-buildsystem.cmake
@@ -1,0 +1,15 @@
+# This file is called macros.aaa-buildsystem.cmake
+# to sort alphabetically before macros.buildsystem.cmake.
+# When this file is installed but macros.buildsystem.cmake is not
+# this macro will cause the package with the real macro to be installed.
+# When macros.buildsystem.cmake is installed, it overrides this macro.
+# Note: This takes arbitrary options, to ease addition of new options to the real macro.
+%cmake_buildrequires(-) echo 'cmake' && exit 0
+
+# Declarative buildsystem, requires RPM 4.20+ to work
+# https://rpm-software-management.github.io/rpm/manual/buildsystem.html
+%buildsystem_cmake_conf() %nil
+%buildsystem_cmake_generate_buildrequires() %cmake_buildrequires %*
+%buildsystem_cmake_build() %nil
+%buildsystem_cmake_install() %nil
+%buildsystem_cmake_check() %nil

--- a/SPECS/rpm-config-openruyi/macros.aaa-buildsystem.golang
+++ b/SPECS/rpm-config-openruyi/macros.aaa-buildsystem.golang
@@ -1,0 +1,12 @@
+# This file is called macros.aaa-buildsystem.golang
+# to sort alphabetically before macros.buildsystem.golang.
+# When this file is installed but macros.buildsystem.golang is not
+# this macro will cause the package with the real macro to be installed.
+# When macros.buildsystem.golang is installed, it overrides this macro.
+# Note: This takes arbitrary options, to ease addition of new options to the real macro.
+
+%buildsystem_golang_conf() %nil
+%buildsystem_golang_generate_buildrequires() echo 'go-rpm-macros' && exit 0
+%buildsystem_golang_build() %nil
+%buildsystem_golang_install() %nil
+%buildsystem_golang_check() %nil

--- a/SPECS/rpm-config-openruyi/macros.aaa-buildsystem.golangmodules
+++ b/SPECS/rpm-config-openruyi/macros.aaa-buildsystem.golangmodules
@@ -1,0 +1,12 @@
+# This file is called macros.aaa-buildsystem.golangmodules
+# to sort alphabetically before macros.buildsystem.golangmodules.
+# When this file is installed but macros.buildsystem.golangmodules is not
+# this macro will cause the package with the real macro to be installed.
+# When macros.buildsystem.golangmodules is installed, it overrides this macro.
+# Note: This takes arbitrary options, to ease addition of new options to the real macro.
+
+%buildsystem_golangmodules_conf() %nil
+%buildsystem_golangmodules_generate_buildrequires() echo 'go-rpm-macros' && exit 0
+%buildsystem_golangmodules_build() %nil
+%buildsystem_golangmodules_install() %nil
+%buildsystem_golangmodules_check() %nil

--- a/SPECS/rpm-config-openruyi/macros.aaa-buildsystem.perlbuild
+++ b/SPECS/rpm-config-openruyi/macros.aaa-buildsystem.perlbuild
@@ -1,0 +1,12 @@
+# This file is called macros.aaa-buildsystem.perlbuild
+# to sort alphabetically before macros.buildsystem.perlbuild.
+# When this file is installed but macros.buildsystem.perlbuild is not
+# this macro will cause the package with the real macro to be installed.
+# When macros.buildsystem.perlbuild is installed, it overrides this macro.
+# Note: This takes arbitrary options, to ease addition of new options to the real macro.
+
+%buildsystem_perlbuild_conf() %nil
+%buildsystem_perlbuild_generate_buildrequires() echo 'perl-rpm-macros' && exit 0
+%buildsystem_perlbuild_build() %nil
+%buildsystem_perlbuild_install() %nil
+%buildsystem_perlbuild_check() %nil

--- a/SPECS/rpm-config-openruyi/macros.aaa-buildsystem.perlmaker
+++ b/SPECS/rpm-config-openruyi/macros.aaa-buildsystem.perlmaker
@@ -1,0 +1,12 @@
+# This file is called macros.aaa-buildsystem.perlmaker
+# to sort alphabetically before macros.buildsystem.perlmaker.
+# When this file is installed but macros.buildsystem.perlmaker is not
+# this macro will cause the package with the real macro to be installed.
+# When macros.buildsystem.perlmaker is installed, it overrides this macro.
+# Note: This takes arbitrary options, to ease addition of new options to the real macro.
+
+%buildsystem_perlmaker_conf() %nil
+%buildsystem_perlmaker_generate_buildrequires() echo 'perl-rpm-macros' && exit 0
+%buildsystem_perlmaker_build() %nil
+%buildsystem_perlmaker_install() %nil
+%buildsystem_perlmaker_check() %nil

--- a/SPECS/rpm-config-openruyi/macros.aaa-buildsystem.rust
+++ b/SPECS/rpm-config-openruyi/macros.aaa-buildsystem.rust
@@ -1,0 +1,12 @@
+# This file is called macros.aaa-buildsystem.rust
+# to sort alphabetically before macros.buildsystem.rust.
+# When this file is installed but macros.buildsystem.rust is not
+# this macro will cause the package with the real macro to be installed.
+# When macros.buildsystem.rust is installed, it overrides this macro.
+# Note: This takes arbitrary options, to ease addition of new options to the real macro.
+
+%buildsystem_rust_conf() %nil
+%buildsystem_rust_generate_buildrequires() echo 'rust-rpm-macros' && exit 0
+%buildsystem_rust_build() %nil
+%buildsystem_rust_install() %nil
+%buildsystem_rust_check() %nil

--- a/SPECS/rpm-config-openruyi/macros.aaa-buildsystem.rustcrates
+++ b/SPECS/rpm-config-openruyi/macros.aaa-buildsystem.rustcrates
@@ -1,0 +1,12 @@
+# This file is called macros.aaa-buildsystem.rustcrates
+# to sort alphabetically before macros.buildsystem.rustcrates.
+# When this file is installed but macros.buildsystem.rustcrates is not
+# this macro will cause the package with the real macro to be installed.
+# When macros.buildsystem.rustcrates is installed, it overrides this macro.
+# Note: This takes arbitrary options, to ease addition of new options to the real macro.
+
+%buildsystem_rustcrates_conf() %nil
+%buildsystem_rustcrates_generate_buildrequires() echo 'rust-rpm-macros' && exit 0
+%buildsystem_rustcrates_build() %nil
+%buildsystem_rustcrates_install() %nil
+%buildsystem_rustcrates_check() %nil

--- a/SPECS/rpm-config-openruyi/macros.aaa-meson
+++ b/SPECS/rpm-config-openruyi/macros.aaa-meson
@@ -1,0 +1,15 @@
+# This file is called macros.aaa-meson
+# to sort alphabetically before macros.meson.
+# When this file is installed but macros.meson is not
+# this macro will cause the package with the real macro to be installed.
+# When macros.meson is installed, it overrides this macro.
+# Note: This takes arbitrary options, to ease addition of new options to the real macro.
+%meson_buildrequires(-) echo 'meson' && exit 0
+
+# Declarative buildsystem, requires RPM 4.20+ to work
+# https://rpm-software-management.github.io/rpm/manual/buildsystem.html
+%buildsystem_meson_conf() %nil
+%buildsystem_meson_generate_buildrequires() %meson_buildrequires %*
+%buildsystem_meson_build() %nil
+%buildsystem_meson_install() %nil
+%buildsystem_meson_check() %nil

--- a/SPECS/rpm-config-openruyi/rpm-config-openruyi.spec
+++ b/SPECS/rpm-config-openruyi/rpm-config-openruyi.spec
@@ -29,6 +29,14 @@ brp-openruyi
 firmware.attr
 firmware.prov
 macros
+macros.aaa-buildsystem.cmake
+macros.aaa-buildsystem.golang
+macros.aaa-buildsystem.golangmodules
+macros.aaa-buildsystem.perlbuild
+macros.aaa-buildsystem.perlmaker
+macros.aaa-buildsystem.rust
+macros.aaa-buildsystem.rustcrates
+macros.aaa-meson
 macros.buildsystem
 macros.completions
 macros.ldconfig


### PR DESCRIPTION
## Summary

Add some buildsystem stubs to avoid rpm report 'Unknown buildsystem'
when macros is nodefined.

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy

<!-- Message of single commit: -->