### PR TITLE
.github: remoteasset: apt update before apt install

### DIFF
--- a/.github/workflows/remoteasset.yaml
+++ b/.github/workflows/remoteasset.yaml
@@ -26,6 +26,7 @@ jobs:
     steps:
     - name: Install dependencies
       run: |
+        sudo apt update
         sudo apt install -y rpm curl util-linux util-linux-extra
 
     - uses: actions/checkout@v6


### PR DESCRIPTION
Fix some apt missing file errors.

## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

## Related Issue

https://github.com/openRuyi-Project/openRuyi/actions/runs/33589973732/job/100122802772 :(

<!--
Link related issues if applicable.
Example: Resolves #123
-->

## Checklist

- [X] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
