### PR TITLE
SPECS: spdk: Build the uring, rbd and sma modules and fix spdk-tools

### DIFF
--- a/SPECS/python-configshell-fb/python-configshell-fb.spec
+++ b/SPECS/python-configshell-fb/python-configshell-fb.spec
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+# SPDX-FileContributor: Sun Yuechi <sunyuechi@iscas.ac.cn>
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%global srcname configshell-fb
+%global pypi_name configshell_fb
+
+Name:           python-%{srcname}
+Version:        2.0.3
+Release:        %autorelease
+Summary:        A framework to implement simple but nice CLIs
+License:        Apache-2.0
+URL:            https://github.com/open-iscsi/configshell-fb
+#!RemoteAsset:  sha256:dbb086c16c1603a230f9017ef85baccabfd5d87439a01e963377e50f10220f53
+Source0:        https://files.pythonhosted.org/packages/source/c/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    pyproject
+
+BuildOption(install):  -l configshell configshell_fb
+
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python3dist(hatch-vcs)
+BuildRequires:  python3dist(hatchling)
+
+Provides:       python3-%{srcname} = %{version}-%{release}
+%python_provide python3-%{srcname}
+
+%description
+configshell is a Python library that provides a framework for building
+simple but nice CLI-based applications, such as targetcli and spdk-cli.
+
+%prep -a
+# the sdist lacks the configshell_fb symlink the wheel ships
+ln -s configshell configshell_fb
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%files -f %{pyproject_files}
+%doc README.md
+
+%changelog
+%autochangelog

--- a/SPECS/python-grpcio-tools/python-grpcio-tools.spec
+++ b/SPECS/python-grpcio-tools/python-grpcio-tools.spec
@@ -8,13 +8,13 @@
 %global pypi_name grpcio_tools
 
 Name:           python-%{srcname}
-Version:        1.80.0
+Version:        1.82.1
 Release:        %autorelease
 Summary:        Protobuf code generator for gRPC
 License:        Apache-2.0
 URL:            https://grpc.io/
 VCS:            git:https://github.com/grpc/grpc.git
-#!RemoteAsset:  sha256:26052b19c6ce0dcf52d1024496aea3e2bdfa864159f06dc7b97b22d041a94b26
+#!RemoteAsset:  sha256:2bd3176ccdbf7cd1f463eb75b7b83544c7d6429f5ca8a0f7f784b76097dac891
 Source0:        https://files.pythonhosted.org/packages/source/g/%{srcname}/%{pypi_name}-%{version}.tar.gz
 BuildSystem:    pyproject
 

--- a/SPECS/spdk/2004-mcp-fall-back-to-mcp.server.mcpserver-on-mcp-2.0.patch
+++ b/SPECS/spdk/2004-mcp-fall-back-to-mcp.server.mcpserver-on-mcp-2.0.patch
@@ -1,0 +1,33 @@
+From 8df4cbe3d70ccf36acaf56b326814f0953ecbfe2 Mon Sep 17 00:00:00 2001
+From: Sun Yuechi <sunyuechi@iscas.ac.cn>
+Date: Mon, 7 Sep 2026 06:12:50 -0700
+Subject: [PATCH 2004/2004] mcp: fall back to mcp.server.mcpserver on the mcp
+ 2.0 SDK
+
+mcp 2.0 renamed mcp.server.fastmcp.FastMCP to mcp.server.mcpserver.MCPServer.
+
+Signed-off-by: Sun Yuechi <sunyuechi@iscas.ac.cn>
+---
+ python/spdk/mcp/server.py | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/python/spdk/mcp/server.py b/python/spdk/mcp/server.py
+index f9459c5..01bd456 100644
+--- a/python/spdk/mcp/server.py
++++ b/python/spdk/mcp/server.py
+@@ -5,7 +5,11 @@ import os
+ from spdk.rpc import bdev
+ from functools import partial
+ from spdk.rpc.client import JSONRPCClient
+-from mcp.server.fastmcp import FastMCP
++try:
++    from mcp.server.fastmcp import FastMCP
++except ImportError:
++    # mcp 2.0 renamed FastMCP to mcp.server.mcpserver.MCPServer
++    from mcp.server.mcpserver import MCPServer as FastMCP
+ 
+ # Create an MCP server
+ mcp = FastMCP("SPDK")
+-- 
+2.55.0
+

