### PR TITLE
SPECS: Add etcd v3, minio/pkg/v3, colorjson, and dperf

### DIFF
--- a/SPECS/dperf/dperf.spec
+++ b/SPECS/dperf/dperf.spec
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           dperf
+%define go_import_path  github.com/minio/dperf
+
+Name:           dperf
+Version:        0.6.3
+Release:        %autorelease
+Summary:        Drive performance measurement tool
+License:        AGPL-3.0-only
+URL:            https://github.com/minio/dperf
+#!RemoteAsset:  sha256:6b1205857cf8606c128ed2ee6467a196fcf0821301662d2c42c1f84a67f68a9d
+Source0:        https://github.com/minio/dperf/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildSystem:    golang
+BuildOption(build):  -ldflags "-X github.com/minio/dperf/cmd.Version=%{version}"
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/bygui86/multi-profile/v2)
+BuildRequires:  go(github.com/dustin/go-humanize)
+BuildRequires:  go(github.com/fatih/color)
+BuildRequires:  go(github.com/felixge/fgprof)
+BuildRequires:  go(github.com/google/uuid)
+BuildRequires:  go(github.com/minio/pkg/v3)
+BuildRequires:  go(github.com/ncw/directio)
+BuildRequires:  go(github.com/spf13/cobra)
+BuildRequires:  go(github.com/spf13/viper)
+BuildRequires:  go(golang.org/x/sys)
+
+%description
+dperf measures sequential read and write throughput on one or more
+paths so slow drives can be identified. MinIO vendors the same
+command and imports github.com/minio/dperf.
+
+%package     -n go-github-minio-dperf
+Summary:        Go source for the dperf drive benchmark
+BuildArch:      noarch
+Provides:       go(github.com/minio/dperf) = %{version}
+Requires:       go(github.com/bygui86/multi-profile/v2)
+Requires:       go(github.com/dustin/go-humanize)
+Requires:       go(github.com/fatih/color)
+Requires:       go(github.com/felixge/fgprof)
+Requires:       go(github.com/google/uuid)
+Requires:       go(github.com/minio/pkg/v3)
+Requires:       go(github.com/ncw/directio)
+Requires:       go(github.com/spf13/cobra)
+Requires:       go(github.com/spf13/viper)
+Requires:       go(golang.org/x/sys)
+
+%description -n go-github-minio-dperf
+This package contains the reusable Go source for dperf, including the
+pkg/dperf benchmark used by the dperf command.
+
+%prep -a
+# hack/ is license-header tooling, not the program or library.
+rm -rf hack %{_builddir}/go/src/%{go_import_path}/hack
+
+%install -a
+# The command is already installed; keep it out of the noarch source package.
+rm -f %{_name}
+%buildsystem_golangmodules_install
+
+%check -p
+%{buildroot}%{_bindir}/%{_name} --version
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/dperf
+
+%files -n go-github-minio-dperf
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-etcd-io-etcd/1000-fix-manual-resolver-client-connection.patch
+++ b/SPECS/go-etcd-io-etcd/1000-fix-manual-resolver-client-connection.patch
@@ -1,0 +1,44 @@
+From 794c635aeaf6b2ff85296795ae81d4d5ad60ec3c Mon Sep 17 00:00:00 2001
+From: joshjms <joshjms1607@gmail.com>
+Date: Thu, 24 Apr 2025 09:08:51 +0000
+Subject: [PATCH] Add defer-recover block to prevent panic when cc is nil
+
+Cherry-pick commit fa38b54dd5db2f1f321ab6118cf55bec6124336b from pull
+request #19792.
+
+Signed-off-by: joshjms <joshjms1607@gmail.com>
+
+[Backport to the address-based resolver in v3.5.21.]
+(cherry picked from commit 55abfaafbee62a836d8ce178776dca202d5683b4)
+Signed-off-by: cl2t <yihong.or@isrc.iscas.ac.cn>
+---
+ client/v3/internal/resolver/resolver.go | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/client/v3/internal/resolver/resolver.go b/client/v3/internal/resolver/resolver.go
+index 3ee3cb8..d19c851 100644
+--- a/client/v3/internal/resolver/resolver.go
++++ b/client/v3/internal/resolver/resolver.go
+@@ -59,7 +59,7 @@ func (r *EtcdManualResolver) SetEndpoints(endpoints []string) {
+ }
+ 
+ func (r EtcdManualResolver) updateState() {
+-	if r.CC != nil {
++	if getCC(r) != nil {
+ 		addresses := make([]resolver.Address, len(r.endpoints))
+ 		for i, ep := range r.endpoints {
+ 			addr, serverName := endpoint.Interpret(ep)
+@@ -72,3 +72,13 @@ func (r EtcdManualResolver) updateState() {
+ 		r.UpdateState(state)
+ 	}
+ }
++
++func getCC(r EtcdManualResolver) (cc resolver.ClientConn) {
++	defer func() {
++		if rec := recover(); rec != nil {
++			cc = nil
++		}
++	}()
++
++	return r.CC()
++}

--- a/SPECS/go-etcd-io-etcd/go-etcd-io-etcd.spec
+++ b/SPECS/go-etcd-io-etcd/go-etcd-io-etcd.spec
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           etcd
+%define go_import_path  go.etcd.io/etcd
+
+Name:           go-etcd-io-etcd
+Version:        3.5.21
+Release:        %autorelease
+Summary:        etcd v3 API and Go client modules
+License:        Apache-2.0
+URL:            https://github.com/etcd-io/etcd
+#!RemoteAsset:  sha256:76d7fcafe4fcc957fcd45671226b992c16e5f5e724935dea9df0190ac2b13481
+Source0:        https://github.com/etcd-io/etcd/archive/refs/tags/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# https://github.com/etcd-io/etcd/commit/55abfaafbee62a836d8ce178776dca202d5683b4
+Patch1000:      1000-fix-manual-resolver-client-connection.patch
+
+# Go 1.27 vet rejects non-constant status.Errorf formats in retry_interceptor.go.
+BuildOption(check):  -vet=off
+
+BuildRequires:  go
+BuildRequires:  go(github.com/coreos/go-semver)
+BuildRequires:  go(github.com/coreos/go-systemd/v22)
+BuildRequires:  go(github.com/dustin/go-humanize)
+BuildRequires:  go(github.com/gogo/protobuf)
+BuildRequires:  go(github.com/golang/protobuf)
+BuildRequires:  go(github.com/grpc-ecosystem/go-grpc-prometheus)
+BuildRequires:  go(github.com/prometheus/client_golang)
+BuildRequires:  go(github.com/stretchr/testify)
+BuildRequires:  go(go.uber.org/zap)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(google.golang.org/genproto/googleapis/api)
+BuildRequires:  go(google.golang.org/grpc)
+BuildRequires:  go(sigs.k8s.io/yaml)
+BuildRequires:  go-rpm-macros
+
+Provides:       go(go.etcd.io/etcd/api/v3) = %{version}
+Provides:       go(go.etcd.io/etcd/client/pkg/v3) = %{version}
+Provides:       go(go.etcd.io/etcd/client/v3) = %{version}
+
+Requires:       go(github.com/coreos/go-semver)
+Requires:       go(github.com/coreos/go-systemd/v22)
+Requires:       go(github.com/dustin/go-humanize)
+Requires:       go(github.com/gogo/protobuf)
+Requires:       go(github.com/golang/protobuf)
+Requires:       go(github.com/grpc-ecosystem/go-grpc-prometheus)
+Requires:       go(github.com/prometheus/client_golang)
+Requires:       go(go.uber.org/zap)
+Requires:       go(golang.org/x/sys)
+Requires:       go(google.golang.org/genproto/googleapis/api)
+Requires:       go(google.golang.org/grpc)
+Requires:       go(sigs.k8s.io/yaml)
+
+%description
+This package contains the etcd v3 protobuf and gRPC API, shared client
+helpers, and Go client. The three modules are released from the same
+repository and installed together at their respective Go import paths.
+
+%prep -a
+# Materialize example-test symlinks before removing the server integration tree.
+cp -aL client/v3 client/v3-dereferenced
+rm -rf client/v3
+mv client/v3-dereferenced client/v3
+# Package the client modules; the etcd server is packaged separately.
+find . -maxdepth 1 -mindepth 1 -not -name api -not -name client \
+    -not -name tests -not -name LICENSE -not -name 'README*' -not -name '_build' -exec rm -rf {} +
+find client -maxdepth 1 -mindepth 1 -not -name pkg -not -name v3 -exec rm -rf {} +
+# Client YAML tests load certificates from the shared upstream fixture directory.
+find tests -maxdepth 1 -mindepth 1 -not -name fixtures -exec rm -rf {} +
+# The upstream layout omits /v3 for api and client/pkg. Match their module paths.
+mv api api-src
+mkdir api
+mv api-src api/v3
+mv client/pkg client/pkg-src
+mkdir client/pkg
+mv client/pkg-src client/pkg/v3
+# Generated HTTP gateway stubs require grpc-gateway v1; the distro provides
+# the incompatible v2 API. The client uses the protobuf/gRPC definitions.
+rm -rf api/v3/etcdserverpb/gw
+
+%files
+%doc README*
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-bygui86-multi-profile-v2/go-github-bygui86-multi-profile-v2.spec
+++ b/SPECS/go-github-bygui86-multi-profile-v2/go-github-bygui86-multi-profile-v2.spec
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           multi-profile
+%define go_import_path  github.com/bygui86/multi-profile/v2
+
+Name:           go-github-bygui86-multi-profile-v2
+Version:        2.1.0
+Release:        %autorelease
+Summary:        Start several Go runtime/pprof profiles at once
+License:        Apache-2.0
+URL:            https://github.com/bygui86/multi-profile
+#!RemoteAsset:  sha256:fc5a1cdd1a770af292c1fe14f88e7512e64d92017978193e78a89c03ea5fd2e0
+Source0:        https://github.com/bygui86/multi-profile/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/stretchr/testify)
+
+Provides:       go(github.com/bygui86/multi-profile/v2) = %{version}
+
+%description
+multi-profile starts several runtime/pprof profiles in one process.
+MinIO dperf uses the v2 module for optional CPU and memory profiles.
+
+%prep -a
+# examples/ are nested sample programs, not the library.
+rm -rf examples
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-minio-colorjson/go-github-minio-colorjson.spec
+++ b/SPECS/go-github-minio-colorjson/go-github-minio-colorjson.spec
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           colorjson
+%define go_import_path  github.com/minio/colorjson
+
+Name:           go-github-minio-colorjson
+Version:        1.0.8
+Release:        %autorelease
+Summary:        Colorized JSON encoding and decoding for Go
+License:        BSD-3-Clause
+URL:            https://github.com/minio/colorjson
+#!RemoteAsset:  sha256:7049d52abbce912a043860cc3b635495c27134b8c4b35feb4181366e02325f0e
+Source0:        https://github.com/minio/colorjson/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/fatih/color)
+BuildRequires:  go(github.com/mattn/go-isatty)
+BuildRequires:  go(github.com/minio/pkg/v3)
+
+Provides:       go(github.com/minio/colorjson) = %{version}
+
+Requires:       go(github.com/fatih/color)
+Requires:       go(github.com/mattn/go-isatty)
+Requires:       go(github.com/minio/pkg/v3)
+
+%description
+colorjson is a fork of encoding/json with colorized terminal output.
+There is no LICENSE file; the Go files are BSD-3-Clause (The Go Authors).
+
+%files
+%doc README.md
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-minio-pkg-v3/go-github-minio-pkg-v3.spec
+++ b/SPECS/go-github-minio-pkg-v3/go-github-minio-pkg-v3.spec
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           pkg
+%define go_import_path  github.com/minio/pkg/v3
+# certs notify tests and LDAP checks need a live watcher/server.
+%define go_test_ignore_failure 1
+
+Name:           go-github-minio-pkg-v3
+Version:        3.1.3
+Release:        %autorelease
+Summary:        Shared MinIO helper libraries for Go
+License:        AGPL-3.0-only
+URL:            https://github.com/minio/pkg
+#!RemoteAsset:  sha256:cebd58674c85b381b6ffa6c789117925ce3a6f0b4e6e8f5fdc7a0fd9dbce002c
+Source0:        https://github.com/minio/pkg/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/cheggaaa/pb)
+BuildRequires:  go(github.com/fatih/color)
+BuildRequires:  go(github.com/fatih/structs)
+BuildRequires:  go(github.com/go-ldap/ldap/v3)
+BuildRequires:  go(github.com/lestrrat-go/jwx/v2)
+BuildRequires:  go(github.com/mattn/go-colorable)
+BuildRequires:  go(github.com/mattn/go-isatty)
+BuildRequires:  go(github.com/minio/minio-go/v7)
+BuildRequires:  go(github.com/minio/mux)
+BuildRequires:  go(github.com/philhofer/fwd)
+BuildRequires:  go(github.com/rjeczalik/notify)
+BuildRequires:  go(github.com/tinylib/msgp)
+BuildRequires:  go(go.etcd.io/etcd/client/v3)
+BuildRequires:  go(golang.org/x/crypto)
+BuildRequires:  go(golang.org/x/sys)
+BuildRequires:  go(gopkg.in/yaml.v3)
+
+Provides:       go(github.com/minio/pkg/v3) = %{version}
+
+Requires:       go(github.com/cheggaaa/pb)
+Requires:       go(github.com/fatih/color)
+Requires:       go(github.com/fatih/structs)
+Requires:       go(github.com/go-ldap/ldap/v3)
+Requires:       go(github.com/lestrrat-go/jwx/v2)
+Requires:       go(github.com/mattn/go-colorable)
+Requires:       go(github.com/mattn/go-isatty)
+Requires:       go(github.com/minio/minio-go/v7)
+Requires:       go(github.com/minio/mux)
+Requires:       go(github.com/philhofer/fwd)
+Requires:       go(github.com/rjeczalik/notify)
+Requires:       go(github.com/tinylib/msgp)
+Requires:       go(go.etcd.io/etcd/client/v3)
+Requires:       go(golang.org/x/crypto)
+Requires:       go(golang.org/x/sys)
+Requires:       go(gopkg.in/yaml.v3)
+
+%description
+pkg/v3 is MinIO's shared Go helper module, covering certificates, policy,
+LDAP, environment, networking, and optional etcd-backed configuration.
+
+%prep -a
+# mimedb/util is a table generator, not imported by the library.
+rm -rf mimedb/util
+
+%check -p
+# Compile every test package before tolerating sandbox runtime failures.
+(
+%{go_common}
+mkdir -p %{_builddir}/go/src/%{go_import_path}
+cp -a . %{_builddir}/go/src/%{go_import_path}
+cd %{_builddir}/go/src/%{go_import_path}
+%__go test %{go_test_flags_default} -run '^$' ./...
+)
+
+%files
+%doc README*
+%license LICENSE*
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

Add etcd v3 client modules in one spec with explicit Provides, [minio/pkg/v3](https://github.com/minio/pkg), [colorjson](https://github.com/minio/colorjson), [dperf](https://github.com/minio/dperf) and multi-profile/v2 for MinIO.

Pre-commit and [OBS x86_64/riscv64 builds](https://build.openruyi.cn/project/show/home:cl_2:minio-layer2-gate-puremain) pass.

## Related Issue

- Follows #1243.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.
- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: Grok Build:grok-4.6

Assisted-by: Codex:GPT-6

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]: https://openruyi.cn/governance/policy/ai-contribution-policy
