### PR TITLE
CI: build: Prefer python-torch

### DIFF
--- a/.github/build/_config
+++ b/.github/build/_config
@@ -29,6 +29,7 @@ Prefer: libomp
 Prefer: glib-devel glib
 Prefer: python3-libs python3-devel
 Prefer: python3 python3-packaging python3-pip python3-wheel
+Prefer: python-torch
 Prefer: rust
 
 Prefer: libgcc-s


### PR DESCRIPTION
## Summary

Add `Prefer: python-torch` to the GitHub pbuild prjconf (`.github/build/_config`).

`python3dist(torch)` is provided by both `python-torch` and `python-torch-rocm`. Without a Prefer, the CI solver reports `have choice` and any package that `BuildRequires: python3dist(torch)` fails the `build` gate (seen on #1214). OBS already has this Prefer in the `openruyi` prjconf, so this aligns the GitHub gate with OBS.

Packages that explicitly `BuildRequires: python-torch-rocm` are unaffected.

## Related Issue

- Related to #1214

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.
- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: Grok:grok-4.6

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy