### PR TITLE
SPECS: Add lazygit and tcell/v3

### DIFF
--- a/SPECS/go-github-clipperhouse-displaywidth/go-github-clipperhouse-displaywidth.spec
+++ b/SPECS/go-github-clipperhouse-displaywidth/go-github-clipperhouse-displaywidth.spec
@@ -12,12 +12,12 @@
 }
 
 Name:           go-github-clipperhouse-displaywidth
-Version:        0.6.2
+Version:        0.11.0
 Release:        %autorelease
 Summary:        Measure the display column width of strings in Go
 License:        MIT
 URL:            https://github.com/clipperhouse/displaywidth
-#!RemoteAsset
+#!RemoteAsset:  sha256:e8c6d58a7acb5295be484034ed08a4256f6c8eaeea9667353b5aadef9c2eaa9e
 Source0:        https://github.com/clipperhouse/displaywidth/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
@@ -26,12 +26,10 @@ BuildOption(prep):  -n %{_name}-%{version}
 
 BuildRequires:  go
 BuildRequires:  go-rpm-macros
-BuildRequires:  go(github.com/clipperhouse/stringish)
 BuildRequires:  go(github.com/clipperhouse/uax29/v2)
 
 Provides:       go(github.com/clipperhouse/displaywidth) = %{version}
 
-Requires:       go(github.com/clipperhouse/stringish)
 Requires:       go(github.com/clipperhouse/uax29/v2)
 
 %description
@@ -39,9 +37,9 @@ A high-performance Go package for measuring the monospace display width
 of strings, UTF-8 bytes, and runes.
 
 %files
-%license LICENSE*
 %doc README*
+%license LICENSE*
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/go-github-clipperhouse-uax29-v2/go-github-clipperhouse-uax29-v2.spec
+++ b/SPECS/go-github-clipperhouse-uax29-v2/go-github-clipperhouse-uax29-v2.spec
@@ -6,15 +6,22 @@
 
 %define _name           uax29
 %define go_import_path  github.com/clipperhouse/uax29/v2
-%define go_test_exclude_glob github.com/clipperhouse/uax29/v2/internal/gen*
+# internal/gen is a Unicode table generator. The comparative suites import
+# other tokenizers (uniseg, bleve segment, charmbracelet ansi) that are not
+# part of this library.
+%define go_test_exclude_glob %{shrink:
+    github.com/clipperhouse/uax29/v2/internal/gen*
+    github.com/clipperhouse/uax29/v2/graphemes/comparative
+    github.com/clipperhouse/uax29/v2/words/comparative
+}
 
 Name:           go-github-clipperhouse-uax29-v2
-Version:        2.3.0
+Version:        2.7.0
 Release:        %autorelease