--- a/SPECS/spdk/2005-mcp-make-the-spdk-mcp-entry-point-callable.patch
+++ b/SPECS/spdk/2005-mcp-make-the-spdk-mcp-entry-point-callable.patch
@@ -1,0 +1,47 @@
+From 07981e276bbbaf83a210f788d87912f47d53cd20 Mon Sep 17 00:00:00 2001
+From: Sun Yuechi <sunyuechi@iscas.ac.cn>
+Date: Mon, 7 Sep 2026 22:21:41 -0700
+Subject: [PATCH] mcp: make the spdk-mcp entry point callable
+
+spdk.mcp:server resolves to the server module, not a function, so the
+console script fails with "'module' object is not callable". Point it at
+a main() that runs the server.
+
+Signed-off-by: Sun Yuechi <sunyuechi@iscas.ac.cn>
+---
+ python/pyproject.toml     | 2 +-
+ python/spdk/mcp/server.py | 7 ++++++-
+ 2 files changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/python/pyproject.toml b/python/pyproject.toml
+index a02d8cde0..e61613450 100644
+--- a/python/pyproject.toml
++++ b/python/pyproject.toml
+@@ -44,7 +44,7 @@ dependencies = []
+ spdk-rpc = "spdk.spdk_rpc:main"
+ spdk-sma = "spdk.spdk_sma:main"
+ spdk-cli = "spdk.spdk_cli:main"
+-spdk-mcp = "spdk.mcp:server"
++spdk-mcp = "spdk.mcp.server:main"
+ 
+ [project.optional-dependencies]
+ sma = [
+diff --git a/python/spdk/mcp/server.py b/python/spdk/mcp/server.py
+index 01bd4566a..57622b6e1 100644
+--- a/python/spdk/mcp/server.py
++++ b/python/spdk/mcp/server.py
+@@ -34,5 +34,10 @@ for func in bdev_functions:
+     newfunc.__doc__ = func.__doc__
+     mcp.add_tool(newfunc)
+ 
+-if __name__ == "__main__":
++
++def main():
+     mcp.run()
++
++
++if __name__ == "__main__":
++    main()
+-- 
+2.55.0
+

--- a/SPECS/spdk/2006-python-rpc-use-functools.wraps-to-fix-deprecation-decorator.patch
+++ b/SPECS/spdk/2006-python-rpc-use-functools.wraps-to-fix-deprecation-decorator.patch
@@ -1,0 +1,43 @@
+From 5be4c11f482e88cb763391ab0eecc5cd5e33075d Mon Sep 17 00:00:00 2001
+From: Boris Glimcher <Boris.Glimcher@emc.com>
+Date: Thu, 16 Oct 2025 13:44:13 -0400
+Subject: [PATCH] python/rpc: use functools.wraps to fix deprecation decorator
+
+Fixes #3752
+
+Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
+Reviewed-on: https://review.spdk.io/c/spdk/spdk/+/26927
+Reviewed-by: Karol Latecki <karol.latecki@nutanix.com>
+Tested-by: SPDK Automated Test System <spdkbot@gmail.com>
+Reviewed-by: Tomasz Zawadzki <tomasz@tzawadzki.com>
+Reviewed-by: Amit Engel <amit.engel@dell.com>
+Reviewed-by: Michal Berger <michal.berger@nutanix.com>
+Reviewed-by: Konrad Sztyber <ksztyber@nvidia.com>
+(cherry picked from commit 117acba97e503632e278ead1889cb8f91e481ad9)
+---
+ python/spdk/rpc/helpers.py | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/python/spdk/rpc/helpers.py b/python/spdk/rpc/helpers.py
+index 9eed61e71..2c0906120 100644
+--- a/python/spdk/rpc/helpers.py
++++ b/python/spdk/rpc/helpers.py
+@@ -3,6 +3,7 @@
+ #  All rights reserved.
+ 
+ import sys
++import functools
+ 
+ deprecated_aliases = {}
+ 
+@@ -23,6 +24,7 @@ def deprecated_alias(old_name):
+ def deprecated_method(method):
+     method.deprecated_warning = False
+ 
++    @functools.wraps(method)
+     def wrap(*args, **kwargs):
+         if not method.deprecated_warning:
+             print(f'{method.__name__} is deprecated, use JSONRPCClient directly', file=sys.stderr)
+-- 
+2.55.0
+

--- a/SPECS/spdk/spdk.spec
+++ b/SPECS/spdk/spdk.spec
@@ -40,6 +40,8 @@ BuildRequires:  pkgconfig(libisal_crypto)
 BuildRequires:  pkgconfig(libibverbs)
 BuildRequires:  pkgconfig(librdmacm)
 BuildRequires:  pkgconfig(libiscsi)
+BuildRequires:  pkgconfig(liburing)
+BuildRequires:  ceph-devel
 
 Requires:       dpdk
 Requires:       numactl
@@ -99,6 +101,8 @@ export CXX="g++ -fuse-ld=bfd"
     --with-dpdk \
     --with-rdma \
     --with-iscsi-initiator \
+    --with-uring \
+    --with-rbd \
     --disable-examples \
     --disable-tests \
     --disable-unit-tests \
@@ -160,7 +164,9 @@ find scripts -type f -regextype egrep -regex '.*(spdkcli|rpc).*[.]py' \
 %{_libdir}/pkgconfig/spdk_bdev_nvme.pc
 %{_libdir}/pkgconfig/spdk_bdev_passthru.pc
 %{_libdir}/pkgconfig/spdk_bdev_raid.pc
+%{_libdir}/pkgconfig/spdk_bdev_rbd.pc
 %{_libdir}/pkgconfig/spdk_bdev_split.pc
+%{_libdir}/pkgconfig/spdk_bdev_uring.pc
 %{_libdir}/pkgconfig/spdk_bdev_virtio.pc
 %{_libdir}/pkgconfig/spdk_bdev_zone_block.pc
 %{_libdir}/pkgconfig/spdk_blob.pc
@@ -214,6 +220,7 @@ find scripts -type f -regextype egrep -regex '.*(spdkcli|rpc).*[.]py' \
 %{_libdir}/pkgconfig/spdk_sock.pc
 %{_libdir}/pkgconfig/spdk_sock_modules.pc
 %{_libdir}/pkgconfig/spdk_sock_posix.pc
+%{_libdir}/pkgconfig/spdk_sock_uring.pc
 %{_libdir}/pkgconfig/spdk_syslibs.pc
 %{_libdir}/pkgconfig/spdk_thread.pc
 %{_libdir}/pkgconfig/spdk_trace.pc

--- a/SPECS/spdk/spdk.spec
+++ b/SPECS/spdk/spdk.spec
@@ -42,6 +42,9 @@ BuildRequires:  pkgconfig(librdmacm)
 BuildRequires:  pkgconfig(libiscsi)
 BuildRequires:  pkgconfig(liburing)
 BuildRequires:  ceph-devel
+# for --with-sma
+BuildRequires:  python3dist(grpcio)
+BuildRequires:  python3dist(grpcio-tools)
 
 Requires:       dpdk
 Requires:       numactl
@@ -64,6 +67,12 @@ applications.
 2001-with-system-isal.patch
 # Add support for ISA-L_crypto library on RISC-V 64
 2002-ISAL_CRYPTO.patch
+# mcp 2.0 renamed FastMCP to MCPServer
+2004-mcp-fall-back-to-mcp.server.mcpserver-on-mcp-2.0.patch
+# spdk.mcp:server is a module, not a function
+2005-mcp-make-the-spdk-mcp-entry-point-callable.patch
+# upstream 117acba97: every rpc function was named "wrap", so spdk-mcp registered one tool
+2006-python-rpc-use-functools.wraps-to-fix-deprecation-decorator.patch
 
 %package        devel
 Summary:        Storage Performance Development Kit development files
@@ -85,6 +94,13 @@ Development Kit.
 %package        tools
 Summary:        Storage Performance Development Kit tools files
 Requires:       %{name} = %{version}-%{release}
+# imported by spdk-cli, spdk-sma and spdk-mcp
+Requires:       python3dist(configshell-fb)
+Requires:       python3dist(grpcio)
+Requires:       python3dist(mcp)
+Requires:       python3dist(protobuf)
+Requires:       python3dist(pyparsing)
+Requires:       python3dist(pyyaml)
 BuildArch:      noarch
 
 %description    tools
@@ -103,6 +119,7 @@ export CXX="g++ -fuse-ld=bfd"
     --with-iscsi-initiator \
     --with-uring \
     --with-rbd \
+    --with-sma \
     --disable-examples \
     --disable-tests \
     --disable-unit-tests \


### PR DESCRIPTION
## Summary

Enable `--with-uring`, `--with-rbd` and `--with-sma`, and require the python libraries the spdk-tools scripts import. configshell-fb is new, and grpcio-tools is updated to 1.82.1 for protobuf 7.

## Related Issue

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy