### PR TITLE
SPECS: Fix Go module build checks for Go 1.27

### DIFF
--- a/SPECS/go-codeberg-go-pdf-fpdf/go-codeberg-go-pdf-fpdf.spec
+++ b/SPECS/go-codeberg-go-pdf-fpdf/go-codeberg-go-pdf-fpdf.spec
@@ -22,7 +22,8 @@ BuildArch:      noarch
 BuildSystem:    golangmodules
 
 BuildOption(prep):  -n %{_name}-%{version}
-BuildOption(check):  -skip ExampleFpdf_RegisterImageReader
+# Golang 1.27 changed the encoded output from Writer
+BuildOption(check):  -skip 'ExampleFpdf_(RegisterImageReader|AddUTF8Font|SetAttachments|AddOutputIntent)'
 
 BuildRequires:  go
 BuildRequires:  go-rpm-macros

--- a/SPECS/go-github-aws-aws-sdk-go-v2/2000-Wrap-status-code-error-value-for-Go-1.27.patch
+++ b/SPECS/go-github-aws-aws-sdk-go-v2/2000-Wrap-status-code-error-value-for-Go-1.27.patch
@@ -1,0 +1,25 @@
+From 31e618ed823439ba2e00af9872e2d72612fdc6ac Mon Sep 17 00:00:00 2001
+From: misaka00251 <liuxin@iscas.ac.cn>
+Date: Tue, 8 Sep 2026 15:36:29 +0800
+Subject: [PATCH] Wrap status code error value for Go 1.27
+
+---
+ aws/retry/retryable_error_test.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/aws/retry/retryable_error_test.go b/aws/retry/retryable_error_test.go
+index aa0317b3..0bb21e90 100644
+--- a/aws/retry/retryable_error_test.go
++++ b/aws/retry/retryable_error_test.go
+@@ -164,7 +164,7 @@ func TestRetryHTTPStatusCodes(t *testing.T) {
+ 			Expect: aws.TrueTernary,
+ 		},
+ 		"nested": {
+-			Err:    fmt.Errorf("some error, %w", &mockStatusCodeError{code: 500}),
++			Err:    fmt.Errorf("some error, %w", mockStatusCodeError{code: 500}),
+ 			Expect: aws.TrueTernary,
+ 		},
+ 		"response error": {
+-- 
+2.55.0
+

--- a/SPECS/go-github-aws-aws-sdk-go-v2/go-github-aws-aws-sdk-go-v2.spec
+++ b/SPECS/go-github-aws-aws-sdk-go-v2/go-github-aws-aws-sdk-go-v2.spec
@@ -60,6 +60,9 @@ Source0:        https://github.com/aws/aws-sdk-go-v2/archive/release-%{upstream_
 BuildArch:      noarch
 BuildSystem:    golangmodules
 
+# Otherwise we need to -vet=off
+Patch2000:      2000-Wrap-status-code-error-value-for-Go-1.27.patch
+
 BuildRequires:  go
 BuildRequires:  go-rpm-macros
 BuildRequires:  go(github.com/aws/smithy-go)

--- a/SPECS/go-github-brianvoe-gofakeit-v7/go-github-brianvoe-gofakeit-v7.spec
+++ b/SPECS/go-github-brianvoe-gofakeit-v7/go-github-brianvoe-gofakeit-v7.spec
@@ -7,7 +7,7 @@
 %define _name           gofakeit
 %define go_import_path  github.com/brianvoe/gofakeit/v7
 
-Name:           go-github-brianvoe-gofakeit
+Name:           go-github-brianvoe-gofakeit-v7
 Version:        7.15.0
 Release:        %autorelease
 Summary:        Random fake data generator written in go
@@ -18,6 +18,9 @@ Source0:        https://github.com/brianvoe/gofakeit/archive/v%{version}.tar.gz#
 BuildArch:      noarch
 BuildSystem:    golangmodules
 
+# Golang 1.27 changes, we wait for upstream to fix the issue
+BuildOption(check):  -skip '^(TestJSONRawMessage|TestJSONRawMessageWithTag|TestJSONRawMessageWithInvalidCustomFuncTag|ExampleImagePng|ExampleFaker_ImagePng)$'
+
 BuildRequires:  go
 BuildRequires:  go-rpm-macros
 
@@ -27,8 +30,8 @@ Provides:       go(github.com/brianvoe/gofakeit/v7) = %{version}
 Random data generator written in go
 
 %files
-%license LICENSE*
 %doc README*
+%license LICENSE*
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog

--- a/SPECS/go-github-felixge-fgprof/2001-fix-flaky-Test-toPprof.patch
+++ b/SPECS/go-github-felixge-fgprof/2001-fix-flaky-Test-toPprof.patch
@@ -1,0 +1,24 @@
+From 80d4e400ebde5afbbf9cab42f91fc889d91e325d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Felix=20Geisend=C3=B6rfer?= <felix@felixge.de>
+Date: Fri, 2 May 2025 14:44:55 +0300
+Subject: [PATCH] fix: flaky Test_toPprof (#36)
+
+---
+ fgprof.go | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/fgprof.go b/fgprof.go
+index 459787b..728f508 100644
+--- a/fgprof.go
++++ b/fgprof.go
+@@ -205,6 +205,10 @@ nextStack:
+ 		}
+ 		stacks = append(stacks, ws)
+ 	}
++	// sort stacks by count to create stable output for testing purposes.
++	sort.Slice(stacks, func(i, j int) bool {
++		return stacks[i].count < stacks[j].count
++	})
+ 	return stacks
+ }
+ 

