### PR TITLE
SPECS: mesa: enable NVK

### DIFF
--- a/SPECS/mesa/mesa.spec
+++ b/SPECS/mesa/mesa.spec
@@ -27,9 +27,8 @@ Patch1:         mesa-26.2.1-zink-kmsro-for-img-blob.patch
 # Patches to fix CTS failures and advertise BXM-4-64 as conformant
 Patch2:         mesa-26.2.1-pvr-conformance.patch
 
-# nvk is blocked by Rust packaging
 BuildOption(conf):  -Dgallium-drivers=llvmpipe,softpipe,r300,r600,radeonsi,nouveau,virgl,iris,etnaviv,zink,crocus
-BuildOption(conf):  -Dvulkan-drivers=amd,intel,swrast,imagination,virtio,gfxstream,intel_hasvk
+BuildOption(conf):  -Dvulkan-drivers=amd,intel,swrast,imagination,virtio,gfxstream,intel_hasvk,nouveau
 BuildOption(conf):  -Dplatforms=x11,wayland
 
 BuildOption(conf):  -Degl=enabled
@@ -74,6 +73,9 @@ BuildRequires:  python3dist(pycparser)
 BuildRequires:  flex
 BuildRequires:  bison
 BuildRequires:  glslang
+BuildRequires:  rust
+BuildRequires:  bindgen
+BuildRequires:  cbindgen
 BuildRequires:  pkgconfig(zlib)
 BuildRequires:  pkgconfig(libdrm)
 BuildRequires:  pkgconfig(libdrm_amdgpu)
@@ -100,6 +102,13 @@ BuildRequires:  pkgconfig(wayland-client)
 BuildRequires:  pkgconfig(wayland-egl-backend)
 BuildRequires:  pkgconfig(libva)
 BuildRequires:  pkgconfig(vulkan)
+# FIXME: use crate(xxx) when it's allowed by pre-commit hook
+BuildRequires:  rust-syn-2 >= 2.0.87
+BuildRequires:  rust-quote-1 >= 1.0.35
+BuildRequires:  rust-proc-macro2-1 >= 1.0.86
+BuildRequires:  rust-rustc-hash-2 >= 2.1.1
+BuildRequires:  rust-paste-1 >= 1.0.14
+BuildRequires:  rust-unicode-ident-1 >= 1.0.12
 BuildRequires:  lm_sensors-devel
 BuildRequires:  zstd-devel
 BuildRequires:  llvm-devel
@@ -205,6 +214,33 @@ Summary:        Vulkan layers provided by Mesa
 This package contains Vulkan layers provided as part of Mesa project, which
 are to be loaded by the Khronos Vulkan loader, and can be used even for
 non-Mesa drivers.
+
+%prep -a
+# The .wrap files shipped by Mesa hardcodes a version number (which seems to be
+# the minimal requirement). Here, in semantics versioning we trust, so oR-shipped
+# version is wrapped instead.
+update_crate_wrap() {
+    local dirname wrapfile cachedir
+    dirname="$(ls -d /usr/share/cargo/registry/"$1"*)"
+    test -d "$dirname" || exit 1
+    wrapfile="%{_vpath_srcdir}/subprojects/$1-rs.wrap"
+    test -e "$wrapfile" || exit 1
+    cachedir="%{_vpath_srcdir}/subprojects/packagecache/"
+    mkdir -p "$cachedir"
+    cp -r "$dirname" "$cachedir"
+    cat > "$wrapfile" << EOF
+[wrap-file]
+directory = $(basename "$dirname")
+patch_directory = $1-rs
+EOF
+}
+
+update_crate_wrap unicode-ident-1
+update_crate_wrap proc-macro2-1
+update_crate_wrap quote-1
+update_crate_wrap syn-2
+update_crate_wrap rustc-hash-2
+update_crate_wrap paste-1
 
 %files -n libgbm
 %{_libdir}/libgbm.so.1*


### PR DESCRIPTION
## Summary

Enable the first Rust-demand Mesa component, the NVK driver.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
