### PR TITLE
Xwayland, xorg-server: switch download server to xorg.freedesktop.org

### DIFF
--- a/SPECS/Xwayland/Xwayland.spec
+++ b/SPECS/Xwayland/Xwayland.spec
@@ -13,7 +13,7 @@ License:        MIT
 URL:            http://www.x.org
 VCS:            git:https://gitlab.freedesktop.org/xorg/xserver
 #!RemoteAsset:  sha256:27115a1a8819078409bf6fecfeb7724e8137bd36426de7005a5b3aae0a2138ff
-Source0:        https://www.x.org/pub/individual/xserver/xwayland-%{version}.tar.xz
+Source0:        https://xorg.freedesktop.org/archive/individual/xserver/xwayland-%{version}.tar.xz
 BuildSystem:    meson
 
 BuildOption(conf):  -Dbuilder_string="%{vendor_name} %{name} %{version}-%{release}"

--- a/SPECS/xorg-server/xorg-server.spec
+++ b/SPECS/xorg-server/xorg-server.spec
@@ -12,7 +12,7 @@ Summary:        The X.org X server
 License:        Adobe-Display-PostScript AND BSD-3-Clause AND DEC-3-Clause AND HPND AND HPND-sell-MIT-disclaimer-xserver AND HPND-sell-variant AND ICU AND ISC AND MIT AND MIT-open-group AND NTP AND SGI-B-2.0 AND SMLNJ AND X11 AND X11-distribute-modifications-variant
 URL:            https://gitlab.freedesktop.org/xorg/xserver
 #!RemoteAsset:  sha256:c0cbe5545b3f645bae6024b830d1d1154a956350683a4e52b2fff5b0fa1ab519
-Source:         https://www.x.org/releases/individual/xserver/xorg-server-%{version}.tar.xz
+Source:         https://xorg.freedesktop.org/archive/individual/xserver/xorg-server-%{version}.tar.xz
 BuildSystem:    meson
 
 BuildOption(conf):  -Dxorg=false


### PR DESCRIPTION
## Summary

Switch download URL to xorg.freedesktop.org because x.org/pub is now 301 and OBS doesn't like 301.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
