### PR TITLE
SPECS: Add python-deepspeed and dependencies (hjson, ninja)

### DIFF
--- a/SPECS/python-deepspeed/python-deepspeed.spec
+++ b/SPECS/python-deepspeed/python-deepspeed.spec
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname deepspeed
+
+# DeepSpeed compiles its C++/CUDA ops just-in-time at runtime (DS_BUILD_OPS=0
+# is the default on Linux), so the wheel is pure Python and noarch. Only a
+# top-level import smoke test is run in %%check: the real test suite needs
+# GPUs and a distributed multi-process setup not available in the build env.
+
+Name:           python-%{srcname}
+Version:        0.19.6
+Release:        %autorelease
+Summary:        Deep learning optimization library for distributed training and inference
+License:        Apache-2.0
+URL:            https://pypi.org/project/deepspeed/
+#!RemoteAsset:  sha256:31593acffbe4794c74446094122b1bc29d8c73a137e37aff899ca4a6480df2d8
+Source0:        https://files.pythonhosted.org/packages/source/d/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l %{srcname} +auto
+BuildOption(check):  -t
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+# Runtime dependencies that need to be available during build for import checks
+BuildRequires:  python3dist(einops)
+BuildRequires:  python3dist(hjson)
+BuildRequires:  python3dist(msgpack)
+BuildRequires:  python3dist(ninja)
+BuildRequires:  python3dist(numpy)
+BuildRequires:  python3dist(psutil)
+BuildRequires:  python3dist(py-cpuinfo)
+BuildRequires:  python3dist(pydantic)
+BuildRequires:  python3dist(torch)
+BuildRequires:  python3dist(tqdm)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+DeepSpeed is a deep learning optimization library that makes distributed
+training and inference easy, efficient, and effective. It provides
+ZeRO-powered data parallelism, pipeline and tensor parallelism, optimized
+kernels, and memory-efficient optimizers for large-scale models.
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+%autochangelog

--- a/SPECS/python-hjson/python-hjson.spec
+++ b/SPECS/python-hjson/python-hjson.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname hjson
+
+Name:           python-%{srcname}
+Version:        3.1.0
+Release:        %autorelease
+Summary:        Hjson, a user interface for JSON
+License:        MIT OR AFL-2.1
+URL:            https://pypi.org/project/hjson/
+#!RemoteAsset:  sha256:55af475a27cf83a7969c808399d7bccdec8fb836a07ddbd574587593b9cdcf75
+Source0:        https://files.pythonhosted.org/packages/source/h/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+# hjson.ordered_dict is dead Python 2 fallback code (it does
+# "from UserDict import DictMixin") that is only imported when
+# collections.OrderedDict is missing, which never happens on Python 3.
+# Exclude it from the import check; it is never used at runtime.
+BuildOption(install):  -l %{srcname} +auto
+BuildOption(check):  -e hjson.ordered_dict
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(wheel)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Hjson is a syntax extension to JSON intended to be used as a configuration
+file format that is easy for humans to read and edit. It adds comments,
+optional commas and quotes, and multiline strings on top of plain JSON.
+
+%files -f %{pyproject_files}
+%doc README.rst
+%license LICENSE.txt
+
+%changelog
+%autochangelog

--- a/SPECS/python-ninja/python-ninja.spec
+++ b/SPECS/python-ninja/python-ninja.spec
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: tangyihong <yihong.or@isrc.iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname ninja
+
+Name:           python-%{srcname}
+Version:        1.13.2
+Release:        %autorelease
+Summary:        Ninja is a small build system with a focus on speed
+License:        Apache-2.0
+URL:            https://pypi.org/project/ninja/
+#!RemoteAsset:  sha256:525bfa3fc88aa30a4467df270fd5be6f9fcae8061d54d4df74ea1dc5abd5a975
+Source0:        https://files.pythonhosted.org/packages/source/n/%{srcname}/%{srcname}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+# Upstream bundles and builds the ninja binary into %%{_bindir}/ninja, which
+# clashes with the system "ninja" package. We ship only the Python wrapper
+# module (which simply shells out to the ninja binary) and reuse the system
+# ninja binary via the runtime dependency below.
+# Upstream's bundled ninja sources build a googletest-based test suite that
+# is fetched from the network via CMake FetchContent; disable it (we do not
+# run ninja's own test suite) so the build works in the offline build env.
+BuildOption(build):  -C cmake.define.BUILD_TESTING=OFF
+BuildOption(install):  -l %{srcname} -L
+
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  cmake
+BuildRequires:  (python3dist(pip) >= 19 with python3dist(pip))
+BuildRequires:  python3dist(scikit-build-core)
+BuildRequires:  python3dist(setuptools-scm)
+BuildRequires:  python3dist(hatch-fancy-pypi-readme)
+
+Requires:       ninja
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+Ninja is a small build system with a focus on speed. This package provides
+the Python interface (the ninja module and ninja_syntax helper) that wraps
+the ninja build tool; the ninja executable itself is provided by the system
+ninja package.
+
+%generate_buildrequires
+%pyproject_buildrequires -p
+
+%files -f %{pyproject_files}
+%doc README.rst HISTORY.rst
+%license LICENSE_Apache_20 ninja-upstream/COPYING
+%exclude %{_bindir}/ninja
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

Add `python-deepspeed` and its two missing runtime dependencies.

- **python-hjson** 3.1.0 (MIT OR AFL-2.1) — JSON syntax extension used by
  DeepSpeed for config files. The `hjson.ordered_dict` submodule is dead
  Python 2 fallback code and is excluded from the import check.
- **python-ninja** 1.13.2 (Apache-2.0) — Python wrapper around the ninja
  build tool required by DeepSpeed's just-in-time op compilation. Only the
  Python module is shipped (`%exclude %{_bindir}/ninja`); the executable
  comes from the system `ninja` package via `Requires: ninja`.
- **python-deepspeed** 0.19.6 (Apache-2.0) — Microsoft's deep learning
  optimization library for distributed training and inference (ZeRO, pipeline
  and tensor parallelism, memory-efficient optimizers). The Linux wheel is
  pure Python (`DS_BUILD_OPS=0` default, ops are JIT-compiled at runtime), so
  the package is `noarch`; `%check` runs a top-level import smoke test since
  the real suite needs GPUs and a distributed setup.

All three build and pass checks on x86_64 and riscv64 in OBS.

Upstream: https://github.com/deepspeedai/DeepSpeed

## Related Issue

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.
- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: Claude Code:gpt-5.6-sol

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
