### PR TITLE
SPECS: Add libguestfs and runtime dependencies

### DIFF
--- a/SPECS/fuse2/0001-conditionally-define-closefrom.patch
+++ b/SPECS/fuse2/0001-conditionally-define-closefrom.patch
@@ -1,0 +1,63 @@
+From 5a43d0f724c56f8836f3f92411e0de1b5f82db32 Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Sat, 24 Jul 2021 22:02:45 +0100
+Subject: [PATCH] util/ulockmgr_server.c: conditionally define closefrom (fix
+ glibc-2.34+)
+
+closefrom(3) has joined us in glibc-land from *BSD and Solaris. Since
+it's available in glibc 2.34+, we want to detect it and only define our
+fallback if the libc doesn't provide it.
+
+Bug: https://bugs.gentoo.org/803923
+Signed-off-by: Sam James <sam@gentoo.org>
+(cherry picked from commit 5a43d0f724c56f8836f3f92411e0de1b5f82db32)
+Upstream: https://github.com/libfuse/libfuse/commit/5a43d0f724c56f8836f3f92411e0de1b5f82db32
+Signed-off-by: cl2t <yihong.or@isrc.iscas.ac.cn>
+---
+ configure.ac           | 1 +
+ util/ulockmgr_server.c | 6 ++++++
+ 2 files changed, 7 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index 9946a0efa..a2d481aa9 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -55,6 +55,7 @@ fi
+ 
+ AC_CHECK_FUNCS([fork setxattr fdatasync splice vmsplice utimensat])
+ AC_CHECK_FUNCS([posix_fallocate])
++AC_CHECK_FUNCS([closefrom])
+ AC_CHECK_MEMBERS([struct stat.st_atim])
+ AC_CHECK_MEMBERS([struct stat.st_atimespec])
+ 
+diff --git a/util/ulockmgr_server.c b/util/ulockmgr_server.c
+index 273c7d923..a04dac5c6 100644
+--- a/util/ulockmgr_server.c
++++ b/util/ulockmgr_server.c
+@@ -22,6 +22,10 @@
+ #include <sys/socket.h>
+ #include <sys/wait.h>
+ 
++#ifdef HAVE_CONFIG_H
++	#include "config.h"
++#endif
++
+ struct message {
+ 	unsigned intr : 1;
+ 	unsigned nofd : 1;
+@@ -124,6 +128,7 @@ static int receive_message(int sock, void *buf, size_t buflen, int *fdp,
+ 	return res;
+ }
+ 
++#if !defined(HAVE_CLOSEFROM)
+ static int closefrom(int minfd)
+ {
+ 	DIR *dir = opendir("/proc/self/fd");
+@@ -141,6 +146,7 @@ static int closefrom(int minfd)
+ 	}
+ 	return 0;
+ }
++#endif
+ 
+ static void send_reply(int cfd, struct message *msg)
+ {

--- a/SPECS/fuse2/fuse2.spec
+++ b/SPECS/fuse2/fuse2.spec
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           fuse2
+Version:        2.9.9
+Release:        %autorelease
+Summary:        FUSE 2 compatibility libraries
+License:        LGPL-2.1-only AND GPL-2.0-only
+URL:            https://github.com/libfuse/libfuse
+VCS:            git:https://github.com/libfuse/libfuse.git
+#!RemoteAsset:  sha256:d0e69d5d608cc22ff4843791ad097f554dd32540ddc9bed7638cc6fea7c1b4b5
+Source0:        https://github.com/libfuse/libfuse/releases/download/fuse-%{version}/fuse-%{version}.tar.gz
+BuildSystem:    autotools
+
+# Backport upstream glibc 2.34 closefrom detection (Sam James).
+# https://github.com/libfuse/libfuse/commit/5a43d0f724c56f8836f3f92411e0de1b5f82db32
+Patch0001:      0001-conditionally-define-closefrom.patch
+
+BuildOption(conf):  --disable-static
+BuildOption(conf):  --disable-util
+BuildOption(conf):  --disable-example
+BuildOption(conf):  --disable-mtab
+
+BuildRequires:  autoconf
+BuildRequires:  automake
+BuildRequires:  libtool
+BuildRequires:  pkgconfig
+BuildRequires:  fuse3
+# fuse3 owns the unversioned fusermount and the shared configuration.
+Requires:       fuse3
+
+%description
+Compatibility libraries for applications using the FUSE 2 API, including
+libfuse and libulockmgr. Mounting uses the fusermount helper supplied by
+fuse3, allowing both library versions to be installed together.
+
+%package        devel
+Summary:        Development files for the FUSE 2 API
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       pkgconfig
+
+%description    devel
+Headers and linker files for building applications against FUSE 2.
+
+%prep
+%autosetup -p1 -n fuse-%{version}
+# Regenerate configure and config.h.in for upstream closefrom detection.
+# AM_ICONV is shipped by gettext-tools in the standard build environment.
+autoreconf -fi -I %{_datadir}/gettext/m4
+
+%build -a
+# Build only the lock manager helper; do not build the old mount helpers.
+%make_build -C util ulockmgr_server
+%make_build -C example hello
+
+%install -a
+install -D -m 0755 util/ulockmgr_server %{buildroot}%{_bindir}/ulockmgr_server
+# The mount helpers and their manual pages belong to fuse3.
+rm -f %{buildroot}%{_mandir}/man1/fusermount.1*
+rm -f %{buildroot}%{_mandir}/man8/mount.fuse.8*
+
+%check
+# The upstream example exits 1 after displaying --version (no mount).
+# Check both the FUSE 2 library and the FUSE 3 helper it actually invoked.
+status=0
+output=$(LD_LIBRARY_PATH=%{buildroot}%{_libdir} ./example/.libs/hello --version 2>&1) || status=$?
+test "$status" -eq 1
+printf '%s\n' "$output"
+printf '%s\n' "$output" | grep -F 'FUSE library version: %{version}'
+printf '%s\n' "$output" | grep -F 'fusermount3 version:'
+
+%files
+%doc AUTHORS ChangeLog NEWS README.md
+%license COPYING COPYING.LIB
+%{_libdir}/libfuse.so.*
+%{_libdir}/libulockmgr.so.*
+%{_bindir}/ulockmgr_server
+%{_mandir}/man1/ulockmgr_server.1*
+
+%files devel
+%{_includedir}/fuse.h
+%{_includedir}/fuse/
+%{_includedir}/ulockmgr.h
+%{_libdir}/libfuse.so
+%{_libdir}/libulockmgr.so
+%{_libdir}/pkgconfig/fuse.pc
+
+%changelog
+%autochangelog

--- a/SPECS/hivex/hivex.spec
+++ b/SPECS/hivex/hivex.spec
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           hivex
+Version:        1.3.24
+Release:        %autorelease
+Summary:        Windows Registry hive extraction library
+License:        LGPL-2.1-or-later
+URL:            https://libguestfs.org/
+VCS:            git:https://github.com/libguestfs/hivex.git
+#!RemoteAsset:  sha256:ad919b43b3b6da483bff475ec101581e97ebd2fd3309e2a0745d28bb6d3345d1
+Source0:        https://github.com/libguestfs/hivex/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+BuildSystem:    autotools
+
+BuildOption(conf):  --disable-static
+BuildOption(conf):  --disable-perl
+BuildOption(conf):  --disable-python
+BuildOption(conf):  --disable-ruby
+BuildOption(conf):  --enable-ocaml
+
+BuildRequires:  autoconf
+BuildRequires:  automake
+BuildRequires:  gettext-devel
+BuildRequires:  libtool
+BuildRequires:  ocaml
+BuildRequires:  ocaml-devel
+BuildRequires:  ocaml-findlib
+BuildRequires:  pkgconfig(libzstd)
+BuildRequires:  pkgconfig(libxml-2.0)
+BuildRequires:  pkgconfig(readline)
+BuildRequires:  perl
+
+%description
+Hivex is a library for reading and writing Windows Registry "hive"
+files. It is used by libguestfs to inspect Windows virtual machines.
+
+%package        devel
+Summary:        Development files for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+This package contains the headers and linker files needed to build
+software against %{name}.
+
+%package     -n ocaml-hivex
+Summary:        OCaml bindings for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       ocaml-findlib
+
+%description -n ocaml-hivex
+OCaml bindings for %{name}. Required to build the libguestfs daemon.
+
+%prep -a
+autoreconf -fi
+# GitHub tag archive omits generated headers, pods, and language bindings.
+ocaml generator/generator.ml
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/hivexget
+%{_bindir}/hivexml
+%{_bindir}/hivexsh
+%{_libdir}/libhivex.so.*
+%{_datadir}/locale/*/LC_MESSAGES/hivex.mo
+%{_mandir}/man1/hivexget.1*
+%{_mandir}/man1/hivexml.1*
+%{_mandir}/man1/hivexsh.1*
+
+%files devel
+%{_includedir}/hivex.h
+%{_libdir}/libhivex.so
+%{_libdir}/pkgconfig/hivex.pc
+%{_mandir}/man3/hivex.3*
+
+%files -n ocaml-hivex
+%{_libdir}/ocaml/hivex/
+%{_libdir}/ocaml/stublibs/dllmlhivex.so
+%{_libdir}/ocaml/stublibs/dllmlhivex.so.owner
+
+%changelog
+%autochangelog

--- a/SPECS/libguestfs/2000-add-openruyi-appliance.patch
+++ b/SPECS/libguestfs/2000-add-openruyi-appliance.patch
@@ -1,0 +1,58 @@
+From: cl2t <yihong.or@isrc.iscas.ac.cn>
+Subject: [PATCH] appliance: add openRuyi RPM package names
+
+Use openRuyi package names and the RPM dependency query when preparing
+the appliance. The distro ID is already read from os-release.
+
+This patch was authored downstream for openRuyi and has not been submitted
+upstream.
+
+Signed-off-by: cl2t <yihong.or@isrc.iscas.ac.cn>
+---
+
+diff --git a/appliance/packagelist.in b/appliance/packagelist.in
+--- a/appliance/packagelist.in
++++ b/appliance/packagelist.in
+@@ -4,6 +4,7 @@
+ dnl This file is processed by m4 with one of the
+ dnl following symbols defined (depending on the distro):
+ dnl
++dnl   OPENRUYI=1    For openRuyi.
+ dnl   REDHAT=1      For Fedora, RHEL, EPEL and workalikes.
+ dnl   DEBIAN=1      For Debian.
+ dnl   UBUNTU=1      For Ubuntu.
+@@ -23,6 +24,22 @@
+ 
+ dnl Basically the same with a few minor tweaks.
+ ifelse(UBUNTU,1,`define(`DEBIAN',1)')
++
++ifelse(OPENRUYI,1,
++  cryptsetup
++  dhcpcd
++  gptfdisk
++  iproute2
++  iputils
++  linux
++  ntfs-3g
++  openssh-clients
++  rpm
++  systemd
++  systemd-udev
++  xz
++  zstd
++)
+ 
+ ifelse(REDHAT,1,
+   apfs-fuse
+diff --git a/m4/guestfs-appliance.m4 b/m4/guestfs-appliance.m4
+--- a/m4/guestfs-appliance.m4
++++ b/m4/guestfs-appliance.m4
+@@ -132,7 +132,7 @@
+     AC_SUBST([DISTRO])
+ fi
+ AM_CONDITIONAL([HAVE_RPM],
+-    [AS_CASE([$DISTRO], [REDHAT | SUSE | OPENMANDRIVA | MAGEIA | OPENCLOUDOS | TENCENTOS | OPENEULER ], [true],
++    [AS_CASE([$DISTRO], [REDHAT | SUSE | OPENMANDRIVA | MAGEIA | OPENCLOUDOS | TENCENTOS | OPENEULER | OPENRUYI ], [true],
+                         [*], [false])])
+ AM_CONDITIONAL([HAVE_DPKG],
+     [AS_CASE([$DISTRO], [DEBIAN | UBUNTU ], [true],

--- a/SPECS/libguestfs/libguestfs.spec
+++ b/SPECS/libguestfs/libguestfs.spec
@@ -1,0 +1,327 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           libguestfs
+Version:        1.60.1
+Release:        %autorelease
+Summary:        Library and tools for accessing and modifying VM disk images
+License:        LGPL-2.1-or-later AND GPL-2.0-or-later
+URL:            https://libguestfs.org/
+VCS:            git:https://github.com/libguestfs/libguestfs.git
+#!RemoteAsset:  sha256:6311c686700c293c92a9e804074040f4ae536fcbcef0a69973f418c77d3441e9
+Source0:        https://download.libguestfs.org/1.60-stable/%{name}-%{version}.tar.gz
+Source2000:     test-python-fuse.py
+#!RemoteAsset:  sha256:30c36c4c57547bc4253d438b63f0ac89602e508870b73918646f3d840532a188
+Source2001:     https://raw.githubusercontent.com/libfuse/libfuse/fuse-3.18.2/example/hello.c
+BuildSystem:    autotools
+
+# Downstream openRuyi appliance package names and RPM conditional.
+Patch2000:      2000-add-openruyi-appliance.patch
+
+BuildOption(conf):  --disable-static
+BuildOption(conf):  --enable-appliance
+BuildOption(conf):  --enable-daemon
+BuildOption(conf):  --with-supermin-extra-options=--use-installed
+BuildOption(conf):  --disable-ocaml
+BuildOption(conf):  --disable-perl
+BuildOption(conf):  --enable-python
+BuildOption(conf):  --disable-ruby
+BuildOption(conf):  --disable-haskell
+BuildOption(conf):  --disable-php
+BuildOption(conf):  --disable-erlang
+BuildOption(conf):  --disable-lua
+BuildOption(conf):  --disable-golang
+BuildOption(conf):  --without-java
+BuildOption(conf):  --enable-fuse
+BuildOption(conf):  --with-distro=OPENRUYI
+BuildOption(conf):  --with-extra='openruyi'
+BuildOption(conf):  --with-default-backend=direct
+
+BuildRequires:  autoconf
+BuildRequires:  automake
+BuildRequires:  bison
+BuildRequires:  flex
+BuildRequires:  gperf
+BuildRequires:  libtool
+BuildRequires:  ocaml
+BuildRequires:  ocaml-devel
+BuildRequires:  ocaml-findlib
+BuildRequires:  ocaml-augeas
+BuildRequires:  ocaml-hivex
+BuildRequires:  acl-devel
+BuildRequires:  pkgconfig(libcap)
+BuildRequires:  pkgconfig(rpm)
+BuildRequires:  pkgconfig(libsystemd)
+BuildRequires:  supermin
+BuildRequires:  pkgconfig(fuse)
+# Independent host-permission probe; not used to build libguestfs.
+BuildRequires:  pkgconfig(fuse3)
+BuildRequires:  python3-devel
+BuildRequires:  python-rpm-macros
+BuildRequires:  python-libvirt
+# Additional appliance dependencies beyond the standard build environment.
+BuildRequires:  acl
+BuildRequires:  attr
+BuildRequires:  augeas
+BuildRequires:  btrfs-progs
+BuildRequires:  cryptsetup
+BuildRequires:  dhcpcd
+BuildRequires:  dosfstools
+BuildRequires:  e2fsprogs
+BuildRequires:  exfatprogs
+BuildRequires:  f2fs-tools
+BuildRequires:  gptfdisk
+BuildRequires:  hivex
+BuildRequires:  iproute2
+BuildRequires:  iputils
+BuildRequires:  json-c
+BuildRequires:  kmod
+BuildRequires:  less
+BuildRequires:  libcap
+BuildRequires:  libtirpc
+BuildRequires:  libxml2
+BuildRequires:  linux
+BuildRequires:  lsof
+BuildRequires:  lsscsi
+BuildRequires:  lvm2
+BuildRequires:  lzop
+BuildRequires:  mdadm
+BuildRequires:  ntfs-3g
+BuildRequires:  openssh-clients
+BuildRequires:  parted
+BuildRequires:  pciutils
+BuildRequires:  pcre2
+BuildRequires:  procps-ng
+BuildRequires:  psmisc
+BuildRequires:  rsync
+BuildRequires:  squashfs-tools
+BuildRequires:  strace
+BuildRequires:  systemd
+BuildRequires:  systemd-udev
+BuildRequires:  xfsprogs
+BuildRequires:  zstd
+BuildRequires:  pkgconfig(augeas)
+BuildRequires:  pkgconfig(hivex)
+BuildRequires:  pkgconfig(json-c)
+BuildRequires:  pkgconfig(libpcre2-8)
+BuildRequires:  pkgconfig(libtirpc)
+BuildRequires:  pkgconfig(libvirt)
+BuildRequires:  pkgconfig(libxml-2.0)
+BuildRequires:  pkgconfig(liblzma)
+BuildRequires:  pkgconfig(libzstd)
+BuildRequires:  pkgconfig(libmagic)
+BuildRequires:  pkgconfig(ncurses)
+BuildRequires:  pkgconfig(readline)
+BuildRequires:  pkgconfig(bash-completion)
+BuildRequires:  rpcgen
+BuildRequires:  xorriso
+BuildRequires:  perl
+BuildRequires:  qemu
+# qemu Requires qemu-user, also provided by qemu-user-static; pick one.
+BuildRequires:  qemu-user
+%ifarch x86_64
+BuildRequires:  seabios
+%endif
+
+Requires:       qemu
+Requires:       supermin
+Requires:       xorriso
+%ifarch x86_64
+Requires:       seabios
+%endif
+# Keep these installed for supermin reconstruction, including the
+# shared libraries used by guestfsd inside daemon.tar.gz.
+Requires:       acl
+Requires:       attr
+Requires:       augeas
+Requires:       bash
+Requires:       binutils
+Requires:       btrfs-progs
+Requires:       bzip2
+Requires:       coreutils
+Requires:       cpio
+Requires:       cryptsetup
+Requires:       dhcpcd
+Requires:       diffutils
+Requires:       dosfstools
+Requires:       e2fsprogs
+Requires:       exfatprogs
+Requires:       f2fs-tools
+Requires:       file
+Requires:       findutils
+Requires:       gawk
+Requires:       gptfdisk
+Requires:       grep
+Requires:       gzip
+Requires:       hivex
+Requires:       iproute2
+Requires:       iputils
+Requires:       json-c
+Requires:       kmod
+Requires:       less
+Requires:       libcap
+Requires:       libtirpc
+Requires:       libxml2
+Requires:       linux
+Requires:       lsof
+Requires:       lsscsi
+Requires:       lvm2
+Requires:       lzop
+Requires:       mdadm
+Requires:       ntfs-3g
+Requires:       openssh-clients
+Requires:       parted
+Requires:       pciutils
+Requires:       pcre2
+Requires:       procps-ng
+Requires:       psmisc
+Requires:       rpm
+Requires:       rsync
+Requires:       sed
+Requires:       squashfs-tools
+Requires:       strace
+Requires:       systemd
+Requires:       systemd-udev
+Requires:       tar
+Requires:       util-linux
+Requires:       xfsprogs
+Requires:       xz
+Requires:       zstd
+
+%description
+Libguestfs is a set of tools for accessing and modifying virtual
+machine disk images. It can inspect guests, copy files in and out, and
+run commands in the guest. This build ships the C library and
+command-line tools, including a supermin appliance with guestfsd.
+The bootable appliance is assembled and cached on first use.
+
+%package        devel
+Summary:        Development files for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+This package contains the headers and linker files needed to build
+software against %{name}.
+
+%package     -n python-%{name}
+Summary:        Python bindings for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       python3
+Provides:       python3-%{name} = %{version}-%{release}
+
+%description -n python-%{name}
+The guestfs Python module provides access to the libguestfs API for
+inspecting and modifying virtual machine disk images.
+
+%prep -a
+# Regenerate the RPM distro conditional changed by Patch2000.
+autoconf
+
+%install -a
+# Bindings were disabled; drop leftover man pages if the build still
+# installed them.
+rm -f %{buildroot}%{_mandir}/man3/guestfs-ocaml.3*
+rm -f %{buildroot}%{_mandir}/man3/guestfs-perl.3*
+rm -f %{buildroot}%{_mandir}/man3/guestfs-ruby.3*
+rm -f %{buildroot}%{_mandir}/man3/guestfs-golang.3*
+rm -f %{buildroot}%{_mandir}/man3/guestfs-java.3*
+rm -f %{buildroot}%{_mandir}/man3/guestfs-lua.3*
+rm -f %{buildroot}%{_mandir}/man3/guestfs-php.3*
+rm -f %{buildroot}%{_mandir}/man3/guestfs-haskell.3*
+rm -f %{buildroot}%{_mandir}/man3/guestfs-erlang.3*
+
+# Generate packaged bytecode during installation, even with --nocheck.
+%py_byte_compile %{__python3} %{buildroot}%{python3_sitearch}
+
+%check
+# Probe the existing FUSE 3 stack before testing our FUSE 2 integration.
+# Some OBS hosts expose /dev/fuse but prohibit the mount operation.
+%{__cc} %{build_cflags} %{SOURCE2001} -o fuse3-host-probe $(pkg-config --cflags --libs fuse3) %{build_ldflags}
+probe_status=0
+python3 %{SOURCE2000} --probe-host ./fuse3-host-probe || probe_status=$?
+case "$probe_status" in
+    0) ;;
+    77) export SKIP_TEST_FUSE_SH=1 OPENRUYI_SKIP_HOST_FUSE=1 ;;
+    *) exit "$probe_status" ;;
+esac
+
+# Run library and daemon unit tests, then boot the appliance using TCG
+# so validation does not require nested KVM in OBS workers.
+%make_build -C lib check
+%make_build -C daemon check
+export LIBGUESTFS_BACKEND=direct
+export LIBGUESTFS_BACKEND_SETTINGS=force_tcg
+# Python libvirt tests need only this empty fixture, not all guest images.
+%make_build -C test-data/phony-guests blank-disk.img
+%make_build -C python check
+# Run upstream FUSE tests which do not require the optional Fedora fixture.
+%make_build -C fuse check TESTS="test-docs.sh test-guestunmount-fd test-guestunmount-not-mounted.sh test-fuse"
+# Exercise the installed payload, including its packaged appliance.
+export LD_LIBRARY_PATH=%{buildroot}%{_libdir}
+export LIBGUESTFS_PATH=%{buildroot}%{_libdir}/guestfs
+%{buildroot}%{_bindir}/libguestfs-test-tool --timeout 600
+
+# Check that a file survives shutdown and reopening the disk image.
+%{buildroot}%{_bindir}/guestfish -N appliance-test.img=fs:ext4 -m /dev/sda1 <<'EOF'
+write /openruyi-test "libguestfs appliance works"
+sync
+EOF
+result=$(%{buildroot}%{_bindir}/guestfish --ro -a appliance-test.img -m /dev/sda1 cat /openruyi-test)
+test "$result" = "libguestfs appliance works"
+rm -f appliance-test.img
+
+# Import the staged Python module, then exercise Python and host FUSE I/O.
+export PYTHONDONTWRITEBYTECODE=1
+export PYTHONPATH=%{buildroot}%{python3_sitearch}
+export PATH=%{buildroot}%{_bindir}:$PATH
+python3 %{SOURCE2000}
+
+%files
+%doc README
+%license COPYING COPYING.LIB
+%config(noreplace) %{_sysconfdir}/libguestfs-tools.conf
+%{_bindir}/guestfish
+%{_bindir}/guestmount
+%{_bindir}/guestunmount
+%{_bindir}/libguestfs-test-tool
+%{_bindir}/libguestfs-make-fixed-appliance
+%{_bindir}/virt-copy-in
+%{_bindir}/virt-copy-out
+%{_bindir}/virt-tar-in
+%{_bindir}/virt-tar-out
+%{_bindir}/virt-rescue
+%{_libdir}/libguestfs.so.*
+%{_libdir}/guestfs/
+%{_datadir}/locale/*/LC_MESSAGES/libguestfs.mo
+%{_mandir}/man1/guestfish.1*
+%{_mandir}/man1/guestmount.1*
+%{_mandir}/man1/guestunmount.1*
+%{_mandir}/man1/libguestfs-test-tool.1*
+%{_mandir}/man1/libguestfs-make-fixed-appliance.1*
+%{_mandir}/man1/virt-copy-in.1*
+%{_mandir}/man1/virt-copy-out.1*
+%{_mandir}/man1/virt-tar-in.1*
+%{_mandir}/man1/virt-tar-out.1*
+%{_mandir}/man1/virt-rescue.1*
+%{_mandir}/man1/guestfs-*.1*
+%{_mandir}/man5/libguestfs-tools.conf.5*
+%{bash_completions_dir}/*
+
+%files devel
+%{_includedir}/guestfs.h
+%{_libdir}/libguestfs.so
+%{_libdir}/pkgconfig/libguestfs.pc
+%{_mandir}/man3/guestfs.3*
+%{_mandir}/man3/guestfs-examples.3*
+%{_mandir}/man3/libguestfs.3*
+
+%files -n python-%{name}
+%{python3_sitearch}/guestfs.py
+%{python3_sitearch}/libguestfsmod*.so
+%{python3_sitearch}/__pycache__/guestfs.*.pyc
+%{_mandir}/man3/guestfs-python.3*
+
+%changelog
+%autochangelog

--- a/SPECS/libguestfs/test-python-fuse.py
+++ b/SPECS/libguestfs/test-python-fuse.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-License-Identifier: MulanPSL-2.0
+"""Exercise the installed Python binding and guestmount with a temporary image."""
+
+import contextlib
+import errno
+import os
+from pathlib import Path
+import selectors
+import subprocess
+import tempfile
+import sys
+import time
+
+
+@contextlib.contextmanager
+def handle(image, readonly=False):
+    import guestfs
+
+    g = guestfs.GuestFS(python_return_dict=True)
+    try:
+        g.add_drive_opts(str(image), format="raw", readonly=readonly)
+        g.launch()
+        yield g
+        g.shutdown()
+    finally:
+        g.close()
+
+
+@contextlib.contextmanager
+def host_mount(image, directory, readonly=False):
+    read_fd, write_fd = os.pipe()
+    command = ["guestmount", "--no-fork", "--fd", str(write_fd),
+               "--format=raw", "-a", str(image), "-m", "/dev/sda1"]
+    if readonly:
+        command.append("--ro")
+    command.append(str(directory))
+    process = None
+    mounted = False
+    try:
+        process = subprocess.Popen(command, pass_fds=(write_fd,))
+        os.close(write_fd)
+        write_fd = None
+        with selectors.DefaultSelector() as selector:
+            selector.register(read_fd, selectors.EVENT_READ)
+            if not selector.select(timeout=600) or not os.read(read_fd, 1):
+                raise RuntimeError("guestmount did not signal a successful mount")
+        mounted = True
+        yield
+    finally:
+        os.close(read_fd)
+        if write_fd is not None:
+            os.close(write_fd)
+        try:
+            if mounted:
+                subprocess.run(["guestunmount", str(directory)], check=True,
+                               timeout=60)
+            if process is not None:
+                status = process.wait(timeout=60)
+                if mounted and status != 0:
+                    raise RuntimeError(f"guestmount exited with status {status}")
+        finally:
+            if process is not None and process.poll() is None:
+                process.kill()
+                process.wait()
+
+
+def probe_host(binary):
+    """Check host permissions with the independent, existing FUSE 3 stack."""
+    if not os.access("/dev/fuse", os.R_OK | os.W_OK):
+        print("SKIP: FUSE 3 host probe: /dev/fuse is unavailable", flush=True)
+        return 77
+    with tempfile.TemporaryDirectory(prefix="fuse3-host-probe-") as temporary:
+        directory = Path(temporary)
+        mountpoint = directory / "mount"
+        mountpoint.mkdir()
+        mounted = False
+        with (directory / "helper.log").open("w+") as log:
+            process = subprocess.Popen(
+                [str(Path(binary).resolve()), "-f", str(mountpoint)],
+                stdout=log, stderr=log, env={**os.environ, "LC_ALL": "C"})
+            try:
+                deadline = time.monotonic() + 60
+                while time.monotonic() < deadline:
+                    if os.path.ismount(mountpoint):
+                        mounted = True
+                        break
+                    if process.poll() is not None:
+                        break
+                    time.sleep(0.1)
+                if mounted:
+                    assert (mountpoint / "hello").read_bytes() == b"Hello World!\n"
+                    subprocess.run(["fusermount3", "-u", str(mountpoint)],
+                                   check=True, timeout=60)
+                    mounted = False
+                    assert process.wait(timeout=60) == 0
+                    print("PASS: independent FUSE 3 host mount probe", flush=True)
+                    return 0
+                if process.poll() is None:
+                    raise RuntimeError("FUSE 3 host probe timed out")
+                log.seek(0)
+                message = log.read()
+                print(message, end="", flush=True)
+                # Only established host permission restrictions permit a skip.
+                # Missing libraries, crashes and other errors remain failures.
+                if ("fusermount3: mount failed: Operation not permitted" in message
+                        or "fuse: failed to open /dev/fuse: Permission denied" in message):
+                    print("SKIP: independent FUSE 3 mount denied by host", flush=True)
+                    for line in Path("/proc/self/status").read_text().splitlines():
+                        if line.startswith(("CapEff:", "NoNewPrivs:", "Seccomp:")):
+                            print(line, flush=True)
+                    return 77
+                raise RuntimeError(f"FUSE 3 host probe failed: {process.returncode}")
+            finally:
+                try:
+                    if mounted:
+                        subprocess.run(["fusermount3", "-u", str(mountpoint)],
+                                       check=True, timeout=60)
+                finally:
+                    if process.poll() is None:
+                        process.kill()
+                        process.wait()
+
+
+def test_payload():
+    import guestfs
+    import libguestfsmod
+
+    # During RPM checks ensure neither import came from the build source tree.
+    if os.environ.get("PYTHONPATH"):
+        installed = Path(os.environ["PYTHONPATH"]).resolve()
+        for module in (guestfs, libguestfsmod):
+            assert Path(module.__file__).resolve().is_relative_to(installed), module.__file__
+    print("Python module:", guestfs.__file__, flush=True)
+    print("Python extension:", libguestfsmod.__file__, flush=True)
+
+    with tempfile.TemporaryDirectory(prefix="libguestfs-bindings-") as temporary:
+        directory = Path(temporary)
+        image = directory / "disk.img"
+        g = guestfs.GuestFS()
+        try:
+            g.disk_create(str(image), "raw", 256 * 1024 * 1024)
+        finally:
+            g.close()
+        with handle(image) as g:
+            g.part_disk("/dev/sda", "mbr")
+            g.mkfs("ext4", "/dev/sda1")
+            g.mount("/dev/sda1", "/")
+            g.write("/python-test", b"written through Python\n")
+            g.sync()
+
+        fuse_available = os.environ.get("OPENRUYI_SKIP_HOST_FUSE") != "1"
+        if fuse_available:
+            mountpoint = directory / "mount"
+            mountpoint.mkdir()
+            with host_mount(image, mountpoint):
+                assert (mountpoint / "python-test").read_bytes() == b"written through Python\n"
+                (mountpoint / "fuse-test").write_bytes(b"written through FUSE\n")
+            with host_mount(image, mountpoint, readonly=True):
+                assert (mountpoint / "fuse-test").read_bytes() == b"written through FUSE\n"
+                try:
+                    (mountpoint / "should-not-exist").write_bytes(b"read-only")
+                except OSError as error:
+                    assert error.errno == errno.EROFS, error
+                else:
+                    raise AssertionError("read-only guestmount accepted a write")
+            print("PASS: guestmount write, unmount, read-only remount and write rejection", flush=True)
+        else:
+            print("SKIP: host FUSE mount test; independent FUSE 3 probe found host restriction", flush=True)
+
+        with handle(image, readonly=True) as g:
+            g.mount_ro("/dev/sda1", "/")
+            assert g.read_file("/python-test") == b"written through Python\n"
+            if fuse_available:
+                assert g.read_file("/fuse-test") == b"written through FUSE\n"
+        print("PASS: Python create, write, shutdown and read-only reopen", flush=True)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 3 and sys.argv[1] == "--probe-host":
+        sys.exit(probe_host(sys.argv[2]))
+    if len(sys.argv) != 1:
+        raise SystemExit("usage: test-python-fuse.py [--probe-host FUSE3_HELLO]")
+    test_payload()

--- a/SPECS/ocaml-augeas/ocaml-augeas.spec
+++ b/SPECS/ocaml-augeas/ocaml-augeas.spec
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global debug_package %{nil}
+# test_augeas.ml must compile after augeas.cmi; parallel make races.
+%global _smp_mflags -j1
+
+Name:           ocaml-augeas
+Version:        0.7
+Release:        %autorelease
+Summary:        OCaml bindings for Augeas
+License:        LGPL-2.1-or-later
+URL:            https://libguestfs.org/
+VCS:            git:https://github.com/libguestfs/libguestfs.git
+#!RemoteAsset:  sha256:ee3899c85d5b22cdcc659183e571add0980725a8a705a9fe7bf53ddc2ba2dd63
+Source0:        https://download.libguestfs.org/ocaml-augeas/%{name}-%{version}.tar.gz
+BuildSystem:    autotools
+
+BuildRequires:  autoconf
+BuildRequires:  automake
+BuildRequires:  ocaml
+BuildRequires:  ocaml-devel
+BuildRequires:  ocaml-findlib
+BuildRequires:  pkgconfig(libzstd)
+BuildRequires:  pkgconfig(augeas)
+BuildRequires:  pkgconfig(libxml-2.0)
+
+Requires:       ocaml-findlib
+Requires:       augeas%{?_isa}
+
+%description
+OCaml bindings for the Augeas configuration-editing library. Required
+to build the libguestfs daemon.
+
+%install
+export OCAMLFIND_DESTDIR=%{buildroot}%{_libdir}/ocaml
+export OCAMLFIND_LDCONF=ignore
+mkdir -p ${OCAMLFIND_DESTDIR}
+%make_install
+
+%files
+%license COPYING.LIB
+%{_libdir}/ocaml/augeas/
+
+%changelog
+%autochangelog

--- a/SPECS/ocaml-findlib/ocaml-findlib.spec
+++ b/SPECS/ocaml-findlib/ocaml-findlib.spec
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global debug_package %{nil}
+%global __strip /bin/true
+%global srcname ocamlfind
+
+Name:           ocaml-findlib
+Version:        1.9.8
+Release:        %autorelease
+Summary:        OCaml library manager
+License:        MIT
+URL:            https://github.com/ocaml/ocamlfind
+VCS:            git:https://github.com/ocaml/ocamlfind.git
+#!RemoteAsset:  sha256:d6899935ccabf67f067a9af3f3f88d94e310075d13c648fa03ff498769ce039d
+Source0:        https://github.com/ocaml/ocamlfind/archive/refs/tags/findlib-%{version}.tar.gz#/%{srcname}-findlib-%{version}.tar.gz
+
+BuildRequires:  ocaml
+# topfind.cmo needs Toploop/Topdirs from compiler-libs.
+BuildRequires:  ocaml-devel
+# ocamlc -custom links a runtime that was built against zstd.
+BuildRequires:  pkgconfig(libzstd)
+
+Provides:       ocamlfind = %{version}-%{release}
+Requires:       ocaml
+Requires:       ocaml-devel
+
+%description
+Findlib is a library manager for OCaml. It provides a convention for
+storing and referencing OCaml libraries, and the ocamlfind command
+used to compile against those libraries.
+
+%prep
+%autosetup -p1 -n %{srcname}-findlib-%{version}
+
+%build
+./configure \
+    -bindir %{_bindir} \
+    -mandir %{_mandir} \
+    -sitelib %{_libdir}/ocaml \
+    -config %{_sysconfdir}/findlib.conf
+# findlib's makefile is not safe for parallel make.
+%make_build -j1 all
+%make_build -j1 opt
+
+%install
+# findlib's Makefile honours prefix as the install root.
+make prefix=%{buildroot} install
+# Native ocamlfind is installed as ocamlfind; keep ocamlfind_opt as a copy
+# when the opt backend was built.
+if [ -f src/findlib/ocamlfind_opt ]; then
+    install -p -m 0755 src/findlib/ocamlfind_opt %{buildroot}%{_bindir}/ocamlfind_opt
+fi
+
+%files
+%doc README.md
+%license LICENSE
+%config(noreplace) %{_sysconfdir}/findlib.conf
+%{_bindir}/ocamlfind
+%{_bindir}/ocamlfind_opt
+%{_libdir}/ocaml/findlib/
+%{_libdir}/ocaml/topfind
+%{_libdir}/ocaml/bytes/
+
+%changelog
+%autochangelog

--- a/SPECS/ocaml/ocaml.spec
+++ b/SPECS/ocaml/ocaml.spec
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+# Bytecode runtimes are mixed-mode images; stripping them destroys the
+# interpreter. Skip debuginfo for the same reason.
+%global debug_package %{nil}
+%global __strip /bin/true
+
+Name:           ocaml
+Version:        5.4.1
+Release:        %autorelease
+Summary:        The OCaml programming language
+License:        LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception
+URL:            https://ocaml.org/
+VCS:            git:https://github.com/ocaml/ocaml.git
+#!RemoteAsset:  sha256:d4528517aaa1a44b8e2b1bc109a1ed0a5e0014f3ddc4feb8906b11a7e063e89a
+Source0:        https://github.com/ocaml/ocaml/archive/refs/tags/%{version}.tar.gz#/%{name}-%{version}.tar.gz
+
+BuildRequires:  pkgconfig(libzstd)
+
+Provides:       ocaml-runtime = %{version}-%{release}
+Provides:       ocaml-compiler-libs = %{version}-%{release}
+
+%description
+OCaml is a functional, statically typed programming language from the
+ML family. This package provides the bytecode and native-code compilers,
+the runtime, and the standard library.
+
+%package        devel
+Summary:        Development files for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+Compiler libraries and extra development files for %{name}.
+
+%prep
+%autosetup -p1
+
+%build
+./configure \
+    --prefix=%{_prefix} \
+    --bindir=%{_bindir} \
+    --libdir=%{_libdir}/ocaml \
+    --mandir=%{_mandir} \
+    --disable-ocamltest
+%make_build
+
+%install
+%make_install
+# Ship docs via %doc/%license from the source tree, not the make-install copies.
+rm -rf %{buildroot}%{_docdir}/%{name}
+
+%check
+# ocamlc is a script with #!/usr/bin/ocamlrun; that path does not exist
+# until the package is installed. Use the in-tree runtime and native
+# compilers instead.
+./runtime/ocamlrun -version
+./ocamlc.opt -version
+./ocamlopt.opt -version
+
+%files
+%doc README.adoc Changes README.win32.adoc
+%license LICENSE
+%{_bindir}/ocaml*
+%{_libdir}/ocaml/
+%exclude %{_libdir}/ocaml/compiler-libs
+%{_mandir}/man1/ocaml*
+%{_mandir}/man3/*.3o*
+
+%files devel
+%{_libdir}/ocaml/compiler-libs/
+
+%changelog
+%autochangelog

--- a/SPECS/seabios/seabios.spec
+++ b/SPECS/seabios/seabios.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           seabios
+Version:        1.17.0
+Release:        %autorelease
+Summary:        Legacy x86 BIOS firmware for QEMU
+License:        LGPL-3.0-only AND BSD-3-Clause
+URL:            https://seabios.org/
+VCS:            git:https://github.com/coreboot/seabios.git
+#!RemoteAsset:  sha256:cb708a548e4244c5021590a5e78ab6e331ded1750120b687039042994033a07c
+Source0:        https://github.com/coreboot/seabios/archive/refs/tags/rel-%{version}.tar.gz#/%{name}-%{version}.tar.gz
+ExclusiveArch:  x86_64
+
+BuildRequires:  acpica
+BuildRequires:  python3
+
+%description
+SeaBIOS implements a legacy x86 BIOS for virtual machines. This package
+provides the 256 KiB firmware used by QEMU to boot its PC machines,
+including the libguestfs appliance.
+
+%prep
+%autosetup -p1 -n %{name}-rel-%{version}
+echo '%{version}' > .version
+cat > .config <<'EOF'
+CONFIG_QEMU=y
+CONFIG_ROM_SIZE=256
+EOF
+
+%build
+%make_build PYTHON=python3 EXTRAVERSION=-openruyi-%{release} olddefconfig
+%make_build PYTHON=python3 EXTRAVERSION=-openruyi-%{release}
+
+%install
+install -D -p -m 0644 out/bios.bin %{buildroot}%{_datadir}/seabios/bios-256k.bin
+
+%files
+%doc README
+%license COPYING COPYING.LESSER src/jpeg.c src/sha256.c src/sha512.c
+%{_datadir}/seabios/
+
+%changelog
+%autochangelog

--- a/SPECS/supermin/2000-recognize-openruyi.patch
+++ b/SPECS/supermin/2000-recognize-openruyi.patch
@@ -1,0 +1,36 @@
+From: cl2t <yihong.or@isrc.iscas.ac.cn>
+Subject: [PATCH] rpm: recognize openRuyi and exercise its package handler
+
+openRuyi uses RPM and DNF5. Reuse the Fedora RPM handler and run
+the existing RPM appliance tests on openRuyi as well.
+
+This patch was authored downstream for openRuyi and has not been submitted
+upstream.
+
+Signed-off-by: cl2t <yihong.or@isrc.iscas.ac.cn>
+---
+
+diff --git a/src/ph_rpm.ml b/src/ph_rpm.ml
+--- a/src/ph_rpm.ml
++++ b/src/ph_rpm.ml
+@@ -32,7 +32,7 @@
+ let fedora_detect () =
+   Config.rpm <> "no" && Config.rpm2cpio <> "no" && rpm_is_available () &&
+     (Config.yumdownloader <> "no" || Config.dnf <> "no") &&
+-    (List.mem (Os_release.get_id ()) [ "fedora"; "rhel"; "centos"; "openEuler"; "anolis"; "KylinSecOS" ] ||
++    (List.mem (Os_release.get_id ()) [ "fedora"; "rhel"; "centos"; "openruyi"; "openEuler"; "anolis"; "KylinSecOS" ] ||
+      try
+        (stat "/etc/redhat-release").st_kind = S_REG ||
+        (stat "/etc/fedora-release").st_kind = S_REG ||
+diff --git a/tests/test-harder.sh b/tests/test-harder.sh
+--- a/tests/test-harder.sh
++++ b/tests/test-harder.sh
+@@ -28,7 +28,7 @@
+ if [ -f /etc/os-release ]; then
+     distro=$(. /etc/os-release && echo $ID)
+     case "$distro" in
+-        fedora|rhel|centos) distro=redhat ;;
++        fedora|rhel|centos|openruyi) distro=redhat ;;
+         opensuse*|sled|sles) distro=suse ;;
+         ubuntu) distro=debian ;;
+         openmandriva) distro=openmandriva ;;

--- a/SPECS/supermin/2001-use-configured-rpm-database.patch
+++ b/SPECS/supermin/2001-use-configured-rpm-database.patch
@@ -1,0 +1,44 @@
+From: cl2t <yihong.or@isrc.iscas.ac.cn>
+Subject: [PATCH] rpm: find the package database through RPM configuration
+
+Respect the configured database path and recognize NDB alongside SQLite
+and Berkeley DB when checking whether a cached appliance needs rebuilding.
+
+This patch was authored downstream for openRuyi and has not been submitted
+upstream.
+
+Signed-off-by: cl2t <yihong.or@isrc.iscas.ac.cn>
+---
+
+diff --git a/src/ph_rpm.ml b/src/ph_rpm.ml
+--- a/src/ph_rpm.ml
++++ b/src/ph_rpm.ml
+@@ -237,19 +237,21 @@
+   let rpm = rpm_of_pkg pkg in
+   rpm.name
+ 
+-let rpmdb_locations = [
+-  "/usr/lib/sysimage/rpm/rpmdb.sqlite";
+-  "/var/lib/rpm/rpmdb.sqlite";
+-  "/var/lib/rpm/Packages"
+-]
+-
+ let find_rpmdb () =
++  (* Honour the RPM configuration, including distributions using NDB. *)
++  let cmd = sprintf "%s --eval '%%{_dbpath}'" Config.rpm in
++  let dbpaths = run_command_get_lines cmd in
++  let locations =
++    List.concat (List.map (fun path ->
++      List.map (fun name -> path // name)
++        [ "rpmdb.sqlite"; "Packages.db"; "Packages" ]
++    ) dbpaths) in
+   let rec loop = function
+     | [] -> error "rpm: cannot locate RPM database; if this is a normal RPM-based Linux distro then this is probably a supermin bug"
+     | db :: rest ->
+        if Sys.file_exists db then db else loop rest
+   in
+-  loop rpmdb_locations
++  loop locations
+ 
+ let rpm_get_package_database_mtime () =
+   (lstat (find_rpmdb ())).st_mtime

--- a/SPECS/supermin/supermin.spec
+++ b/SPECS/supermin/supermin.spec
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+Name:           supermin
+Version:        5.3.5
+Release:        %autorelease
+Summary:        Tool for creating supermin appliances
+License:        GPL-2.0-or-later
+URL:            https://github.com/libguestfs/supermin
+VCS:            git:https://github.com/libguestfs/supermin.git
+#!RemoteAsset:  sha256:58d6e2262cb2ade036d3da4080331066888efede401c7f9fecd2317518947b4e
+Source0:        https://github.com/libguestfs/supermin/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+BuildSystem:    autotools
+
+# Downstream openRuyi distro detection and RPM handler tests.
+Patch2000:      2000-recognize-openruyi.patch
+# Downstream support for the configured RPM database path and NDB.
+Patch2001:      2001-use-configured-rpm-database.patch
+
+# OBS and similar environments have no outbound package-download access.
+BuildOption(conf):  --disable-network-tests
+
+BuildRequires:  autoconf
+BuildRequires:  automake
+BuildRequires:  augeas
+BuildRequires:  dnf5
+BuildRequires:  glibc-static
+BuildRequires:  hivex
+BuildRequires:  linux
+BuildRequires:  libtool
+BuildRequires:  ocaml
+BuildRequires:  ocaml-devel
+BuildRequires:  ocaml-findlib
+BuildRequires:  pkgconfig(libzstd)
+BuildRequires:  pkgconfig(com_err)
+BuildRequires:  pkgconfig(ext2fs)
+BuildRequires:  pkgconfig(rpm)
+BuildRequires:  perl
+BuildRequires:  e2fsprogs
+BuildRequires:  zstd
+
+Requires:       cpio
+Requires:       dnf5
+Requires:       e2fsprogs
+Requires:       rpm
+Requires:       xz
+Requires:       zstd
+
+%description
+Supermin is a tool for building supermin appliances. These are tiny
+appliances which get fully instantiated on the fly when you need to
+boot one of them. libguestfs uses supermin to construct its appliance.
+
+%prep -a
+autoreconf -fi
+
+%check
+rpm --eval 'RPM database: %{_dbpath} (%{_db_backend})'
+# The offline suite prepares appliances from installed RPMs and builds
+# both chroots and ext2 images, including their kernel and initrd.
+%make_build check
+
+%files
+%doc README examples
+%license COPYING
+%{_bindir}/supermin
+%{_mandir}/man1/supermin.1*
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

Add [libguestfs](https://libguestfs.org/) 1.60.1 and seven dependencies, with openRuyi appliance support, Python bindings and FUSE tools.

Pre-commit and [OBS builds](https://build.openruyi.cn/project/show/home:cl_2:libguestfs-puremain) pass on supported architectures. RISC-V FUSE mounting remains unvalidated due to worker restrictions.

## Related Issue

- N/A.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.
- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: Codex:GPT-6

GLM:GLM-5.3 was tried for review only.

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]: https://openruyi.cn/governance/policy/ai-contribution-policy