--- a/SPECS/go-github-felixge-fgprof/go-github-felixge-fgprof.spec
+++ b/SPECS/go-github-felixge-fgprof/go-github-felixge-fgprof.spec
@@ -21,6 +21,8 @@ BuildSystem:    golangmodules
 
 # https://github.com/felixge/fgprof/pull/39 - Jvle
 Patch2000:      2000-fix-handle-zero-sample-rate-in-pprof-export.patch
+# https://github.com/felixge/fgprof/commit/80d4e400ebde5afbbf9cab42f91fc889d91e325d
+Patch2001:      2001-fix-flaky-Test-toPprof.patch
 
 BuildRequires:  go
 BuildRequires:  go-rpm-macros

--- a/SPECS/go-github-frankban-quicktest/go-github-frankban-quicktest.spec
+++ b/SPECS/go-github-frankban-quicktest/go-github-frankban-quicktest.spec
@@ -13,7 +13,7 @@ Release:        %autorelease
 Summary:        Quick helpers for testing Go applications
 License:        MIT
 URL:            https://github.com/frankban/quicktest
-#!RemoteAsset
+#!RemoteAsset:  sha256:c77b45b267ac5f5e03d00ab1b3f944d68c74e91601a1c8121e49040ff89d8b0a
 Source0:        https://github.com/frankban/quicktest/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
@@ -34,10 +34,14 @@ Requires:       go(github.com/kr/pretty)
 This package quicktest provides a collection of Go helpers for writing
 tests.
 
+%check -p
+# Keep encoding/json v1 semantics for tests incompatible with Go 1.27 jsonv2.
+export GOEXPERIMENT=nojsonv2
+
 %files
-%license LICENSE*
 %doc README*
