### PR TITLE
SPECS: Add MinIO FTP dependencies and fix sio provider

### DIFF
--- a/SPECS/go-github-jlaffaye-ftp/2000-fix-file-size-test-format.patch
+++ b/SPECS/go-github-jlaffaye-ftp/2000-fix-file-size-test-format.patch
@@ -1,0 +1,26 @@
+From 98a78373e48a3d15daf150900a3e520e9d9dd952 Mon Sep 17 00:00:00 2001
+From: cl2t <yihong.or@isrc.iscas.ac.cn>
+Date: Wed, 9 Sep 2026 09:57:30 +0800
+Subject: [PATCH] tests: use integer format for file sizes
+
+The file size is int64. Use a decimal format in the failure message so
+current go vet accepts the test. Production code is unchanged.
+
+Signed-off-by: cl2t <yihong.or@isrc.iscas.ac.cn>
+---
+ client_test.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/client_test.go b/client_test.go
+index 4e6bb42..8b81a65 100644
+--- a/client_test.go
++++ b/client_test.go
+@@ -118,7 +118,7 @@ func testConn(t *testing.T, disableEPSV bool) {
+ 		t.Error(err)
+ 	}
+ 	if fileSize != 42 {
+-		t.Errorf("file size %q, expected %q", fileSize, 42)
++		t.Errorf("file size %d, expected %d", fileSize, 42)
+ 	}
+ 
+ 	_, err = c.FileSize("not-found")