-Summary:        A tokenizer based on Unicode text segmentation (UAX #29), for Go. Split graphemes, words, sentences.
+Summary:        Unicode text segmentation (UAX #29) tokenizer for Go
 License:        MIT
 URL:            https://github.com/clipperhouse/uax29
-#!RemoteAsset
+#!RemoteAsset:  sha256:e127ac39f501dc7c92b20b980a4a6a5766c2d95b54f9d2a0d1b2ef373817f9a0
 Source0:        https://github.com/clipperhouse/uax29/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
@@ -23,26 +30,17 @@ BuildOption(prep):  -n %{_name}-%{version}
 
 BuildRequires:  go
 BuildRequires:  go-rpm-macros
-BuildRequires:  go(github.com/clipperhouse/stringish)
-BuildRequires:  go(golang.org/x/text)
-BuildRequires:  go(github.com/blevesearch/segment)
-BuildRequires:  go(github.com/rivo/uniseg)
 
 Provides:       go(github.com/clipperhouse/uax29/v2) = %{version}
 
-Requires:       go(github.com/clipperhouse/stringish)
-Requires:       go(golang.org/x/text)
-Requires:       go(github.com/blevesearch/segment)
-Requires:       go(github.com/rivo/uniseg)
-
 %description
-This package tokenizes (splits) words, sentences and graphemes, based on
-Unicode text segmentation (https://unicode.org/reports/tr29/).
+This package tokenizes words, sentences and graphemes based on Unicode text
+segmentation (https://unicode.org/reports/tr29/).
 
 %files
-%license LICENSE*
 %doc README*
+%license LICENSE*
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/go-github-gdamore-tcell-v3/go-github-gdamore-tcell-v3.spec
+++ b/SPECS/go-github-gdamore-tcell-v3/go-github-gdamore-tcell-v3.spec
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           tcell
+%define go_import_path  github.com/gdamore/tcell/v3
+
+Name:           go-github-gdamore-tcell-v3
+Version:        3.4.2
+Release:        %autorelease
+Summary:        Cell-based terminal package for Go
+License:        Apache-2.0
+URL:            https://github.com/gdamore/tcell
+#!RemoteAsset:  sha256:25c2327d78e767166296d951bf0ba7e38f7d3a3f40f981f5f4225d4f1f79334e
+Source0:        https://github.com/gdamore/tcell/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/clipperhouse/displaywidth)
+BuildRequires:  go(github.com/clipperhouse/uax29/v2)
+BuildRequires:  go(github.com/gdamore/encoding)
+BuildRequires:  go(github.com/lucasb-eyer/go-colorful)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(golang.org/x/term)
+BuildRequires:  go(golang.org/x/text)
+
+Provides:       go(github.com/gdamore/tcell/v3) = %{version}
+
+Requires:       go(github.com/clipperhouse/displaywidth)
+Requires:       go(github.com/clipperhouse/uax29/v2)
+Requires:       go(github.com/gdamore/encoding)
+Requires:       go(github.com/lucasb-eyer/go-colorful)
+Requires:       go(golang.org/x/sys)
+Requires:       go(golang.org/x/term)
+Requires:       go(golang.org/x/text)
+
+%description
+Tcell provides a cell-based view for text terminals, with support for colors,
+Unicode, keyboard input, and mouse events. This package ships the v3 API.
+
+%prep -a
+# demos are example programs, not the importable library.
+rm -rf demos
+
+%files
+%doc README* TUTORIAL*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/lazygit/lazygit.spec
+++ b/SPECS/lazygit/lazygit.spec
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           lazygit
+%define go_import_path  github.com/jesseduffield/lazygit
+
+Name:           lazygit
+Version:        0.65.0
+Release:        %autorelease
+Summary:        Simple terminal UI for git commands
+License:        MIT AND BSD-3-Clause
+URL:            https://github.com/jesseduffield/lazygit
+#!RemoteAsset:  sha256:972151d83d8fdfa5c7c881c34349ba4a38c37b7085667696b85c443d2fca97ed
+Source0:        https://github.com/jesseduffield/lazygit/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildSystem:    golang
+BuildOption(build):  -ldflags "-X main.version=%{version} -X main.buildSource=openRuyi"
+# Go 1.27 vet rejects upstream non-constant format strings in TextStyle.Sprintf.
+# Match upstream unit tests; integration tests skip themselves in short mode.
+BuildOption(check):  -vet=off -short
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  git
+BuildRequires:  go(dario.cat/mergo)
+BuildRequires:  go(github.com/adrg/xdg)
+BuildRequires:  go(github.com/atotto/clipboard)
+BuildRequires:  go(github.com/aybabtme/humanlog)
+BuildRequires:  go(github.com/cli/go-gh/v2)
+BuildRequires:  go(github.com/cloudfoundry/jibber_jabber)
+BuildRequires:  go(github.com/creack/pty)
+BuildRequires:  go(github.com/gdamore/tcell/v3)
+BuildRequires:  go(github.com/go-errors/errors)
+BuildRequires:  go(github.com/gookit/color)
+BuildRequires:  go(github.com/integrii/flaggy)
+BuildRequires:  go(github.com/jesseduffield/generics)
+BuildRequires:  go(github.com/jesseduffield/lazycore)
+BuildRequires:  go(github.com/kardianos/osext)
+BuildRequires:  go(github.com/karimkhaleel/jsonschema)
+BuildRequires:  go(github.com/kyokomi/emoji/v2)
+BuildRequires:  go(github.com/lucasb-eyer/go-colorful)
+BuildRequires:  go(github.com/mgutz/str)
+BuildRequires:  go(github.com/mitchellh/go-ps)
+BuildRequires:  go(github.com/petermattis/goid)
+BuildRequires:  go(github.com/rivo/uniseg)
+BuildRequires:  go(github.com/sahilm/fuzzy)
+BuildRequires:  go(github.com/samber/lo)
+BuildRequires:  go(github.com/sanity-io/litter)
+BuildRequires:  go(github.com/sasha-s/go-deadlock)
+BuildRequires:  go(github.com/sirupsen/logrus)
+BuildRequires:  go(github.com/spf13/afero)
+BuildRequires:  go(github.com/spkg/bom)
+BuildRequires:  go(github.com/stefanhaller/git-todo-parser)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(github.com/xo/terminfo)
+BuildRequires:  go(golang.org/x/exp)
+BuildRequires:  go(golang.org/x/sync)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(gopkg.in/ozeidan/fuzzy-patricia.v3)
+BuildRequires:  go(gopkg.in/yaml.v3)
+
+Requires:       git
+
+%description
+lazygit is a simple terminal UI for git commands, providing panels for files,
+branches, commits, stashes and more.
+
+%package     -n go-github-jesseduffield-lazygit
+Summary:        Go source for the lazygit terminal UI
+BuildArch:      noarch
+Provides:       go(github.com/jesseduffield/lazygit) = %{version}
+Requires:       go(dario.cat/mergo)
+Requires:       go(github.com/adrg/xdg)
+Requires:       go(github.com/atotto/clipboard)
+Requires:       go(github.com/aybabtme/humanlog)
+Requires:       go(github.com/cli/go-gh/v2)
+Requires:       go(github.com/cloudfoundry/jibber_jabber)
+Requires:       go(github.com/creack/pty)
+Requires:       go(github.com/gdamore/tcell/v3)
+Requires:       go(github.com/go-errors/errors)
+Requires:       go(github.com/gookit/color)
+Requires:       go(github.com/integrii/flaggy)
+Requires:       go(github.com/jesseduffield/generics)
+Requires:       go(github.com/jesseduffield/lazycore)
+Requires:       go(github.com/kardianos/osext)
+Requires:       go(github.com/karimkhaleel/jsonschema)
+Requires:       go(github.com/kyokomi/emoji/v2)
+Requires:       go(github.com/lucasb-eyer/go-colorful)
+Requires:       go(github.com/mgutz/str)
+Requires:       go(github.com/mitchellh/go-ps)
+Requires:       go(github.com/petermattis/goid)
+Requires:       go(github.com/rivo/uniseg)
+Requires:       go(github.com/sahilm/fuzzy)
+Requires:       go(github.com/samber/lo)
+Requires:       go(github.com/sanity-io/litter)
+Requires:       go(github.com/sasha-s/go-deadlock)
+Requires:       go(github.com/sirupsen/logrus)
+Requires:       go(github.com/spf13/afero)
+Requires:       go(github.com/spkg/bom)
+Requires:       go(github.com/stefanhaller/git-todo-parser)
+Requires:       go(github.com/xo/terminfo)
+Requires:       go(golang.org/x/exp)
+Requires:       go(golang.org/x/sync)
+Requires:       go(golang.org/x/sys)
+Requires:       go(gopkg.in/ozeidan/fuzzy-patricia.v3)
+Requires:       go(gopkg.in/yaml.v3)
+
+%description -n go-github-jesseduffield-lazygit
+This package contains the reusable Go source for lazygit, including the
+in-tree gocui terminal UI used by the lazygit command.
+
+# Remove bundled dependencies from both the source tree and the GOPATH copy
+# prepared by the golang BuildSystem, so builds and tests use distro packages.
+%prep -a
+rm -rf vendor %{_builddir}/go/src/%{go_import_path}/vendor
+
+%install -a
+# The default install has already installed the command. Keep its build output
+# out of the noarch Go source subpackage.
+rm -f %{_name}
+# Preserve the two different license texts under distinct installed names.
+cp pkg/gocui/LICENSE LICENSE.gocui
+%buildsystem_golangmodules_install
+
+%check -p
+export TERM=xterm-256color
+unset NO_COLOR
+%{buildroot}%{_bindir}/%{_name} --version
+# Fixture unit tests locate the project root through .git, absent in archives.
+git init -q %{_builddir}/go/src/%{go_import_path}
+
+%files
+%doc README* docs
+%license LICENSE LICENSE.gocui
+%{_bindir}/lazygit
+
+%files -n go-github-jesseduffield-lazygit
+%doc README*
+%license LICENSE LICENSE.gocui
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

Add [lazygit](https://github.com/jesseduffield/lazygit) 0.65.0 and [tcell/v3](https://github.com/gdamore/tcell) 3.4.2; update uax29/v2 to 2.7.0 and displaywidth to 0.11.0 for compatibility.

Pre-commit and [OBS x86_64/riscv64 builds](https://build.openruyi.cn/project/show/home:cl_2:pr1244-review-puremain) pass.

## Related Issue

- Follows #751.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.
- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: Grok Build:grok-4.6

Assisted-by: Codex:GPT-6

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]: https://openruyi.cn/governance/policy/ai-contribution-policy
