### PR TITLE
SPECS: dpdk: Build with libarchive so the EAL can load compressed fir…

### DIFF
--- a/SPECS/dpdk/dpdk.spec
+++ b/SPECS/dpdk/dpdk.spec
@@ -46,6 +46,7 @@ BuildRequires:  zlib-devel
 BuildRequires:  numactl-devel
 BuildRequires:  openssl-devel
 BuildRequires:  rdma-core-devel
+BuildRequires:  pkgconfig(libarchive)
 
 %patchlist
 # 25.11


### PR DESCRIPTION
## Summary

The ice PMD fails to probe an E810 because linux-firmware ships the DDP
package as ice.pkg.xz and rte_firmware_read() cannot decompress it
without libarchive.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