--- a/SPECS/go-github-jlaffaye-ftp/go-github-jlaffaye-ftp.spec
+++ b/SPECS/go-github-jlaffaye-ftp/go-github-jlaffaye-ftp.spec
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           ftp
+%define go_import_path  github.com/jlaffaye/ftp
+%define commit_id       c1312a7102bfa91477d0c16ce91dcfd3aa9e3f06
+
+Name:           go-github-jlaffaye-ftp
+Version:        0+git20260909.c1312a7
+Release:        %autorelease
+Summary:        Implements a FTP client as described in RFC 959
+License:        ISC
+URL:            https://github.com/jlaffaye/ftp
+#!RemoteAsset:  sha256:64085a9304384a2d7b1881b27c794cd10cb3ab0d2f0d3a1de7a6802d326e9b71
+Source0:        https://github.com/jlaffaye/ftp/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# openRuyi test compatibility fix for the current Go toolchain.
+Patch2000:      2000-fix-file-size-test-format.patch
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/stretchr/testify)
+
+Provides:       go(github.com/jlaffaye/ftp) = %{version}
+
+%description
+FTP client library implementing file transfers, directory listings and
+connection management according to RFC 959.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-minio-minio-go-v6/2000-fix-tests-for-current-go.patch
+++ b/SPECS/go-github-minio-minio-go-v6/2000-fix-tests-for-current-go.patch
@@ -1,0 +1,60 @@
+From f72bdb909e39a11ede21f81d6296d980ab0677f8 Mon Sep 17 00:00:00 2001
+From: cl2t <yihong.or@isrc.iscas.ac.cn>
+Date: Wed, 9 Sep 2026 09:57:30 +0800
+Subject: [PATCH] tests: support current Go URL errors and content lengths
+
+Check the structured URL parsing error instead of its Go-version-dependent
+rendering. Encode the Content-Length fixture as decimal digits instead of
+a single rune. Production code is unchanged.
+
+Signed-off-by: cl2t <yihong.or@isrc.iscas.ac.cn>
+---
+ pkg/credentials/iam_aws_test.go           | 6 ++++--
+ pkg/s3signer/request-signature-v4_test.go | 3 ++-
+ 2 files changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/pkg/credentials/iam_aws_test.go b/pkg/credentials/iam_aws_test.go
+index 2015146..f11a6a4 100644
+--- a/pkg/credentials/iam_aws_test.go
++++ b/pkg/credentials/iam_aws_test.go
+@@ -24,6 +24,7 @@ import (
+ 	"io/ioutil"
+ 	"net/http"
+ 	"net/http/httptest"
++	"net/url"
+ 	"os"
+ 	"testing"
+ 	"time"
+@@ -135,8 +136,9 @@ func TestIAMMalformedEndpoint(t *testing.T) {
+ 	if err == nil {
+ 		t.Fatal("Unexpected should fail here")
+ 	}
+-	if err.Error() != `parse %%%%: invalid URL escape "%%%"` {
+-		t.Fatalf("Expected parse %%%%%%%%: invalid URL escape \"%%%%%%\", got %s", err)
++	parseErr, ok := err.(*url.Error)
++	if !ok || parseErr.Op != "parse" || parseErr.URL != "%%%%" || parseErr.Err != url.EscapeError("%%%") {
++		t.Fatalf("Expected URL parse error for invalid escape, got %v", err)
+ 	}
+ }
+ 
+diff --git a/pkg/s3signer/request-signature-v4_test.go b/pkg/s3signer/request-signature-v4_test.go
+index d0c9e30..33cb8b9 100644
+--- a/pkg/s3signer/request-signature-v4_test.go
++++ b/pkg/s3signer/request-signature-v4_test.go
+@@ -20,6 +20,7 @@ package s3signer
+ import (
+ 	"io"
+ 	"net/http"
++	"strconv"
+ 	"strings"
+ 	"testing"
+ )
+@@ -42,7 +43,7 @@ func buildRequest(serviceName, region, body string) (*http.Request, io.ReadSeeke
+ 	req.URL.Opaque = "//example.org/bucket/key-._~,!@#$%^&*()"
+ 	req.Header.Add("X-Amz-Target", "prefix.Operation")
+ 	req.Header.Add("Content-Type", "application/x-amz-json-1.0")
+-	req.Header.Add("Content-Length", string(len(body)))
++	req.Header.Add("Content-Length", strconv.Itoa(len(body)))
+ 	req.Header.Add("X-Amz-Meta-Other-Header", "some-value=!@#$%^&* (+)")
+ 	req.Header.Add("X-Amz-Meta-Other-Header_With_Underscore", "some-value=!@#$%^&* (+)")
+ 	req.Header.Add("X-amz-Meta-Other-Header_With_Underscore", "some-value=!@#$%^&* (+)")

--- a/SPECS/go-github-minio-minio-go-v6/go-github-minio-minio-go-v6.spec
+++ b/SPECS/go-github-minio-minio-go-v6/go-github-minio-minio-go-v6.spec
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           minio-go
+%define go_import_path  github.com/minio/minio-go/v6
+
+Name:           go-github-minio-minio-go-v6
+Version:        6.0.46
+Release:        %autorelease
+Summary:        MinIO Go client SDK for S3 compatible object storage
+License:        Apache-2.0
+URL:            https://github.com/minio/minio-go
+#!RemoteAsset:  sha256:e855dae328eac30c4ec7523ab9a9b7affc6d8b1606a8885666c40f65db268290
+Source0:        https://github.com/minio/minio-go/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+# openRuyi test compatibility fix for the current Go toolchain.
+Patch2000:      2000-fix-tests-for-current-go.patch
+
+# Upstream uses testing.Short to skip tests requiring a live S3 endpoint.
+BuildOption(check):  -short
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/minio/sha256-simd)
+BuildRequires:  go(github.com/mitchellh/go-homedir)
+BuildRequires:  go(golang.org/x/crypto)
+BuildRequires:  go(golang.org/x/net)
+BuildRequires:  go(gopkg.in/ini.v1)
+
+Provides:       go(github.com/minio/minio-go/v6) = %{version}
+
+Requires:       go(github.com/minio/sha256-simd)
+Requires:       go(github.com/mitchellh/go-homedir)
+Requires:       go(golang.org/x/crypto)
+Requires:       go(golang.org/x/net)
+Requires:       go(gopkg.in/ini.v1)
+
+%description
+Version 6 of the MinIO Go client SDK for Amazon S3 compatible object
+storage. This package includes the client library and its public helpers.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog

--- a/SPECS/go-github-minio-sio/go-github-minio-sio.spec
+++ b/SPECS/go-github-minio-sio/go-github-minio-sio.spec
@@ -24,7 +24,11 @@ BuildRequires:  go(golang.org/x/crypto)
 BuildRequires:  go(golang.org/x/sys)
 BuildRequires:  go(golang.org/x/term)
 
-Provides:       go(github.com/minio/minio-sio) = %{version}
+Provides:       go(github.com/minio/sio) = %{version}
+
+Requires:       go(golang.org/x/crypto)
+Requires:       go(golang.org/x/sys)
+Requires:       go(golang.org/x/term)
 
 %description
 Secure IO
@@ -41,8 +45,8 @@ sophisticated attacks. Anyone who has access to the stored data can try
 to manipulate the data - even if the data is encrypted.
 
 %files
-%license LICENSE*
 %doc README*
+%license LICENSE*
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog

--- a/SPECS/go-goftp-server-v2/go-goftp-server-v2.spec
+++ b/SPECS/go-goftp-server-v2/go-goftp-server-v2.spec
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (C) 2026 Institute of Software, Chinese Academy of Sciences (ISCAS)
+# SPDX-FileCopyrightText: (C) 2026 openRuyi Project Contributors
+#
+# SPDX-License-Identifier: MulanPSL-2.0
+
+%define _name           server
+%define go_import_path  goftp.io/server/v2
+
+Name:           go-goftp-server-v2
+Version:        2.0.1
+Release:        %autorelease
+Summary:        Extensible FTP server framework for Go
+License:        MIT
+URL:            https://gitea.com/goftp/server
+#!RemoteAsset:  sha256:f720bdc94324e5b35c711a5cb78d28cdda4bb422b04dc1b486a1ba392432df36
+Source0:        https://gitea.com/goftp/server/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
+BuildArch:      noarch
+BuildSystem:    golangmodules
+
+BuildRequires:  go
+BuildRequires:  go-rpm-macros
+BuildRequires:  go(github.com/jlaffaye/ftp)
+BuildRequires:  go(github.com/minio/minio-go/v6)
+BuildRequires:  go(github.com/stretchr/testify)
+
+Provides:       go(goftp.io/server/v2) = %{version}
+
+Requires:       go(github.com/minio/minio-go/v6)
+
+%description
+FTP server framework with pluggable authentication, permissions and storage
+drivers. Includes the filesystem and MinIO storage drivers.
+
+%files
+%doc README.md
+%license LICENSE
+%{go_sys_gopath}/%{go_import_path}
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Summary

Add [ftp](https://github.com/jlaffaye/ftp), [minio-go/v6](https://github.com/minio/minio-go) and [goftp/server/v2](https://gitea.com/goftp/server) for MinIO; correct the existing sio module provider.

Pre-commit and [OBS x86_64/riscv64 builds](https://build.openruyi.cn/project/show/home:cl_2:minio-independent-puremain) pass.

## Related Issue

- Continues MinIO dependencies alongside #1247 and #1248; builds independently.

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.
- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: Codex:GPT-6

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]: https://openruyi.cn/governance/policy/ai-contribution-policy
