### PR TITLE
SPECS: glmark2: enable gbm variants

### DIFF
--- a/SPECS/glmark2/glmark2.spec
+++ b/SPECS/glmark2/glmark2.spec
@@ -10,14 +10,15 @@ Release:        %autorelease
 Summary:        A OpenGL (ES) 2.0 benchmark
 License:        MIT AND BSD-3-Clause AND GPL-3.0-or-later
 URL:            https://github.com/glmark2/glmark2
-#!RemoteAsset
-Source:         https://github.com/glmark2/glmark2/archive/refs/tags/%{version}.tar.gz
+#!RemoteAsset:  git+https://github.com/glmark2/glmark2.git#%{version}
+#!CreateArchive
+Source:         glmark2-%{version}.tar.gz
 BuildSystem:    meson
 
 # Fixes visual config match for drivers bind depth with stencil (e.g. IMG proprietary GLES)
 Patch1:         glmark2-2023.01-backport-visual-config-match.patch
 
-BuildOption(conf):  -Dflavors=drm-gl,drm-glesv2,wayland-gl,wayland-glesv2,x11-gl,x11-glesv2,x11-gl-egl
+BuildOption(conf):  -Dflavors=drm-gl,drm-glesv2,wayland-gl,wayland-glesv2,x11-gl,x11-glesv2,x11-gl-egl,gbm-gl,gbm-glesv2
 
 BuildRequires:  meson
 BuildRequires:  pkgconfig(libjpeg)
@@ -50,4 +51,4 @@ properly weighted.
 %{_mandir}/man1/glmark*.1*
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
## Summary

Enable headless GBM variants of glmark2, and switch to CreateArchive because the upstream only creates git tags.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [ ] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by:

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