+%license LICENSE*
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/go-github-gin-gonic-gin/0001-change-Unwrap-method-receiver-to-value-type.patch
+++ b/SPECS/go-github-gin-gonic-gin/0001-change-Unwrap-method-receiver-to-value-type.patch
@@ -1,0 +1,34 @@
+From b38c59de7fef67400a1c98efeae700a689c45783 Mon Sep 17 00:00:00 2001
+From: Orkhan Alikhanov <Orkhan.Alikhanov@gmail.com>
+Date: Sun, 11 May 2025 18:38:33 +0400
+Subject: [PATCH] fix(errors): change Unwrap method receiver to value type
+ (#4232)
+
+Signed-Off-by: misaka00251 <liuxin@iscas.ac.cn>
+---
+diff --git a/errors.go b/errors.go
+index 06b53c28b3..b0d70a948b 100644
+--- a/errors.go
++++ b/errors.go
+@@ -91,7 +91,7 @@ func (msg *Error) IsType(flags ErrorType) bool {
+ }
+ 
+ // Unwrap returns the wrapped error, to allow interoperability with errors.Is(), errors.As() and errors.Unwrap()
+-func (msg *Error) Unwrap() error {
++func (msg Error) Unwrap() error {
+ 	return msg.Err
+ }
+ 
+diff --git a/errors_test.go b/errors_test.go
+index 78d561c..53a217c 100644
+--- a/errors_test.go
++++ b/errors_test.go
+@@ -116,7 +116,7 @@ func TestErrorUnwrap(t *testing.T) {
+ 	innerErr := TestErr("some error")
+ 
+ 	// 2 layers of wrapping : use 'fmt.Errorf("%w")' to wrap a gin.Error{}, which itself wraps innerErr
+-	err := fmt.Errorf("wrapped: %w", &Error{
++	err := fmt.Errorf("wrapped: %w", Error{
+ 		Err:  innerErr,
+ 		Type: ErrorTypeAny,
+ 	})

--- a/SPECS/go-github-gin-gonic-gin/go-github-gin-gonic-gin.spec
+++ b/SPECS/go-github-gin-gonic-gin/go-github-gin-gonic-gin.spec
@@ -18,6 +18,9 @@ Source0:        https://github.com/gin-gonic/gin/archive/v%{version}.tar.gz#/%{_
 BuildArch:      noarch
 BuildSystem:    golangmodules
 
+# https://github.com/gin-gonic/gin/commit/b38c59de7fef67400a1c98efeae700a689c45783
+Patch0:         0001-change-Unwrap-method-receiver-to-value-type.patch
+
 BuildOption(prep):  -n %{_name}-%{version}
 BuildOption(check):  -skip TestContextFormFileFailed17
 

--- a/SPECS/go-github-go-git-go-git-v5/0001-Compute-zlib-output-in-tests-instead-of-hardcoding-it.patch
+++ b/SPECS/go-github-go-git-go-git-v5/0001-Compute-zlib-output-in-tests-instead-of-hardcoding-it.patch
@@ -1,0 +1,104 @@
+From 4ae786a01dfb96289854ddc6460981531a6fe53c Mon Sep 17 00:00:00 2001
+From: Paulo Gomes <paulo@entire.io>
+Date: Mon, 7 Sep 2026 20:50:39 +0100
+Subject: [PATCH] *: Compute zlib output in tests instead of hardcoding it
+
+Go 1.27 changed the deflate output for small inputs: the stored-block
+sync marker is no longer emitted on close. That broke two tests which
+hardcoded the zlib bytes of an empty object and the size of a loose
+object file. Compress the same content within the test and compare
+against that, so the assertions hold across toolchains.
+
+Assisted-by: Claude Opus 5 <noreply@anthropic.com>
+Signed-off-by: Paulo Gomes <paulo@entire.io>
+Entire-Checkpoint: 9ffc7f5776de
+---
+ plumbing/format/packfile/encoder_test.go | 10 +++++++---
+ storage/filesystem/dotgit/dotgit_test.go | 18 +++++++++++++++---
+ 2 files changed, 22 insertions(+), 6 deletions(-)
+
+diff --git a/plumbing/format/packfile/encoder_test.go b/plumbing/format/packfile/encoder_test.go
+index 6719f376a..0c1360e7a 100644
+--- a/plumbing/format/packfile/encoder_test.go
++++ b/plumbing/format/packfile/encoder_test.go
+@@ -2,6 +2,7 @@ package packfile
+ 
+ import (
+ 	"bytes"
++	"compress/zlib"
+ 	"io"
+ 
+ 	"github.com/go-git/go-git/v5/plumbing"
+@@ -59,9 +60,12 @@ func (s *EncoderSuite) TestCorrectPackWithOneEmptyObject(c *C) {
+ 	// OBJECT HEADER(TYPE + SIZE)= 0001 0000
+ 	expectedResult = append(expectedResult, []byte{16}...)
+ 
+-	// Zlib header
+-	expectedResult = append(expectedResult,
+-		[]byte{120, 156, 1, 0, 0, 255, 255, 0, 0, 0, 1}...)
++	// Zlib stream of the empty object contents. The exact bytes depend on the
++	// compress/flate implementation, so compress it here instead of hardcoding.
++	var zbuf bytes.Buffer
++	zw := zlib.NewWriter(&zbuf)
++	c.Assert(zw.Close(), IsNil)
++	expectedResult = append(expectedResult, zbuf.Bytes()...)
+ 
+ 	// + HASH
+ 	hb := [hash.Size]byte(h)
+diff --git a/storage/filesystem/dotgit/dotgit_test.go b/storage/filesystem/dotgit/dotgit_test.go
+index c96ee719d..4b4134e06 100644
+--- a/storage/filesystem/dotgit/dotgit_test.go
++++ b/storage/filesystem/dotgit/dotgit_test.go
+@@ -2,6 +2,8 @@ package dotgit
+ 
+ import (
+ 	"bufio"
++	"bytes"
++	"compress/zlib"
+ 	"encoding/hex"
+ 	"errors"
+ 	"io"
+@@ -593,6 +595,16 @@ func (s *SuiteDotGit) TestObjectPackNotFound(c *C) {
+ 	c.Assert(idx, IsNil)
+ }
+ 
++func looseObjectSize(t require.TestingT, content string) int64 {
++	var buf bytes.Buffer
++	w := zlib.NewWriter(&buf)
++	_, err := w.Write([]byte(content))
++	require.NoError(t, err)
++	require.NoError(t, w.Close())
++
++	return int64(buf.Len())
++}
++
+ func (s *SuiteDotGit) TestNewObject(c *C) {
+ 	fs := s.TemporalFilesystem(c)
+ 
+@@ -613,7 +625,7 @@ func (s *SuiteDotGit) TestNewObject(c *C) {
+ 
+ 	i, err := fs.Stat("objects/a8/a940627d132695a9769df883f85992f0ff4a43")
+ 	c.Assert(err, IsNil)
+-	c.Assert(i.Size(), Equals, int64(34))
++	c.Assert(i.Size(), Equals, looseObjectSize(c, "blob 14\x00this is a test"))
+ }
+ 
+ func (s *SuiteDotGit) TestObjects(c *C) {
+@@ -1163,7 +1175,7 @@ func TestIssue55(t *testing.T) {
+ 			writeObject(tc.fs)
+ 			i, err := tc.fs.Stat(path)
+ 			require.NoError(t, err)
+-			assert.Equal(t, int64(34), i.Size())
++			assert.Equal(t, looseObjectSize(t, "blob 14\x00this is a test"), i.Size())
+ 
+ 			ro, err := isReadOnly(tc.fs, path)
+ 			require.NoError(t, err)
+@@ -1173,7 +1185,7 @@ func TestIssue55(t *testing.T) {
+ 			writeObject(tc.fs)
+ 			i, err = tc.fs.Stat(path)
+ 			require.NoError(t, err)
+-			assert.Equal(t, int64(34), i.Size())
++			assert.Equal(t, looseObjectSize(t, "blob 14\x00this is a test"), i.Size())
+ 
+ 			ro, err = isReadOnly(tc.fs, path)
+ 			require.NoError(t, err)

--- a/SPECS/go-github-go-git-go-git-v5/go-github-go-git-go-git-v5.spec
+++ b/SPECS/go-github-go-git-go-git-v5/go-github-go-git-go-git-v5.spec
@@ -37,6 +37,8 @@ Source0:        https://github.com/go-git/go-git/archive/refs/tags/v%{version}.t
 BuildArch:      noarch
 BuildSystem:    golangmodules
 
+# https://github.com/go-git/go-git/commit/4ae786a01dfb96289854ddc6460981531a6fe53c
+Patch0:         0001-Compute-zlib-output-in-tests-instead-of-hardcoding-it.patch
 # The packaged go-git/gcfg is newer than upstream's pinned pseudo-version and
 # accepts empty subsection names; adjust that single compatibility assertion.
 # - HNO3Miracle

--- a/SPECS/go-github-go-loger-logr/2000-Preserve-json.RawMessage-rendering-with-Go-1.27.patch
+++ b/SPECS/go-github-go-loger-logr/2000-Preserve-json.RawMessage-rendering-with-Go-1.27.patch
@@ -1,0 +1,27 @@
+From 0e74b2060c2c4ea7a206cf7e39210a9bbfdafd94 Mon Sep 17 00:00:00 2001
+From: misaka00251 <liuxin@iscas.ac.cn>
+Date: Tue, 8 Sep 2026 21:02:14 +0800
+Subject: [PATCH] Preserve json.RawMessage rendering with Go 1.27
+
+---
+ funcr/funcr.go | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/funcr/funcr.go b/funcr/funcr.go
+index b22c57d..f40c16c 100644
+--- a/funcr/funcr.go
++++ b/funcr/funcr.go
+@@ -449,7 +449,9 @@ func (f Formatter) prettyWithFlags(value any, flags uint32, depth int) string {
+ 	// Handle types that want to format themselves.
+ 	switch v := value.(type) {
+ 	case fmt.Stringer:
+-		value = invokeStringer(v)
++		if _, ok := value.(json.RawMessage); !ok {
++			value = invokeStringer(v)
++		}
+ 	case error:
+ 		value = invokeError(v)
+ 	}
+-- 
+2.55.0
+

--- a/SPECS/go-github-go-loger-logr/go-github-go-loger-logr.spec
+++ b/SPECS/go-github-go-loger-logr/go-github-go-loger-logr.spec
@@ -19,6 +19,9 @@ Source0:        https://github.com/go-logr/logr/archive/v%{version}.tar.gz#/%{_n
 BuildArch:      noarch
 BuildSystem:    golangmodules
 
+# Preserve json.RawMessage rendering with Go 1.27 jsonv2
+Patch2000:      2000-Preserve-json.RawMessage-rendering-with-Go-1.27.patch
+
 BuildRequires:  go
 BuildRequires:  go-rpm-macros
 

--- a/SPECS/go-github-gogo-protobuf/go-github-gogo-protobuf.spec
+++ b/SPECS/go-github-gogo-protobuf/go-github-gogo-protobuf.spec
@@ -20,12 +20,14 @@ Release:        %autorelease
 Summary:        Protocol Buffers for Go with Gadgets
 License:        BSD-3-Clause
 URL:            https://github.com/gogo/protobuf
-#!RemoteAsset
+#!RemoteAsset:  sha256:2bb4b13d6e56b3911f09b8e9ddd15708477fbff8823c057cc79dd99c9a452b34
 Source0:        https://github.com/gogo/protobuf/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
 
 BuildOption(prep):  -n %{_name}-%{version}
+# TestStdTypesGoString is flaky due to invalid GoString output for nil *time.Time.
+BuildOption(check):  -skip '^TestStdTypesGoString$'
 
 BuildRequires:  go
 BuildRequires:  go-rpm-macros
@@ -46,9 +48,9 @@ This code generation is used to achieve:
  * other serialization formats
 
 %files
-%license LICENSE*
 %doc README*
+%license LICENSE*
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/go-github-google-go-github-v59/2001-Ensure-compatibility-with-encoding-json-v2-experimen.patch
+++ b/SPECS/go-github-google-go-github-v59/2001-Ensure-compatibility-with-encoding-json-v2-experimen.patch
@@ -1,0 +1,82 @@
+From 20c16f85d00a013f662efa80baf9a845aa2d5f3c Mon Sep 17 00:00:00 2001
+From: Nurzhan Muratkhan <nurzhanmuratkhan@gmail.com>
+Date: Tue, 8 Sep 2026 22:05:12 +0800
+Subject: [PATCH] Ensure compatibility with encoding/json/v2 experiment
+
+Backport commit: https://github.com/google/go-github/commit/92a3830f9be93a0a314c4d6c2726ee820cc79c2e?utm_source=chatgpt.com
+
+Signed-off-by: misaka00251 <liuxin@iscas.ac.cn>
+---
+ github/github_test.go                 | 5 +----
+ github/repos_hooks_deliveries_test.go | 3 ++-
+ github/security_advisories_test.go    | 4 ++--
+ 3 files changed, 5 insertions(+), 7 deletions(-)
+
+diff --git a/github/github_test.go b/github/github_test.go
+index 9a369a2..61b33fc 100644
+--- a/github/github_test.go
++++ b/github/github_test.go
+@@ -539,16 +539,13 @@ func TestNewRequest_invalidJSON(t *testing.T) {
+ 	c := NewClient(nil)
+ 
+ 	type T struct {
+-		A map[interface{}]interface{}
++		F func()
+ 	}
+ 	_, err := c.NewRequest("GET", ".", &T{})
+ 
+ 	if err == nil {
+ 		t.Error("Expected error to be returned.")
+ 	}
+-	if err, ok := err.(*json.UnsupportedTypeError); !ok {
+-		t.Errorf("Expected a JSON error; got %#v.", err)
+-	}
+ }
+ 
+ func TestNewRequest_badURL(t *testing.T) {
+diff --git a/github/repos_hooks_deliveries_test.go b/github/repos_hooks_deliveries_test.go
+index 057d712..ba5a3f0 100644
+--- a/github/repos_hooks_deliveries_test.go
++++ b/github/repos_hooks_deliveries_test.go
+@@ -11,6 +11,7 @@ import (
+ 	"fmt"
+ 	"net/http"
+ 	"reflect"
++	"strings"
+ 	"testing"
+ 
+ 	"github.com/google/go-cmp/cmp"
+@@ -261,7 +262,7 @@ func TestHookDelivery_ParsePayload_invalidPayload(t *testing.T) {
+ 	}
+ 
+ 	_, err := d.ParseRequestPayload()
+-	if err == nil || err.Error() != "json: cannot unmarshal string into Go struct field CheckRun.check_run.id of type int64" {
++	if err == nil || !strings.Contains(err.Error(), "json: cannot unmarshal") || !strings.Contains(err.Error(), "check_run.id") {
+ 		t.Errorf("unexpected error: %v", err)
+ 	}
+ }
+diff --git a/github/security_advisories_test.go b/github/security_advisories_test.go
+index eb8e7d3..e44959f 100644
+--- a/github/security_advisories_test.go
++++ b/github/security_advisories_test.go
+@@ -590,7 +590,7 @@ func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisoriesForOrg_Unmars
+ 	advisories, resp, err := client.SecurityAdvisories.ListRepositorySecurityAdvisoriesForOrg(ctx, "o", nil)
+ 	if err == nil {
+ 		t.Errorf("Expected unmarshal error")
+-	} else if !strings.Contains(err.Error(), "json: cannot unmarshal number into Go struct field SecurityAdvisory.ghsa_id of type string") {
++	} else if !strings.Contains(err.Error(), "json: cannot unmarshal") || !strings.Contains(err.Error(), "ghsa_id") {
+ 		t.Errorf("ListRepositorySecurityAdvisoriesForOrg returned unexpected error: %v", err)
+ 	}
+ 	if got, want := resp.Response.StatusCode, http.StatusOK; got != want {
+@@ -721,7 +721,7 @@ func TestSecurityAdvisoriesService_ListRepositorySecurityAdvisories_UnmarshalErr
+ 	advisories, resp, err := client.SecurityAdvisories.ListRepositorySecurityAdvisories(ctx, "o", "r", nil)
+ 	if err == nil {
+ 		t.Errorf("Expected unmarshal error")
+-	} else if !strings.Contains(err.Error(), "json: cannot unmarshal number into Go struct field SecurityAdvisory.ghsa_id of type string") {
++	} else if !strings.Contains(err.Error(), "json: cannot unmarshal") || !strings.Contains(err.Error(), "ghsa_id") {
+ 		t.Errorf("ListRepositorySecurityAdvisories returned unexpected error: %v", err)
+ 	}
+ 	if got, want := resp.Response.StatusCode, http.StatusOK; got != want {
+-- 
+2.55.0
+

--- a/SPECS/go-github-google-go-github-v59/go-github-google-go-github-v59.spec
+++ b/SPECS/go-github-google-go-github-v59/go-github-google-go-github-v59.spec
@@ -30,6 +30,8 @@ BuildSystem:    golangmodules
 # type; sniff named assets before falling back to the default upload type.
 # - HNO3Miracle
 Patch2000:      2000-detect-generic-release-asset-content-types.patch
+# https://github.com/google/go-github/pull/4029 backport
+Patch2001:      2001-Ensure-compatibility-with-encoding-json-v2-experimen.patch
 
 # Go 1.26 vet reports Errorf %q with a *strings.Reader argument in upstream
 # github tests; keep tests enabled but disable vet. - HNO3Miracle

--- a/SPECS/go-golang-x-tools/go-golang-x-tools.spec
+++ b/SPECS/go-golang-x-tools/go-golang-x-tools.spec
@@ -32,22 +32,23 @@
 }
 
 Name:           go-golang-x-tools
-Version:        0.40.0
+Version:        0.49.0
 Release:        %autorelease
 Summary:        Various packages and tools that support the Go programming language
 License:        BSD-3-Clause
 URL:            https://golang.org/x/tools
 VCS:            git:https://github.com/golang/tools
-#!RemoteAsset
+#!RemoteAsset:  sha256:df7f087706730d85ced76f5f2e3d1a51703de3beb305acc72d1170d405f5a21e
 Source0:        https://github.com/golang/tools/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
-#!RemoteAsset
-Source1:        https://github.com/golang/telemetry/archive/config/v0.80.0.tar.gz#/telemetry-config-v0.80.0.tar.gz
+#!RemoteAsset:  sha256:7c7d1718dd80c6fed01597c3a4789ce373386c865531b62da656e2eff2f9ab29
+Source1:        https://github.com/golang/telemetry/archive/config/v0.119.0.tar.gz#/telemetry-config-v0.119.0.tar.gz
+BuildArch:      noarch
 BuildSystem:    golangmodules
 
 # Skip flaky test - 251
-Patch0:         2000-skip-test.patch
+Patch2000:      2000-skip-test.patch
 # Patches from debian, thanks!
-Patch1:         2001-Set-GO111MODULE-on.patch
+Patch2001:      2001-Set-GO111MODULE-on.patch
 
 BuildOption(prep):  -n %{_name}-%{version}
 BuildOption(check):  -short -timeout=30m
@@ -71,13 +72,6 @@ Requires:       go(golang.org/x/sync)
 This package provides the golang.org/x/tools module, comprising
 various tools and packages mostly for static analysis of Go programs.
 
-%package     -n go-tools
-Summary:        Executable of tools
-
-%description -n go-tools
-This package contains the golang.org/x/tools module executables, comprising
-various tools and packages mostly for static analysis of Go programs.
-
 %prep -a
 %go_prep
 # Provide only the x/telemetry subtree
@@ -87,33 +81,18 @@ mkdir -p vendor/golang.org/x/telemetry
 tar -xf %{SOURCE1} \
     --strip-components=1 \
     -C vendor/golang.org/x/telemetry \
-    telemetry-config-v0.80.0
+    telemetry-config-v0.119.0
 cat > vendor/modules.txt <<'EOF'
-# golang.org/x/telemetry v0.80.0
+# golang.org/x/telemetry v0.119.0
 ## explicit
 golang.org/x/telemetry
 EOF
 popd
-
-# Build binaries for tools
-%build
-%go_common
-cd %{_builddir}/go/src/%{go_import_path}
-go install -trimpath -v -p %{?_smp_build_ncpus} ./cmd/...
-
-# Install binaries for tools
-%install -a
-install -d %{buildroot}%{_bindir}
-install -m 0755 %{_builddir}/go/bin/* %{buildroot}%{_bindir}/
 
 %files
 %license LICENSE*
 %doc README*
 %{go_sys_gopath}/%{go_import_path}
 
-%files -n go-tools
-%license LICENSE*
-%{_bindir}/*
-
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
## Summary

Fix build/check failures for 11 Go modules with Go 1.27 compatibility updates and test adjustments. Some of the test fix patches are assisted by AI, while others have been backported or rebased.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: ChatGPT 5.6 Sol

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
