### PR TITLE
X.org packages: switch download url

### DIFF
--- a/SPECS/libICE/libICE.spec
+++ b/SPECS/libICE/libICE.spec
@@ -13,8 +13,8 @@ Summary:        X.Org X11 ICE runtime library
 License:        MIT-open-group
 URL:            http://www.x.org
 VCS:            git:https://gitlab.freedesktop.org/xorg/lib/libice.git
-#!RemoteAsset
-Source0:        https://www.x.org/pub/individual/lib/%{name}-%{version}.tar.xz
+#!RemoteAsset:  sha256:974e4ed414225eb3c716985df9709f4da8d22a67a2890066bc6dfc89ad298625
+Source0:        https://xorg.freedesktop.org/archive/individual/lib/%{name}-%{version}.tar.xz
 BuildSystem:    autotools
 
 BuildOption(conf):  --disable-static
@@ -50,4 +50,4 @@ The X.Org X11 ICE (Inter-Client Exchange) development package.
 %{_docdir}/%{name}/*.xml
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/libSM/libSM.spec
+++ b/SPECS/libSM/libSM.spec
@@ -13,8 +13,8 @@ Summary:        X.Org X11 SM runtime library
 License:        MIT AND MIT-open-group
 URL:            http://www.x.org
 VCS:            git:https://gitlab.freedesktop.org/xorg/lib/libsm.git
-#!RemoteAsset
-Source0:        https://www.x.org/pub/individual/lib/%{name}-%{version}.tar.xz
+#!RemoteAsset:  sha256:be7c0abdb15cbfd29ac62573c1c82e877f9d4047ad15321e7ea97d1e43d835be
+Source0:        https://xorg.freedesktop.org/archive/individual/lib/%{name}-%{version}.tar.xz
 BuildSystem:    autotools
 
 BuildOption(conf):  --with-libuuid
@@ -41,7 +41,7 @@ The X.Org X11 SM (Session Management) development package.
 %{_libdir}/libSM.so.6*
 %doc %{_docdir}/%{name}
 
-%files          devel
+%files devel
 %{_includedir}/X11/*
 %{_libdir}/libSM.so
 %{_libdir}/pkgconfig/sm.pc
@@ -49,4 +49,4 @@ The X.Org X11 SM (Session Management) development package.
 %doc README.md
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/libX11/libX11.spec
+++ b/SPECS/libX11/libX11.spec
@@ -14,7 +14,7 @@ License:        MIT
 URL:            https://www.x.org
 VCS:            git:https://gitlab.freedesktop.org/xorg/lib/libx11.git
 #!RemoteAsset:  sha256:69606f485c2c07c14ef64f75b7bb326d48587af33795d9ab3e607c0b5f94f11c
-Source0:        https://www.x.org/releases/individual/lib/%{name}-%{version}.tar.xz
+Source0:        https://xorg.freedesktop.org/archive/individual/lib/%{name}-%{version}.tar.xz
 BuildSystem:    autotools
 
 BuildOption(conf):  --disable-silent-rules

--- a/SPECS/libXau/libXau.spec
+++ b/SPECS/libXau/libXau.spec
@@ -14,7 +14,7 @@ License:        MIT-open-group
 URL:            http://www.x.org
 VCS:            git:https://gitlab.freedesktop.org/xorg/lib/libxau
 #!RemoteAsset:  sha256:74d0e4dfa3d39ad8939e99bda37f5967aba528211076828464d2777d477fc0fb
-Source0:        https://www.x.org/pub/individual/lib/%{name}-%{version}.tar.xz
+Source0:        https://xorg.freedesktop.org/archive/individual/lib/%{name}-%{version}.tar.xz
 BuildSystem:    autotools
 
 BuildOption(conf):  --disable-static

--- a/SPECS/libXdamage/libXdamage.spec
+++ b/SPECS/libXdamage/libXdamage.spec
@@ -11,7 +11,7 @@ Summary:        X Damage extension library
 License:        MIT
 URL:            https://gitlab.freedesktop.org/xorg/lib/libXdamage
 #!RemoteAsset:  sha256:127067f521d3ee467b97bcb145aeba1078e2454d448e8748eb984d5b397bde24
-Source0:        https://www.x.org/pub/individual/lib/libXdamage-%{version}.tar.xz
+Source0:        https://xorg.freedesktop.org/archive/individual/lib/libXdamage-%{version}.tar.xz
 BuildSystem:    autotools
 
 BuildOption(conf):  --disable-static

--- a/SPECS/libXi/libXi.spec
+++ b/SPECS/libXi/libXi.spec
@@ -9,14 +9,14 @@
 %bcond asciidoc 0
 
 Name:           libXi
-Version:        1.8.2
+Version:        1.8.3
 Release:        %autorelease
 Summary:        X.Org X11 libXi runtime library
 License:        MIT
 URL:            https://www.x.org/
 VCS:            git:https://gitlab.freedesktop.org/xorg/lib/libxi.git
-#!RemoteAsset
-Source0:        https://www.x.org/releases/individual/lib/%{name}-%{version}.tar.xz
+#!RemoteAsset:  sha256:7ad60056f01af4f786cfe93b3a7707447711626fc8da2637bec71a90409babe5
+Source0:        https://xorg.freedesktop.org/archive/individual/lib/%{name}-%{version}.tar.xz
 BuildSystem:    autotools
 
 BuildOption(conf):  --disable-static
@@ -63,4 +63,4 @@ X.Org X11 libXi development package
 %{_mandir}/man3/*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/libXrender/libXrender.spec
+++ b/SPECS/libXrender/libXrender.spec
@@ -13,8 +13,8 @@ Summary:        X.Org X11 libXrender runtime library
 License:        MIT
 URL:            https://www.x.org
 VCS:            git:https://gitlab.freedesktop.org/xorg/lib/libxrender.git
-#!RemoteAsset
-Source0:        https://www.x.org/releases/individual/lib/%{name}-%{version}.tar.xz
+#!RemoteAsset:  sha256:b832128da48b39c8d608224481743403ad1691bf4e554e4be9c174df171d1b97
+Source0:        https://xorg.freedesktop.org/archive/individual/lib/%{name}-%{version}.tar.xz
 BuildSystem:    autotools
 
 BuildOption(conf):  --disable-static
@@ -54,4 +54,4 @@ autoreconf -fiv
 %{_docdir}/libXrender/*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/libXres/libXres.spec
+++ b/SPECS/libXres/libXres.spec
@@ -6,14 +6,14 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 Name:           libXres
-Version:        1.2.2
+Version:        1.2.3
 Release:        %autorelease
 Summary:        X-Resource extension client library
 License:        X11
 URL:            http://www.x.org
 VCS:            git:https://gitlab.freedesktop.org/xorg/lib/libxres.git
-#!RemoteAsset
-Source0:        https://www.x.org/pub/individual/lib/%{name}-%{version}.tar.xz
+#!RemoteAsset:  sha256:d2de8f5401d6c86a8992791654547eb8def585dfdc0c08cc16e24ef6aeeb69dc
+Source0:        https://xorg.freedesktop.org/archive/individual/lib/%{name}-%{version}.tar.xz
 BuildSystem:    autotools
 
 BuildRequires:  autoconf
@@ -51,4 +51,4 @@ rm %{buildroot}%{_libdir}/*.a
 %{_mandir}/man3/*.3*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/libXt/libXt.spec
+++ b/SPECS/libXt/libXt.spec
@@ -13,8 +13,8 @@ Summary:        X.Org X11 libXt runtime library
 License:        MIT
 URL:            https://www.x.org
 VCS:            git:https://gitlab.freedesktop.org/xorg/lib/libxt.git
-#!RemoteAsset
-Source0:        https://www.x.org/releases/individual/lib/%{name}-%{version}.tar.xz
+#!RemoteAsset:  sha256:e0a774b33324f4d4c05b199ea45050f87206586d81655f8bef4dba434d931288
+Source0:        https://xorg.freedesktop.org/archive/individual/lib/%{name}-%{version}.tar.xz
 BuildSystem:    autotools
 
 BuildOption(conf):  --disable-static
@@ -67,4 +67,4 @@ mkdir -p -m 0755 %{buildroot}%{_datadir}/X11/app-defaults
 %doc %{_datadir}/doc/*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/libXtst/libXtst.spec
+++ b/SPECS/libXtst/libXtst.spec
@@ -13,8 +13,8 @@ Summary:        X.Org X11 libXtst runtime library
 License:        MIT
 URL:            https://www.x.org
 VCS:            git:https://gitlab.freedesktop.org/xorg/lib/libxtst.git
-#!RemoteAsset
-Source0:        https://www.x.org/releases/individual/lib/%{name}-%{version}.tar.xz
+#!RemoteAsset:  sha256:b50d4c25b97009a744706c1039c598f4d8e64910c9fde381994e1cae235d9242
+Source0:        https://xorg.freedesktop.org/archive/individual/lib/%{name}-%{version}.tar.xz
 BuildSystem:    autotools
 
 BuildOption(conf):  --disable-static
@@ -52,4 +52,4 @@ X.Org X11 libXtst development package
 %{_mandir}/man3/XTest*.3*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/libxkbfile/libxkbfile.spec
+++ b/SPECS/libxkbfile/libxkbfile.spec
@@ -5,19 +5,16 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 Name:           libxkbfile
-Version:        1.1.3
+Version:        1.2.0
 Release:        %autorelease
 Summary:        X.Org X11 libxkbfile runtime library
 License:        MIT-open-group AND HPND AND SMLNJ
 URL:            https://gitlab.freedesktop.org/xorg/lib/libxkbfile/
-#!RemoteAsset
-Source0:        https://www.x.org/pub/individual/lib/libxkbfile-%{version}.tar.xz
-BuildSystem:    autotools
+#!RemoteAsset:  sha256:7f71884e5faf56fb0e823f3848599cf9b5a9afce51c90982baeb64f635233ebf
+Source0:        https://xorg.freedesktop.org/archive/individual/lib/libxkbfile-%{version}.tar.xz
+BuildSystem:    meson
 
-BuildOption(conf):  --disable-static
-BuildOption(conf):  CFLAGS="%{optflags} -fno-strict-aliasing"
-
-BuildRequires:  make
+BuildRequires:  meson
 BuildRequires:  gcc
 BuildRequires:  pkgconfig(xproto)
 BuildRequires:  pkgconfig(x11)
@@ -34,7 +31,7 @@ Requires:       %{name}%{?_isa} = %{version}-%{release}
 Development files for libxkbfile.
 
 %files
-%doc COPYING ChangeLog
+%doc COPYING README.md
 %{_libdir}/libxkbfile.so.1*
 
 %files devel
@@ -44,4 +41,4 @@ Development files for libxkbfile.
 %{_libdir}/pkgconfig/xkbfile.pc
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/util-macros/util-macros.spec
+++ b/SPECS/util-macros/util-macros.spec
@@ -14,7 +14,7 @@ License:        MIT
 URL:            https://xorg.freedesktop.org/
 VCS:            git:https://gitlab.freedesktop.org/xorg/util/macros.git
 #!RemoteAsset:  sha256:9ac269eba24f672d7d7b3574e4be5f333d13f04a7712303b1821b2a51ac82e8e
-Source:         https://www.x.org/releases/individual/util/util-macros-%{version}.tar.xz
+Source:         https://xorg.freedesktop.org/archive/individual/util/util-macros-%{version}.tar.xz
 BuildSystem:    autotools
 
 BuildOption(build):  CFLAGS="%{optflags} -fno-strict-aliasing"

--- a/SPECS/xauth/xauth.spec
+++ b/SPECS/xauth/xauth.spec
@@ -12,7 +12,7 @@ License:        MIT-open-group
 URL:            https://gitlab.freedesktop.org/xorg/app/xauth
 VCS:            git:https://gitlab.freedesktop.org/xorg/app/xauth.git
 #!RemoteAsset:  sha256:a4000e2f441facebf569026bedecc23ba262cc6927be52070abe0002625cfbe0
-Source0:        https://www.x.org/pub/individual/app/%{name}-%{version}.tar.xz
+Source0:        https://xorg.freedesktop.org/archive/individual/app/%{name}-%{version}.tar.xz
 BuildSystem:    autotools
 
 BuildRequires:  autoconf

--- a/SPECS/xcursorgen/xcursorgen.spec
+++ b/SPECS/xcursorgen/xcursorgen.spec
@@ -11,7 +11,7 @@ Summary:        Prepare X11 cursor sets for use with libXcursor
 License:        HPND-sell-variant
 URL:            https://gitlab.freedesktop.org/xorg/app/xcursorgen
 #!RemoteAsset:  sha256:0cc9e156ac84ca16ea902710af35e0faffa51d13797071e3b4b6cc7cbd493bbc
-Source0:        https://www.x.org/pub/individual/app/xcursorgen-%{version}.tar.xz
+Source0:        https://xorg.freedesktop.org/archive/individual/app/xcursorgen-%{version}.tar.xz
 BuildSystem:    autotools
 
 BuildRequires:  automake
@@ -35,4 +35,4 @@ autoreconf -fiv
 %{_mandir}/man1/xcursorgen.1*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/xkbcomp/xkbcomp.spec
+++ b/SPECS/xkbcomp/xkbcomp.spec
@@ -10,8 +10,8 @@ Release:        %autorelease
 Summary:        XKB keymap compiler
 License:        MIT-open-group AND HPND-DEC
 URL:            https://gitlab.freedesktop.org/xorg/app/xkbcomp
-#!RemoteAsset
-Source0:        https://www.x.org/pub/individual/app/xkbcomp-%{version}.tar.xz
+#!RemoteAsset:  sha256:2ac31f26600776db6d9cd79b3fcd272263faebac7eb85fb2f33c7141b8486060
+Source0:        https://xorg.freedesktop.org/archive/individual/app/xkbcomp-%{version}.tar.xz
 BuildSystem:    autotools
 
 BuildOption(conf):  --disable-silent-rules
@@ -41,4 +41,4 @@ This package contains the pkg-config file for xkbcomp.
 %{_libdir}/pkgconfig/xkbcomp.pc
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/xorgproto/xorgproto.spec
+++ b/SPECS/xorgproto/xorgproto.spec
@@ -7,14 +7,14 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 Name:           xorgproto
-Version:        2024.1
+Version:        2025.1
 Release:        %autorelease
 Summary:        X.Org X11 Protocol headers
 License:        BSD-2-Clause AND HPND AND HPND-sell-variant AND ICU AND MIT AND MIT-open-group AND SGI-B-2.0 AND SMLNJ AND X11 AND X11-distribute-modifications-variant
 URL:            https://www.x.org
 VCS:            git:https://gitlab.freedesktop.org/xorg/proto/xorgproto.git
-#!RemoteAsset:  sha256:372225fd40815b8423547f5d890c5debc72e88b91088fbfb13158c20495ccb59
-Source0:        https://www.x.org/pub/individual/proto/xorgproto-%{version}.tar.xz
+#!RemoteAsset:  sha256:56898c716c0578df8a2d828c9c3e5c528277705c0484381a81960fe1a67668e8
+Source0:        https://xorg.freedesktop.org/archive/individual/proto/xorgproto-%{version}.tar.xz
 BuildArch:      noarch
 BuildSystem:    meson
 

--- a/SPECS/xrdb/xrdb.spec
+++ b/SPECS/xrdb/xrdb.spec
@@ -5,13 +5,13 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 Name:           xrdb
-Version:        1.2.2
+Version:        1.2.3
 Release:        %autorelease
 Summary:        X server resource database utility
 License:        MIT
 URL:            https://gitlab.freedesktop.org/xorg/app/xrdb
-#!RemoteAsset:  sha256:31f5fcab231b38f255b00b066cf7ea3b496df712c9eb2d0d50c670b63e5033f4
-Source0:        https://www.x.org/pub/individual/app/xrdb-%{version}.tar.xz
+#!RemoteAsset:  sha256:c88f560243278c896ce4fc92ae5a45a2b505a316ffa427fe55b02e5d5914c4e4
+Source0:        https://xorg.freedesktop.org/archive/individual/app/xrdb-%{version}.tar.xz
 BuildSystem:    autotools
 
 BuildOption(conf):  --disable-silent-rules
@@ -39,4 +39,4 @@ autoreconf -fiv
 %{_mandir}/man1/xrdb.1*
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/xtrans/xtrans.spec
+++ b/SPECS/xtrans/xtrans.spec
@@ -13,8 +13,8 @@ Summary:        X.Org X11 developmental X transport library
 License:        HPND AND HPND-sell-variant AND MIT AND MIT-open-group AND X11
 URL:            http://www.x.org
 VCS:            git:http://gitlab.freedesktop.org/xorg/lib/libxtrans.git
-#!RemoteAsset
-Source0:        https://www.x.org/releases/individual/lib/%{name}-%{version}.tar.xz
+#!RemoteAsset:  sha256:faafea166bf2451a173d9d593352940ec6404145c5d1da5c213423ce4d359e92
+Source0:        https://xorg.freedesktop.org/archive/individual/lib/%{name}-%{version}.tar.xz
 BuildArch:      noarch
 BuildSystem:    autotools
 
@@ -40,4 +40,4 @@ X.Org X11 developmental X transport library
 %{_datadir}/pkgconfig/xtrans.pc
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
## Summary

www.x.org/pub is now 301 and OBS doesn't like it.

Switch to xorg.freedesktop.org .

Also affected packages are checked for newer versions and updated.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
