### PR TITLE
SPECS: libtomcrypt: Restore upstream test suite

### DIFF
--- a/SPECS/libtomcrypt/libtomcrypt.spec
+++ b/SPECS/libtomcrypt/libtomcrypt.spec
@@ -3,6 +3,7 @@
 # SPDX-FileContributor: Zheng Junjie <zhengjunjie@iscas.ac.cn>
 # SPDX-FileContributor: yyjeqhc <jialin.oerv@isrc.iscas.ac.cn>
 # SPDX-FileContributor: misaka00251 <liuxin@iscas.ac.cn>
+# SPDX-FileContributor: corestudy <2760018909@qq.com>
 #
 # SPDX-License-Identifier: MulanPSL-2.0
 
@@ -15,7 +16,7 @@ Summary:        A comprehensive, portable cryptographic toolkit
 License:        Unlicense OR WTFPL
 URL:            http://www.libtom.net/
 VCS:            git:https://github.com/libtom/libtomcrypt
-#!RemoteAsset
+#!RemoteAsset:  sha256:d870fad1e31cb787c85161a8894abb9d7283c2a654a9d3d4c6d45a1eba59952c
 Source:         https://github.com/libtom/libtomcrypt/archive/v%{version}/libtomcrypt-%{version}.tar.gz
 BuildSystem:    autotools
 
@@ -29,6 +30,9 @@ BuildOption(install):  INSTALL_OPTS="-m 755"
 BuildOption(install):  INCPATH="%{_includedir}"
 BuildOption(install):  LIBPATH="%{_libdir}"
 BuildOption(install):  -f makefile.shared
+BuildOption(check):  EXTRALIBS="-ltommath"
+BuildOption(check):  CFLAGS="%{optflags} -DLTM_DESC -DUSE_LTM"
+BuildOption(check):  -f makefile.shared && ./test
 
 BuildRequires:  pkgconfig(libtommath)
 BuildRequires:  libtool
@@ -58,9 +62,6 @@ sed -i \
     -e 's|^libdir=.*|libdir=${prefix}/%{_lib}|g' \
     %{buildroot}%{_libdir}/pkgconfig/%{name}.pc
 
-# TODO: Fix test build.
-%check
-
 %files
 %license LICENSE
 %{_libdir}/*.so.*
@@ -71,4 +72,4 @@ sed -i \
 %{_libdir}/pkgconfig/libtomcrypt.pc
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
## Summary

libtomcrypt: Restore upstream test suite
obs validation: [home:corestudy:libtomcrypt]


## Related Issue

OSPP 2026 openruyi   task

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: ChatGPT:GPT-5.6 Sol

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
 [home:corestudy:libtomcrypt]:https://build.openruyi.cn/package/show/home:corestudy/libtomcrypt