### PR TITLE
util-linux: suggests systemd-udev

### DIFF
--- a/SPECS/util-linux/util-linux.spec
+++ b/SPECS/util-linux/util-linux.spec
@@ -14,7 +14,7 @@ License:        GPL-2.0-or-later and others
 URL:            https://www.kernel.org/pub/linux/utils/util-linux/
 VCS:            git:https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git
 #!RemoteAsset:  sha256:3330d873f0fceb5560b89a7dc14e4f3288bbd880e96903ed9b50ec2b5799e58b
-Source0:        https://www.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-%{version}.tar.xz
+Source0:        https://cdn.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-%{version}.tar.xz
 # These files define the default behavior for openRuyi.
 Source10:       login.pam
 Source11:       su-l.pam

--- a/SPECS/util-linux/util-linux.spec
+++ b/SPECS/util-linux/util-linux.spec
@@ -86,6 +86,7 @@ Requires:       ncurses
 Requires:       pam
 Requires:       readline
 Requires:       zlib
+Suggests:       systemd-udev
 
 %description
 The util-linux package contains a large variety of low-level system


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue
Add it make dnf prefer use systemd-udev, not libudev-zero on install.
<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy