### PR TITLE
SPECS: systemd: use x.pool.ntp.org for timesyncd

### DIFF
--- a/SPECS/systemd/systemd.spec
+++ b/SPECS/systemd/systemd.spec
@@ -96,6 +96,7 @@ BuildOption(conf):  -Dlibidn2=enabled
 BuildOption(conf):  -Dnetworkd=%{?with_network:true}%{!?with_network:false}
 BuildOption(conf):  -Dresolve=%{?with_network:true}%{!?with_network:false}
 BuildOption(conf):  -Dnss-resolve=%{?with_network:enabled}%{!?with_network:disabled}
+BuildOption(conf):  -Dntp-servers="0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org 3.pool.ntp.org"
 BuildOption(conf):  -Dlibcurl=enabled
 BuildOption(conf):  -Dlibfido2=%{?with_fido2:enabled}%{!?with_fido2:disabled}
 BuildOption(conf):  -Defi=true


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->
Use pool.ntp.org for better availability.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
