### PR TITLE
Fix several golang modules

### DIFF
--- a/SPECS/go-k8s-apimachinery/0001-Tolerate-json-v2-invalid-UTF-8-munging-in-unstructured-serialization-tests.patch
+++ b/SPECS/go-k8s-apimachinery/0001-Tolerate-json-v2-invalid-UTF-8-munging-in-unstructured-serialization-tests.patch
@@ -1,0 +1,63 @@
+From 2bbf31a193cf138aac3c66187b3925ae34cac3f4 Mon Sep 17 00:00:00 2001
+From: Joe Betz <jpbetz@google.com>
+Date: Tue, 19 May 2026 11:02:28 -0400
+Subject: [PATCH] Tolerate json/v2 invalid UTF-8 munging in unstructured
+ serialization tests
+
+Kubernetes-commit: c71f9ad8351dd8aea4e0e7a46c2071e6bccf907f
+---
+ pkg/runtime/serializer/json/collections_test.go | 13 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/pkg/runtime/serializer/json/collections_test.go b/pkg/runtime/serializer/json/collections_test.go
+index 544f8453b..5d9e1a0ae 100644
+--- a/pkg/runtime/serializer/json/collections_test.go
++++ b/pkg/runtime/serializer/json/collections_test.go
+@@ -19,6 +19,7 @@ package json
+ import (
+ 	"bytes"
+ 	"fmt"
++	"slices"
+ 	"testing"
+ 
+ 	"github.com/google/go-cmp/cmp"
+@@ -51,6 +52,10 @@ func testCollectionsEncoding(t *testing.T, s *Serializer, streamingEnabled bool)
+ 		in           runtime.Object
+ 		cannotStream bool
+ 		expect       string
++		// allow provides allowed alternate representations.
++		// For the json v1->v2 transition, this is used to tolerate changes
++		// in how malformed input in munged.
++		allow []string
+ 	}{
+ 		// Preserving the distinction between integers and floating-point numbers
+ 		{
+@@ -114,6 +119,8 @@ func testCollectionsEncoding(t *testing.T, s *Serializer, streamingEnabled bool)
+ 				},
+ 			},
+ 			expect: "{\"items\":[],\"key\":\"\\ufffd\"}\n",
++			// Go json/v2 emits U+FFFD as raw UTF-8 bytes rather than the \ufffd escape.
++			allow: []string{"{\"items\":[],\"key\":\"\ufffd\"}\n"},
+ 		},
+ 		{
+ 			name: "UnstructuredList items invalid UTF-8 ",
+@@ -127,6 +134,8 @@ func testCollectionsEncoding(t *testing.T, s *Serializer, streamingEnabled bool)
+ 				},
+ 			},
+ 			expect: "{\"items\":[{\"key\":\"\\ufffd\"}]}\n",
++			// Go json/v2 emits U+FFFD as raw UTF-8 bytes rather than the \ufffd escape.
++			allow: []string{"{\"items\":[{\"key\":\"\ufffd\"}]}\n"},
+ 		},
+ 		// Preserving the distinction between absent, present-but-null, and present-and-empty states for slices and maps
+ 		{
+@@ -577,8 +586,8 @@ func testCollectionsEncoding(t *testing.T, s *Serializer, streamingEnabled bool)
+ 				t.Fatalf("unexpected error: %v", err)
+ 			}
+ 			t.Logf("encoded: %s", buf.String())
+-			if diff := cmp.Diff(buf.String(), tc.expect); diff != "" {
+-				t.Errorf("not matching:\n%s", diff)
++			if got := buf.String(); got != tc.expect && !slices.Contains(tc.allow, got) {
++				t.Errorf("not matching:\n%s", cmp.Diff(got, tc.expect))
+ 			}
+ 			expectStreaming := !tc.cannotStream && streamingEnabled
+ 			if expectStreaming && buf.writeCount <= 1 {

--- a/SPECS/go-k8s-apimachinery/go-k8s-apimachinery.spec
+++ b/SPECS/go-k8s-apimachinery/go-k8s-apimachinery.spec
@@ -25,6 +25,9 @@ Source0:        https://github.com/kubernetes/apimachinery/archive/refs/tags/v%{
 BuildArch:      noarch
 BuildSystem:    golangmodules
 
+# Tolerate Go 1.27 json/v2 UTF-8 encoding in serializer tests.
+Patch0:         0001-Tolerate-json-v2-invalid-UTF-8-munging-in-unstructured-serialization-tests.patch
+
 BuildRequires:  go
 BuildRequires:  go-rpm-macros
 BuildRequires:  go(github.com/armon/go-socks5)

--- a/SPECS/go-k8s-kube-openapi/0001-Insulate-go-json-experiment-from-stdlib.patch
+++ b/SPECS/go-k8s-kube-openapi/0001-Insulate-go-json-experiment-from-stdlib.patch
@@ -1,0 +1,11837 @@
+From 357cd4e3dcc586776e4312fbf620760f479807b4 Mon Sep 17 00:00:00 2001
+From: Jordan Liggitt <liggitt@google.com>
+Date: Thu, 18 Jun 2026 16:49:11 -0400
+Subject: [PATCH 1/2] Insulate go-json-experiment from stdlib
+
+---
+ hack/update-json-library.sh | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/hack/update-json-library.sh b/hack/update-json-library.sh
+index 8c9d9876c..93d81504f 100755
+--- a/hack/update-json-library.sh
++++ b/hack/update-json-library.sh
+@@ -40,3 +40,10 @@ rm -rf internal/jsontest/testdata
+ rm -rf internal/zstd
+ # Update references to point to the fork
+ find . -type f -name "*.go" -print0 | xargs -0 perl -pi -e "s#github.com/go-json-experiment/json#k8s.io/kube-openapi/${GO_JSON_EXPERIMENT_DIR}#g"
++
++# eliminate links to stdlib
++rm -fr v1
++rm -fr alias.go jsontext/alias.go
++# remove conditional build tags
++find . -type f -name "*.go" -print0 | xargs -0 perl -pi -e 's#\Q//go:build !goexperiment.jsonv2 || !go1.25\E##g'
++find . -type f -name "*.go" -print0 | xargs -0 gofmt -w -s
+\ No newline at end of file
+
+From 8d7c10782fb495858ca96d19489755d20a252b86 Mon Sep 17 00:00:00 2001
+From: Jordan Liggitt <liggitt@google.com>
+Date: Thu, 18 Jun 2026 16:49:49 -0400
+Subject: [PATCH 2/2] Update go-json-experiment import
+
+---
+ .../go-json-experiment/json/alias.go          |  967 ------
+ .../go-json-experiment/json/arshal.go         |    2 -
+ .../go-json-experiment/json/arshal_any.go     |    2 -
+ .../go-json-experiment/json/arshal_default.go |    2 -
+ .../go-json-experiment/json/arshal_funcs.go   |    2 -
+ .../go-json-experiment/json/arshal_inlined.go |    2 -
+ .../go-json-experiment/json/arshal_methods.go |    2 -
+ .../go-json-experiment/json/arshal_test.go    |    2 -
+ .../go-json-experiment/json/arshal_time.go    |    2 -
+ .../json/arshal_time_test.go                  |    2 -
+ .../go-json-experiment/json/doc.go            |    2 -
+ .../go-json-experiment/json/errors.go         |    2 -
+ .../go-json-experiment/json/errors_test.go    |    2 -
+ .../json/example_orderedobject_test.go        |    2 -
+ .../go-json-experiment/json/example_test.go   |    2 -
+ .../go-json-experiment/json/fields.go         |    2 -
+ .../go-json-experiment/json/fields_test.go    |    2 -
+ .../go-json-experiment/json/fold.go           |    2 -
+ .../go-json-experiment/json/fold_test.go      |    2 -
+ .../go-json-experiment/json/fuzz_test.go      |    2 -
+ .../go-json-experiment/json/inline_test.go    |    2 -
+ .../go-json-experiment/json/intern.go         |    2 -
+ .../json/internal/internal.go                 |    2 -
+ .../json/internal/jsonflags/flags.go          |    2 -
+ .../json/internal/jsonflags/flags_test.go     |    2 -
+ .../json/internal/jsonopts/options.go         |    2 -
+ .../json/internal/jsonopts/options_test.go    |    2 -
+ .../json/internal/jsontest/testcase.go        |    2 -
+ .../json/internal/jsonwire/decode.go          |    2 -
+ .../json/internal/jsonwire/decode_test.go     |    2 -
+ .../json/internal/jsonwire/encode.go          |    2 -
+ .../json/internal/jsonwire/encode_test.go     |    2 -
+ .../json/internal/jsonwire/wire.go            |    2 -
+ .../json/internal/jsonwire/wire_test.go       |    2 -
+ .../go-json-experiment/json/jsontext/alias.go |  536 ---
+ .../json/jsontext/coder_test.go               |    2 -
+ .../json/jsontext/decode.go                   |    2 -
+ .../json/jsontext/decode_test.go              |    2 -
+ .../go-json-experiment/json/jsontext/doc.go   |    2 -
+ .../json/jsontext/encode.go                   |    2 -
+ .../json/jsontext/encode_test.go              |    2 -
+ .../json/jsontext/errors.go                   |    2 -
+ .../json/jsontext/example_test.go             |    2 -
+ .../json/jsontext/export.go                   |    2 -
+ .../json/jsontext/options.go                  |    2 -
+ .../go-json-experiment/json/jsontext/pools.go |    2 -
+ .../go-json-experiment/json/jsontext/quote.go |    2 -
+ .../go-json-experiment/json/jsontext/state.go |    2 -
+ .../json/jsontext/state_test.go               |    2 -
+ .../go-json-experiment/json/jsontext/token.go |    2 -
+ .../json/jsontext/token_test.go               |    2 -
+ .../go-json-experiment/json/jsontext/value.go |    2 -
+ .../json/jsontext/value_test.go               |    2 -
+ .../go-json-experiment/json/options.go        |    2 -
+ .../go-json-experiment/json/v1/alias.go       |  845 -----
+ .../go-json-experiment/json/v1/decode.go      |  245 --
+ .../go-json-experiment/json/v1/decode_test.go | 2861 -----------------
+ .../go-json-experiment/json/v1/diff_test.go   | 1130 -------
+ .../go-json-experiment/json/v1/encode.go      |  251 --
+ .../go-json-experiment/json/v1/encode_test.go | 1410 --------
+ .../json/v1/example_marshaling_test.go        |   76 -
+ .../json/v1/example_test.go                   |  313 --
+ .../json/v1/example_text_marshaling_test.go   |   70 -
+ .../go-json-experiment/json/v1/fuzz_test.go   |   85 -
+ .../go-json-experiment/json/v1/indent.go      |  129 -
+ .../go-json-experiment/json/v1/inject.go      |  156 -
+ .../go-json-experiment/json/v1/options.go     |  546 ----
+ .../go-json-experiment/json/v1/scanner.go     |   86 -
+ .../json/v1/scanner_test.go                   |  307 --
+ .../go-json-experiment/json/v1/stream.go      |  242 --
+ .../go-json-experiment/json/v1/stream_test.go |  539 ----
+ .../go-json-experiment/json/v1/tagkey_test.go |  121 -
+ 72 files changed, 11019 deletions(-)
+ delete mode 100644 pkg/internal/third_party/go-json-experiment/json/alias.go
+ delete mode 100644 pkg/internal/third_party/go-json-experiment/json/jsontext/alias.go
+ delete mode 100644 pkg/internal/third_party/go-json-experiment/json/v1/alias.go
+ delete mode 100644 pkg/internal/third_party/go-json-experiment/json/v1/decode.go
+ delete mode 100644 pkg/internal/third_party/go-json-experiment/json/v1/decode_test.go
+ delete mode 100644 pkg/internal/third_party/go-json-experiment/json/v1/diff_test.go
+ delete mode 100644 pkg/internal/third_party/go-json-experiment/json/v1/encode.go
+ delete mode 100644 pkg/internal/third_party/go-json-experiment/json/v1/encode_test.go
+ delete mode 100644 pkg/internal/third_party/go-json-experiment/json/v1/example_marshaling_test.go
+ delete mode 100644 pkg/internal/third_party/go-json-experiment/json/v1/example_test.go
+ delete mode 100644 pkg/internal/third_party/go-json-experiment/json/v1/example_text_marshaling_test.go
+ delete mode 100644 pkg/internal/third_party/go-json-experiment/json/v1/fuzz_test.go
+ delete mode 100644 pkg/internal/third_party/go-json-experiment/json/v1/indent.go
+ delete mode 100644 pkg/internal/third_party/go-json-experiment/json/v1/inject.go
+ delete mode 100644 pkg/internal/third_party/go-json-experiment/json/v1/options.go
+ delete mode 100644 pkg/internal/third_party/go-json-experiment/json/v1/scanner.go
+ delete mode 100644 pkg/internal/third_party/go-json-experiment/json/v1/scanner_test.go
+ delete mode 100644 pkg/internal/third_party/go-json-experiment/json/v1/stream.go
+ delete mode 100644 pkg/internal/third_party/go-json-experiment/json/v1/stream_test.go
+ delete mode 100644 pkg/internal/third_party/go-json-experiment/json/v1/tagkey_test.go
+
+diff --git a/pkg/internal/third_party/go-json-experiment/json/alias.go b/pkg/internal/third_party/go-json-experiment/json/alias.go
+deleted file mode 100644
+index fbf256d52..000000000
+--- a/pkg/internal/third_party/go-json-experiment/json/alias.go
++++ /dev/null
+@@ -1,967 +0,0 @@
+-// Copyright 2025 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-// Code generated by alias_gen.go; DO NOT EDIT.
+-
+-//go:build goexperiment.jsonv2 && go1.25
+-
+-// Package json implements semantic processing of JSON as specified in RFC 8259.
+-// JSON is a simple data interchange format that can represent
+-// primitive data types such as booleans, strings, and numbers,
+-// in addition to structured data types such as objects and arrays.
+-//
+-// [Marshal] and [Unmarshal] encode and decode Go values
+-// to/from JSON text contained within a []byte.
+-// [MarshalWrite] and [UnmarshalRead] operate on JSON text
+-// by writing to or reading from an [io.Writer] or [io.Reader].
+-// [MarshalEncode] and [UnmarshalDecode] operate on JSON text
+-// by encoding to or decoding from a [jsontext.Encoder] or [jsontext.Decoder].
+-// [Options] may be passed to each of the marshal or unmarshal functions
+-// to configure the semantic behavior of marshaling and unmarshaling
+-// (i.e., alter how JSON data is understood as Go data and vice versa).
+-// [jsontext.Options] may also be passed to the marshal or unmarshal functions
+-// to configure the syntactic behavior of encoding or decoding.
+-//
+-// The data types of JSON are mapped to/from the data types of Go based on
+-// the closest logical equivalent between the two type systems. For example,
+-// a JSON boolean corresponds with a Go bool,
+-// a JSON string corresponds with a Go string,
+-// a JSON number corresponds with a Go int, uint or float,
+-// a JSON array corresponds with a Go slice or array, and
+-// a JSON object corresponds with a Go struct or map.
+-// See the documentation on [Marshal] and [Unmarshal] for a comprehensive list
+-// of how the JSON and Go type systems correspond.
+-//
+-// Arbitrary Go types can customize their JSON representation by implementing
+-// [Marshaler], [MarshalerTo], [Unmarshaler], or [UnmarshalerFrom].
+-// This provides authors of Go types with control over how their types are
+-// serialized as JSON. Alternatively, users can implement functions that match
+-// [MarshalFunc], [MarshalToFunc], [UnmarshalFunc], or [UnmarshalFromFunc]
+-// to specify the JSON representation for arbitrary types.
+-// This provides callers of JSON functionality with control over
+-// how any arbitrary type is serialized as JSON.
+-//
+-// # JSON Representation of Go structs
+-//
+-// A Go struct is naturally represented as a JSON object,
+-// where each Go struct field corresponds with a JSON object member.
+-// When marshaling, all Go struct fields are recursively encoded in depth-first
+-// order as JSON object members except those that are ignored or omitted.
+-// When unmarshaling, JSON object members are recursively decoded
+-// into the corresponding Go struct fields.
+-// Object members that do not match any struct fields,
+-// also known as “unknown members”, are ignored by default or rejected
+-// if [RejectUnknownMembers] is specified.
+-//
+-// The representation of each struct field can be customized in the
+-// "json" struct field tag, where the tag is a comma separated list of options.
+-// As a special case, if the entire tag is `json:"-"`,
+-// then the field is ignored with regard to its JSON representation.
+-// Some options also have equivalent behavior controlled by a caller-specified [Options].
+-// Field-specified options take precedence over caller-specified options.
+-//
+-// The first option is the JSON object name override for the Go struct field.
+-// If the name is not specified, then the Go struct field name
+-// is used as the JSON object name. JSON names containing commas or quotes,
+-// or names identical to "" or "-", can be specified using
+-// a single-quoted string literal, where the syntax is identical to
+-// the Go grammar for a double-quoted string literal,
+-// but instead uses single quotes as the delimiters.
+-// By default, unmarshaling uses case-sensitive matching to identify
+-// the Go struct field associated with a JSON object name.
+-//
+-// After the name, the following tag options are supported:
+-//
+-//   - omitzero: When marshaling, the "omitzero" option specifies that
+-//     the struct field should be omitted if the field value is zero
+-//     as determined by the "IsZero() bool" method if present,
+-//     otherwise based on whether the field is the zero Go value.
+-//     This option has no effect when unmarshaling.
+-//
+-//   - omitempty: When marshaling, the "omitempty" option specifies that
+-//     the struct field should be omitted if the field value would have been
+-//     encoded as a JSON null, empty string, empty object, or empty array.
+-//     This option has no effect when unmarshaling.
+-//
+-//   - string: The "string" option specifies that [StringifyNumbers]
+-//     be set when marshaling or unmarshaling a struct field value.
+-//     This causes numeric types to be encoded as a JSON number
+-//     within a JSON string, and to be decoded from a JSON string
+-//     containing the JSON number without any surrounding whitespace.
+-//     This extra level of encoding is often necessary since
+-//     many JSON parsers cannot precisely represent 64-bit integers.
+-//
+-//   - case: When unmarshaling, the "case" option specifies how
+-//     JSON object names are matched with the JSON name for Go struct fields.
+-//     The option is a key-value pair specified as "case:value" where
+-//     the value must either be 'ignore' or 'strict'.
+-//     The 'ignore' value specifies that matching is case-insensitive
+-//     where dashes and underscores are also ignored. If multiple fields match,
+-//     the first declared field in breadth-first order takes precedence.
+-//     The 'strict' value specifies that matching is case-sensitive.
+-//     This takes precedence over the [MatchCaseInsensitiveNames] option.
+-//
+-//   - inline: The "inline" option specifies that
+-//     the JSON representable content of this field type is to be promoted
+-//     as if they were specified in the parent struct.
+-//     It is the JSON equivalent of Go struct embedding.
+-//     A Go embedded field is implicitly inlined unless an explicit JSON name
+-//     is specified. The inlined field must be a Go struct
+-//     (that does not implement any JSON methods), [jsontext.Value],
+-//     map[~string]T, or an unnamed pointer to such types. When marshaling,
+-//     inlined fields from a pointer type are omitted if it is nil.
+-//     Inlined fields of type [jsontext.Value] and map[~string]T are called
+-//     “inlined fallbacks” as they can represent all possible
+-//     JSON object members not directly handled by the parent struct.
+-//     Only one inlined fallback field may be specified in a struct,
+-//     while many non-fallback fields may be specified. This option
+-//     must not be specified with any other option (including the JSON name).
+-//
+-//   - unknown: The "unknown" option is a specialized variant
+-//     of the inlined fallback to indicate that this Go struct field
+-//     contains any number of unknown JSON object members. The field type must
+-//     be a [jsontext.Value], map[~string]T, or an unnamed pointer to such types.
+-//     If [DiscardUnknownMembers] is specified when marshaling,
+-//     the contents of this field are ignored.
+-//     If [RejectUnknownMembers] is specified when unmarshaling,
+-//     any unknown object members are rejected regardless of whether
+-//     an inlined fallback with the "unknown" option exists. This option
+-//     must not be specified with any other option (including the JSON name).
+-//
+-//   - format: The "format" option specifies a format flag
+-//     used to specialize the formatting of the field value.
+-//     The option is a key-value pair specified as "format:value" where
+-//     the value must be either a literal consisting of letters and numbers
+-//     (e.g., "format:RFC3339") or a single-quoted string literal
+-//     (e.g., "format:'2006-01-02'"). The interpretation of the format flag
+-//     is determined by the struct field type.
+-//
+-// The "omitzero" and "omitempty" options are mostly semantically identical.
+-// The former is defined in terms of the Go type system,
+-// while the latter in terms of the JSON type system.
+-// Consequently they behave differently in some circumstances.
+-// For example, only a nil slice or map is omitted under "omitzero", while
+-// an empty slice or map is omitted under "omitempty" regardless of nilness.
+-// The "omitzero" option is useful for types with a well-defined zero value
+-// (e.g., [net/netip.Addr]) or have an IsZero method (e.g., [time.Time.IsZero]).
+-//
+-// Every Go struct corresponds to a list of JSON representable fields
+-// which is constructed by performing a breadth-first search over
+-// all struct fields (excluding unexported or ignored fields),
+-// where the search recursively descends into inlined structs.
+-// The set of non-inlined fields in a struct must have unique JSON names.
+-// If multiple fields all have the same JSON name, then the one
+-// at shallowest depth takes precedence and the other fields at deeper depths
+-// are excluded from the list of JSON representable fields.
+-// If multiple fields at the shallowest depth have the same JSON name,
+-// but exactly one is explicitly tagged with a JSON name,
+-// then that field takes precedence and all others are excluded from the list.
+-// This is analogous to Go visibility rules for struct field selection
+-// with embedded struct types.
+-//
+-// Marshaling or unmarshaling a non-empty struct
+-// without any JSON representable fields results in a [SemanticError].
+-// Unexported fields must not have any `json` tags except for `json:"-"`.
+-//
+-// # Security Considerations
+-//
+-// JSON is frequently used as a data interchange format to communicate
+-// between different systems, possibly implemented in different languages.
+-// For interoperability and security reasons, it is important that
+-// all implementations agree upon the semantic meaning of the data.
+-//
+-// [For example, suppose we have two micro-services.]
+-// The first service is responsible for authenticating a JSON request,
+-// while the second service is responsible for executing the request
+-// (having assumed that the prior service authenticated the request).
+-// If an attacker were able to maliciously craft a JSON request such that
+-// both services believe that the same request is from different users,
+-// it could bypass the authenticator with valid credentials for one user,
+-// but maliciously perform an action on behalf of a different user.
+-//
+-// According to RFC 8259, there unfortunately exist many JSON texts
+-// that are syntactically valid but semantically ambiguous.
+-// For example, the standard does not define how to interpret duplicate
+-// names within an object.
+-//
+-// The v1 [encoding/json] and [encoding/json/v2] packages
+-// interpret some inputs in different ways. In particular:
+-//
+-//   - The standard specifies that JSON must be encoded using UTF-8.
+-//     By default, v1 replaces invalid bytes of UTF-8 in JSON strings
+-//     with the Unicode replacement character,
+-//     while v2 rejects inputs with invalid UTF-8.
+-//     To change the default, specify the [jsontext.AllowInvalidUTF8] option.
+-//     The replacement of invalid UTF-8 is a form of data corruption
+-//     that alters the precise meaning of strings.
+-//
+-//   - The standard does not specify a particular behavior when
+-//     duplicate names are encountered within a JSON object,
+-//     which means that different implementations may behave differently.
+-//     By default, v1 allows for the presence of duplicate names,
+-//     while v2 rejects duplicate names.
+-//     To change the default, specify the [jsontext.AllowDuplicateNames] option.
+-//     If allowed, object members are processed in the order they are observed,
+-//     meaning that later values will replace or be merged into prior values,
+-//     depending on the Go value type.
+-//
+-//   - The standard defines a JSON object as an unordered collection of name/value pairs.
+-//     While ordering can be observed through the underlying [jsontext] API,
+-//     both v1 and v2 generally avoid exposing the ordering.
+-//     No application should semantically depend on the order of object members.
+-//     Allowing duplicate names is a vector through which ordering of members
+-//     can accidentally be observed and depended upon.
+-//
+-//   - The standard suggests that JSON object names are typically compared
+-//     based on equality of the sequence of Unicode code points,
+-//     which implies that comparing names is often case-sensitive.
+-//     When unmarshaling a JSON object into a Go struct,
+-//     by default, v1 uses a (loose) case-insensitive match on the name,
+-//     while v2 uses a (strict) case-sensitive match on the name.
+-//     To change the default, specify the [MatchCaseInsensitiveNames] option.
+-//     The use of case-insensitive matching provides another vector through
+-//     which duplicate names can occur. Allowing case-insensitive matching
+-//     means that v1 or v2 might interpret JSON objects differently from most
+-//     other JSON implementations (which typically use a case-sensitive match).
+-//
+-//   - The standard does not specify a particular behavior when
+-//     an unknown name in a JSON object is encountered.
+-//     When unmarshaling a JSON object into a Go struct, by default
+-//     both v1 and v2 ignore unknown names and their corresponding values.
+-//     To change the default, specify the [RejectUnknownMembers] option.
+-//
+-//   - The standard suggests that implementations may use a float64
+-//     to represent a JSON number. Consequently, large JSON integers
+-//     may lose precision when stored as a floating-point type.
+-//     Both v1 and v2 correctly preserve precision when marshaling and
+-//     unmarshaling a concrete integer type. However, even if v1 and v2
+-//     preserve precision for concrete types, other JSON implementations
+-//     may not be able to preserve precision for outputs produced by v1 or v2.
+-//     The `string` tag option can be used to specify that an integer type
+-//     is to be quoted within a JSON string to avoid loss of precision.
+-//     Furthermore, v1 and v2 may still lose precision when unmarshaling
+-//     into an any interface value, where unmarshal uses a float64
+-//     by default to represent a JSON number.
+-//     To change the default, specify the [WithUnmarshalers] option
+-//     with a custom unmarshaler that pre-populates the interface value
+-//     with a concrete Go type that can preserve precision.
+-//
+-// RFC 8785 specifies a canonical form for any JSON text,
+-// which explicitly defines specific behaviors that RFC 8259 leaves undefined.
+-// In theory, if a text can successfully [jsontext.Value.Canonicalize]
+-// without changing the semantic meaning of the data, then it provides a
+-// greater degree of confidence that the data is more secure and interoperable.
+-//
+-// The v2 API generally chooses more secure defaults than v1,
+-// but care should still be taken with large integers or unknown members.
+-//
+-// [For example, suppose we have two micro-services.]: https://www.youtube.com/watch?v=avilmOcHKHE&t=1057s
+-package json
+-
+-import (
+-	"encoding/json/jsontext"
+-	"encoding/json/v2"
+-	"io"
+-)
+-
+-// Marshal serializes a Go value as a []byte according to the provided
+-// marshal and encode options (while ignoring unmarshal or decode options).
+-// It does not terminate the output with a newline.
+-//
+-// Type-specific marshal functions and methods take precedence
+-// over the default representation of a value.
+-// Functions or methods that operate on *T are only called when encoding
+-// a value of type T (by taking its address) or a non-nil value of *T.
+-// Marshal ensures that a value is always addressable
+-// (by boxing it on the heap if necessary) so that
+-// these functions and methods can be consistently called. For performance,
+-// it is recommended that Marshal be passed a non-nil pointer to the value.
+-//
+-// The input value is encoded as JSON according the following rules:
+-//
+-//   - If any type-specific functions in a [WithMarshalers] option match
+-//     the value type, then those functions are called to encode the value.
+-//     If all applicable functions return [SkipFunc],
+-//     then the value is encoded according to subsequent rules.
+-//
+-//   - If the value type implements [MarshalerTo],
+-//     then the MarshalJSONTo method is called to encode the value.
+-//
+-//   - If the value type implements [Marshaler],
+-//     then the MarshalJSON method is called to encode the value.
+-//
+-//   - If the value type implements [encoding.TextAppender],
+-//     then the AppendText method is called to encode the value and
+-//     subsequently encode its result as a JSON string.
+-//
+-//   - If the value type implements [encoding.TextMarshaler],
+-//     then the MarshalText method is called to encode the value and
+-//     subsequently encode its result as a JSON string.
+-//
+-//   - Otherwise, the value is encoded according to the value's type
+-//     as described in detail below.
+-//
+-// Most Go types have a default JSON representation.
+-// Certain types support specialized formatting according to
+-// a format flag optionally specified in the Go struct tag
+-// for the struct field that contains the current value
+-// (see the “JSON Representation of Go structs” section for more details).
+-//
+-// The representation of each type is as follows:
+-//
+-//   - A Go boolean is encoded as a JSON boolean (e.g., true or false).
+-//     It does not support any custom format flags.
+-//
+-//   - A Go string is encoded as a JSON string.
+-//     It does not support any custom format flags.
+-//
+-//   - A Go []byte or [N]byte is encoded as a JSON string containing
+-//     the binary value encoded using RFC 4648.
+-//     If the format is "base64" or unspecified, then this uses RFC 4648, section 4.
+-//     If the format is "base64url", then this uses RFC 4648, section 5.
+-//     If the format is "base32", then this uses RFC 4648, section 6.
+-//     If the format is "base32hex", then this uses RFC 4648, section 7.
+-//     If the format is "base16" or "hex", then this uses RFC 4648, section 8.
+-//     If the format is "array", then the bytes value is encoded as a JSON array
+-//     where each byte is recursively JSON-encoded as each JSON array element.
+-//
+-//   - A Go integer is encoded as a JSON number without fractions or exponents.
+-//     If [StringifyNumbers] is specified or encoding a JSON object name,
+-//     then the JSON number is encoded within a JSON string.
+-//     It does not support any custom format flags.
+-//
+-//   - A Go float is encoded as a JSON number.
+-//     If [StringifyNumbers] is specified or encoding a JSON object name,
+-//     then the JSON number is encoded within a JSON string.
+-//     If the format is "nonfinite", then NaN, +Inf, and -Inf are encoded as
+-//     the JSON strings "NaN", "Infinity", and "-Infinity", respectively.
+-//     Otherwise, the presence of non-finite numbers results in a [SemanticError].
+-//
+-//   - A Go map is encoded as a JSON object, where each Go map key and value
+-//     is recursively encoded as a name and value pair in the JSON object.
+-//     The Go map key must encode as a JSON string, otherwise this results
+-//     in a [SemanticError]. The Go map is traversed in a non-deterministic order.
+-//     For deterministic encoding, consider using the [Deterministic] option.
+-//     If the format is "emitnull", then a nil map is encoded as a JSON null.
+-//     If the format is "emitempty", then a nil map is encoded as an empty JSON object,
+-//     regardless of whether [FormatNilMapAsNull] is specified.
+-//     Otherwise by default, a nil map is encoded as an empty JSON object.
+-//
+-//   - A Go struct is encoded as a JSON object.
+-//     See the “JSON Representation of Go structs” section
+-//     in the package-level documentation for more details.
+-//
+-//   - A Go slice is encoded as a JSON array, where each Go slice element
+-//     is recursively JSON-encoded as the elements of the JSON array.
+-//     If the format is "emitnull", then a nil slice is encoded as a JSON null.
+-//     If the format is "emitempty", then a nil slice is encoded as an empty JSON array,
+-//     regardless of whether [FormatNilSliceAsNull] is specified.
+-//     Otherwise by default, a nil slice is encoded as an empty JSON array.
+-//
+-//   - A Go array is encoded as a JSON array, where each Go array element
+-//     is recursively JSON-encoded as the elements of the JSON array.
+-//     The JSON array length is always identical to the Go array length.
+-//     It does not support any custom format flags.
+-//
+-//   - A Go pointer is encoded as a JSON null if nil, otherwise it is
+-//     the recursively JSON-encoded representation of the underlying value.
+-//     Format flags are forwarded to the encoding of the underlying value.
+-//
+-//   - A Go interface is encoded as a JSON null if nil, otherwise it is
+-//     the recursively JSON-encoded representation of the underlying value.
+-//     It does not support any custom format flags.
+-//
+-//   - A Go [time.Time] is encoded as a JSON string containing the timestamp
+-//     formatted in RFC 3339 with nanosecond precision.
+-//     If the format matches one of the format constants declared
+-//     in the time package (e.g., RFC1123), then that format is used.
+-//     If the format is "unix", "unixmilli", "unixmicro", or "unixnano",
+-//     then the timestamp is encoded as a possibly fractional JSON number
+-//     of the number of seconds (or milliseconds, microseconds, or nanoseconds)
+-//     since the Unix epoch, which is January 1st, 1970 at 00:00:00 UTC.
+-//     To avoid a fractional component, round the timestamp to the relevant unit.
+-//     Otherwise, the format is used as-is with [time.Time.Format] if non-empty.
+-//
+-//   - A Go [time.Duration] currently has no default representation and
+-//     requires an explicit format to be specified.
+-//     If the format is "sec", "milli", "micro", or "nano",
+-//     then the duration is encoded as a possibly fractional JSON number
+-//     of the number of seconds (or milliseconds, microseconds, or nanoseconds).
+-//     To avoid a fractional component, round the duration to the relevant unit.
+-//     If the format is "units", it is encoded as a JSON string formatted using
+-//     [time.Duration.String] (e.g., "1h30m" for 1 hour 30 minutes).
+-//     If the format is "iso8601", it is encoded as a JSON string using the
+-//     ISO 8601 standard for durations (e.g., "PT1H30M" for 1 hour 30 minutes)
+-//     using only accurate units of hours, minutes, and seconds.
+-//
+-//   - All other Go types (e.g., complex numbers, channels, and functions)
+-//     have no default representation and result in a [SemanticError].
+-//
+-// JSON cannot represent cyclic data structures and Marshal does not handle them.
+-// Passing cyclic structures will result in an error.
+-func Marshal(in any, opts ...Options) (out []byte, err error) {
+-	return json.Marshal(in, opts...)
+-}
+-
+-// MarshalWrite serializes a Go value into an [io.Writer] according to the provided
+-// marshal and encode options (while ignoring unmarshal or decode options).
+-// It does not terminate the output with a newline.
+-// See [Marshal] for details about the conversion of a Go value into JSON.
+-func MarshalWrite(out io.Writer, in any, opts ...Options) (err error) {
+-	return json.MarshalWrite(out, in, opts...)
+-}
+-
+-// MarshalEncode serializes a Go value into an [jsontext.Encoder] according to
+-// the provided marshal options (while ignoring unmarshal, encode, or decode options).
+-// Any marshal-relevant options already specified on the [jsontext.Encoder]
+-// take lower precedence than the set of options provided by the caller.
+-// Unlike [Marshal] and [MarshalWrite], encode options are ignored because
+-// they must have already been specified on the provided [jsontext.Encoder].
+-//
+-// See [Marshal] for details about the conversion of a Go value into JSON.
+-func MarshalEncode(out *jsontext.Encoder, in any, opts ...Options) (err error) {
+-	return json.MarshalEncode(out, in, opts...)
+-}
+-
+-// Unmarshal decodes a []byte input into a Go value according to the provided
+-// unmarshal and decode options (while ignoring marshal or encode options).
+-// The input must be a single JSON value with optional whitespace interspersed.
+-// The output must be a non-nil pointer.
+-//
+-// Type-specific unmarshal functions and methods take precedence
+-// over the default representation of a value.
+-// Functions or methods that operate on *T are only called when decoding
+-// a value of type T (by taking its address) or a non-nil value of *T.
+-// Unmarshal ensures that a value is always addressable
+-// (by boxing it on the heap if necessary) so that
+-// these functions and methods can be consistently called.
+-//
+-// The input is decoded into the output according the following rules:
+-//
+-//   - If any type-specific functions in a [WithUnmarshalers] option match
+-//     the value type, then those functions are called to decode the JSON
+-//     value. If all applicable functions return [SkipFunc],
+-//     then the input is decoded according to subsequent rules.
+-//
+-//   - If the value type implements [UnmarshalerFrom],
+-//     then the UnmarshalJSONFrom method is called to decode the JSON value.
+-//
+-//   - If the value type implements [Unmarshaler],
+-//     then the UnmarshalJSON method is called to decode the JSON value.
+-//
+-//   - If the value type implements [encoding.TextUnmarshaler],
+-//     then the input is decoded as a JSON string and
+-//     the UnmarshalText method is called with the decoded string value.
+-//     This fails with a [SemanticError] if the input is not a JSON string.
+-//
+-//   - Otherwise, the JSON value is decoded according to the value's type
+-//     as described in detail below.
+-//
+-// Most Go types have a default JSON representation.
+-// Certain types support specialized formatting according to
+-// a format flag optionally specified in the Go struct tag
+-// for the struct field that contains the current value
+-// (see the “JSON Representation of Go structs” section for more details).
+-// A JSON null may be decoded into every supported Go value where
+-// it is equivalent to storing the zero value of the Go value.
+-// If the input JSON kind is not handled by the current Go value type,
+-// then this fails with a [SemanticError]. Unless otherwise specified,
+-// the decoded value replaces any pre-existing value.
+-//
+-// The representation of each type is as follows:
+-//
+-//   - A Go boolean is decoded from a JSON boolean (e.g., true or false).
+-//     It does not support any custom format flags.
+-//
+-//   - A Go string is decoded from a JSON string.
+-//     It does not support any custom format flags.
+-//
+-//   - A Go []byte or [N]byte is decoded from a JSON string
+-//     containing the binary value encoded using RFC 4648.
+-//     If the format is "base64" or unspecified, then this uses RFC 4648, section 4.
+-//     If the format is "base64url", then this uses RFC 4648, section 5.
+-//     If the format is "base32", then this uses RFC 4648, section 6.
+-//     If the format is "base32hex", then this uses RFC 4648, section 7.
+-//     If the format is "base16" or "hex", then this uses RFC 4648, section 8.
+-//     If the format is "array", then the Go slice or array is decoded from a
+-//     JSON array where each JSON element is recursively decoded for each byte.
+-//     When decoding into a non-nil []byte, the slice length is reset to zero
+-//     and the decoded input is appended to it.
+-//     When decoding into a [N]byte, the input must decode to exactly N bytes,
+-//     otherwise it fails with a [SemanticError].
+-//
+-//   - A Go integer is decoded from a JSON number.
+-//     It must be decoded from a JSON string containing a JSON number
+-//     if [StringifyNumbers] is specified or decoding a JSON object name.
+-//     It fails with a [SemanticError] if the JSON number
+-//     has a fractional or exponent component.
+-//     It also fails if it overflows the representation of the Go integer type.
+-//     It does not support any custom format flags.
+-//
+-//   - A Go float is decoded from a JSON number.
+-//     It must be decoded from a JSON string containing a JSON number
+-//     if [StringifyNumbers] is specified or decoding a JSON object name.
+-//     It fails if it overflows the representation of the Go float type.
+-//     If the format is "nonfinite", then the JSON strings
+-//     "NaN", "Infinity", and "-Infinity" are decoded as NaN, +Inf, and -Inf.
+-//     Otherwise, the presence of such strings results in a [SemanticError].
+-//
+-//   - A Go map is decoded from a JSON object,
+-//     where each JSON object name and value pair is recursively decoded
+-//     as the Go map key and value. Maps are not cleared.
+-//     If the Go map is nil, then a new map is allocated to decode into.
+-//     If the decoded key matches an existing Go map entry, the entry value
+-//     is reused by decoding the JSON object value into it.
+-//     The formats "emitnull" and "emitempty" have no effect when decoding.
+-//
+-//   - A Go struct is decoded from a JSON object.
+-//     See the “JSON Representation of Go structs” section
+-//     in the package-level documentation for more details.
+-//
+-//   - A Go slice is decoded from a JSON array, where each JSON element
+-//     is recursively decoded and appended to the Go slice.
+-//     Before appending into a Go slice, a new slice is allocated if it is nil,
+-//     otherwise the slice length is reset to zero.
+-//     The formats "emitnull" and "emitempty" have no effect when decoding.
+-//
+-//   - A Go array is decoded from a JSON array, where each JSON array element
+-//     is recursively decoded as each corresponding Go array element.
+-//     Each Go array element is zeroed before decoding into it.
+-//     It fails with a [SemanticError] if the JSON array does not contain
+-//     the exact same number of elements as the Go array.
+-//     It does not support any custom format flags.
+-//
+-//   - A Go pointer is decoded based on the JSON kind and underlying Go type.
+-//     If the input is a JSON null, then this stores a nil pointer.
+-//     Otherwise, it allocates a new underlying value if the pointer is nil,
+-//     and recursively JSON decodes into the underlying value.
+-//     Format flags are forwarded to the decoding of the underlying type.
+-//
+-//   - A Go interface is decoded based on the JSON kind and underlying Go type.
+-//     If the input is a JSON null, then this stores a nil interface value.
+-//     Otherwise, a nil interface value of an empty interface type is initialized
+-//     with a zero Go bool, string, float64, map[string]any, or []any if the
+-//     input is a JSON boolean, string, number, object, or array, respectively.
+-//     If the interface value is still nil, then this fails with a [SemanticError]
+-//     since decoding could not determine an appropriate Go type to decode into.
+-//     For example, unmarshaling into a nil io.Reader fails since
+-//     there is no concrete type to populate the interface value with.
+-//     Otherwise an underlying value exists and it recursively decodes
+-//     the JSON input into it. It does not support any custom format flags.
+-//
+-//   - A Go [time.Time] is decoded from a JSON string containing the time
+-//     formatted in RFC 3339 with nanosecond precision.
+-//     If the format matches one of the format constants declared in
+-//     the time package (e.g., RFC1123), then that format is used for parsing.
+-//     If the format is "unix", "unixmilli", "unixmicro", or "unixnano",
+-//     then the timestamp is decoded from an optionally fractional JSON number
+-//     of the number of seconds (or milliseconds, microseconds, or nanoseconds)
+-//     since the Unix epoch, which is January 1st, 1970 at 00:00:00 UTC.
+-//     Otherwise, the format is used as-is with [time.Time.Parse] if non-empty.
+-//
+-//   - A Go [time.Duration] currently has no default representation and
+-//     requires an explicit format to be specified.
+-//     If the format is "sec", "milli", "micro", or "nano",
+-//     then the duration is decoded from an optionally fractional JSON number
+-//     of the number of seconds (or milliseconds, microseconds, or nanoseconds).
+-//     If the format is "units", it is decoded from a JSON string parsed using
+-//     [time.ParseDuration] (e.g., "1h30m" for 1 hour 30 minutes).
+-//     If the format is "iso8601", it is decoded from a JSON string using the
+-//     ISO 8601 standard for durations (e.g., "PT1H30M" for 1 hour 30 minutes)
+-//     accepting only accurate units of hours, minutes, or seconds.
+-//
+-//   - All other Go types (e.g., complex numbers, channels, and functions)
+-//     have no default representation and result in a [SemanticError].
+-//
+-// In general, unmarshaling follows merge semantics (similar to RFC 7396)
+-// where the decoded Go value replaces the destination value
+-// for any JSON kind other than an object.
+-// For JSON objects, the input object is merged into the destination value
+-// where matching object members recursively apply merge semantics.
+-func Unmarshal(in []byte, out any, opts ...Options) (err error) {
+-	return json.Unmarshal(in, out, opts...)
+-}
+-
+-// UnmarshalRead deserializes a Go value from an [io.Reader] according to the
+-// provided unmarshal and decode options (while ignoring marshal or encode options).
+-// The input must be a single JSON value with optional whitespace interspersed.
+-// It consumes the entirety of [io.Reader] until [io.EOF] is encountered,
+-// without reporting an error for EOF. The output must be a non-nil pointer.
+-// See [Unmarshal] for details about the conversion of JSON into a Go value.
+-func UnmarshalRead(in io.Reader, out any, opts ...Options) (err error) {
+-	return json.UnmarshalRead(in, out, opts...)
+-}
+-
+-// UnmarshalDecode deserializes a Go value from a [jsontext.Decoder] according to
+-// the provided unmarshal options (while ignoring marshal, encode, or decode options).
+-// Any unmarshal options already specified on the [jsontext.Decoder]
+-// take lower precedence than the set of options provided by the caller.
+-// Unlike [Unmarshal] and [UnmarshalRead], decode options are ignored because
+-// they must have already been specified on the provided [jsontext.Decoder].
+-//
+-// The input may be a stream of one or more JSON values,
+-// where this only unmarshals the next JSON value in the stream.
+-// The output must be a non-nil pointer.
+-// See [Unmarshal] for details about the conversion of JSON into a Go value.
+-func UnmarshalDecode(in *jsontext.Decoder, out any, opts ...Options) (err error) {
+-	return json.UnmarshalDecode(in, out, opts...)
+-}
+-
+-// Marshalers is a list of functions that may override the marshal behavior
+-// of specific types. Populate [WithMarshalers] to use it with
+-// [Marshal], [MarshalWrite], or [MarshalEncode].
+-// A nil *Marshalers is equivalent to an empty list.
+-// There are no exported fields or methods on Marshalers.
+-type Marshalers = json.Marshalers
+-
+-// JoinMarshalers constructs a flattened list of marshal functions.
+-// If multiple functions in the list are applicable for a value of a given type,
+-// then those earlier in the list take precedence over those that come later.
+-// If a function returns [SkipFunc], then the next applicable function is called,
+-// otherwise the default marshaling behavior is used.
+-//
+-// For example:
+-//
+-//	m1 := JoinMarshalers(f1, f2)
+-//	m2 := JoinMarshalers(f0, m1, f3)     // equivalent to m3
+-//	m3 := JoinMarshalers(f0, f1, f2, f3) // equivalent to m2
+-func JoinMarshalers(ms ...*Marshalers) *Marshalers {
+-	return json.JoinMarshalers(ms...)
+-}
+-
+-// Unmarshalers is a list of functions that may override the unmarshal behavior
+-// of specific types. Populate [WithUnmarshalers] to use it with
+-// [Unmarshal], [UnmarshalRead], or [UnmarshalDecode].
+-// A nil *Unmarshalers is equivalent to an empty list.
+-// There are no exported fields or methods on Unmarshalers.
+-type Unmarshalers = json.Unmarshalers
+-
+-// JoinUnmarshalers constructs a flattened list of unmarshal functions.
+-// If multiple functions in the list are applicable for a value of a given type,
+-// then those earlier in the list take precedence over those that come later.
+-// If a function returns [SkipFunc], then the next applicable function is called,
+-// otherwise the default unmarshaling behavior is used.
+-//
+-// For example:
+-//
+-//	u1 := JoinUnmarshalers(f1, f2)
+-//	u2 := JoinUnmarshalers(f0, u1, f3)     // equivalent to u3
+-//	u3 := JoinUnmarshalers(f0, f1, f2, f3) // equivalent to u2
+-func JoinUnmarshalers(us ...*Unmarshalers) *Unmarshalers {
+-	return json.JoinUnmarshalers(us...)
+-}
+-
+-// MarshalFunc constructs a type-specific marshaler that
+-// specifies how to marshal values of type T.
+-// T can be any type except a named pointer.
+-// The function is always provided with a non-nil pointer value
+-// if T is an interface or pointer type.
+-//
+-// The function must marshal exactly one JSON value.
+-// The value of T must not be retained outside the function call.
+-// It may not return [SkipFunc].
+-func MarshalFunc[T any](fn func(T) ([]byte, error)) *Marshalers {
+-	return json.MarshalFunc[T](fn)
+-}
+-
+-// MarshalToFunc constructs a type-specific marshaler that
+-// specifies how to marshal values of type T.
+-// T can be any type except a named pointer.
+-// The function is always provided with a non-nil pointer value
+-// if T is an interface or pointer type.
+-//
+-// The function must marshal exactly one JSON value by calling write methods
+-// on the provided encoder. It may return [SkipFunc] such that marshaling can
+-// move on to the next marshal function. However, no mutable method calls may
+-// be called on the encoder if [SkipFunc] is returned.
+-// The pointer to [jsontext.Encoder] and the value of T
+-// must not be retained outside the function call.
+-func MarshalToFunc[T any](fn func(*jsontext.Encoder, T) error) *Marshalers {
+-	return json.MarshalToFunc[T](fn)
+-}
+-
+-// UnmarshalFunc constructs a type-specific unmarshaler that
+-// specifies how to unmarshal values of type T.
+-// T must be an unnamed pointer or an interface type.
+-// The function is always provided with a non-nil pointer value.
+-//
+-// The function must unmarshal exactly one JSON value.
+-// The input []byte must not be mutated.
+-// The input []byte and value T must not be retained outside the function call.
+-// It may not return [SkipFunc].
+-func UnmarshalFunc[T any](fn func([]byte, T) error) *Unmarshalers {
+-	return json.UnmarshalFunc[T](fn)
+-}
+-
+-// UnmarshalFromFunc constructs a type-specific unmarshaler that
+-// specifies how to unmarshal values of type T.
+-// T must be an unnamed pointer or an interface type.
+-// The function is always provided with a non-nil pointer value.
+-//
+-// The function must unmarshal exactly one JSON value by calling read methods
+-// on the provided decoder. It may return [SkipFunc] such that unmarshaling can
+-// move on to the next unmarshal function. However, no mutable method calls may
+-// be called on the decoder if [SkipFunc] is returned.
+-// The pointer to [jsontext.Decoder] and the value of T
+-// must not be retained outside the function call.
+-func UnmarshalFromFunc[T any](fn func(*jsontext.Decoder, T) error) *Unmarshalers {
+-	return json.UnmarshalFromFunc[T](fn)
+-}
+-
+-// Marshaler is implemented by types that can marshal themselves.
+-// It is recommended that types implement [MarshalerTo] unless the implementation
+-// is trying to avoid a hard dependency on the "jsontext" package.
+-//
+-// It is recommended that implementations return a buffer that is safe
+-// for the caller to retain and potentially mutate.
+-type Marshaler = json.Marshaler
+-
+-// MarshalerTo is implemented by types that can marshal themselves.
+-// It is recommended that types implement MarshalerTo instead of [Marshaler]
+-// since this is both more performant and flexible.
+-// If a type implements both Marshaler and MarshalerTo,
+-// then MarshalerTo takes precedence. In such a case, both implementations
+-// should aim to have equivalent behavior for the default marshal options.
+-//
+-// The implementation must write only one JSON value to the Encoder and
+-// must not retain the pointer to [jsontext.Encoder].
+-type MarshalerTo = json.MarshalerTo
+-
+-// Unmarshaler is implemented by types that can unmarshal themselves.
+-// It is recommended that types implement [UnmarshalerFrom] unless the implementation
+-// is trying to avoid a hard dependency on the "jsontext" package.
+-//
+-// The input can be assumed to be a valid encoding of a JSON value
+-// if called from unmarshal functionality in this package.
+-// UnmarshalJSON must copy the JSON data if it is retained after returning.
+-// It is recommended that UnmarshalJSON implement merge semantics when
+-// unmarshaling into a pre-populated value.
+-//
+-// Implementations must not retain or mutate the input []byte.
+-type Unmarshaler = json.Unmarshaler
+-
+-// UnmarshalerFrom is implemented by types that can unmarshal themselves.
+-// It is recommended that types implement UnmarshalerFrom instead of [Unmarshaler]
+-// since this is both more performant and flexible.
+-// If a type implements both Unmarshaler and UnmarshalerFrom,
+-// then UnmarshalerFrom takes precedence. In such a case, both implementations
+-// should aim to have equivalent behavior for the default unmarshal options.
+-//
+-// The implementation must read only one JSON value from the Decoder.
+-// It is recommended that UnmarshalJSONFrom implement merge semantics when
+-// unmarshaling into a pre-populated value.
+-//
+-// Implementations must not retain the pointer to [jsontext.Decoder].
+-type UnmarshalerFrom = json.UnmarshalerFrom
+-
+-// ErrUnknownName indicates that a JSON object member could not be
+-// unmarshaled because the name is not known to the target Go struct.
+-// This error is directly wrapped within a [SemanticError] when produced.
+-//
+-// The name of an unknown JSON object member can be extracted as:
+-//
+-//	err := ...
+-//	var serr json.SemanticError
+-//	if errors.As(err, &serr) && serr.Err == json.ErrUnknownName {
+-//		ptr := serr.JSONPointer // JSON pointer to unknown name
+-//		name := ptr.LastToken() // unknown name itself
+-//		...
+-//	}
+-//
+-// This error is only returned if [RejectUnknownMembers] is true.
+-var ErrUnknownName = json.ErrUnknownName
+-
+-// SemanticError describes an error determining the meaning
+-// of JSON data as Go data or vice-versa.
+-//
+-// The contents of this error as produced by this package may change over time.
+-type SemanticError = json.SemanticError
+-
+-// Options configure [Marshal], [MarshalWrite], [MarshalEncode],
+-// [Unmarshal], [UnmarshalRead], and [UnmarshalDecode] with specific features.
+-// Each function takes in a variadic list of options, where properties
+-// set in later options override the value of previously set properties.
+-//
+-// The Options type is identical to [encoding/json.Options] and
+-// [encoding/json/jsontext.Options]. Options from the other packages can
+-// be used interchangeably with functionality in this package.
+-//
+-// Options represent either a singular option or a set of options.
+-// It can be functionally thought of as a Go map of option properties
+-// (even though the underlying implementation avoids Go maps for performance).
+-//
+-// The constructors (e.g., [Deterministic]) return a singular option value:
+-//
+-//	opt := Deterministic(true)
+-//
+-// which is analogous to creating a single entry map:
+-//
+-//	opt := Options{"Deterministic": true}
+-//
+-// [JoinOptions] composes multiple options values to together:
+-//
+-//	out := JoinOptions(opts...)
+-//
+-// which is analogous to making a new map and copying the options over:
+-//
+-//	out := make(Options)
+-//	for _, m := range opts {
+-//		for k, v := range m {
+-//			out[k] = v
+-//		}
+-//	}
+-//
+-// [GetOption] looks up the value of options parameter:
+-//
+-//	v, ok := GetOption(opts, Deterministic)
+-//
+-// which is analogous to a Go map lookup:
+-//
+-//	v, ok := Options["Deterministic"]
+-//
+-// There is a single Options type, which is used with both marshal and unmarshal.
+-// Some options affect both operations, while others only affect one operation:
+-//
+-//   - [StringifyNumbers] affects marshaling and unmarshaling
+-//   - [Deterministic] affects marshaling only
+-//   - [FormatNilSliceAsNull] affects marshaling only
+-//   - [FormatNilMapAsNull] affects marshaling only
+-//   - [OmitZeroStructFields] affects marshaling only
+-//   - [MatchCaseInsensitiveNames] affects marshaling and unmarshaling
+-//   - [DiscardUnknownMembers] affects marshaling only
+-//   - [RejectUnknownMembers] affects unmarshaling only
+-//   - [WithMarshalers] affects marshaling only
+-//   - [WithUnmarshalers] affects unmarshaling only
+-//
+-// Options that do not affect a particular operation are ignored.
+-type Options = json.Options
+-
+-// JoinOptions coalesces the provided list of options into a single Options.
+-// Properties set in later options override the value of previously set properties.
+-func JoinOptions(srcs ...Options) Options {
+-	return json.JoinOptions(srcs...)
+-}
+-
+-// GetOption returns the value stored in opts with the provided setter,
+-// reporting whether the value is present.
+-//
+-// Example usage:
+-//
+-//	v, ok := json.GetOption(opts, json.Deterministic)
+-//
+-// Options are most commonly introspected to alter the JSON representation of
+-// [MarshalerTo.MarshalJSONTo] and [UnmarshalerFrom.UnmarshalJSONFrom] methods, and
+-// [MarshalToFunc] and [UnmarshalFromFunc] functions.
+-// In such cases, the presence bit should generally be ignored.
+-func GetOption[T any](opts Options, setter func(T) Options) (T, bool) {
+-	return json.GetOption[T](opts, setter)
+-}
+-
+-// DefaultOptionsV2 is the full set of all options that define v2 semantics.
+-// It is equivalent to all options under [Options], [encoding/json.Options],
+-// and [encoding/json/jsontext.Options] being set to false or the zero value,
+-// except for the options related to whitespace formatting.
+-func DefaultOptionsV2() Options {
+-	return json.DefaultOptionsV2()
+-}
+-
+-// StringifyNumbers specifies that numeric Go types should be marshaled
+-// as a JSON string containing the equivalent JSON number value.
+-// When unmarshaling, numeric Go types are parsed from a JSON string
+-// containing the JSON number without any surrounding whitespace.
+-//
+-// According to RFC 8259, section 6, a JSON implementation may choose to
+-// limit the representation of a JSON number to an IEEE 754 binary64 value.
+-// This may cause decoders to lose precision for int64 and uint64 types.
+-// Quoting JSON numbers as a JSON string preserves the exact precision.
+-//
+-// This affects either marshaling or unmarshaling.
+-func StringifyNumbers(v bool) Options {
+-	return json.StringifyNumbers(v)
+-}
+-
+-// Deterministic specifies that the same input value will be serialized
+-// as the exact same output bytes. Different processes of
+-// the same program will serialize equal values to the same bytes,
+-// but different versions of the same program are not guaranteed
+-// to produce the exact same sequence of bytes.
+-//
+-// This only affects marshaling and is ignored when unmarshaling.
+-func Deterministic(v bool) Options {
+-	return json.Deterministic(v)
+-}
+-
+-// FormatNilSliceAsNull specifies that a nil Go slice should marshal as a
+-// JSON null instead of the default representation as an empty JSON array
+-// (or an empty JSON string in the case of ~[]byte).
+-// Slice fields explicitly marked with `format:emitempty` still marshal
+-// as an empty JSON array.
+-//
+-// This only affects marshaling and is ignored when unmarshaling.
+-func FormatNilSliceAsNull(v bool) Options {
+-	return json.FormatNilSliceAsNull(v)
+-}
+-
+-// FormatNilMapAsNull specifies that a nil Go map should marshal as a
+-// JSON null instead of the default representation as an empty JSON object.
+-// Map fields explicitly marked with `format:emitempty` still marshal
+-// as an empty JSON object.
+-//
+-// This only affects marshaling and is ignored when unmarshaling.
+-func FormatNilMapAsNull(v bool) Options {
+-	return json.FormatNilMapAsNull(v)
+-}
+-
+-// OmitZeroStructFields specifies that a Go struct should marshal in such a way
+-// that all struct fields that are zero are omitted from the marshaled output
+-// if the value is zero as determined by the "IsZero() bool" method if present,
+-// otherwise based on whether the field is the zero Go value.
+-// This is semantically equivalent to specifying the `omitzero` tag option
+-// on every field in a Go struct.
+-//
+-// This only affects marshaling and is ignored when unmarshaling.
+-func OmitZeroStructFields(v bool) Options {
+-	return json.OmitZeroStructFields(v)
+-}
+-
+-// MatchCaseInsensitiveNames specifies that JSON object members are matched
+-// against Go struct fields using a case-insensitive match of the name.
+-// Go struct fields explicitly marked with `case:strict` or `case:ignore`
+-// always use case-sensitive (or case-insensitive) name matching,
+-// regardless of the value of this option.
+-//
+-// This affects either marshaling or unmarshaling.
+-// For marshaling, this option may alter the detection of duplicate names
+-// (assuming [jsontext.AllowDuplicateNames] is false) from inlined fields
+-// if it matches one of the declared fields in the Go struct.
+-func MatchCaseInsensitiveNames(v bool) Options {
+-	return json.MatchCaseInsensitiveNames(v)
+-}
+-
+-// RejectUnknownMembers specifies that unknown members should be rejected
+-// when unmarshaling a JSON object, regardless of whether there is a field
+-// to store unknown members.
+-//
+-// This only affects unmarshaling and is ignored when marshaling.
+-func RejectUnknownMembers(v bool) Options {
+-	return json.RejectUnknownMembers(v)
+-}
+-
+-// WithMarshalers specifies a list of type-specific marshalers to use,
+-// which can be used to override the default marshal behavior for values
+-// of particular types.
+-//
+-// This only affects marshaling and is ignored when unmarshaling.
+-func WithMarshalers(v *Marshalers) Options {
+-	return json.WithMarshalers(v)
+-}
+-
+-// WithUnmarshalers specifies a list of type-specific unmarshalers to use,
+-// which can be used to override the default unmarshal behavior for values
+-// of particular types.
+-//
+-// This only affects unmarshaling and is ignored when marshaling.
+-func WithUnmarshalers(v *Unmarshalers) Options {
+-	return json.WithUnmarshalers(v)
+-}
+diff --git a/pkg/internal/third_party/go-json-experiment/json/arshal.go b/pkg/internal/third_party/go-json-experiment/json/arshal.go
+index 85d530389..dbf92432d 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/arshal.go
++++ b/pkg/internal/third_party/go-json-experiment/json/arshal.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package json
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/arshal_any.go b/pkg/internal/third_party/go-json-experiment/json/arshal_any.go
+index 22ed430fb..fd034c1a1 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/arshal_any.go
++++ b/pkg/internal/third_party/go-json-experiment/json/arshal_any.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package json
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/arshal_default.go b/pkg/internal/third_party/go-json-experiment/json/arshal_default.go
+index 64d2b7a9b..3f21c8d35 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/arshal_default.go
++++ b/pkg/internal/third_party/go-json-experiment/json/arshal_default.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package json
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/arshal_funcs.go b/pkg/internal/third_party/go-json-experiment/json/arshal_funcs.go
+index 1f5d01868..50dca26b8 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/arshal_funcs.go
++++ b/pkg/internal/third_party/go-json-experiment/json/arshal_funcs.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package json
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/arshal_inlined.go b/pkg/internal/third_party/go-json-experiment/json/arshal_inlined.go
+index f73ed3240..4509b87e4 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/arshal_inlined.go
++++ b/pkg/internal/third_party/go-json-experiment/json/arshal_inlined.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package json
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/arshal_methods.go b/pkg/internal/third_party/go-json-experiment/json/arshal_methods.go
+index d6736342b..42d6ee876 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/arshal_methods.go
++++ b/pkg/internal/third_party/go-json-experiment/json/arshal_methods.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package json
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/arshal_test.go b/pkg/internal/third_party/go-json-experiment/json/arshal_test.go
+index 258d416ce..f365dae78 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/arshal_test.go
++++ b/pkg/internal/third_party/go-json-experiment/json/arshal_test.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package json
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/arshal_time.go b/pkg/internal/third_party/go-json-experiment/json/arshal_time.go
+index 4d328ebee..30dd584d1 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/arshal_time.go
++++ b/pkg/internal/third_party/go-json-experiment/json/arshal_time.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package json
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/arshal_time_test.go b/pkg/internal/third_party/go-json-experiment/json/arshal_time_test.go
+index bd9e3b661..dd7f161ef 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/arshal_time_test.go
++++ b/pkg/internal/third_party/go-json-experiment/json/arshal_time_test.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package json
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/doc.go b/pkg/internal/third_party/go-json-experiment/json/doc.go
+index a46316858..ff70951ab 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/doc.go
++++ b/pkg/internal/third_party/go-json-experiment/json/doc.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ // Package json implements semantic processing of JSON as specified in RFC 8259.
+ // JSON is a simple data interchange format that can represent
+ // primitive data types such as booleans, strings, and numbers,
+diff --git a/pkg/internal/third_party/go-json-experiment/json/errors.go b/pkg/internal/third_party/go-json-experiment/json/errors.go
+index 5b5d5f93a..1df765384 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/errors.go
++++ b/pkg/internal/third_party/go-json-experiment/json/errors.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package json
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/errors_test.go b/pkg/internal/third_party/go-json-experiment/json/errors_test.go
+index d1890aaf5..1d1750b5e 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/errors_test.go
++++ b/pkg/internal/third_party/go-json-experiment/json/errors_test.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package json
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/example_orderedobject_test.go b/pkg/internal/third_party/go-json-experiment/json/example_orderedobject_test.go
+index 74784f3e6..2498df3f2 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/example_orderedobject_test.go
++++ b/pkg/internal/third_party/go-json-experiment/json/example_orderedobject_test.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package json_test
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/example_test.go b/pkg/internal/third_party/go-json-experiment/json/example_test.go
+index aeb5fec1f..60a7a1665 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/example_test.go
++++ b/pkg/internal/third_party/go-json-experiment/json/example_test.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package json_test
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/fields.go b/pkg/internal/third_party/go-json-experiment/json/fields.go
+index 045c6988a..d539feedd 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/fields.go
++++ b/pkg/internal/third_party/go-json-experiment/json/fields.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package json
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/fields_test.go b/pkg/internal/third_party/go-json-experiment/json/fields_test.go
+index 777d887e7..e25b07720 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/fields_test.go
++++ b/pkg/internal/third_party/go-json-experiment/json/fields_test.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package json
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/fold.go b/pkg/internal/third_party/go-json-experiment/json/fold.go
+index 973f52e73..9ab735814 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/fold.go
++++ b/pkg/internal/third_party/go-json-experiment/json/fold.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package json
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/fold_test.go b/pkg/internal/third_party/go-json-experiment/json/fold_test.go
+index c42c5d416..5dbfcd4db 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/fold_test.go
++++ b/pkg/internal/third_party/go-json-experiment/json/fold_test.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package json
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/fuzz_test.go b/pkg/internal/third_party/go-json-experiment/json/fuzz_test.go
+index f02a1503c..2b583ed59 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/fuzz_test.go
++++ b/pkg/internal/third_party/go-json-experiment/json/fuzz_test.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package json
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/inline_test.go b/pkg/internal/third_party/go-json-experiment/json/inline_test.go
+index 4302c6476..28c37df0c 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/inline_test.go
++++ b/pkg/internal/third_party/go-json-experiment/json/inline_test.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package json
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/intern.go b/pkg/internal/third_party/go-json-experiment/json/intern.go
+index 1bfb8ca63..42fc3d471 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/intern.go
++++ b/pkg/internal/third_party/go-json-experiment/json/intern.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package json
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/internal/internal.go b/pkg/internal/third_party/go-json-experiment/json/internal/internal.go
+index 00b43fa30..05801c6b2 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/internal/internal.go
++++ b/pkg/internal/third_party/go-json-experiment/json/internal/internal.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package internal
+ 
+ import "errors"
+diff --git a/pkg/internal/third_party/go-json-experiment/json/internal/jsonflags/flags.go b/pkg/internal/third_party/go-json-experiment/json/internal/jsonflags/flags.go
+index 36300011e..810128b51 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/internal/jsonflags/flags.go
++++ b/pkg/internal/third_party/go-json-experiment/json/internal/jsonflags/flags.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ // jsonflags implements all the optional boolean flags.
+ // These flags are shared across both "json", "jsontext", and "jsonopts".
+ package jsonflags
+diff --git a/pkg/internal/third_party/go-json-experiment/json/internal/jsonflags/flags_test.go b/pkg/internal/third_party/go-json-experiment/json/internal/jsonflags/flags_test.go
+index 7626b5ae4..58dc08844 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/internal/jsonflags/flags_test.go
++++ b/pkg/internal/third_party/go-json-experiment/json/internal/jsonflags/flags_test.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsonflags
+ 
+ import "testing"
+diff --git a/pkg/internal/third_party/go-json-experiment/json/internal/jsonopts/options.go b/pkg/internal/third_party/go-json-experiment/json/internal/jsonopts/options.go
+index c4fc8dba8..142653518 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/internal/jsonopts/options.go
++++ b/pkg/internal/third_party/go-json-experiment/json/internal/jsonopts/options.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsonopts
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/internal/jsonopts/options_test.go b/pkg/internal/third_party/go-json-experiment/json/internal/jsonopts/options_test.go
+index 3870c1c15..9daa5e9e5 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/internal/jsonopts/options_test.go
++++ b/pkg/internal/third_party/go-json-experiment/json/internal/jsonopts/options_test.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsonopts_test
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/internal/jsontest/testcase.go b/pkg/internal/third_party/go-json-experiment/json/internal/jsontest/testcase.go
+index c2e0dcff9..aaff78629 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/internal/jsontest/testcase.go
++++ b/pkg/internal/third_party/go-json-experiment/json/internal/jsontest/testcase.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsontest
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/internal/jsonwire/decode.go b/pkg/internal/third_party/go-json-experiment/json/internal/jsonwire/decode.go
+index 6a5acb8ec..02787719c 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/internal/jsonwire/decode.go
++++ b/pkg/internal/third_party/go-json-experiment/json/internal/jsonwire/decode.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsonwire
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/internal/jsonwire/decode_test.go b/pkg/internal/third_party/go-json-experiment/json/internal/jsonwire/decode_test.go
+index ed653df63..1748b59dd 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/internal/jsonwire/decode_test.go
++++ b/pkg/internal/third_party/go-json-experiment/json/internal/jsonwire/decode_test.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsonwire
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/internal/jsonwire/encode.go b/pkg/internal/third_party/go-json-experiment/json/internal/jsonwire/encode.go
+index e74ed713e..35b238a2e 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/internal/jsonwire/encode.go
++++ b/pkg/internal/third_party/go-json-experiment/json/internal/jsonwire/encode.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsonwire
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/internal/jsonwire/encode_test.go b/pkg/internal/third_party/go-json-experiment/json/internal/jsonwire/encode_test.go
+index 82ac93fbb..b4ec50b98 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/internal/jsonwire/encode_test.go
++++ b/pkg/internal/third_party/go-json-experiment/json/internal/jsonwire/encode_test.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsonwire
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/internal/jsonwire/wire.go b/pkg/internal/third_party/go-json-experiment/json/internal/jsonwire/wire.go
+index a0622c65b..1831a66bd 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/internal/jsonwire/wire.go
++++ b/pkg/internal/third_party/go-json-experiment/json/internal/jsonwire/wire.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ // Package jsonwire implements stateless functionality for handling JSON text.
+ package jsonwire
+ 
+diff --git a/pkg/internal/third_party/go-json-experiment/json/internal/jsonwire/wire_test.go b/pkg/internal/third_party/go-json-experiment/json/internal/jsonwire/wire_test.go
+index b7633a5e8..d15be750c 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/internal/jsonwire/wire_test.go
++++ b/pkg/internal/third_party/go-json-experiment/json/internal/jsonwire/wire_test.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsonwire
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/jsontext/alias.go b/pkg/internal/third_party/go-json-experiment/json/jsontext/alias.go
+deleted file mode 100644
+index dc18d5d55..000000000
+--- a/pkg/internal/third_party/go-json-experiment/json/jsontext/alias.go
++++ /dev/null
+@@ -1,536 +0,0 @@
+-// Copyright 2025 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-// Code generated by alias_gen.go; DO NOT EDIT.
+-
+-//go:build goexperiment.jsonv2 && go1.25
+-
+-// Package jsontext implements syntactic processing of JSON
+-// as specified in RFC 4627, RFC 7159, RFC 7493, RFC 8259, and RFC 8785.
+-// JSON is a simple data interchange format that can represent
+-// primitive data types such as booleans, strings, and numbers,
+-// in addition to structured data types such as objects and arrays.
+-//
+-// The [Encoder] and [Decoder] types are used to encode or decode
+-// a stream of JSON tokens or values.
+-//
+-// # Tokens and Values
+-//
+-// A JSON token refers to the basic structural elements of JSON:
+-//
+-//   - a JSON literal (i.e., null, true, or false)
+-//   - a JSON string (e.g., "hello, world!")
+-//   - a JSON number (e.g., 123.456)
+-//   - a begin or end delimiter for a JSON object (i.e., '{' or '}')
+-//   - a begin or end delimiter for a JSON array (i.e., '[' or ']')
+-//
+-// A JSON token is represented by the [Token] type in Go. Technically,
+-// there are two additional structural characters (i.e., ':' and ','),
+-// but there is no [Token] representation for them since their presence
+-// can be inferred by the structure of the JSON grammar itself.
+-// For example, there must always be an implicit colon between
+-// the name and value of a JSON object member.
+-//
+-// A JSON value refers to a complete unit of JSON data:
+-//
+-//   - a JSON literal, string, or number
+-//   - a JSON object (e.g., `{"name":"value"}`)
+-//   - a JSON array (e.g., `[1,2,3,]`)
+-//
+-// A JSON value is represented by the [Value] type in Go and is a []byte
+-// containing the raw textual representation of the value. There is some overlap
+-// between tokens and values as both contain literals, strings, and numbers.
+-// However, only a value can represent the entirety of a JSON object or array.
+-//
+-// The [Encoder] and [Decoder] types contain methods to read or write the next
+-// [Token] or [Value] in a sequence. They maintain a state machine to validate
+-// whether the sequence of JSON tokens and/or values produces a valid JSON.
+-// [Options] may be passed to the [NewEncoder] or [NewDecoder] constructors
+-// to configure the syntactic behavior of encoding and decoding.
+-//
+-// # Terminology
+-//
+-// The terms "encode" and "decode" are used for syntactic functionality
+-// that is concerned with processing JSON based on its grammar, and
+-// the terms "marshal" and "unmarshal" are used for semantic functionality
+-// that determines the meaning of JSON values as Go values and vice-versa.
+-// This package (i.e., [jsontext]) deals with JSON at a syntactic layer,
+-// while [encoding/json/v2] deals with JSON at a semantic layer.
+-// The goal is to provide a clear distinction between functionality that
+-// is purely concerned with encoding versus that of marshaling.
+-// For example, one can directly encode a stream of JSON tokens without
+-// needing to marshal a concrete Go value representing them.
+-// Similarly, one can decode a stream of JSON tokens without
+-// needing to unmarshal them into a concrete Go value.
+-//
+-// This package uses JSON terminology when discussing JSON, which may differ
+-// from related concepts in Go or elsewhere in computing literature.
+-//
+-//   - a JSON "object" refers to an unordered collection of name/value members.
+-//   - a JSON "array" refers to an ordered sequence of elements.
+-//   - a JSON "value" refers to either a literal (i.e., null, false, or true),
+-//     string, number, object, or array.
+-//
+-// See RFC 8259 for more information.
+-//
+-// # Specifications
+-//
+-// Relevant specifications include RFC 4627, RFC 7159, RFC 7493, RFC 8259,
+-// and RFC 8785. Each RFC is generally a stricter subset of another RFC.
+-// In increasing order of strictness:
+-//
+-//   - RFC 4627 and RFC 7159 do not require (but recommend) the use of UTF-8
+-//     and also do not require (but recommend) that object names be unique.
+-//   - RFC 8259 requires the use of UTF-8,
+-//     but does not require (but recommends) that object names be unique.
+-//   - RFC 7493 requires the use of UTF-8
+-//     and also requires that object names be unique.
+-//   - RFC 8785 defines a canonical representation. It requires the use of UTF-8
+-//     and also requires that object names be unique and in a specific ordering.
+-//     It specifies exactly how strings and numbers must be formatted.
+-//
+-// The primary difference between RFC 4627 and RFC 7159 is that the former
+-// restricted top-level values to only JSON objects and arrays, while
+-// RFC 7159 and subsequent RFCs permit top-level values to additionally be
+-// JSON nulls, booleans, strings, or numbers.
+-//
+-// By default, this package operates on RFC 7493, but can be configured
+-// to operate according to the other RFC specifications.
+-// RFC 7493 is a stricter subset of RFC 8259 and fully compliant with it.
+-// In particular, it makes specific choices about behavior that RFC 8259
+-// leaves as undefined in order to ensure greater interoperability.
+-//
+-// # Security Considerations
+-//
+-// See the "Security Considerations" section in [encoding/json/v2].
+-package jsontext
+-
+-import (
+-	"encoding/json/jsontext"
+-	"io"
+-)
+-
+-// Decoder is a streaming decoder for raw JSON tokens and values.
+-// It is used to read a stream of top-level JSON values,
+-// each separated by optional whitespace characters.
+-//
+-// [Decoder.ReadToken] and [Decoder.ReadValue] calls may be interleaved.
+-// For example, the following JSON value:
+-//
+-//	{"name":"value","array":[null,false,true,3.14159],"object":{"k":"v"}}
+-//
+-// can be parsed with the following calls (ignoring errors for brevity):
+-//
+-//	d.ReadToken() // {
+-//	d.ReadToken() // "name"
+-//	d.ReadToken() // "value"
+-//	d.ReadValue() // "array"
+-//	d.ReadToken() // [
+-//	d.ReadToken() // null
+-//	d.ReadToken() // false
+-//	d.ReadValue() // true
+-//	d.ReadToken() // 3.14159
+-//	d.ReadToken() // ]
+-//	d.ReadValue() // "object"
+-//	d.ReadValue() // {"k":"v"}
+-//	d.ReadToken() // }
+-//
+-// The above is one of many possible sequence of calls and
+-// may not represent the most sensible method to call for any given token/value.
+-// For example, it is probably more common to call [Decoder.ReadToken] to obtain a
+-// string token for object names.
+-type Decoder = jsontext.Decoder
+-
+-// NewDecoder constructs a new streaming decoder reading from r.
+-//
+-// If r is a [bytes.Buffer], then the decoder parses directly from the buffer
+-// without first copying the contents to an intermediate buffer.
+-// Additional writes to the buffer must not occur while the decoder is in use.
+-func NewDecoder(r io.Reader, opts ...Options) *Decoder {
+-	return jsontext.NewDecoder(r, opts...)
+-}
+-
+-// Encoder is a streaming encoder from raw JSON tokens and values.
+-// It is used to write a stream of top-level JSON values,
+-// each terminated with a newline character.
+-//
+-// [Encoder.WriteToken] and [Encoder.WriteValue] calls may be interleaved.
+-// For example, the following JSON value:
+-//
+-//	{"name":"value","array":[null,false,true,3.14159],"object":{"k":"v"}}
+-//
+-// can be composed with the following calls (ignoring errors for brevity):
+-//
+-//	e.WriteToken(BeginObject)        // {
+-//	e.WriteToken(String("name"))     // "name"
+-//	e.WriteToken(String("value"))    // "value"
+-//	e.WriteValue(Value(`"array"`))   // "array"
+-//	e.WriteToken(BeginArray)         // [
+-//	e.WriteToken(Null)               // null
+-//	e.WriteToken(False)              // false
+-//	e.WriteValue(Value("true"))      // true
+-//	e.WriteToken(Float(3.14159))     // 3.14159
+-//	e.WriteToken(EndArray)           // ]
+-//	e.WriteValue(Value(`"object"`))  // "object"
+-//	e.WriteValue(Value(`{"k":"v"}`)) // {"k":"v"}
+-//	e.WriteToken(EndObject)          // }
+-//
+-// The above is one of many possible sequence of calls and
+-// may not represent the most sensible method to call for any given token/value.
+-// For example, it is probably more common to call [Encoder.WriteToken] with a string
+-// for object names.
+-type Encoder = jsontext.Encoder
+-
+-// NewEncoder constructs a new streaming encoder writing to w
+-// configured with the provided options.
+-// It flushes the internal buffer when the buffer is sufficiently full or
+-// when a top-level value has been written.
+-//
+-// If w is a [bytes.Buffer], then the encoder appends directly into the buffer
+-// without copying the contents from an intermediate buffer.
+-func NewEncoder(w io.Writer, opts ...Options) *Encoder {
+-	return jsontext.NewEncoder(w, opts...)
+-}
+-
+-// SyntacticError is a description of a syntactic error that occurred when
+-// encoding or decoding JSON according to the grammar.
+-//
+-// The contents of this error as produced by this package may change over time.
+-type SyntacticError = jsontext.SyntacticError
+-
+-// Options configures [NewEncoder], [Encoder.Reset], [NewDecoder],
+-// and [Decoder.Reset] with specific features.
+-// Each function takes in a variadic list of options, where properties
+-// set in latter options override the value of previously set properties.
+-//
+-// There is a single Options type, which is used with both encoding and decoding.
+-// Some options affect both operations, while others only affect one operation:
+-//
+-//   - [AllowDuplicateNames] affects encoding and decoding
+-//   - [AllowInvalidUTF8] affects encoding and decoding
+-//   - [EscapeForHTML] affects encoding only
+-//   - [EscapeForJS] affects encoding only
+-//   - [PreserveRawStrings] affects encoding only
+-//   - [CanonicalizeRawInts] affects encoding only
+-//   - [CanonicalizeRawFloats] affects encoding only
+-//   - [ReorderRawObjects] affects encoding only
+-//   - [SpaceAfterColon] affects encoding only
+-//   - [SpaceAfterComma] affects encoding only
+-//   - [Multiline] affects encoding only
+-//   - [WithIndent] affects encoding only
+-//   - [WithIndentPrefix] affects encoding only
+-//
+-// Options that do not affect a particular operation are ignored.
+-//
+-// The Options type is identical to [encoding/json.Options] and
+-// [encoding/json/v2.Options]. Options from the other packages may
+-// be passed to functionality in this package, but are ignored.
+-// Options from this package may be used with the other packages.
+-type Options = jsontext.Options
+-
+-// AllowDuplicateNames specifies that JSON objects may contain
+-// duplicate member names. Disabling the duplicate name check may provide
+-// performance benefits, but breaks compliance with RFC 7493, section 2.3.
+-// The input or output will still be compliant with RFC 8259,
+-// which leaves the handling of duplicate names as unspecified behavior.
+-//
+-// This affects either encoding or decoding.
+-func AllowDuplicateNames(v bool) Options {
+-	return jsontext.AllowDuplicateNames(v)
+-}
+-
+-// AllowInvalidUTF8 specifies that JSON strings may contain invalid UTF-8,
+-// which will be mangled as the Unicode replacement character, U+FFFD.
+-// This causes the encoder or decoder to break compliance with
+-// RFC 7493, section 2.1, and RFC 8259, section 8.1.
+-//
+-// This affects either encoding or decoding.
+-func AllowInvalidUTF8(v bool) Options {
+-	return jsontext.AllowInvalidUTF8(v)
+-}
+-
+-// EscapeForHTML specifies that '<', '>', and '&' characters within JSON strings
+-// should be escaped as a hexadecimal Unicode codepoint (e.g., \u003c) so that
+-// the output is safe to embed within HTML.
+-//
+-// This only affects encoding and is ignored when decoding.
+-func EscapeForHTML(v bool) Options {
+-	return jsontext.EscapeForHTML(v)
+-}
+-
+-// EscapeForJS specifies that U+2028 and U+2029 characters within JSON strings
+-// should be escaped as a hexadecimal Unicode codepoint (e.g., \u2028) so that
+-// the output is valid to embed within JavaScript. See RFC 8259, section 12.
+-//
+-// This only affects encoding and is ignored when decoding.
+-func EscapeForJS(v bool) Options {
+-	return jsontext.EscapeForJS(v)
+-}
+-
+-// PreserveRawStrings specifies that when encoding a raw JSON string in a
+-// [Token] or [Value], pre-escaped sequences
+-// in a JSON string are preserved to the output.
+-// However, raw strings still respect [EscapeForHTML] and [EscapeForJS]
+-// such that the relevant characters are escaped.
+-// If [AllowInvalidUTF8] is enabled, bytes of invalid UTF-8
+-// are preserved to the output.
+-//
+-// This only affects encoding and is ignored when decoding.
+-func PreserveRawStrings(v bool) Options {
+-	return jsontext.PreserveRawStrings(v)
+-}
+-
+-// CanonicalizeRawInts specifies that when encoding a raw JSON
+-// integer number (i.e., a number without a fraction and exponent) in a
+-// [Token] or [Value], the number is canonicalized
+-// according to RFC 8785, section 3.2.2.3. As a special case,
+-// the number -0 is canonicalized as 0.
+-//
+-// JSON numbers are treated as IEEE 754 double precision numbers.
+-// Any numbers with precision beyond what is representable by that form
+-// will lose their precision when canonicalized. For example,
+-// integer values beyond ±2⁵³ will lose their precision.
+-// For example, 1234567890123456789 is formatted as 1234567890123456800.
+-//
+-// This only affects encoding and is ignored when decoding.
+-func CanonicalizeRawInts(v bool) Options {
+-	return jsontext.CanonicalizeRawInts(v)
+-}
+-
+-// CanonicalizeRawFloats specifies that when encoding a raw JSON
+-// floating-point number (i.e., a number with a fraction or exponent) in a
+-// [Token] or [Value], the number is canonicalized
+-// according to RFC 8785, section 3.2.2.3. As a special case,
+-// the number -0 is canonicalized as 0.
+-//
+-// JSON numbers are treated as IEEE 754 double precision numbers.
+-// It is safe to canonicalize a serialized single precision number and
+-// parse it back as a single precision number and expect the same value.
+-// If a number exceeds ±1.7976931348623157e+308, which is the maximum
+-// finite number, then it saturated at that value and formatted as such.
+-//
+-// This only affects encoding and is ignored when decoding.
+-func CanonicalizeRawFloats(v bool) Options {
+-	return jsontext.CanonicalizeRawFloats(v)
+-}
+-
+-// ReorderRawObjects specifies that when encoding a raw JSON object in a
+-// [Value], the object members are reordered according to
+-// RFC 8785, section 3.2.3.
+-//
+-// This only affects encoding and is ignored when decoding.
+-func ReorderRawObjects(v bool) Options {
+-	return jsontext.ReorderRawObjects(v)
+-}
+-
+-// SpaceAfterColon specifies that the JSON output should emit a space character
+-// after each colon separator following a JSON object name.
+-// If false, then no space character appears after the colon separator.
+-//
+-// This only affects encoding and is ignored when decoding.
+-func SpaceAfterColon(v bool) Options {
+-	return jsontext.SpaceAfterColon(v)
+-}
+-
+-// SpaceAfterComma specifies that the JSON output should emit a space character
+-// after each comma separator following a JSON object value or array element.
+-// If false, then no space character appears after the comma separator.
+-//
+-// This only affects encoding and is ignored when decoding.
+-func SpaceAfterComma(v bool) Options {
+-	return jsontext.SpaceAfterComma(v)
+-}
+-
+-// Multiline specifies that the JSON output should expand to multiple lines,
+-// where every JSON object member or JSON array element appears on
+-// a new, indented line according to the nesting depth.
+-//
+-// If [SpaceAfterColon] is not specified, then the default is true.
+-// If [SpaceAfterComma] is not specified, then the default is false.
+-// If [WithIndent] is not specified, then the default is "\t".
+-//
+-// If set to false, then the output is a single-line,
+-// where the only whitespace emitted is determined by the current
+-// values of [SpaceAfterColon] and [SpaceAfterComma].
+-//
+-// This only affects encoding and is ignored when decoding.
+-func Multiline(v bool) Options {
+-	return jsontext.Multiline(v)
+-}
+-
+-// WithIndent specifies that the encoder should emit multiline output
+-// where each element in a JSON object or array begins on a new, indented line
+-// beginning with the indent prefix (see [WithIndentPrefix])
+-// followed by one or more copies of indent according to the nesting depth.
+-// The indent must only be composed of space or tab characters.
+-//
+-// If the intent to emit indented output without a preference for
+-// the particular indent string, then use [Multiline] instead.
+-//
+-// This only affects encoding and is ignored when decoding.
+-// Use of this option implies [Multiline] being set to true.
+-func WithIndent(indent string) Options {
+-	return jsontext.WithIndent(indent)
+-}
+-
+-// WithIndentPrefix specifies that the encoder should emit multiline output
+-// where each element in a JSON object or array begins on a new, indented line
+-// beginning with the indent prefix followed by one or more copies of indent
+-// (see [WithIndent]) according to the nesting depth.
+-// The prefix must only be composed of space or tab characters.
+-//
+-// This only affects encoding and is ignored when decoding.
+-// Use of this option implies [Multiline] being set to true.
+-func WithIndentPrefix(prefix string) Options {
+-	return jsontext.WithIndentPrefix(prefix)
+-}
+-
+-// AppendQuote appends a double-quoted JSON string literal representing src
+-// to dst and returns the extended buffer.
+-// It uses the minimal string representation per RFC 8785, section 3.2.2.2.
+-// Invalid UTF-8 bytes are replaced with the Unicode replacement character
+-// and an error is returned at the end indicating the presence of invalid UTF-8.
+-// The dst must not overlap with the src.
+-func AppendQuote[Bytes ~[]byte | ~string](dst []byte, src Bytes) ([]byte, error) {
+-	return jsontext.AppendQuote[Bytes](dst, src)
+-}
+-
+-// AppendUnquote appends the decoded interpretation of src as a
+-// double-quoted JSON string literal to dst and returns the extended buffer.
+-// The input src must be a JSON string without any surrounding whitespace.
+-// Invalid UTF-8 bytes are replaced with the Unicode replacement character
+-// and an error is returned at the end indicating the presence of invalid UTF-8.
+-// Any trailing bytes after the JSON string literal results in an error.
+-// The dst must not overlap with the src.
+-func AppendUnquote[Bytes ~[]byte | ~string](dst []byte, src Bytes) ([]byte, error) {
+-	return jsontext.AppendUnquote[Bytes](dst, src)
+-}
+-
+-// ErrDuplicateName indicates that a JSON token could not be
+-// encoded or decoded because it results in a duplicate JSON object name.
+-// This error is directly wrapped within a [SyntacticError] when produced.
+-//
+-// The name of a duplicate JSON object member can be extracted as:
+-//
+-//	err := ...
+-//	var serr jsontext.SyntacticError
+-//	if errors.As(err, &serr) && serr.Err == jsontext.ErrDuplicateName {
+-//		ptr := serr.JSONPointer // JSON pointer to duplicate name
+-//		name := ptr.LastToken() // duplicate name itself
+-//		...
+-//	}
+-//
+-// This error is only returned if [AllowDuplicateNames] is false.
+-var ErrDuplicateName = jsontext.ErrDuplicateName
+-
+-// ErrNonStringName indicates that a JSON token could not be
+-// encoded or decoded because it is not a string,
+-// as required for JSON object names according to RFC 8259, section 4.
+-// This error is directly wrapped within a [SyntacticError] when produced.
+-var ErrNonStringName = jsontext.ErrNonStringName
+-
+-// Pointer is a JSON Pointer (RFC 6901) that references a particular JSON value
+-// relative to the root of the top-level JSON value.
+-//
+-// A Pointer is a slash-separated list of tokens, where each token is
+-// either a JSON object name or an index to a JSON array element
+-// encoded as a base-10 integer value.
+-// It is impossible to distinguish between an array index and an object name
+-// (that happens to be an base-10 encoded integer) without also knowing
+-// the structure of the top-level JSON value that the pointer refers to.
+-//
+-// There is exactly one representation of a pointer to a particular value,
+-// so comparability of Pointer values is equivalent to checking whether
+-// they both point to the exact same value.
+-type Pointer = jsontext.Pointer
+-
+-// Token represents a lexical JSON token, which may be one of the following:
+-//   - a JSON literal (i.e., null, true, or false)
+-//   - a JSON string (e.g., "hello, world!")
+-//   - a JSON number (e.g., 123.456)
+-//   - a begin or end delimiter for a JSON object (i.e., { or } )
+-//   - a begin or end delimiter for a JSON array (i.e., [ or ] )
+-//
+-// A Token cannot represent entire array or object values, while a [Value] can.
+-// There is no Token to represent commas and colons since
+-// these structural tokens can be inferred from the surrounding context.
+-type Token = jsontext.Token
+-
+-var (
+-	Null        = jsontext.Null
+-	False       = jsontext.False
+-	True        = jsontext.True
+-	BeginObject = jsontext.BeginObject
+-	EndObject   = jsontext.EndObject
+-	BeginArray  = jsontext.BeginArray
+-	EndArray    = jsontext.EndArray
+-)
+-
+-// Bool constructs a Token representing a JSON boolean.
+-func Bool(b bool) Token {
+-	return jsontext.Bool(b)
+-}
+-
+-// String constructs a Token representing a JSON string.
+-// The provided string should contain valid UTF-8, otherwise invalid characters
+-// may be mangled as the Unicode replacement character.
+-func String(s string) Token {
+-	return jsontext.String(s)
+-}
+-
+-// Float constructs a Token representing a JSON number.
+-// The values NaN, +Inf, and -Inf will be represented
+-// as a JSON string with the values "NaN", "Infinity", and "-Infinity".
+-func Float(n float64) Token {
+-	return jsontext.Float(n)
+-}
+-
+-// Int constructs a Token representing a JSON number from an int64.
+-func Int(n int64) Token {
+-	return jsontext.Int(n)
+-}
+-
+-// Uint constructs a Token representing a JSON number from a uint64.
+-func Uint(n uint64) Token {
+-	return jsontext.Uint(n)
+-}
+-
+-// Kind represents each possible JSON token kind with a single byte,
+-// which is conveniently the first byte of that kind's grammar
+-// with the restriction that numbers always be represented with '0':
+-//
+-//   - 'n': null
+-//   - 'f': false
+-//   - 't': true
+-//   - '"': string
+-//   - '0': number
+-//   - '{': object begin
+-//   - '}': object end
+-//   - '[': array begin
+-//   - ']': array end
+-//
+-// An invalid kind is usually represented using 0,
+-// but may be non-zero due to invalid JSON data.
+-type Kind = jsontext.Kind
+-
+-// AppendFormat formats the JSON value in src and appends it to dst
+-// according to the specified options.
+-// See [Value.Format] for more details about the formatting behavior.
+-//
+-// The dst and src may overlap.
+-// If an error is reported, then the entirety of src is appended to dst.
+-func AppendFormat(dst, src []byte, opts ...Options) ([]byte, error) {
+-	return jsontext.AppendFormat(dst, src, opts...)
+-}
+-
+-// Value represents a single raw JSON value, which may be one of the following:
+-//   - a JSON literal (i.e., null, true, or false)
+-//   - a JSON string (e.g., "hello, world!")
+-//   - a JSON number (e.g., 123.456)
+-//   - an entire JSON object (e.g., {"fizz":"buzz"} )
+-//   - an entire JSON array (e.g., [1,2,3] )
+-//
+-// Value can represent entire array or object values, while [Token] cannot.
+-// Value may contain leading and/or trailing whitespace.
+-type Value = jsontext.Value
+diff --git a/pkg/internal/third_party/go-json-experiment/json/jsontext/coder_test.go b/pkg/internal/third_party/go-json-experiment/json/jsontext/coder_test.go
+index bdd71f3c2..b6d5f265a 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/jsontext/coder_test.go
++++ b/pkg/internal/third_party/go-json-experiment/json/jsontext/coder_test.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsontext
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/jsontext/decode.go b/pkg/internal/third_party/go-json-experiment/json/jsontext/decode.go
+index 7e847de37..96fd5c27c 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/jsontext/decode.go
++++ b/pkg/internal/third_party/go-json-experiment/json/jsontext/decode.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsontext
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/jsontext/decode_test.go b/pkg/internal/third_party/go-json-experiment/json/jsontext/decode_test.go
+index 4ac0fe2b0..2b9144285 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/jsontext/decode_test.go
++++ b/pkg/internal/third_party/go-json-experiment/json/jsontext/decode_test.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsontext
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/jsontext/doc.go b/pkg/internal/third_party/go-json-experiment/json/jsontext/doc.go
+index 22081df05..bea3ccd34 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/jsontext/doc.go
++++ b/pkg/internal/third_party/go-json-experiment/json/jsontext/doc.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ // Package jsontext implements syntactic processing of JSON
+ // as specified in RFC 4627, RFC 7159, RFC 7493, RFC 8259, and RFC 8785.
+ // JSON is a simple data interchange format that can represent
+diff --git a/pkg/internal/third_party/go-json-experiment/json/jsontext/encode.go b/pkg/internal/third_party/go-json-experiment/json/jsontext/encode.go
+index c2e88045a..36bf7efdf 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/jsontext/encode.go
++++ b/pkg/internal/third_party/go-json-experiment/json/jsontext/encode.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsontext
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/jsontext/encode_test.go b/pkg/internal/third_party/go-json-experiment/json/jsontext/encode_test.go
+index 8fc21dc2c..a21ee4d65 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/jsontext/encode_test.go
++++ b/pkg/internal/third_party/go-json-experiment/json/jsontext/encode_test.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsontext
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/jsontext/errors.go b/pkg/internal/third_party/go-json-experiment/json/jsontext/errors.go
+index 3c53151b3..1af86d5b6 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/jsontext/errors.go
++++ b/pkg/internal/third_party/go-json-experiment/json/jsontext/errors.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsontext
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/jsontext/example_test.go b/pkg/internal/third_party/go-json-experiment/json/jsontext/example_test.go
+index 414a4458f..d13c5773a 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/jsontext/example_test.go
++++ b/pkg/internal/third_party/go-json-experiment/json/jsontext/example_test.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsontext_test
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/jsontext/export.go b/pkg/internal/third_party/go-json-experiment/json/jsontext/export.go
+index 0d6dc58c0..b30bb99ed 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/jsontext/export.go
++++ b/pkg/internal/third_party/go-json-experiment/json/jsontext/export.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsontext
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/jsontext/options.go b/pkg/internal/third_party/go-json-experiment/json/jsontext/options.go
+index d22d0635d..e973b58d6 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/jsontext/options.go
++++ b/pkg/internal/third_party/go-json-experiment/json/jsontext/options.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsontext
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/jsontext/pools.go b/pkg/internal/third_party/go-json-experiment/json/jsontext/pools.go
+index cf59d99b9..63941baac 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/jsontext/pools.go
++++ b/pkg/internal/third_party/go-json-experiment/json/jsontext/pools.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsontext
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/jsontext/quote.go b/pkg/internal/third_party/go-json-experiment/json/jsontext/quote.go
+index a4353be3a..77897b43f 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/jsontext/quote.go
++++ b/pkg/internal/third_party/go-json-experiment/json/jsontext/quote.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsontext
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/jsontext/state.go b/pkg/internal/third_party/go-json-experiment/json/jsontext/state.go
+index 6f1aa8e21..fdbfd5d3d 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/jsontext/state.go
++++ b/pkg/internal/third_party/go-json-experiment/json/jsontext/state.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsontext
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/jsontext/state_test.go b/pkg/internal/third_party/go-json-experiment/json/jsontext/state_test.go
+index 06c2cfb76..b0ab5eca8 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/jsontext/state_test.go
++++ b/pkg/internal/third_party/go-json-experiment/json/jsontext/state_test.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsontext
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/jsontext/token.go b/pkg/internal/third_party/go-json-experiment/json/jsontext/token.go
+index 3e87c9140..ea8c30eb5 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/jsontext/token.go
++++ b/pkg/internal/third_party/go-json-experiment/json/jsontext/token.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsontext
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/jsontext/token_test.go b/pkg/internal/third_party/go-json-experiment/json/jsontext/token_test.go
+index fa420c0ca..b19b4de09 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/jsontext/token_test.go
++++ b/pkg/internal/third_party/go-json-experiment/json/jsontext/token_test.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsontext
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/jsontext/value.go b/pkg/internal/third_party/go-json-experiment/json/jsontext/value.go
+index f29f32356..3ea05d3a0 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/jsontext/value.go
++++ b/pkg/internal/third_party/go-json-experiment/json/jsontext/value.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsontext
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/jsontext/value_test.go b/pkg/internal/third_party/go-json-experiment/json/jsontext/value_test.go
+index f77115078..8ae87eadd 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/jsontext/value_test.go
++++ b/pkg/internal/third_party/go-json-experiment/json/jsontext/value_test.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package jsontext
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/options.go b/pkg/internal/third_party/go-json-experiment/json/options.go
+index de401b0de..2f4744980 100644
+--- a/pkg/internal/third_party/go-json-experiment/json/options.go
++++ b/pkg/internal/third_party/go-json-experiment/json/options.go
+@@ -2,8 +2,6 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+ package json
+ 
+ import (
+diff --git a/pkg/internal/third_party/go-json-experiment/json/v1/alias.go b/pkg/internal/third_party/go-json-experiment/json/v1/alias.go
+deleted file mode 100644
+index 76a7d11f5..000000000
+--- a/pkg/internal/third_party/go-json-experiment/json/v1/alias.go
++++ /dev/null
+@@ -1,845 +0,0 @@
+-// Copyright 2025 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-// Code generated by alias_gen.go; DO NOT EDIT.
+-
+-//go:build goexperiment.jsonv2 && go1.25
+-
+-// Package json implements encoding and decoding of JSON as defined in
+-// RFC 7159. The mapping between JSON and Go values is described
+-// in the documentation for the Marshal and Unmarshal functions.
+-//
+-// See "JSON and Go" for an introduction to this package:
+-// https://golang.org/doc/articles/json_and_go.html
+-//
+-// # Security Considerations
+-//
+-// See the "Security Considerations" section in [encoding/json/v2].
+-//
+-// For historical reasons, the default behavior of v1 [encoding/json]
+-// unfortunately operates with less secure defaults.
+-// New usages of JSON in Go are encouraged to use [encoding/json/v2] instead.
+-// Migrating to v2
+-//
+-// This package (i.e., [encoding/json]) is now formally known as the v1 package
+-// since a v2 package now exists at [encoding/json/v2].
+-// All the behavior of the v1 package is implemented in terms of
+-// the v2 package with the appropriate set of options specified that
+-// preserve the historical behavior of v1.
+-//
+-// The [jsonv2.Marshal] function is the newer equivalent of v1 [Marshal].
+-// The [jsonv2.Unmarshal] function is the newer equivalent of v1 [Unmarshal].
+-// The v2 functions have the same calling signature as the v1 equivalent
+-// except that they take in variadic [Options] arguments that can be specified
+-// to alter the behavior of marshal or unmarshal. Both v1 and v2 generally
+-// behave in similar ways, but there are some notable differences.
+-//
+-// The following is a list of differences between v1 and v2:
+-//
+-//   - In v1, JSON object members are unmarshaled into a Go struct using a
+-//     case-insensitive name match with the JSON name of the fields.
+-//     In contrast, v2 matches fields using an exact, case-sensitive match.
+-//     The [jsonv2.MatchCaseInsensitiveNames] and [MatchCaseSensitiveDelimiter]
+-//     options control this behavior difference. To explicitly specify a Go struct
+-//     field to use a particular name matching scheme, either the `case:ignore`
+-//     or the `case:strict` field option can be specified.
+-//     Field-specified options take precedence over caller-specified options.
+-//
+-//   - In v1, when marshaling a Go struct, a field marked as `omitempty`
+-//     is omitted if the field value is an "empty" Go value, which is defined as
+-//     false, 0, a nil pointer, a nil interface value, and
+-//     any empty array, slice, map, or string. In contrast, v2 redefines
+-//     `omitempty` to omit a field if it encodes as an "empty" JSON value,
+-//     which is defined as a JSON null, or an empty JSON string, object, or array.
+-//     The [OmitEmptyWithLegacySemantics] option controls this behavior difference.
+-//     Note that `omitempty` behaves identically in both v1 and v2 for a
+-//     Go array, slice, map, or string (assuming no user-defined MarshalJSON method
+-//     overrides the default representation). Existing usages of `omitempty` on a
+-//     Go bool, number, pointer, or interface value should migrate to specifying
+-//     `omitzero` instead (which is identically supported in both v1 and v2).
+-//
+-//   - In v1, a Go struct field marked as `string` can be used to quote a
+-//     Go string, bool, or number as a JSON string. It does not recursively
+-//     take effect on composite Go types. In contrast, v2 restricts
+-//     the `string` option to only quote a Go number as a JSON string.
+-//     It does recursively take effect on Go numbers within a composite Go type.
+-//     The [StringifyWithLegacySemantics] option controls this behavior difference.
+-//
+-//   - In v1, a nil Go slice or Go map is marshaled as a JSON null.
+-//     In contrast, v2 marshals a nil Go slice or Go map as
+-//     an empty JSON array or JSON object, respectively.
+-//     The [jsonv2.FormatNilSliceAsNull] and [jsonv2.FormatNilMapAsNull] options
+-//     control this behavior difference. To explicitly specify a Go struct field
+-//     to use a particular representation for nil, either the `format:emitempty`
+-//     or `format:emitnull` field option can be specified.
+-//     Field-specified options take precedence over caller-specified options.
+-//
+-//   - In v1, a Go array may be unmarshaled from a JSON array of any length.
+-//     In contrast, in v2 a Go array must be unmarshaled from a JSON array
+-//     of the same length, otherwise it results in an error.
+-//     The [UnmarshalArrayFromAnyLength] option controls this behavior difference.
+-//
+-//   - In v1, a Go byte array is represented as a JSON array of JSON numbers.
+-//     In contrast, in v2 a Go byte array is represented as a Base64-encoded JSON string.
+-//     The [FormatByteArrayAsArray] option controls this behavior difference.
+-//     To explicitly specify a Go struct field to use a particular representation,
+-//     either the `format:array` or `format:base64` field option can be specified.
+-//     Field-specified options take precedence over caller-specified options.
+-//
+-//   - In v1, MarshalJSON methods declared on a pointer receiver are only called
+-//     if the Go value is addressable. In contrast, in v2 a MarshalJSON method
+-//     is always callable regardless of addressability.
+-//     The [CallMethodsWithLegacySemantics] option controls this behavior difference.
+-//
+-//   - In v1, MarshalJSON and UnmarshalJSON methods are never called for Go map keys.
+-//     In contrast, in v2 a MarshalJSON or UnmarshalJSON method is eligible for
+-//     being called for Go map keys.
+-//     The [CallMethodsWithLegacySemantics] option controls this behavior difference.
+-//
+-//   - In v1, a Go map is marshaled in a deterministic order.
+-//     In contrast, in v2 a Go map is marshaled in a non-deterministic order.
+-//     The [jsonv2.Deterministic] option controls this behavior difference.
+-//
+-//   - In v1, JSON strings are encoded with HTML-specific or JavaScript-specific
+-//     characters being escaped. In contrast, in v2 JSON strings use the minimal
+-//     encoding and only escape if required by the JSON grammar.
+-//     The [jsontext.EscapeForHTML] and [jsontext.EscapeForJS] options
+-//     control this behavior difference.
+-//
+-//   - In v1, bytes of invalid UTF-8 within a string are silently replaced with
+-//     the Unicode replacement character. In contrast, in v2 the presence of
+-//     invalid UTF-8 results in an error. The [jsontext.AllowInvalidUTF8] option
+-//     controls this behavior difference.
+-//
+-//   - In v1, a JSON object with duplicate names is permitted.
+-//     In contrast, in v2 a JSON object with duplicate names results in an error.
+-//     The [jsontext.AllowDuplicateNames] option controls this behavior difference.
+-//
+-//   - In v1, when unmarshaling a JSON null into a non-empty Go value it will
+-//     inconsistently either zero out the value or do nothing.
+-//     In contrast, in v2 unmarshaling a JSON null will consistently and always
+-//     zero out the underlying Go value. The [MergeWithLegacySemantics] option
+-//     controls this behavior difference.
+-//
+-//   - In v1, when unmarshaling a JSON value into a non-zero Go value,
+-//     it merges into the original Go value for array elements, slice elements,
+-//     struct fields (but not map values),
+-//     pointer values, and interface values (only if a non-nil pointer).
+-//     In contrast, in v2 unmarshal merges into the Go value
+-//     for struct fields, map values, pointer values, and interface values.
+-//     In general, the v2 semantic merges when unmarshaling a JSON object,
+-//     otherwise it replaces the value. The [MergeWithLegacySemantics] option
+-//     controls this behavior difference.
+-//
+-//   - In v1, a [time.Duration] is represented as a JSON number containing
+-//     the decimal number of nanoseconds. In contrast, in v2 a [time.Duration]
+-//     has no default representation and results in a runtime error.
+-//     The [FormatDurationAsNano] option controls this behavior difference.
+-//     To explicitly specify a Go struct field to use a particular representation,
+-//     either the `format:nano` or `format:units` field option can be specified.
+-//     Field-specified options take precedence over caller-specified options.
+-//
+-//   - In v1, errors are never reported at runtime for Go struct types
+-//     that have some form of structural error (e.g., a malformed tag option).
+-//     In contrast, v2 reports a runtime error for Go types that are invalid
+-//     as they relate to JSON serialization. For example, a Go struct
+-//     with only unexported fields cannot be serialized.
+-//     The [ReportErrorsWithLegacySemantics] option controls this behavior difference.
+-//
+-// As mentioned, the entirety of v1 is implemented in terms of v2,
+-// where options are implicitly specified to opt into legacy behavior.
+-// For example, [Marshal] directly calls [jsonv2.Marshal] with [DefaultOptionsV1].
+-// Similarly, [Unmarshal] directly calls [jsonv2.Unmarshal] with [DefaultOptionsV1].
+-// The [DefaultOptionsV1] option represents the set of all options that specify
+-// default v1 behavior.
+-//
+-// For many of the behavior differences, there are Go struct field options
+-// that the author of a Go type can specify to control the behavior such that
+-// the type is represented identically in JSON under either v1 or v2 semantics.
+-//
+-// The availability of [DefaultOptionsV1] and [jsonv2.DefaultOptionsV2],
+-// where later options take precedence over former options allows for
+-// a gradual migration from v1 to v2. For example:
+-//
+-//   - jsonv1.Marshal(v)
+-//     uses default v1 semantics.
+-//
+-//   - jsonv2.Marshal(v, jsonv1.DefaultOptionsV1())
+-//     is semantically equivalent to jsonv1.Marshal
+-//     and thus uses default v1 semantics.
+-//
+-//   - jsonv2.Marshal(v, jsonv1.DefaultOptionsV1(), jsontext.AllowDuplicateNames(false))
+-//     uses mostly v1 semantics, but opts into one particular v2-specific behavior.
+-//
+-//   - jsonv2.Marshal(v, jsonv1.CallMethodsWithLegacySemantics(true))
+-//     uses mostly v2 semantics, but opts into one particular v1-specific behavior.
+-//
+-//   - jsonv2.Marshal(v, ..., jsonv2.DefaultOptionsV2())
+-//     is semantically equivalent to jsonv2.Marshal since
+-//     jsonv2.DefaultOptionsV2 overrides any options specified earlier
+-//     and thus uses default v2 semantics.
+-//
+-//   - jsonv2.Marshal(v)
+-//     uses default v2 semantics.
+-//
+-// All new usages of "json" in Go should use the v2 package,
+-// but the v1 package will forever remain supported.
+-package json
+-
+-import (
+-	"bytes"
+-	"encoding/json"
+-	"io"
+-)
+-
+-// Unmarshal parses the JSON-encoded data and stores the result
+-// in the value pointed to by v. If v is nil or not a pointer,
+-// Unmarshal returns an [InvalidUnmarshalError].
+-//
+-// Unmarshal uses the inverse of the encodings that
+-// [Marshal] uses, allocating maps, slices, and pointers as necessary,
+-// with the following additional rules:
+-//
+-// To unmarshal JSON into a pointer, Unmarshal first handles the case of
+-// the JSON being the JSON literal null. In that case, Unmarshal sets
+-// the pointer to nil. Otherwise, Unmarshal unmarshals the JSON into
+-// the value pointed at by the pointer. If the pointer is nil, Unmarshal
+-// allocates a new value for it to point to.
+-//
+-// To unmarshal JSON into a value implementing [Unmarshaler],
+-// Unmarshal calls that value's [Unmarshaler.UnmarshalJSON] method, including
+-// when the input is a JSON null.
+-// Otherwise, if the value implements [encoding.TextUnmarshaler]
+-// and the input is a JSON quoted string, Unmarshal calls
+-// [encoding.TextUnmarshaler.UnmarshalText] with the unquoted form of the string.
+-//
+-// To unmarshal JSON into a struct, Unmarshal matches incoming object
+-// keys to the keys used by [Marshal] (either the struct field name or its tag),
+-// preferring an exact match but also accepting a case-insensitive match. By
+-// default, object keys which don't have a corresponding struct field are
+-// ignored (see [Decoder.DisallowUnknownFields] for an alternative).
+-//
+-// To unmarshal JSON into an interface value,
+-// Unmarshal stores one of these in the interface value:
+-//
+-//   - bool, for JSON booleans
+-//   - float64, for JSON numbers
+-//   - string, for JSON strings
+-//   - []any, for JSON arrays
+-//   - map[string]any, for JSON objects
+-//   - nil for JSON null
+-//
+-// To unmarshal a JSON array into a slice, Unmarshal resets the slice length
+-// to zero and then appends each element to the slice.
+-// As a special case, to unmarshal an empty JSON array into a slice,
+-// Unmarshal replaces the slice with a new empty slice.
+-//
+-// To unmarshal a JSON array into a Go array, Unmarshal decodes
+-// JSON array elements into corresponding Go array elements.
+-// If the Go array is smaller than the JSON array,
+-// the additional JSON array elements are discarded.
+-// If the JSON array is smaller than the Go array,
+-// the additional Go array elements are set to zero values.
+-//
+-// To unmarshal a JSON object into a map, Unmarshal first establishes a map to
+-// use. If the map is nil, Unmarshal allocates a new map. Otherwise Unmarshal
+-// reuses the existing map, keeping existing entries. Unmarshal then stores
+-// key-value pairs from the JSON object into the map. The map's key type must
+-// either be any string type, an integer, or implement [encoding.TextUnmarshaler].
+-//
+-// If the JSON-encoded data contain a syntax error, Unmarshal returns a [SyntaxError].
+-//
+-// If a JSON value is not appropriate for a given target type,
+-// or if a JSON number overflows the target type, Unmarshal
+-// skips that field and completes the unmarshaling as best it can.
+-// If no more serious errors are encountered, Unmarshal returns
+-// an [UnmarshalTypeError] describing the earliest such error. In any
+-// case, it's not guaranteed that all the remaining fields following
+-// the problematic one will be unmarshaled into the target object.
+-//
+-// The JSON null value unmarshals into an interface, map, pointer, or slice
+-// by setting that Go value to nil. Because null is often used in JSON to mean
+-// “not present,” unmarshaling a JSON null into any other Go type has no effect
+-// on the value and produces no error.
+-//
+-// When unmarshaling quoted strings, invalid UTF-8 or
+-// invalid UTF-16 surrogate pairs are not treated as an error.
+-// Instead, they are replaced by the Unicode replacement
+-// character U+FFFD.
+-func Unmarshal(data []byte, v any) error {
+-	return json.Unmarshal(data, v)
+-}
+-
+-// Unmarshaler is the interface implemented by types
+-// that can unmarshal a JSON description of themselves.
+-// The input can be assumed to be a valid encoding of
+-// a JSON value. UnmarshalJSON must copy the JSON data
+-// if it wishes to retain the data after returning.
+-type Unmarshaler = json.Unmarshaler
+-
+-// An UnmarshalTypeError describes a JSON value that was
+-// not appropriate for a value of a specific Go type.
+-type UnmarshalTypeError = json.UnmarshalTypeError
+-
+-// An UnmarshalFieldError describes a JSON object key that
+-// led to an unexported (and therefore unwritable) struct field.
+-//
+-// Deprecated: No longer used; kept for compatibility.
+-type UnmarshalFieldError = json.UnmarshalFieldError
+-
+-// An InvalidUnmarshalError describes an invalid argument passed to [Unmarshal].
+-// (The argument to [Unmarshal] must be a non-nil pointer.)
+-type InvalidUnmarshalError = json.InvalidUnmarshalError
+-
+-// A Number represents a JSON number literal.
+-type Number = json.Number
+-
+-// Marshal returns the JSON encoding of v.
+-//
+-// Marshal traverses the value v recursively.
+-// If an encountered value implements [Marshaler]
+-// and is not a nil pointer, Marshal calls [Marshaler.MarshalJSON]
+-// to produce JSON. If no [Marshaler.MarshalJSON] method is present but the
+-// value implements [encoding.TextMarshaler] instead, Marshal calls
+-// [encoding.TextMarshaler.MarshalText] and encodes the result as a JSON string.
+-// The nil pointer exception is not strictly necessary
+-// but mimics a similar, necessary exception in the behavior of
+-// [Unmarshaler.UnmarshalJSON].
+-//
+-// Otherwise, Marshal uses the following type-dependent default encodings:
+-//
+-// Boolean values encode as JSON booleans.
+-//
+-// Floating point, integer, and [Number] values encode as JSON numbers.
+-// NaN and +/-Inf values will return an [UnsupportedValueError].
+-//
+-// String values encode as JSON strings coerced to valid UTF-8,
+-// replacing invalid bytes with the Unicode replacement rune.
+-// So that the JSON will be safe to embed inside HTML <script> tags,
+-// the string is encoded using [HTMLEscape],
+-// which replaces "<", ">", "&", U+2028, and U+2029 are escaped
+-// to "\u003c","\u003e", "\u0026", "\u2028", and "\u2029".
+-// This replacement can be disabled when using an [Encoder],
+-// by calling [Encoder.SetEscapeHTML](false).
+-//
+-// Array and slice values encode as JSON arrays, except that
+-// []byte encodes as a base64-encoded string, and a nil slice
+-// encodes as the null JSON value.
+-//
+-// Struct values encode as JSON objects.
+-// Each exported struct field becomes a member of the object, using the
+-// field name as the object key, unless the field is omitted for one of the
+-// reasons given below.
+-//
+-// The encoding of each struct field can be customized by the format string
+-// stored under the "json" key in the struct field's tag.
+-// The format string gives the name of the field, possibly followed by a
+-// comma-separated list of options. The name may be empty in order to
+-// specify options without overriding the default field name.
+-//
+-// The "omitempty" option specifies that the field should be omitted
+-// from the encoding if the field has an empty value, defined as
+-// false, 0, a nil pointer, a nil interface value, and any array,
+-// slice, map, or string of length zero.
+-//
+-// As a special case, if the field tag is "-", the field is always omitted.
+-// JSON names containing commas or quotes, or names identical to "" or "-",
+-// can be specified using a single-quoted string literal, where the syntax
+-// is identical to the Go grammar for a double-quoted string literal,
+-// but instead uses single quotes as the delimiters.
+-//
+-// Examples of struct field tags and their meanings:
+-//
+-//	// Field appears in JSON as key "myName".
+-//	Field int `json:"myName"`
+-//
+-//	// Field appears in JSON as key "myName" and
+-//	// the field is omitted from the object if its value is empty,
+-//	// as defined above.
+-//	Field int `json:"myName,omitempty"`
+-//
+-//	// Field appears in JSON as key "Field" (the default), but
+-//	// the field is skipped if empty.
+-//	// Note the leading comma.
+-//	Field int `json:",omitempty"`
+-//
+-//	// Field is ignored by this package.
+-//	Field int `json:"-"`
+-//
+-//	// Field appears in JSON as key "-".
+-//	Field int `json:"'-'"`
+-//
+-// The "omitzero" option specifies that the field should be omitted
+-// from the encoding if the field has a zero value, according to rules:
+-//
+-// 1) If the field type has an "IsZero() bool" method, that will be used to
+-// determine whether the value is zero.
+-//
+-// 2) Otherwise, the value is zero if it is the zero value for its type.
+-//
+-// If both "omitempty" and "omitzero" are specified, the field will be omitted
+-// if the value is either empty or zero (or both).
+-//
+-// The "string" option signals that a field is stored as JSON inside a
+-// JSON-encoded string. It applies only to fields of string, floating point,
+-// integer, or boolean types. This extra level of encoding is sometimes used
+-// when communicating with JavaScript programs:
+-//
+-//	Int64String int64 `json:",string"`
+-//
+-// The key name will be used if it's a non-empty string consisting of
+-// only Unicode letters, digits, and ASCII punctuation except quotation
+-// marks, backslash, and comma.
+-//
+-// Embedded struct fields are usually marshaled as if their inner exported fields
+-// were fields in the outer struct, subject to the usual Go visibility rules amended
+-// as described in the next paragraph.
+-// An anonymous struct field with a name given in its JSON tag is treated as
+-// having that name, rather than being anonymous.
+-// An anonymous struct field of interface type is treated the same as having
+-// that type as its name, rather than being anonymous.
+-//
+-// The Go visibility rules for struct fields are amended for JSON when
+-// deciding which field to marshal or unmarshal. If there are
+-// multiple fields at the same level, and that level is the least
+-// nested (and would therefore be the nesting level selected by the
+-// usual Go rules), the following extra rules apply:
+-//
+-// 1) Of those fields, if any are JSON-tagged, only tagged fields are considered,
+-// even if there are multiple untagged fields that would otherwise conflict.
+-//
+-// 2) If there is exactly one field (tagged or not according to the first rule), that is selected.
+-//
+-// 3) Otherwise there are multiple fields, and all are ignored; no error occurs.
+-//
+-// Handling of anonymous struct fields is new in Go 1.1.
+-// Prior to Go 1.1, anonymous struct fields were ignored. To force ignoring of
+-// an anonymous struct field in both current and earlier versions, give the field
+-// a JSON tag of "-".
+-//
+-// Map values encode as JSON objects. The map's key type must either be a
+-// string, an integer type, or implement [encoding.TextMarshaler]. The map keys
+-// are sorted and used as JSON object keys by applying the following rules,
+-// subject to the UTF-8 coercion described for string values above:
+-//   - keys of any string type are used directly
+-//   - keys that implement [encoding.TextMarshaler] are marshaled
+-//   - integer keys are converted to strings
+-//
+-// Pointer values encode as the value pointed to.
+-// A nil pointer encodes as the null JSON value.
+-//
+-// Interface values encode as the value contained in the interface.
+-// A nil interface value encodes as the null JSON value.
+-//
+-// Channel, complex, and function values cannot be encoded in JSON.
+-// Attempting to encode such a value causes Marshal to return
+-// an [UnsupportedTypeError].
+-//
+-// JSON cannot represent cyclic data structures and Marshal does not
+-// handle them. Passing cyclic structures to Marshal will result in
+-// an error.
+-func Marshal(v any) ([]byte, error) {
+-	return json.Marshal(v)
+-}
+-
+-// MarshalIndent is like [Marshal] but applies [Indent] to format the output.
+-// Each JSON element in the output will begin on a new line beginning with prefix
+-// followed by one or more copies of indent according to the indentation nesting.
+-func MarshalIndent(v any, prefix, indent string) ([]byte, error) {
+-	return json.MarshalIndent(v, prefix, indent)
+-}
+-
+-// Marshaler is the interface implemented by types that
+-// can marshal themselves into valid JSON.
+-type Marshaler = json.Marshaler
+-
+-// An UnsupportedTypeError is returned by [Marshal] when attempting
+-// to encode an unsupported value type.
+-type UnsupportedTypeError = json.UnsupportedTypeError
+-
+-// An UnsupportedValueError is returned by [Marshal] when attempting
+-// to encode an unsupported value.
+-type UnsupportedValueError = json.UnsupportedValueError
+-
+-// Before Go 1.2, an InvalidUTF8Error was returned by [Marshal] when
+-// attempting to encode a string value with invalid UTF-8 sequences.
+-// As of Go 1.2, [Marshal] instead coerces the string to valid UTF-8 by
+-// replacing invalid bytes with the Unicode replacement rune U+FFFD.
+-//
+-// Deprecated: No longer used; kept for compatibility.
+-type InvalidUTF8Error = json.InvalidUTF8Error
+-
+-// A MarshalerError represents an error from calling a
+-// [Marshaler.MarshalJSON] or [encoding.TextMarshaler.MarshalText] method.
+-type MarshalerError = json.MarshalerError
+-
+-// HTMLEscape appends to dst the JSON-encoded src with <, >, &, U+2028 and U+2029
+-// characters inside string literals changed to \u003c, \u003e, \u0026, \u2028, \u2029
+-// so that the JSON will be safe to embed inside HTML <script> tags.
+-// For historical reasons, web browsers don't honor standard HTML
+-// escaping within <script> tags, so an alternative JSON encoding must be used.
+-func HTMLEscape(dst *bytes.Buffer, src []byte) {
+-	json.HTMLEscape(dst, src)
+-}
+-
+-// Compact appends to dst the JSON-encoded src with
+-// insignificant space characters elided.
+-func Compact(dst *bytes.Buffer, src []byte) error {
+-	return json.Compact(dst, src)
+-}
+-
+-// Indent appends to dst an indented form of the JSON-encoded src.
+-// Each element in a JSON object or array begins on a new,
+-// indented line beginning with prefix followed by one or more
+-// copies of indent according to the indentation nesting.
+-// The data appended to dst does not begin with the prefix nor
+-// any indentation, to make it easier to embed inside other formatted JSON data.
+-// Although leading space characters (space, tab, carriage return, newline)
+-// at the beginning of src are dropped, trailing space characters
+-// at the end of src are preserved and copied to dst.
+-// For example, if src has no trailing spaces, neither will dst;
+-// if src ends in a trailing newline, so will dst.
+-func Indent(dst *bytes.Buffer, src []byte, prefix, indent string) error {
+-	return json.Indent(dst, src, prefix, indent)
+-}
+-
+-// Options are a set of options to configure the v2 "json" package
+-// to operate with v1 semantics for particular features.
+-// Values of this type can be passed to v2 functions like
+-// [jsonv2.Marshal] or [jsonv2.Unmarshal].
+-// Instead of referencing this type, use [jsonv2.Options].
+-//
+-// See the "Migrating to v2" section for guidance on how to migrate usage
+-// of "json" from using v1 to using v2 instead.
+-type Options = json.Options
+-
+-// DefaultOptionsV1 is the full set of all options that define v1 semantics.
+-// It is equivalent to the following boolean options being set to true:
+-//
+-//   - [CallMethodsWithLegacySemantics]
+-//   - [FormatByteArrayAsArray]
+-//   - [FormatBytesWithLegacySemantics]
+-//   - [FormatDurationAsNano]
+-//   - [MatchCaseSensitiveDelimiter]
+-//   - [MergeWithLegacySemantics]
+-//   - [OmitEmptyWithLegacySemantics]
+-//   - [ParseBytesWithLooseRFC4648]
+-//   - [ParseTimeWithLooseRFC3339]
+-//   - [ReportErrorsWithLegacySemantics]
+-//   - [StringifyWithLegacySemantics]
+-//   - [UnmarshalArrayFromAnyLength]
+-//   - [jsonv2.Deterministic]
+-//   - [jsonv2.FormatNilMapAsNull]
+-//   - [jsonv2.FormatNilSliceAsNull]
+-//   - [jsonv2.MatchCaseInsensitiveNames]
+-//   - [jsontext.AllowDuplicateNames]
+-//   - [jsontext.AllowInvalidUTF8]
+-//   - [jsontext.EscapeForHTML]
+-//   - [jsontext.EscapeForJS]
+-//   - [jsontext.PreserveRawStrings]
+-//
+-// All other boolean options are set to false.
+-// All non-boolean options are set to the zero value,
+-// except for [jsontext.WithIndent], which defaults to "\t".
+-//
+-// The [Marshal] and [Unmarshal] functions in this package are
+-// semantically identical to calling the v2 equivalents with this option:
+-//
+-//	jsonv2.Marshal(v, jsonv1.DefaultOptionsV1())
+-//	jsonv2.Unmarshal(b, v, jsonv1.DefaultOptionsV1())
+-func DefaultOptionsV1() Options {
+-	return json.DefaultOptionsV1()
+-}
+-
+-// CallMethodsWithLegacySemantics specifies that calling of type-provided
+-// marshal and unmarshal methods follow legacy semantics:
+-//
+-//   - When marshaling, a marshal method declared on a pointer receiver
+-//     is only called if the Go value is addressable.
+-//     Values obtained from an interface or map element are not addressable.
+-//     Values obtained from a pointer or slice element are addressable.
+-//     Values obtained from an array element or struct field inherit
+-//     the addressability of the parent. In contrast, the v2 semantic
+-//     is to always call marshal methods regardless of addressability.
+-//
+-//   - When marshaling or unmarshaling, the [Marshaler] or [Unmarshaler]
+-//     methods are ignored for map keys. However, [encoding.TextMarshaler]
+-//     or [encoding.TextUnmarshaler] are still callable.
+-//     In contrast, the v2 semantic is to serialize map keys
+-//     like any other value (with regard to calling methods),
+-//     which may include calling [Marshaler] or [Unmarshaler] methods,
+-//     where it is the implementation's responsibility to represent the
+-//     Go value as a JSON string (as required for JSON object names).
+-//
+-//   - When marshaling, if a map key value implements a marshal method
+-//     and is a nil pointer, then it is serialized as an empty JSON string.
+-//     In contrast, the v2 semantic is to report an error.
+-//
+-//   - When marshaling, if an interface type implements a marshal method
+-//     and the interface value is a nil pointer to a concrete type,
+-//     then the marshal method is always called.
+-//     In contrast, the v2 semantic is to never directly call methods
+-//     on interface values and to instead defer evaluation based upon
+-//     the underlying concrete value. Similar to non-interface values,
+-//     marshal methods are not called on nil pointers and
+-//     are instead serialized as a JSON null.
+-//
+-// This affects either marshaling or unmarshaling.
+-// The v1 default is true.
+-func CallMethodsWithLegacySemantics(v bool) Options {
+-	return json.CallMethodsWithLegacySemantics(v)
+-}
+-
+-// FormatByteArrayAsArray specifies that a Go [N]byte is
+-// formatted as as a normal Go array in contrast to the v2 default of
+-// formatting [N]byte as using binary data encoding (RFC 4648).
+-// If a struct field has a `format` tag option,
+-// then the specified formatting takes precedence.
+-//
+-// This affects either marshaling or unmarshaling.
+-// The v1 default is true.
+-func FormatByteArrayAsArray(v bool) Options {
+-	return json.FormatByteArrayAsArray(v)
+-}
+-
+-// FormatBytesWithLegacySemantics specifies that handling of
+-// []~byte and [N]~byte types follow legacy semantics:
+-//
+-//   - A Go []~byte is to be treated as using some form of
+-//     binary data encoding (RFC 4648) in contrast to the v2 default
+-//     of only treating []byte as such. In particular, v2 does not
+-//     treat slices of named byte types as representing binary data.
+-//
+-//   - When marshaling, if a named byte implements a marshal method,
+-//     then the slice is serialized as a JSON array of elements,
+-//     each of which call the marshal method.
+-//
+-//   - When unmarshaling, if the input is a JSON array,
+-//     then unmarshal into the []~byte as if it were a normal Go slice.
+-//     In contrast, the v2 default is to report an error unmarshaling
+-//     a JSON array when expecting some form of binary data encoding.
+-//
+-// This affects either marshaling or unmarshaling.
+-// The v1 default is true.
+-func FormatBytesWithLegacySemantics(v bool) Options {
+-	return json.FormatBytesWithLegacySemantics(v)
+-}
+-
+-// FormatDurationAsNano specifies that a [time.Duration] is
+-// formatted as a JSON number representing the number of nanoseconds
+-// in contrast to the v2 default of reporting an error.
+-// If a duration field has a `format` tag option,
+-// then the specified formatting takes precedence.
+-//
+-// This affects either marshaling or unmarshaling.
+-// The v1 default is true.
+-func FormatDurationAsNano(v bool) Options {
+-	return json.FormatDurationAsNano(v)
+-}
+-
+-// MatchCaseSensitiveDelimiter specifies that underscores and dashes are
+-// not to be ignored when performing case-insensitive name matching which
+-// occurs under [jsonv2.MatchCaseInsensitiveNames] or the `case:ignore` tag option.
+-// Thus, case-insensitive name matching is identical to [strings.EqualFold].
+-// Use of this option diminishes the ability of case-insensitive matching
+-// to be able to match common case variants (e.g, "foo_bar" with "fooBar").
+-//
+-// This affects either marshaling or unmarshaling.
+-// The v1 default is true.
+-func MatchCaseSensitiveDelimiter(v bool) Options {
+-	return json.MatchCaseSensitiveDelimiter(v)
+-}
+-
+-// MergeWithLegacySemantics specifies that unmarshaling into a non-zero
+-// Go value follows legacy semantics:
+-//
+-//   - When unmarshaling a JSON null, this preserves the original Go value
+-//     if the kind is a bool, int, uint, float, string, array, or struct.
+-//     Otherwise, it zeros the Go value.
+-//     In contrast, the default v2 behavior is to consistently and always
+-//     zero the Go value when unmarshaling a JSON null into it.
+-//
+-//   - When unmarshaling a JSON value other than null, this merges into
+-//     the original Go value for array elements, slice elements,
+-//     struct fields (but not map values),
+-//     pointer values, and interface values (only if a non-nil pointer).
+-//     In contrast, the default v2 behavior is to merge into the Go value
+-//     for struct fields, map values, pointer values, and interface values.
+-//     In general, the v2 semantic merges when unmarshaling a JSON object,
+-//     otherwise it replaces the original value.
+-//
+-// This only affects unmarshaling and is ignored when marshaling.
+-// The v1 default is true.
+-func MergeWithLegacySemantics(v bool) Options {
+-	return json.MergeWithLegacySemantics(v)
+-}
+-
+-// OmitEmptyWithLegacySemantics specifies that the `omitempty` tag option
+-// follows a definition of empty where a field is omitted if the Go value is
+-// false, 0, a nil pointer, a nil interface value,
+-// or any empty array, slice, map, or string.
+-// This overrides the v2 semantic where a field is empty if the value
+-// marshals as a JSON null or an empty JSON string, object, or array.
+-//
+-// The v1 and v2 definitions of `omitempty` are practically the same for
+-// Go strings, slices, arrays, and maps. Usages of `omitempty` on
+-// Go bools, ints, uints floats, pointers, and interfaces should migrate to use
+-// the `omitzero` tag option, which omits a field if it is the zero Go value.
+-//
+-// This only affects marshaling and is ignored when unmarshaling.
+-// The v1 default is true.
+-func OmitEmptyWithLegacySemantics(v bool) Options {
+-	return json.OmitEmptyWithLegacySemantics(v)
+-}
+-
+-// ParseBytesWithLooseRFC4648 specifies that when parsing
+-// binary data encoded as "base32" or "base64",
+-// to ignore the presence of '\r' and '\n' characters.
+-// In contrast, the v2 default is to report an error in order to be
+-// strictly compliant with RFC 4648, section 3.3,
+-// which specifies that non-alphabet characters must be rejected.
+-//
+-// This only affects unmarshaling and is ignored when marshaling.
+-// The v1 default is true.
+-func ParseBytesWithLooseRFC4648(v bool) Options {
+-	return json.ParseBytesWithLooseRFC4648(v)
+-}
+-
+-// ParseTimeWithLooseRFC3339 specifies that a [time.Time]
+-// parses according to loose adherence to RFC 3339.
+-// In particular, it permits historically incorrect representations,
+-// allowing for deviations in hour format, sub-second separator,
+-// and timezone representation. In contrast, the default v2 behavior
+-// is to strictly comply with the grammar specified in RFC 3339.
+-//
+-// This only affects unmarshaling and is ignored when marshaling.
+-// The v1 default is true.
+-func ParseTimeWithLooseRFC3339(v bool) Options {
+-	return json.ParseTimeWithLooseRFC3339(v)
+-}
+-
+-// ReportErrorsWithLegacySemantics specifies that Marshal and Unmarshal
+-// should report errors with legacy semantics:
+-//
+-//   - When marshaling or unmarshaling, the returned error values are
+-//     usually of types such as [SyntaxError], [MarshalerError],
+-//     [UnsupportedTypeError], [UnsupportedValueError],
+-//     [InvalidUnmarshalError], or [UnmarshalTypeError].
+-//     In contrast, the v2 semantic is to always return errors as either
+-//     [jsonv2.SemanticError] or [jsontext.SyntacticError].
+-//
+-//   - When marshaling, if a user-defined marshal method reports an error,
+-//     it is always wrapped in a [MarshalerError], even if the error itself
+-//     is already a [MarshalerError], which may lead to multiple redundant
+-//     layers of wrapping. In contrast, the v2 semantic is to
+-//     always wrap an error within [jsonv2.SemanticError]
+-//     unless it is already a semantic error.
+-//
+-//   - When unmarshaling, if a user-defined unmarshal method reports an error,
+-//     it is never wrapped and reported verbatim. In contrast, the v2 semantic
+-//     is to always wrap an error within [jsonv2.SemanticError]
+-//     unless it is already a semantic error.
+-//
+-//   - When marshaling or unmarshaling, if a Go struct contains type errors
+-//     (e.g., conflicting names or malformed field tags), then such errors
+-//     are ignored and the Go struct uses a best-effort representation.
+-//     In contrast, the v2 semantic is to report a runtime error.
+-//
+-//   - When unmarshaling, the syntactic structure of the JSON input
+-//     is fully validated before performing the semantic unmarshaling
+-//     of the JSON data into the Go value. Practically speaking,
+-//     this means that JSON input with syntactic errors do not result
+-//     in any mutations of the target Go value. In contrast, the v2 semantic
+-//     is to perform a streaming decode and gradually unmarshal the JSON input
+-//     into the target Go value, which means that the Go value may be
+-//     partially mutated when a syntactic error is encountered.
+-//
+-//   - When unmarshaling, a semantic error does not immediately terminate the
+-//     unmarshal procedure, but rather evaluation continues.
+-//     When unmarshal returns, only the first semantic error is reported.
+-//     In contrast, the v2 semantic is to terminate unmarshal the moment
+-//     an error is encountered.
+-//
+-// This affects either marshaling or unmarshaling.
+-// The v1 default is true.
+-func ReportErrorsWithLegacySemantics(v bool) Options {
+-	return json.ReportErrorsWithLegacySemantics(v)
+-}
+-
+-// StringifyWithLegacySemantics specifies that the `string` tag option
+-// may stringify bools and string values. It only takes effect on fields
+-// where the top-level type is a bool, string, numeric kind, or a pointer to
+-// such a kind. Specifically, `string` will not stringify bool, string,
+-// or numeric kinds within a composite data type
+-// (e.g., array, slice, struct, map, or interface).
+-//
+-// When marshaling, such Go values are serialized as their usual
+-// JSON representation, but quoted within a JSON string.
+-// When unmarshaling, such Go values must be deserialized from
+-// a JSON string containing their usual JSON representation.
+-// A JSON null quoted in a JSON string is a valid substitute for JSON null
+-// while unmarshaling into a Go value that `string` takes effect on.
+-//
+-// This affects either marshaling or unmarshaling.
+-// The v1 default is true.
+-func StringifyWithLegacySemantics(v bool) Options {
+-	return json.StringifyWithLegacySemantics(v)
+-}
+-
+-// UnmarshalArrayFromAnyLength specifies that Go arrays can be unmarshaled
+-// from input JSON arrays of any length. If the JSON array is too short,
+-// then the remaining Go array elements are zeroed. If the JSON array
+-// is too long, then the excess JSON array elements are skipped over.
+-//
+-// This only affects unmarshaling and is ignored when marshaling.
+-// The v1 default is true.
+-func UnmarshalArrayFromAnyLength(v bool) Options {
+-	return json.UnmarshalArrayFromAnyLength(v)
+-}
+-
+-// Valid reports whether data is a valid JSON encoding.
+-func Valid(data []byte) bool {
+-	return json.Valid(data)
+-}
+-
+-// A SyntaxError is a description of a JSON syntax error.
+-// [Unmarshal] will return a SyntaxError if the JSON can't be parsed.
+-type SyntaxError = json.SyntaxError
+-
+-// A Decoder reads and decodes JSON values from an input stream.
+-type Decoder = json.Decoder
+-
+-// NewDecoder returns a new decoder that reads from r.
+-//
+-// The decoder introduces its own buffering and may
+-// read data from r beyond the JSON values requested.
+-func NewDecoder(r io.Reader) *Decoder {
+-	return json.NewDecoder(r)
+-}
+-
+-// An Encoder writes JSON values to an output stream.
+-type Encoder = json.Encoder
+-
+-// NewEncoder returns a new encoder that writes to w.
+-func NewEncoder(w io.Writer) *Encoder {
+-	return json.NewEncoder(w)
+-}
+-
+-// RawMessage is a raw encoded JSON value.
+-// It implements [Marshaler] and [Unmarshaler] and can
+-// be used to delay JSON decoding or precompute a JSON encoding.
+-type RawMessage = json.RawMessage
+-
+-// A Token holds a value of one of these types:
+-//
+-//   - [Delim], for the four JSON delimiters [ ] { }
+-//   - bool, for JSON booleans
+-//   - float64, for JSON numbers
+-//   - [Number], for JSON numbers
+-//   - string, for JSON string literals
+-//   - nil, for JSON null
+-type Token = json.Token
+-
+-// A Delim is a JSON array or object delimiter, one of [ ] { or }.
+-type Delim = json.Delim
+diff --git a/pkg/internal/third_party/go-json-experiment/json/v1/decode.go b/pkg/internal/third_party/go-json-experiment/json/v1/decode.go
+deleted file mode 100644
+index a1c9cf291..000000000
+--- a/pkg/internal/third_party/go-json-experiment/json/v1/decode.go
++++ /dev/null
+@@ -1,245 +0,0 @@
+-// Copyright 2010 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+-// Represents JSON data structure using native Go types: booleans, floats,
+-// strings, arrays, and maps.
+-
+-package json
+-
+-import (
+-	"cmp"
+-	"fmt"
+-	"reflect"
+-	"strconv"
+-
+-	jsonv2 "k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json"
+-	"k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json/internal/jsonwire"
+-	"k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json/jsontext"
+-)
+-
+-// Unmarshal parses the JSON-encoded data and stores the result
+-// in the value pointed to by v. If v is nil or not a pointer,
+-// Unmarshal returns an [InvalidUnmarshalError].
+-//
+-// Unmarshal uses the inverse of the encodings that
+-// [Marshal] uses, allocating maps, slices, and pointers as necessary,
+-// with the following additional rules:
+-//
+-// To unmarshal JSON into a pointer, Unmarshal first handles the case of
+-// the JSON being the JSON literal null. In that case, Unmarshal sets
+-// the pointer to nil. Otherwise, Unmarshal unmarshals the JSON into
+-// the value pointed at by the pointer. If the pointer is nil, Unmarshal
+-// allocates a new value for it to point to.
+-//
+-// To unmarshal JSON into a value implementing [Unmarshaler],
+-// Unmarshal calls that value's [Unmarshaler.UnmarshalJSON] method, including
+-// when the input is a JSON null.
+-// Otherwise, if the value implements [encoding.TextUnmarshaler]
+-// and the input is a JSON quoted string, Unmarshal calls
+-// [encoding.TextUnmarshaler.UnmarshalText] with the unquoted form of the string.
+-//
+-// To unmarshal JSON into a struct, Unmarshal matches incoming object
+-// keys to the keys used by [Marshal] (either the struct field name or its tag),
+-// preferring an exact match but also accepting a case-insensitive match. By
+-// default, object keys which don't have a corresponding struct field are
+-// ignored (see [Decoder.DisallowUnknownFields] for an alternative).
+-//
+-// To unmarshal JSON into an interface value,
+-// Unmarshal stores one of these in the interface value:
+-//
+-//   - bool, for JSON booleans
+-//   - float64, for JSON numbers
+-//   - string, for JSON strings
+-//   - []any, for JSON arrays
+-//   - map[string]any, for JSON objects
+-//   - nil for JSON null
+-//
+-// To unmarshal a JSON array into a slice, Unmarshal resets the slice length
+-// to zero and then appends each element to the slice.
+-// As a special case, to unmarshal an empty JSON array into a slice,
+-// Unmarshal replaces the slice with a new empty slice.
+-//
+-// To unmarshal a JSON array into a Go array, Unmarshal decodes
+-// JSON array elements into corresponding Go array elements.
+-// If the Go array is smaller than the JSON array,
+-// the additional JSON array elements are discarded.
+-// If the JSON array is smaller than the Go array,
+-// the additional Go array elements are set to zero values.
+-//
+-// To unmarshal a JSON object into a map, Unmarshal first establishes a map to
+-// use. If the map is nil, Unmarshal allocates a new map. Otherwise Unmarshal
+-// reuses the existing map, keeping existing entries. Unmarshal then stores
+-// key-value pairs from the JSON object into the map. The map's key type must
+-// either be any string type, an integer, or implement [encoding.TextUnmarshaler].
+-//
+-// If the JSON-encoded data contain a syntax error, Unmarshal returns a [SyntaxError].
+-//
+-// If a JSON value is not appropriate for a given target type,
+-// or if a JSON number overflows the target type, Unmarshal
+-// skips that field and completes the unmarshaling as best it can.
+-// If no more serious errors are encountered, Unmarshal returns
+-// an [UnmarshalTypeError] describing the earliest such error. In any
+-// case, it's not guaranteed that all the remaining fields following
+-// the problematic one will be unmarshaled into the target object.
+-//
+-// The JSON null value unmarshals into an interface, map, pointer, or slice
+-// by setting that Go value to nil. Because null is often used in JSON to mean
+-// “not present,” unmarshaling a JSON null into any other Go type has no effect
+-// on the value and produces no error.
+-//
+-// When unmarshaling quoted strings, invalid UTF-8 or
+-// invalid UTF-16 surrogate pairs are not treated as an error.
+-// Instead, they are replaced by the Unicode replacement
+-// character U+FFFD.
+-func Unmarshal(data []byte, v any) error {
+-	return jsonv2.Unmarshal(data, v, DefaultOptionsV1())
+-}
+-
+-// Unmarshaler is the interface implemented by types
+-// that can unmarshal a JSON description of themselves.
+-// The input can be assumed to be a valid encoding of
+-// a JSON value. UnmarshalJSON must copy the JSON data
+-// if it wishes to retain the data after returning.
+-type Unmarshaler = jsonv2.Unmarshaler
+-
+-// An UnmarshalTypeError describes a JSON value that was
+-// not appropriate for a value of a specific Go type.
+-type UnmarshalTypeError struct {
+-	Value  string       // description of JSON value - "bool", "array", "number -5"
+-	Type   reflect.Type // type of Go value it could not be assigned to
+-	Offset int64        // error occurred after reading Offset bytes
+-	Struct string       // name of the root type containing the field
+-	Field  string       // the full path from root node to the value
+-	Err    error        // may be nil
+-}
+-
+-func (e *UnmarshalTypeError) Error() string {
+-	var s string
+-	if e.Struct != "" || e.Field != "" {
+-		s = "json: cannot unmarshal " + e.Value + " into Go struct field " + e.Struct + "." + e.Field + " of type " + e.Type.String()
+-	} else {
+-		s = "json: cannot unmarshal " + e.Value + " into Go value of type " + e.Type.String()
+-	}
+-	if e.Err != nil {
+-		s += ": " + e.Err.Error()
+-	}
+-	return s
+-}
+-
+-func (e *UnmarshalTypeError) Unwrap() error {
+-	return e.Err
+-}
+-
+-// An UnmarshalFieldError describes a JSON object key that
+-// led to an unexported (and therefore unwritable) struct field.
+-//
+-// Deprecated: No longer used; kept for compatibility.
+-type UnmarshalFieldError struct {
+-	Key   string
+-	Type  reflect.Type
+-	Field reflect.StructField
+-}
+-
+-func (e *UnmarshalFieldError) Error() string {
+-	return "json: cannot unmarshal object key " + strconv.Quote(e.Key) + " into unexported field " + e.Field.Name + " of type " + e.Type.String()
+-}
+-
+-// An InvalidUnmarshalError describes an invalid argument passed to [Unmarshal].
+-// (The argument to [Unmarshal] must be a non-nil pointer.)
+-type InvalidUnmarshalError struct {
+-	Type reflect.Type
+-}
+-
+-func (e *InvalidUnmarshalError) Error() string {
+-	if e.Type == nil {
+-		return "json: Unmarshal(nil)"
+-	}
+-
+-	if e.Type.Kind() != reflect.Pointer {
+-		return "json: Unmarshal(non-pointer " + e.Type.String() + ")"
+-	}
+-	return "json: Unmarshal(nil " + e.Type.String() + ")"
+-}
+-
+-// A Number represents a JSON number literal.
+-type Number string
+-
+-// String returns the literal text of the number.
+-func (n Number) String() string { return string(n) }
+-
+-// Float64 returns the number as a float64.
+-func (n Number) Float64() (float64, error) {
+-	return strconv.ParseFloat(string(n), 64)
+-}
+-
+-// Int64 returns the number as an int64.
+-func (n Number) Int64() (int64, error) {
+-	return strconv.ParseInt(string(n), 10, 64)
+-}
+-
+-var numberType = reflect.TypeFor[Number]()
+-
+-// MarshalJSONTo implements [jsonv2.MarshalerTo].
+-func (n Number) MarshalJSONTo(enc *jsontext.Encoder) error {
+-	opts := enc.Options()
+-	stringify, _ := jsonv2.GetOption(opts, jsonv2.StringifyNumbers)
+-	if k, n := enc.StackIndex(enc.StackDepth()); k == '{' && n%2 == 0 {
+-		stringify = true // expecting a JSON object name
+-	}
+-	n = cmp.Or(n, "0")
+-	var num []byte
+-	val := enc.AvailableBuffer()
+-	if stringify {
+-		val = append(val, '"')
+-		val = append(val, n...)
+-		val = append(val, '"')
+-		num = val[len(`"`) : len(val)-len(`"`)]
+-	} else {
+-		val = append(val, n...)
+-		num = val
+-	}
+-	if n, err := jsonwire.ConsumeNumber(num); n != len(num) || err != nil {
+-		return fmt.Errorf("cannot parse %q as JSON number: %w", val, strconv.ErrSyntax)
+-	}
+-	return enc.WriteValue(val)
+-}
+-
+-// UnmarshalJSONFrom implements [jsonv2.UnmarshalerFrom].
+-func (n *Number) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
+-	opts := dec.Options()
+-	stringify, _ := jsonv2.GetOption(opts, jsonv2.StringifyNumbers)
+-	if k, n := dec.StackIndex(dec.StackDepth()); k == '{' && n%2 == 0 {
+-		stringify = true // expecting a JSON object name
+-	}
+-	val, err := dec.ReadValue()
+-	if err != nil {
+-		return err
+-	}
+-	val0 := val
+-	k := val.Kind()
+-	switch k {
+-	case 'n':
+-		if legacy, _ := jsonv2.GetOption(opts, MergeWithLegacySemantics); !legacy {
+-			*n = ""
+-		}
+-		return nil
+-	case '"':
+-		verbatim := jsonwire.ConsumeSimpleString(val) == len(val)
+-		val = jsonwire.UnquoteMayCopy(val, verbatim)
+-		if n, err := jsonwire.ConsumeNumber(val); n != len(val) || err != nil {
+-			return &jsonv2.SemanticError{JSONKind: val0.Kind(), JSONValue: val0.Clone(), GoType: numberType, Err: strconv.ErrSyntax}
+-		}
+-		*n = Number(val)
+-		return nil
+-	case '0':
+-		if stringify {
+-			break
+-		}
+-		*n = Number(val)
+-		return nil
+-	}
+-	return &jsonv2.SemanticError{JSONKind: k, GoType: numberType}
+-}
+diff --git a/pkg/internal/third_party/go-json-experiment/json/v1/decode_test.go b/pkg/internal/third_party/go-json-experiment/json/v1/decode_test.go
+deleted file mode 100644
+index 64d20719a..000000000
+--- a/pkg/internal/third_party/go-json-experiment/json/v1/decode_test.go
++++ /dev/null
+@@ -1,2861 +0,0 @@
+-// Copyright 2010 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+-package json
+-
+-import (
+-	"bytes"
+-	"encoding"
+-	"errors"
+-	"fmt"
+-	"image"
+-	"io"
+-	"maps"
+-	"math"
+-	"math/big"
+-	"net"
+-	"reflect"
+-	"slices"
+-	"strconv"
+-	"strings"
+-	"testing"
+-	"time"
+-)
+-
+-func len64(s string) int64 {
+-	return int64(len(s))
+-}
+-
+-type T struct {
+-	X string
+-	Y int
+-	Z int `json:"-"`
+-}
+-
+-type U struct {
+-	Alphabet string `json:"alpha"`
+-}
+-
+-type V struct {
+-	F1 any
+-	F2 int32
+-	F3 Number
+-	F4 *VOuter
+-}
+-
+-type VOuter struct {
+-	V V
+-}
+-
+-type W struct {
+-	S SS
+-}
+-
+-type P struct {
+-	PP PP
+-}
+-
+-type PP struct {
+-	T  T
+-	Ts []T
+-}
+-
+-type SS string
+-
+-func (*SS) UnmarshalJSON(data []byte) error {
+-	return &UnmarshalTypeError{Value: "number", Type: reflect.TypeFor[SS]()}
+-}
+-
+-type TAlias T
+-
+-func (tt *TAlias) UnmarshalJSON(data []byte) error {
+-	t := T{}
+-	if err := Unmarshal(data, &t); err != nil {
+-		return err
+-	}
+-	*tt = TAlias(t)
+-	return nil
+-}
+-
+-type TOuter struct {
+-	T TAlias
+-}
+-
+-// ifaceNumAsFloat64/ifaceNumAsNumber are used to test unmarshaling with and
+-// without UseNumber
+-var ifaceNumAsFloat64 = map[string]any{
+-	"k1": float64(1),
+-	"k2": "s",
+-	"k3": []any{float64(1), float64(2.0), float64(3e-3)},
+-	"k4": map[string]any{"kk1": "s", "kk2": float64(2)},
+-}
+-
+-var ifaceNumAsNumber = map[string]any{
+-	"k1": Number("1"),
+-	"k2": "s",
+-	"k3": []any{Number("1"), Number("2.0"), Number("3e-3")},
+-	"k4": map[string]any{"kk1": "s", "kk2": Number("2")},
+-}
+-
+-type tx struct {
+-	x int
+-}
+-
+-type u8 uint8
+-
+-// A type that can unmarshal itself.
+-
+-type unmarshaler struct {
+-	T bool
+-}
+-
+-func (u *unmarshaler) UnmarshalJSON(b []byte) error {
+-	*u = unmarshaler{true} // All we need to see that UnmarshalJSON is called.
+-	return nil
+-}
+-
+-type ustruct struct {
+-	M unmarshaler
+-}
+-
+-type unmarshalerText struct {
+-	A, B string
+-}
+-
+-// needed for re-marshaling tests
+-func (u unmarshalerText) MarshalText() ([]byte, error) {
+-	return []byte(u.A + ":" + u.B), nil
+-}
+-
+-func (u *unmarshalerText) UnmarshalText(b []byte) error {
+-	pos := bytes.IndexByte(b, ':')
+-	if pos == -1 {
+-		return errors.New("missing separator")
+-	}
+-	u.A, u.B = string(b[:pos]), string(b[pos+1:])
+-	return nil
+-}
+-
+-var _ encoding.TextUnmarshaler = (*unmarshalerText)(nil)
+-
+-type ustructText struct {
+-	M unmarshalerText
+-}
+-
+-// u8marshal is an integer type that can marshal/unmarshal itself.
+-type u8marshal uint8
+-
+-func (u8 u8marshal) MarshalText() ([]byte, error) {
+-	return []byte(fmt.Sprintf("u%d", u8)), nil
+-}
+-
+-var errMissingU8Prefix = errors.New("missing 'u' prefix")
+-
+-func (u8 *u8marshal) UnmarshalText(b []byte) error {
+-	if !bytes.HasPrefix(b, []byte{'u'}) {
+-		return errMissingU8Prefix
+-	}
+-	n, err := strconv.Atoi(string(b[1:]))
+-	if err != nil {
+-		return err
+-	}
+-	*u8 = u8marshal(n)
+-	return nil
+-}
+-
+-var _ encoding.TextUnmarshaler = (*u8marshal)(nil)
+-
+-var (
+-	umtrue   = unmarshaler{true}
+-	umslice  = []unmarshaler{{true}}
+-	umstruct = ustruct{unmarshaler{true}}
+-
+-	umtrueXY   = unmarshalerText{"x", "y"}
+-	umsliceXY  = []unmarshalerText{{"x", "y"}}
+-	umstructXY = ustructText{unmarshalerText{"x", "y"}}
+-
+-	ummapXY = map[unmarshalerText]bool{{"x", "y"}: true}
+-)
+-
+-// Test data structures for anonymous fields.
+-
+-type Point struct {
+-	Z int
+-}
+-
+-type Top struct {
+-	Level0 int
+-	Embed0
+-	*Embed0a
+-	*Embed0b `json:"e,omitempty"` // treated as named
+-	Embed0c  `json:"-"`           // ignored
+-	Loop
+-	Embed0p // has Point with X, Y, used
+-	Embed0q // has Point with Z, used
+-	embed   // contains exported field
+-}
+-
+-type Embed0 struct {
+-	Level1a int // overridden by Embed0a's Level1a with json tag
+-	Level1b int // used because Embed0a's Level1b is renamed
+-	Level1c int // used because Embed0a's Level1c is ignored
+-	Level1d int // annihilated by Embed0a's Level1d
+-	Level1e int `json:"x"` // annihilated by Embed0a.Level1e
+-}
+-
+-type Embed0a struct {
+-	Level1a int `json:"Level1a,omitempty"`
+-	Level1b int `json:"LEVEL1B,omitempty"`
+-	Level1c int `json:"-"`
+-	Level1d int // annihilated by Embed0's Level1d
+-	Level1f int `json:"x"` // annihilated by Embed0's Level1e
+-}
+-
+-type Embed0b Embed0
+-
+-type Embed0c Embed0
+-
+-type Embed0p struct {
+-	image.Point
+-}
+-
+-type Embed0q struct {
+-	Point
+-}
+-
+-type embed struct {
+-	Q int
+-}
+-
+-type Loop struct {
+-	Loop1 int `json:",omitempty"`
+-	Loop2 int `json:",omitempty"`
+-	*Loop
+-}
+-
+-// From reflect test:
+-// The X in S6 and S7 annihilate, but they also block the X in S8.S9.
+-type S5 struct {
+-	S6
+-	S7
+-	S8
+-}
+-
+-type S6 struct {
+-	X int
+-}
+-
+-type S7 S6
+-
+-type S8 struct {
+-	S9
+-}
+-
+-type S9 struct {
+-	X int
+-	Y int
+-}
+-
+-// From reflect test:
+-// The X in S11.S6 and S12.S6 annihilate, but they also block the X in S13.S8.S9.
+-type S10 struct {
+-	S11
+-	S12
+-	S13
+-}
+-
+-type S11 struct {
+-	S6
+-}
+-
+-type S12 struct {
+-	S6
+-}
+-
+-type S13 struct {
+-	S8
+-}
+-
+-type Ambig struct {
+-	// Given "hello", the first match should win.
+-	First  int `json:"HELLO"`
+-	Second int `json:"Hello"`
+-}
+-
+-type XYZ struct {
+-	X any
+-	Y any
+-	Z any
+-}
+-
+-type unexportedWithMethods struct{}
+-
+-func (unexportedWithMethods) F() {}
+-
+-type byteWithMarshalJSON byte
+-
+-func (b byteWithMarshalJSON) MarshalJSON() ([]byte, error) {
+-	return []byte(fmt.Sprintf(`"Z%.2x"`, byte(b))), nil
+-}
+-
+-func (b *byteWithMarshalJSON) UnmarshalJSON(data []byte) error {
+-	if len(data) != 5 || data[0] != '"' || data[1] != 'Z' || data[4] != '"' {
+-		return fmt.Errorf("bad quoted string")
+-	}
+-	i, err := strconv.ParseInt(string(data[2:4]), 16, 8)
+-	if err != nil {
+-		return fmt.Errorf("bad hex")
+-	}
+-	*b = byteWithMarshalJSON(i)
+-	return nil
+-}
+-
+-type byteWithPtrMarshalJSON byte
+-
+-func (b *byteWithPtrMarshalJSON) MarshalJSON() ([]byte, error) {
+-	return byteWithMarshalJSON(*b).MarshalJSON()
+-}
+-
+-func (b *byteWithPtrMarshalJSON) UnmarshalJSON(data []byte) error {
+-	return (*byteWithMarshalJSON)(b).UnmarshalJSON(data)
+-}
+-
+-type byteWithMarshalText byte
+-
+-func (b byteWithMarshalText) MarshalText() ([]byte, error) {
+-	return []byte(fmt.Sprintf(`Z%.2x`, byte(b))), nil
+-}
+-
+-func (b *byteWithMarshalText) UnmarshalText(data []byte) error {
+-	if len(data) != 3 || data[0] != 'Z' {
+-		return fmt.Errorf("bad quoted string")
+-	}
+-	i, err := strconv.ParseInt(string(data[1:3]), 16, 8)
+-	if err != nil {
+-		return fmt.Errorf("bad hex")
+-	}
+-	*b = byteWithMarshalText(i)
+-	return nil
+-}
+-
+-type byteWithPtrMarshalText byte
+-
+-func (b *byteWithPtrMarshalText) MarshalText() ([]byte, error) {
+-	return byteWithMarshalText(*b).MarshalText()
+-}
+-
+-func (b *byteWithPtrMarshalText) UnmarshalText(data []byte) error {
+-	return (*byteWithMarshalText)(b).UnmarshalText(data)
+-}
+-
+-type intWithMarshalJSON int
+-
+-func (b intWithMarshalJSON) MarshalJSON() ([]byte, error) {
+-	return []byte(fmt.Sprintf(`"Z%.2x"`, int(b))), nil
+-}
+-
+-func (b *intWithMarshalJSON) UnmarshalJSON(data []byte) error {
+-	if len(data) != 5 || data[0] != '"' || data[1] != 'Z' || data[4] != '"' {
+-		return fmt.Errorf("bad quoted string")
+-	}
+-	i, err := strconv.ParseInt(string(data[2:4]), 16, 8)
+-	if err != nil {
+-		return fmt.Errorf("bad hex")
+-	}
+-	*b = intWithMarshalJSON(i)
+-	return nil
+-}
+-
+-type intWithPtrMarshalJSON int
+-
+-func (b *intWithPtrMarshalJSON) MarshalJSON() ([]byte, error) {
+-	return intWithMarshalJSON(*b).MarshalJSON()
+-}
+-
+-func (b *intWithPtrMarshalJSON) UnmarshalJSON(data []byte) error {
+-	return (*intWithMarshalJSON)(b).UnmarshalJSON(data)
+-}
+-
+-type intWithMarshalText int
+-
+-func (b intWithMarshalText) MarshalText() ([]byte, error) {
+-	return []byte(fmt.Sprintf(`Z%.2x`, int(b))), nil
+-}
+-
+-func (b *intWithMarshalText) UnmarshalText(data []byte) error {
+-	if len(data) != 3 || data[0] != 'Z' {
+-		return fmt.Errorf("bad quoted string")
+-	}
+-	i, err := strconv.ParseInt(string(data[1:3]), 16, 8)
+-	if err != nil {
+-		return fmt.Errorf("bad hex")
+-	}
+-	*b = intWithMarshalText(i)
+-	return nil
+-}
+-
+-type intWithPtrMarshalText int
+-
+-func (b *intWithPtrMarshalText) MarshalText() ([]byte, error) {
+-	return intWithMarshalText(*b).MarshalText()
+-}
+-
+-func (b *intWithPtrMarshalText) UnmarshalText(data []byte) error {
+-	return (*intWithMarshalText)(b).UnmarshalText(data)
+-}
+-
+-type mapStringToStringData struct {
+-	Data map[string]string `json:"data"`
+-}
+-
+-type B struct {
+-	B bool `json:",string"`
+-}
+-
+-type DoublePtr struct {
+-	I **int
+-	J **int
+-}
+-
+-type NestedUnamed struct{ F struct{ V int } }
+-
+-var unmarshalTests = []struct {
+-	CaseName
+-	in                    string
+-	ptr                   any // new(type)
+-	out                   any
+-	err                   error
+-	useNumber             bool
+-	golden                bool
+-	disallowUnknownFields bool
+-}{
+-	// basic types
+-	{CaseName: Name(""), in: `true`, ptr: new(bool), out: true},
+-	{CaseName: Name(""), in: `1`, ptr: new(int), out: 1},
+-	{CaseName: Name(""), in: `1.2`, ptr: new(float64), out: 1.2},
+-	{CaseName: Name(""), in: `-5`, ptr: new(int16), out: int16(-5)},
+-	{CaseName: Name(""), in: `2`, ptr: new(Number), out: Number("2"), useNumber: true},
+-	{CaseName: Name(""), in: `2`, ptr: new(Number), out: Number("2")},
+-	{CaseName: Name(""), in: `2`, ptr: new(any), out: float64(2.0)},
+-	{CaseName: Name(""), in: `2`, ptr: new(any), out: Number("2"), useNumber: true},
+-	{CaseName: Name(""), in: `"a\u1234"`, ptr: new(string), out: "a\u1234"},
+-	{CaseName: Name(""), in: `"http:\/\/"`, ptr: new(string), out: "http://"},
+-	{CaseName: Name(""), in: `"g-clef: \uD834\uDD1E"`, ptr: new(string), out: "g-clef: \U0001D11E"},
+-	{CaseName: Name(""), in: `"invalid: \uD834x\uDD1E"`, ptr: new(string), out: "invalid: \uFFFDx\uFFFD"},
+-	{CaseName: Name(""), in: "null", ptr: new(any), out: nil},
+-	{CaseName: Name(""), in: `{"X": [1,2,3], "Y": 4}`, ptr: new(T), out: T{Y: 4}, err: &UnmarshalTypeError{"array", reflect.TypeFor[string](), len64(`{"X": `), "T", "X", nil}},
+-	{CaseName: Name(""), in: `{"X": 23}`, ptr: new(T), out: T{}, err: &UnmarshalTypeError{"number", reflect.TypeFor[string](), len64(`{"X": `), "T", "X", nil}},
+-	{CaseName: Name(""), in: `{"x": 1}`, ptr: new(tx), out: tx{}},
+-	{CaseName: Name(""), in: `{"x": 1}`, ptr: new(tx), out: tx{}},
+-	{CaseName: Name(""), in: `{"x": 1}`, ptr: new(tx), err: fmt.Errorf("json: unknown field \"x\""), disallowUnknownFields: true},
+-	{CaseName: Name(""), in: `{"S": 23}`, ptr: new(W), out: W{}, err: &UnmarshalTypeError{"number", reflect.TypeFor[SS](), 0, "", "", nil}},
+-	{CaseName: Name(""), in: `{"T": {"X": 23}}`, ptr: new(TOuter), out: TOuter{}, err: &UnmarshalTypeError{"number", reflect.TypeFor[string](), len64(`{"X": `), "T", "X", nil}},
+-	{CaseName: Name(""), in: `{"F1":1,"F2":2,"F3":3}`, ptr: new(V), out: V{F1: float64(1), F2: int32(2), F3: Number("3")}},
+-	{CaseName: Name(""), in: `{"F1":1,"F2":2,"F3":3}`, ptr: new(V), out: V{F1: Number("1"), F2: int32(2), F3: Number("3")}, useNumber: true},
+-	{CaseName: Name(""), in: `{"k1":1,"k2":"s","k3":[1,2.0,3e-3],"k4":{"kk1":"s","kk2":2}}`, ptr: new(any), out: ifaceNumAsFloat64},
+-	{CaseName: Name(""), in: `{"k1":1,"k2":"s","k3":[1,2.0,3e-3],"k4":{"kk1":"s","kk2":2}}`, ptr: new(any), out: ifaceNumAsNumber, useNumber: true},
+-
+-	// raw values with whitespace
+-	{CaseName: Name(""), in: "\n true ", ptr: new(bool), out: true},
+-	{CaseName: Name(""), in: "\t 1 ", ptr: new(int), out: 1},
+-	{CaseName: Name(""), in: "\r 1.2 ", ptr: new(float64), out: 1.2},
+-	{CaseName: Name(""), in: "\t -5 \n", ptr: new(int16), out: int16(-5)},
+-	{CaseName: Name(""), in: "\t \"a\\u1234\" \n", ptr: new(string), out: "a\u1234"},
+-
+-	// Z has a "-" tag.
+-	{CaseName: Name(""), in: `{"Y": 1, "Z": 2}`, ptr: new(T), out: T{Y: 1}},
+-	{CaseName: Name(""), in: `{"Y": 1, "Z": 2}`, ptr: new(T), out: T{Y: 1}, err: fmt.Errorf("json: unknown field \"Z\""), disallowUnknownFields: true},
+-
+-	{CaseName: Name(""), in: `{"alpha": "abc", "alphabet": "xyz"}`, ptr: new(U), out: U{Alphabet: "abc"}},
+-	{CaseName: Name(""), in: `{"alpha": "abc", "alphabet": "xyz"}`, ptr: new(U), out: U{Alphabet: "abc"}, err: fmt.Errorf("json: unknown field \"alphabet\""), disallowUnknownFields: true},
+-	{CaseName: Name(""), in: `{"alpha": "abc"}`, ptr: new(U), out: U{Alphabet: "abc"}},
+-	{CaseName: Name(""), in: `{"alphabet": "xyz"}`, ptr: new(U), out: U{}},
+-	{CaseName: Name(""), in: `{"alphabet": "xyz"}`, ptr: new(U), err: fmt.Errorf("json: unknown field \"alphabet\""), disallowUnknownFields: true},
+-
+-	// syntax errors
+-	{CaseName: Name(""), in: ``, ptr: new(any), err: &SyntaxError{errUnexpectedEnd.Error(), 0}},
+-	{CaseName: Name(""), in: " \n\r\t", ptr: new(any), err: &SyntaxError{errUnexpectedEnd.Error(), len64(" \n\r\t")}},
+-	{CaseName: Name(""), in: `[2, 3`, ptr: new(any), err: &SyntaxError{errUnexpectedEnd.Error(), len64(`[2, 3`)}},
+-	{CaseName: Name(""), in: `{"X": "foo", "Y"}`, err: &SyntaxError{"invalid character '}' after object key", len64(`{"X": "foo", "Y"`)}},
+-	{CaseName: Name(""), in: `[1, 2, 3+]`, err: &SyntaxError{"invalid character '+' after array element", len64(`[1, 2, 3`)}},
+-	{CaseName: Name(""), in: `{"X":12x}`, err: &SyntaxError{"invalid character 'x' after object key:value pair", len64(`{"X":12`)}, useNumber: true},
+-	{CaseName: Name(""), in: `{"F3": -}`, ptr: new(V), err: &SyntaxError{"invalid character '}' in numeric literal", len64(`{"F3": -`)}},
+-
+-	// raw value errors
+-	{CaseName: Name(""), in: "\x01 42", err: &SyntaxError{"invalid character '\\x01' looking for beginning of value", len64(``)}},
+-	{CaseName: Name(""), in: " 42 \x01", err: &SyntaxError{"invalid character '\\x01' after top-level value", len64(` 42 `)}},
+-	{CaseName: Name(""), in: "\x01 true", err: &SyntaxError{"invalid character '\\x01' looking for beginning of value", len64(``)}},
+-	{CaseName: Name(""), in: " false \x01", err: &SyntaxError{"invalid character '\\x01' after top-level value", len64(` false `)}},
+-	{CaseName: Name(""), in: "\x01 1.2", err: &SyntaxError{"invalid character '\\x01' looking for beginning of value", len64(``)}},
+-	{CaseName: Name(""), in: " 3.4 \x01", err: &SyntaxError{"invalid character '\\x01' after top-level value", len64(` 3.4 `)}},
+-	{CaseName: Name(""), in: "\x01 \"string\"", err: &SyntaxError{"invalid character '\\x01' looking for beginning of value", len64(``)}},
+-	{CaseName: Name(""), in: " \"string\" \x01", err: &SyntaxError{"invalid character '\\x01' after top-level value", len64(` "string" `)}},
+-
+-	// array tests
+-	{CaseName: Name(""), in: `[1, 2, 3]`, ptr: new([3]int), out: [3]int{1, 2, 3}},
+-	{CaseName: Name(""), in: `[1, 2, 3]`, ptr: new([1]int), out: [1]int{1}},
+-	{CaseName: Name(""), in: `[1, 2, 3]`, ptr: new([5]int), out: [5]int{1, 2, 3, 0, 0}},
+-	{CaseName: Name(""), in: `[1, 2, 3]`, ptr: new(MustNotUnmarshalJSON), err: errors.New("MustNotUnmarshalJSON was used")},
+-
+-	// empty array to interface test
+-	{CaseName: Name(""), in: `[]`, ptr: new([]any), out: []any{}},
+-	{CaseName: Name(""), in: `null`, ptr: new([]any), out: []any(nil)},
+-	{CaseName: Name(""), in: `{"T":[]}`, ptr: new(map[string]any), out: map[string]any{"T": []any{}}},
+-	{CaseName: Name(""), in: `{"T":null}`, ptr: new(map[string]any), out: map[string]any{"T": any(nil)}},
+-
+-	// composite tests
+-	{CaseName: Name(""), in: allValueIndent, ptr: new(All), out: allValue},
+-	{CaseName: Name(""), in: allValueCompact, ptr: new(All), out: allValue},
+-	{CaseName: Name(""), in: allValueIndent, ptr: new(*All), out: &allValue},
+-	{CaseName: Name(""), in: allValueCompact, ptr: new(*All), out: &allValue},
+-	{CaseName: Name(""), in: pallValueIndent, ptr: new(All), out: pallValue},
+-	{CaseName: Name(""), in: pallValueCompact, ptr: new(All), out: pallValue},
+-	{CaseName: Name(""), in: pallValueIndent, ptr: new(*All), out: &pallValue},
+-	{CaseName: Name(""), in: pallValueCompact, ptr: new(*All), out: &pallValue},
+-
+-	// unmarshal interface test
+-	{CaseName: Name(""), in: `{"T":false}`, ptr: new(unmarshaler), out: umtrue}, // use "false" so test will fail if custom unmarshaler is not called
+-	{CaseName: Name(""), in: `{"T":false}`, ptr: new(*unmarshaler), out: &umtrue},
+-	{CaseName: Name(""), in: `[{"T":false}]`, ptr: new([]unmarshaler), out: umslice},
+-	{CaseName: Name(""), in: `[{"T":false}]`, ptr: new(*[]unmarshaler), out: &umslice},
+-	{CaseName: Name(""), in: `{"M":{"T":"x:y"}}`, ptr: new(ustruct), out: umstruct},
+-
+-	// UnmarshalText interface test
+-	{CaseName: Name(""), in: `"x:y"`, ptr: new(unmarshalerText), out: umtrueXY},
+-	{CaseName: Name(""), in: `"x:y"`, ptr: new(*unmarshalerText), out: &umtrueXY},
+-	{CaseName: Name(""), in: `["x:y"]`, ptr: new([]unmarshalerText), out: umsliceXY},
+-	{CaseName: Name(""), in: `["x:y"]`, ptr: new(*[]unmarshalerText), out: &umsliceXY},
+-	{CaseName: Name(""), in: `{"M":"x:y"}`, ptr: new(ustructText), out: umstructXY},
+-
+-	// integer-keyed map test
+-	{
+-		CaseName: Name(""),
+-		in:       `{"-1":"a","0":"b","1":"c"}`,
+-		ptr:      new(map[int]string),
+-		out:      map[int]string{-1: "a", 0: "b", 1: "c"},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `{"0":"a","10":"c","9":"b"}`,
+-		ptr:      new(map[u8]string),
+-		out:      map[u8]string{0: "a", 9: "b", 10: "c"},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `{"-9223372036854775808":"min","9223372036854775807":"max"}`,
+-		ptr:      new(map[int64]string),
+-		out:      map[int64]string{math.MinInt64: "min", math.MaxInt64: "max"},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `{"18446744073709551615":"max"}`,
+-		ptr:      new(map[uint64]string),
+-		out:      map[uint64]string{math.MaxUint64: "max"},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `{"0":false,"10":true}`,
+-		ptr:      new(map[uintptr]bool),
+-		out:      map[uintptr]bool{0: false, 10: true},
+-	},
+-
+-	// Check that MarshalText and UnmarshalText take precedence
+-	// over default integer handling in map keys.
+-	{
+-		CaseName: Name(""),
+-		in:       `{"u2":4}`,
+-		ptr:      new(map[u8marshal]int),
+-		out:      map[u8marshal]int{2: 4},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `{"2":4}`,
+-		ptr:      new(map[u8marshal]int),
+-		out:      map[u8marshal]int{},
+-		err:      errMissingU8Prefix,
+-	},
+-
+-	// integer-keyed map errors
+-	{
+-		CaseName: Name(""),
+-		in:       `{"abc":"abc"}`,
+-		ptr:      new(map[int]string),
+-		out:      map[int]string{},
+-		err:      &UnmarshalTypeError{Value: "number abc", Type: reflect.TypeFor[int](), Field: "abc", Offset: len64(`{`)},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `{"256":"abc"}`,
+-		ptr:      new(map[uint8]string),
+-		out:      map[uint8]string{},
+-		err:      &UnmarshalTypeError{Value: "number 256", Type: reflect.TypeFor[uint8](), Field: "256", Offset: len64(`{`)},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `{"128":"abc"}`,
+-		ptr:      new(map[int8]string),
+-		out:      map[int8]string{},
+-		err:      &UnmarshalTypeError{Value: "number 128", Type: reflect.TypeFor[int8](), Field: "128", Offset: len64(`{`)},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `{"-1":"abc"}`,
+-		ptr:      new(map[uint8]string),
+-		out:      map[uint8]string{},
+-		err:      &UnmarshalTypeError{Value: "number -1", Type: reflect.TypeFor[uint8](), Field: "-1", Offset: len64(`{`)},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `{"F":{"a":2,"3":4}}`,
+-		ptr:      new(map[string]map[int]int),
+-		out:      map[string]map[int]int{"F": {3: 4}},
+-		err:      &UnmarshalTypeError{Value: "number a", Type: reflect.TypeFor[int](), Field: "F.a", Offset: len64(`{"F":{`)},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `{"F":{"a":2,"3":4}}`,
+-		ptr:      new(map[string]map[uint]int),
+-		out:      map[string]map[uint]int{"F": {3: 4}},
+-		err:      &UnmarshalTypeError{Value: "number a", Type: reflect.TypeFor[uint](), Field: "F.a", Offset: len64(`{"F":{`)},
+-	},
+-
+-	// Map keys can be encoding.TextUnmarshalers.
+-	{CaseName: Name(""), in: `{"x:y":true}`, ptr: new(map[unmarshalerText]bool), out: ummapXY},
+-	// If multiple values for the same key exists, only the most recent value is used.
+-	{CaseName: Name(""), in: `{"x:y":false,"x:y":true}`, ptr: new(map[unmarshalerText]bool), out: ummapXY},
+-
+-	{
+-		CaseName: Name(""),
+-		in: `{
+-			"Level0": 1,
+-			"Level1b": 2,
+-			"Level1c": 3,
+-			"x": 4,
+-			"Level1a": 5,
+-			"LEVEL1B": 6,
+-			"e": {
+-				"Level1a": 8,
+-				"Level1b": 9,
+-				"Level1c": 10,
+-				"Level1d": 11,
+-				"x": 12
+-			},
+-			"Loop1": 13,
+-			"Loop2": 14,
+-			"X": 15,
+-			"Y": 16,
+-			"Z": 17,
+-			"Q": 18
+-		}`,
+-		ptr: new(Top),
+-		out: Top{
+-			Level0: 1,
+-			Embed0: Embed0{
+-				Level1b: 2,
+-				Level1c: 3,
+-			},
+-			Embed0a: &Embed0a{
+-				Level1a: 5,
+-				Level1b: 6,
+-			},
+-			Embed0b: &Embed0b{
+-				Level1a: 8,
+-				Level1b: 9,
+-				Level1c: 10,
+-				Level1d: 11,
+-				Level1e: 12,
+-			},
+-			Loop: Loop{
+-				Loop1: 13,
+-				Loop2: 14,
+-			},
+-			Embed0p: Embed0p{
+-				Point: image.Point{X: 15, Y: 16},
+-			},
+-			Embed0q: Embed0q{
+-				Point: Point{Z: 17},
+-			},
+-			embed: embed{
+-				Q: 18,
+-			},
+-		},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `{"hello": 1}`,
+-		ptr:      new(Ambig),
+-		out:      Ambig{First: 1},
+-	},
+-
+-	{
+-		CaseName: Name(""),
+-		in:       `{"X": 1,"Y":2}`,
+-		ptr:      new(S5),
+-		out:      S5{S8: S8{S9: S9{Y: 2}}},
+-	},
+-	{
+-		CaseName:              Name(""),
+-		in:                    `{"X": 1,"Y":2}`,
+-		ptr:                   new(S5),
+-		out:                   S5{S8: S8{S9{Y: 2}}},
+-		err:                   fmt.Errorf("json: unknown field \"X\""),
+-		disallowUnknownFields: true,
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `{"X": 1,"Y":2}`,
+-		ptr:      new(S10),
+-		out:      S10{S13: S13{S8: S8{S9: S9{Y: 2}}}},
+-	},
+-	{
+-		CaseName:              Name(""),
+-		in:                    `{"X": 1,"Y":2}`,
+-		ptr:                   new(S10),
+-		out:                   S10{S13: S13{S8{S9{Y: 2}}}},
+-		err:                   fmt.Errorf("json: unknown field \"X\""),
+-		disallowUnknownFields: true,
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `{"I": 0, "I": null, "J": null}`,
+-		ptr:      new(DoublePtr),
+-		out:      DoublePtr{I: nil, J: nil},
+-	},
+-
+-	// invalid UTF-8 is coerced to valid UTF-8.
+-	{
+-		CaseName: Name(""),
+-		in:       "\"hello\xffworld\"",
+-		ptr:      new(string),
+-		out:      "hello\ufffdworld",
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       "\"hello\xc2\xc2world\"",
+-		ptr:      new(string),
+-		out:      "hello\ufffd\ufffdworld",
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       "\"hello\xc2\xffworld\"",
+-		ptr:      new(string),
+-		out:      "hello\ufffd\ufffdworld",
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       "\"hello\\ud800world\"",
+-		ptr:      new(string),
+-		out:      "hello\ufffdworld",
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       "\"hello\\ud800\\ud800world\"",
+-		ptr:      new(string),
+-		out:      "hello\ufffd\ufffdworld",
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       "\"hello\\ud800\\ud800world\"",
+-		ptr:      new(string),
+-		out:      "hello\ufffd\ufffdworld",
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       "\"hello\xed\xa0\x80\xed\xb0\x80world\"",
+-		ptr:      new(string),
+-		out:      "hello\ufffd\ufffd\ufffd\ufffd\ufffd\ufffdworld",
+-	},
+-
+-	// Used to be issue 8305, but time.Time implements encoding.TextUnmarshaler so this works now.
+-	{
+-		CaseName: Name(""),
+-		in:       `{"2009-11-10T23:00:00Z": "hello world"}`,
+-		ptr:      new(map[time.Time]string),
+-		out:      map[time.Time]string{time.Date(2009, 11, 10, 23, 0, 0, 0, time.UTC): "hello world"},
+-	},
+-
+-	// issue 8305
+-	{
+-		CaseName: Name(""),
+-		in:       `{"2009-11-10T23:00:00Z": "hello world"}`,
+-		ptr:      new(map[Point]string),
+-		out:      map[Point]string{},
+-		err:      &UnmarshalTypeError{Value: "string", Type: reflect.TypeFor[Point](), Field: `2009-11-10T23:00:00Z`, Offset: len64(`{`)},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `{"asdf": "hello world"}`,
+-		ptr:      new(map[unmarshaler]string),
+-		out:      map[unmarshaler]string{},
+-		err:      &UnmarshalTypeError{Value: "string", Type: reflect.TypeFor[unmarshaler](), Field: "asdf", Offset: len64(`{`)},
+-	},
+-
+-	// related to issue 13783.
+-	// Go 1.7 changed marshaling a slice of typed byte to use the methods on the byte type,
+-	// similar to marshaling a slice of typed int.
+-	// These tests check that, assuming the byte type also has valid decoding methods,
+-	// either the old base64 string encoding or the new per-element encoding can be
+-	// successfully unmarshaled. The custom unmarshalers were accessible in earlier
+-	// versions of Go, even though the custom marshaler was not.
+-	{
+-		CaseName: Name(""),
+-		in:       `"AQID"`,
+-		ptr:      new([]byteWithMarshalJSON),
+-		out:      []byteWithMarshalJSON{1, 2, 3},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `["Z01","Z02","Z03"]`,
+-		ptr:      new([]byteWithMarshalJSON),
+-		out:      []byteWithMarshalJSON{1, 2, 3},
+-		golden:   true,
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `"AQID"`,
+-		ptr:      new([]byteWithMarshalText),
+-		out:      []byteWithMarshalText{1, 2, 3},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `["Z01","Z02","Z03"]`,
+-		ptr:      new([]byteWithMarshalText),
+-		out:      []byteWithMarshalText{1, 2, 3},
+-		golden:   true,
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `"AQID"`,
+-		ptr:      new([]byteWithPtrMarshalJSON),
+-		out:      []byteWithPtrMarshalJSON{1, 2, 3},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `["Z01","Z02","Z03"]`,
+-		ptr:      new([]byteWithPtrMarshalJSON),
+-		out:      []byteWithPtrMarshalJSON{1, 2, 3},
+-		golden:   true,
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `"AQID"`,
+-		ptr:      new([]byteWithPtrMarshalText),
+-		out:      []byteWithPtrMarshalText{1, 2, 3},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `["Z01","Z02","Z03"]`,
+-		ptr:      new([]byteWithPtrMarshalText),
+-		out:      []byteWithPtrMarshalText{1, 2, 3},
+-		golden:   true,
+-	},
+-
+-	// ints work with the marshaler but not the base64 []byte case
+-	{
+-		CaseName: Name(""),
+-		in:       `["Z01","Z02","Z03"]`,
+-		ptr:      new([]intWithMarshalJSON),
+-		out:      []intWithMarshalJSON{1, 2, 3},
+-		golden:   true,
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `["Z01","Z02","Z03"]`,
+-		ptr:      new([]intWithMarshalText),
+-		out:      []intWithMarshalText{1, 2, 3},
+-		golden:   true,
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `["Z01","Z02","Z03"]`,
+-		ptr:      new([]intWithPtrMarshalJSON),
+-		out:      []intWithPtrMarshalJSON{1, 2, 3},
+-		golden:   true,
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `["Z01","Z02","Z03"]`,
+-		ptr:      new([]intWithPtrMarshalText),
+-		out:      []intWithPtrMarshalText{1, 2, 3},
+-		golden:   true,
+-	},
+-
+-	{CaseName: Name(""), in: `0.000001`, ptr: new(float64), out: 0.000001, golden: true},
+-	{CaseName: Name(""), in: `1e-7`, ptr: new(float64), out: 1e-7, golden: true},
+-	{CaseName: Name(""), in: `100000000000000000000`, ptr: new(float64), out: 100000000000000000000.0, golden: true},
+-	{CaseName: Name(""), in: `1e+21`, ptr: new(float64), out: 1e21, golden: true},
+-	{CaseName: Name(""), in: `-0.000001`, ptr: new(float64), out: -0.000001, golden: true},
+-	{CaseName: Name(""), in: `-1e-7`, ptr: new(float64), out: -1e-7, golden: true},
+-	{CaseName: Name(""), in: `-100000000000000000000`, ptr: new(float64), out: -100000000000000000000.0, golden: true},
+-	{CaseName: Name(""), in: `-1e+21`, ptr: new(float64), out: -1e21, golden: true},
+-	{CaseName: Name(""), in: `999999999999999900000`, ptr: new(float64), out: 999999999999999900000.0, golden: true},
+-	{CaseName: Name(""), in: `9007199254740992`, ptr: new(float64), out: 9007199254740992.0, golden: true},
+-	{CaseName: Name(""), in: `9007199254740993`, ptr: new(float64), out: 9007199254740992.0, golden: false},
+-
+-	{
+-		CaseName: Name(""),
+-		in:       `{"V": {"F2": "hello"}}`,
+-		ptr:      new(VOuter),
+-		err: &UnmarshalTypeError{
+-			Value:  "string",
+-			Struct: "VOuter",
+-			Field:  "V.F2",
+-			Type:   reflect.TypeFor[int32](),
+-			Offset: len64(`{"V": {"F2": `),
+-		},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `{"V": {"F4": {}, "F2": "hello"}}`,
+-		ptr:      new(VOuter),
+-		out:      VOuter{V: V{F4: &VOuter{}}},
+-		err: &UnmarshalTypeError{
+-			Value:  "string",
+-			Struct: "VOuter",
+-			Field:  "V.F2",
+-			Type:   reflect.TypeFor[int32](),
+-			Offset: len64(`{"V": {"F4": {}, "F2": `),
+-		},
+-	},
+-
+-	{
+-		CaseName: Name(""),
+-		in:       `{"Level1a": "hello"}`,
+-		ptr:      new(Top),
+-		out:      Top{Embed0a: &Embed0a{}},
+-		err: &UnmarshalTypeError{
+-			Value:  "string",
+-			Struct: "Top",
+-			Field:  "Level1a",
+-			Type:   reflect.TypeFor[int](),
+-			Offset: len64(`{"Level1a": `),
+-		},
+-	},
+-
+-	// issue 15146.
+-	// invalid inputs in wrongStringTests below.
+-	{CaseName: Name(""), in: `{"B":"true"}`, ptr: new(B), out: B{true}, golden: true},
+-	{CaseName: Name(""), in: `{"B":"false"}`, ptr: new(B), out: B{false}, golden: true},
+-	{CaseName: Name(""), in: `{"B": "maybe"}`, ptr: new(B), err: &UnmarshalTypeError{Value: `string "maybe"`, Type: reflect.TypeFor[bool](), Struct: "B", Field: "B", Offset: len64(`{"B": `), Err: strconv.ErrSyntax}},
+-	{CaseName: Name(""), in: `{"B": "tru"}`, ptr: new(B), err: &UnmarshalTypeError{Value: `string "tru"`, Type: reflect.TypeFor[bool](), Struct: "B", Field: "B", Offset: len64(`{"B": `), Err: strconv.ErrSyntax}},
+-	{CaseName: Name(""), in: `{"B": "False"}`, ptr: new(B), err: &UnmarshalTypeError{Value: `string "False"`, Type: reflect.TypeFor[bool](), Struct: "B", Field: "B", Offset: len64(`{"B": `), Err: strconv.ErrSyntax}},
+-	{CaseName: Name(""), in: `{"B": "null"}`, ptr: new(B), out: B{false}},
+-	{CaseName: Name(""), in: `{"B": "nul"}`, ptr: new(B), err: &UnmarshalTypeError{Value: `string "nul"`, Type: reflect.TypeFor[bool](), Struct: "B", Field: "B", Offset: len64(`{"B": `), Err: strconv.ErrSyntax}},
+-	{CaseName: Name(""), in: `{"B": [2, 3]}`, ptr: new(B), err: &UnmarshalTypeError{Value: "array", Type: reflect.TypeFor[bool](), Struct: "B", Field: "B", Offset: len64(`{"B": `)}},
+-
+-	// additional tests for disallowUnknownFields
+-	{
+-		CaseName: Name(""),
+-		in: `{
+-			"Level0": 1,
+-			"Level1b": 2,
+-			"Level1c": 3,
+-			"x": 4,
+-			"Level1a": 5,
+-			"LEVEL1B": 6,
+-			"e": {
+-				"Level1a": 8,
+-				"Level1b": 9,
+-				"Level1c": 10,
+-				"Level1d": 11,
+-				"x": 12
+-			},
+-			"Loop1": 13,
+-			"Loop2": 14,
+-			"X": 15,
+-			"Y": 16,
+-			"Z": 17,
+-			"Q": 18,
+-			"extra": true
+-		}`,
+-		ptr: new(Top),
+-		out: Top{
+-			Level0: 1,
+-			Embed0: Embed0{
+-				Level1b: 2,
+-				Level1c: 3,
+-			},
+-			Embed0a: &Embed0a{Level1a: 5, Level1b: 6},
+-			Embed0b: &Embed0b{Level1a: 8, Level1b: 9, Level1c: 10, Level1d: 11, Level1e: 12},
+-			Loop: Loop{
+-				Loop1: 13,
+-				Loop2: 14,
+-				Loop:  nil,
+-			},
+-			Embed0p: Embed0p{
+-				Point: image.Point{
+-					X: 15,
+-					Y: 16,
+-				},
+-			},
+-			Embed0q: Embed0q{Point: Point{Z: 17}},
+-			embed:   embed{Q: 18},
+-		},
+-		err:                   fmt.Errorf("json: unknown field \"extra\""),
+-		disallowUnknownFields: true,
+-	},
+-	{
+-		CaseName: Name(""),
+-		in: `{
+-			"Level0": 1,
+-			"Level1b": 2,
+-			"Level1c": 3,
+-			"x": 4,
+-			"Level1a": 5,
+-			"LEVEL1B": 6,
+-			"e": {
+-				"Level1a": 8,
+-				"Level1b": 9,
+-				"Level1c": 10,
+-				"Level1d": 11,
+-				"x": 12,
+-				"extra": null
+-			},
+-			"Loop1": 13,
+-			"Loop2": 14,
+-			"X": 15,
+-			"Y": 16,
+-			"Z": 17,
+-			"Q": 18
+-		}`,
+-		ptr: new(Top),
+-		out: Top{
+-			Level0: 1,
+-			Embed0: Embed0{
+-				Level1b: 2,
+-				Level1c: 3,
+-			},
+-			Embed0a: &Embed0a{Level1a: 5, Level1b: 6},
+-			Embed0b: &Embed0b{Level1a: 8, Level1b: 9, Level1c: 10, Level1d: 11, Level1e: 12},
+-			Loop: Loop{
+-				Loop1: 13,
+-				Loop2: 14,
+-				Loop:  nil,
+-			},
+-			Embed0p: Embed0p{
+-				Point: image.Point{
+-					X: 15,
+-					Y: 16,
+-				},
+-			},
+-			Embed0q: Embed0q{Point: Point{Z: 17}},
+-			embed:   embed{Q: 18},
+-		},
+-		err:                   fmt.Errorf("json: unknown field \"extra\""),
+-		disallowUnknownFields: true,
+-	},
+-	// issue 26444
+-	// UnmarshalTypeError without field & struct values
+-	{
+-		CaseName: Name(""),
+-		in:       `{"data":{"test1": "bob", "test2": 123}}`,
+-		ptr:      new(mapStringToStringData),
+-		out:      mapStringToStringData{map[string]string{"test1": "bob", "test2": ""}},
+-		err:      &UnmarshalTypeError{Value: "number", Type: reflect.TypeFor[string](), Offset: len64(`{"data":{"test1": "bob", "test2": `), Struct: "mapStringToStringData", Field: "data.test2"},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `{"data":{"test1": 123, "test2": "bob"}}`,
+-		ptr:      new(mapStringToStringData),
+-		out:      mapStringToStringData{Data: map[string]string{"test1": "", "test2": "bob"}},
+-		err:      &UnmarshalTypeError{Value: "number", Type: reflect.TypeFor[string](), Offset: len64(`{"data":{"test1": `), Struct: "mapStringToStringData", Field: "data.test1"},
+-	},
+-
+-	// trying to decode JSON arrays or objects via TextUnmarshaler
+-	{
+-		CaseName: Name(""),
+-		in:       `[1, 2, 3]`,
+-		ptr:      new(MustNotUnmarshalText),
+-		err:      &UnmarshalTypeError{Value: "array", Type: reflect.TypeFor[MustNotUnmarshalText](), Err: errors.New("JSON value must be string type")},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `{"foo": "bar"}`,
+-		ptr:      new(MustNotUnmarshalText),
+-		err:      &UnmarshalTypeError{Value: "object", Type: reflect.TypeFor[MustNotUnmarshalText](), Err: errors.New("JSON value must be string type")},
+-	},
+-	// #22369
+-	{
+-		CaseName: Name(""),
+-		in:       `{"PP": {"T": {"Y": "bad-type"}}}`,
+-		ptr:      new(P),
+-		err: &UnmarshalTypeError{
+-			Value:  "string",
+-			Struct: "P",
+-			Field:  "PP.T.Y",
+-			Type:   reflect.TypeFor[int](),
+-			Offset: len64(`{"PP": {"T": {"Y": `),
+-		},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `{"Ts": [{"Y": 1}, {"Y": 2}, {"Y": "bad-type"}]}`,
+-		ptr:      new(PP),
+-		out:      PP{Ts: []T{{Y: 1}, {Y: 2}, {Y: 0}}},
+-		err: &UnmarshalTypeError{
+-			Value:  "string",
+-			Struct: "PP",
+-			Field:  "Ts.2.Y",
+-			Type:   reflect.TypeFor[int](),
+-			Offset: len64(`{"Ts": [{"Y": 1}, {"Y": 2}, {"Y": `),
+-		},
+-	},
+-	// #14702
+-	{
+-		CaseName: Name(""),
+-		in:       `invalid`,
+-		ptr:      new(Number),
+-		err: &SyntaxError{
+-			msg:    "invalid character 'i' looking for beginning of value",
+-			Offset: len64(``),
+-		},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `"invalid"`,
+-		ptr:      new(Number),
+-		err:      &UnmarshalTypeError{Value: `string "invalid"`, Type: reflect.TypeFor[Number](), Err: strconv.ErrSyntax},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `{"A":"invalid"}`,
+-		ptr:      new(struct{ A Number }),
+-		err:      &UnmarshalTypeError{Value: `string "invalid"`, Type: reflect.TypeFor[Number](), Err: strconv.ErrSyntax},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `{"A":"invalid"}`,
+-		ptr: new(struct {
+-			A Number `json:",string"`
+-		}),
+-		err: &UnmarshalTypeError{Value: `string "invalid"`, Type: reflect.TypeFor[Number](), Err: strconv.ErrSyntax},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `{"A":"invalid"}`,
+-		ptr:      new(map[string]Number),
+-		out:      map[string]Number{"A": ""},
+-		err:      &UnmarshalTypeError{Value: `string "invalid"`, Type: reflect.TypeFor[Number](), Err: strconv.ErrSyntax},
+-	},
+-
+-	{
+-		CaseName: Name(""),
+-		in:       `5`,
+-		ptr:      new(Number),
+-		out:      Number("5"),
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `"5"`,
+-		ptr:      new(Number),
+-		out:      Number("5"),
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `{"N":5}`,
+-		ptr:      new(struct{ N Number }),
+-		out:      struct{ N Number }{"5"},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `{"N":"5"}`,
+-		ptr:      new(struct{ N Number }),
+-		out:      struct{ N Number }{"5"},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `{"N":5}`,
+-		ptr: new(struct {
+-			N Number `json:",string"`
+-		}),
+-		err: &UnmarshalTypeError{Value: "number", Type: reflect.TypeFor[Number]()},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `{"N":"5"}`,
+-		ptr: new(struct {
+-			N Number `json:",string"`
+-		}),
+-		out: struct {
+-			N Number `json:",string"`
+-		}{"5"},
+-	},
+-
+-	// Verify that syntactic errors are immediately fatal,
+-	// while semantic errors are lazily reported
+-	// (i.e., allow processing to continue).
+-	{
+-		CaseName: Name(""),
+-		in:       `[1,2,true,4,5}`,
+-		ptr:      new([]int),
+-		err:      &SyntaxError{msg: "invalid character '}' after array element", Offset: len64(`[1,2,true,4,5`)},
+-	},
+-	{
+-		CaseName: Name(""),
+-		in:       `[1,2,true,4,5]`,
+-		ptr:      new([]int),
+-		out:      []int{1, 2, 0, 4, 5},
+-		err:      &UnmarshalTypeError{Value: "bool", Type: reflect.TypeFor[int](), Field: "2", Offset: len64(`[1,2,`)},
+-	},
+-
+-	{
+-		CaseName: Name("DashComma"),
+-		in:       `{"-":"hello"}`,
+-		ptr: new(struct {
+-			F string `json:"-,"`
+-		}),
+-		out: struct {
+-			F string `json:"-,"`
+-		}{"hello"},
+-	},
+-	{
+-		CaseName: Name("DashCommaOmitEmpty"),
+-		in:       `{"-":"hello"}`,
+-		ptr: new(struct {
+-			F string `json:"-,omitempty"`
+-		}),
+-		out: struct {
+-			F string `json:"-,omitempty"`
+-		}{"hello"},
+-	},
+-
+-	{
+-		CaseName: Name("ErrorForNestedUnamed"),
+-		in:       `{"F":{"V":"s"}}`,
+-		ptr:      new(NestedUnamed),
+-		out:      NestedUnamed{},
+-		err:      &UnmarshalTypeError{Value: "string", Type: reflect.TypeFor[int](), Offset: 10, Struct: "NestedUnamed", Field: "F.V"},
+-	},
+-	{
+-		CaseName: Name("ErrorInterface"),
+-		in:       `1`,
+-		ptr:      new(error),
+-		out:      error(nil),
+-		err:      &UnmarshalTypeError{Value: "number", Type: reflect.TypeFor[error]()},
+-	},
+-	{
+-		CaseName: Name("ErrorChan"),
+-		in:       `1`,
+-		ptr:      new(chan int),
+-		out:      (chan int)(nil),
+-		err:      &UnmarshalTypeError{Value: "number", Type: reflect.TypeFor[chan int]()},
+-	},
+-}
+-
+-func TestMarshal(t *testing.T) {
+-	b, err := Marshal(allValue)
+-	if err != nil {
+-		t.Fatalf("Marshal error: %v", err)
+-	}
+-	if string(b) != allValueCompact {
+-		t.Errorf("Marshal:")
+-		diff(t, b, []byte(allValueCompact))
+-		return
+-	}
+-
+-	b, err = Marshal(pallValue)
+-	if err != nil {
+-		t.Fatalf("Marshal error: %v", err)
+-	}
+-	if string(b) != pallValueCompact {
+-		t.Errorf("Marshal:")
+-		diff(t, b, []byte(pallValueCompact))
+-		return
+-	}
+-}
+-
+-func TestMarshalInvalidUTF8(t *testing.T) {
+-	tests := []struct {
+-		CaseName
+-		in   string
+-		want string
+-	}{
+-		{Name(""), "hello\xffworld", "\"hello\ufffdworld\""},
+-		{Name(""), "", `""`},
+-		{Name(""), "\xff", "\"\ufffd\""},
+-		{Name(""), "\xff\xff", "\"\ufffd\ufffd\""},
+-		{Name(""), "a\xffb", "\"a\ufffdb\""},
+-		{Name(""), "\xe6\x97\xa5\xe6\x9c\xac\xff\xaa\x9e", "\"日本\ufffd\ufffd\ufffd\""},
+-	}
+-	for _, tt := range tests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			got, err := Marshal(tt.in)
+-			if string(got) != tt.want || err != nil {
+-				t.Errorf("%s: Marshal(%q):\n\tgot:  (%q, %v)\n\twant: (%q, nil)", tt.Where, tt.in, got, err, tt.want)
+-			}
+-		})
+-	}
+-}
+-
+-func TestMarshalNumberZeroVal(t *testing.T) {
+-	var n Number
+-	out, err := Marshal(n)
+-	if err != nil {
+-		t.Fatalf("Marshal error: %v", err)
+-	}
+-	got := string(out)
+-	if got != "0" {
+-		t.Fatalf("Marshal: got %s, want 0", got)
+-	}
+-}
+-
+-func TestMarshalEmbeds(t *testing.T) {
+-	top := &Top{
+-		Level0: 1,
+-		Embed0: Embed0{
+-			Level1b: 2,
+-			Level1c: 3,
+-		},
+-		Embed0a: &Embed0a{
+-			Level1a: 5,
+-			Level1b: 6,
+-		},
+-		Embed0b: &Embed0b{
+-			Level1a: 8,
+-			Level1b: 9,
+-			Level1c: 10,
+-			Level1d: 11,
+-			Level1e: 12,
+-		},
+-		Loop: Loop{
+-			Loop1: 13,
+-			Loop2: 14,
+-		},
+-		Embed0p: Embed0p{
+-			Point: image.Point{X: 15, Y: 16},
+-		},
+-		Embed0q: Embed0q{
+-			Point: Point{Z: 17},
+-		},
+-		embed: embed{
+-			Q: 18,
+-		},
+-	}
+-	got, err := Marshal(top)
+-	if err != nil {
+-		t.Fatalf("Marshal error: %v", err)
+-	}
+-	want := "{\"Level0\":1,\"Level1b\":2,\"Level1c\":3,\"Level1a\":5,\"LEVEL1B\":6,\"e\":{\"Level1a\":8,\"Level1b\":9,\"Level1c\":10,\"Level1d\":11,\"x\":12},\"Loop1\":13,\"Loop2\":14,\"X\":15,\"Y\":16,\"Z\":17,\"Q\":18}"
+-	if string(got) != want {
+-		t.Errorf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
+-	}
+-}
+-
+-func equalError(a, b error) bool {
+-	isJSONError := func(err error) bool {
+-		switch err.(type) {
+-		case
+-			*InvalidUTF8Error,
+-			*InvalidUnmarshalError,
+-			*MarshalerError,
+-			*SyntaxError,
+-			*UnmarshalFieldError,
+-			*UnmarshalTypeError,
+-			*UnsupportedTypeError,
+-			*UnsupportedValueError:
+-			return true
+-		}
+-		return false
+-	}
+-
+-	if a == nil || b == nil {
+-		return a == nil && b == nil
+-	}
+-	if isJSONError(a) || isJSONError(b) {
+-		return reflect.DeepEqual(a, b) // safe for locally defined error types
+-	}
+-	return a.Error() == b.Error()
+-}
+-
+-func TestUnmarshal(t *testing.T) {
+-	for _, tt := range unmarshalTests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			in := []byte(tt.in)
+-			if err := checkValid(in); err != nil {
+-				if !equalError(err, tt.err) {
+-					t.Fatalf("%s: checkValid error:\n\tgot  %#v\n\twant %#v", tt.Where, err, tt.err)
+-				}
+-			}
+-			if tt.ptr == nil {
+-				return
+-			}
+-
+-			typ := reflect.TypeOf(tt.ptr)
+-			if typ.Kind() != reflect.Pointer {
+-				t.Fatalf("%s: unmarshalTest.ptr %T is not a pointer type", tt.Where, tt.ptr)
+-			}
+-			typ = typ.Elem()
+-
+-			// v = new(right-type)
+-			v := reflect.New(typ)
+-
+-			if !reflect.DeepEqual(tt.ptr, v.Interface()) {
+-				// There's no reason for ptr to point to non-zero data,
+-				// as we decode into new(right-type), so the data is
+-				// discarded.
+-				// This can easily mean tests that silently don't test
+-				// what they should. To test decoding into existing
+-				// data, see TestPrefilled.
+-				t.Fatalf("%s: unmarshalTest.ptr %#v is not a pointer to a zero value", tt.Where, tt.ptr)
+-			}
+-
+-			dec := NewDecoder(bytes.NewReader(in))
+-			if tt.useNumber {
+-				dec.UseNumber()
+-			}
+-			if tt.disallowUnknownFields {
+-				dec.DisallowUnknownFields()
+-			}
+-			if tt.err != nil && strings.Contains(tt.err.Error(), errUnexpectedEnd.Error()) {
+-				// In streaming mode, we expect EOF or ErrUnexpectedEOF instead.
+-				if strings.TrimSpace(tt.in) == "" {
+-					tt.err = io.EOF
+-				} else {
+-					tt.err = io.ErrUnexpectedEOF
+-				}
+-			}
+-			if err := dec.Decode(v.Interface()); !equalError(err, tt.err) {
+-				t.Fatalf("%s: Decode error:\n\tgot:  %v\n\twant: %v\n\n\tgot:  %#v\n\twant: %#v", tt.Where, err, tt.err, err, tt.err)
+-			} else if err != nil && tt.out == nil {
+-				// Initialize tt.out during an error where there are no mutations,
+-				// so the output is just the zero value of the input type.
+-				tt.out = reflect.Zero(v.Elem().Type()).Interface()
+-			}
+-			if got := v.Elem().Interface(); !reflect.DeepEqual(got, tt.out) {
+-				gotJSON, _ := Marshal(got)
+-				wantJSON, _ := Marshal(tt.out)
+-				t.Fatalf("%s: Decode:\n\tgot:  %#+v\n\twant: %#+v\n\n\tgotJSON:  %s\n\twantJSON: %s", tt.Where, got, tt.out, gotJSON, wantJSON)
+-			}
+-
+-			// Check round trip also decodes correctly.
+-			if tt.err == nil {
+-				enc, err := Marshal(v.Interface())
+-				if err != nil {
+-					t.Fatalf("%s: Marshal error after roundtrip: %v", tt.Where, err)
+-				}
+-				if tt.golden && !bytes.Equal(enc, in) {
+-					t.Errorf("%s: Marshal:\n\tgot:  %s\n\twant: %s", tt.Where, enc, in)
+-				}
+-				vv := reflect.New(reflect.TypeOf(tt.ptr).Elem())
+-				dec = NewDecoder(bytes.NewReader(enc))
+-				if tt.useNumber {
+-					dec.UseNumber()
+-				}
+-				if err := dec.Decode(vv.Interface()); err != nil {
+-					t.Fatalf("%s: Decode(%#q) error after roundtrip: %v", tt.Where, enc, err)
+-				}
+-				if !reflect.DeepEqual(v.Elem().Interface(), vv.Elem().Interface()) {
+-					t.Fatalf("%s: Decode:\n\tgot:  %#+v\n\twant: %#+v\n\n\tgotJSON:  %s\n\twantJSON: %s",
+-						tt.Where, v.Elem().Interface(), vv.Elem().Interface(),
+-						stripWhitespace(string(enc)), stripWhitespace(string(in)))
+-				}
+-			}
+-		})
+-	}
+-}
+-
+-func TestUnmarshalMarshal(t *testing.T) {
+-	initBig()
+-	var v any
+-	if err := Unmarshal(jsonBig, &v); err != nil {
+-		t.Fatalf("Unmarshal error: %v", err)
+-	}
+-	b, err := Marshal(v)
+-	if err != nil {
+-		t.Fatalf("Marshal error: %v", err)
+-	}
+-	if !bytes.Equal(jsonBig, b) {
+-		t.Errorf("Marshal:")
+-		diff(t, b, jsonBig)
+-		return
+-	}
+-}
+-
+-// Independent of Decode, basic coverage of the accessors in Number
+-func TestNumberAccessors(t *testing.T) {
+-	tests := []struct {
+-		CaseName
+-		in       string
+-		i        int64
+-		intErr   string
+-		f        float64
+-		floatErr string
+-	}{
+-		{CaseName: Name(""), in: "-1.23e1", intErr: "strconv.ParseInt: parsing \"-1.23e1\": invalid syntax", f: -1.23e1},
+-		{CaseName: Name(""), in: "-12", i: -12, f: -12.0},
+-		{CaseName: Name(""), in: "1e1000", intErr: "strconv.ParseInt: parsing \"1e1000\": invalid syntax", floatErr: "strconv.ParseFloat: parsing \"1e1000\": value out of range"},
+-	}
+-	for _, tt := range tests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			n := Number(tt.in)
+-			if got := n.String(); got != tt.in {
+-				t.Errorf("%s: Number(%q).String() = %s, want %s", tt.Where, tt.in, got, tt.in)
+-			}
+-			if i, err := n.Int64(); err == nil && tt.intErr == "" && i != tt.i {
+-				t.Errorf("%s: Number(%q).Int64() = %d, want %d", tt.Where, tt.in, i, tt.i)
+-			} else if (err == nil && tt.intErr != "") || (err != nil && err.Error() != tt.intErr) {
+-				t.Errorf("%s: Number(%q).Int64() error:\n\tgot:  %v\n\twant: %v", tt.Where, tt.in, err, tt.intErr)
+-			}
+-			if f, err := n.Float64(); err == nil && tt.floatErr == "" && f != tt.f {
+-				t.Errorf("%s: Number(%q).Float64() = %g, want %g", tt.Where, tt.in, f, tt.f)
+-			} else if (err == nil && tt.floatErr != "") || (err != nil && err.Error() != tt.floatErr) {
+-				t.Errorf("%s: Number(%q).Float64() error:\n\tgot  %v\n\twant: %v", tt.Where, tt.in, err, tt.floatErr)
+-			}
+-		})
+-	}
+-}
+-
+-func TestLargeByteSlice(t *testing.T) {
+-	s0 := make([]byte, 2000)
+-	for i := range s0 {
+-		s0[i] = byte(i)
+-	}
+-	b, err := Marshal(s0)
+-	if err != nil {
+-		t.Fatalf("Marshal error: %v", err)
+-	}
+-	var s1 []byte
+-	if err := Unmarshal(b, &s1); err != nil {
+-		t.Fatalf("Unmarshal error: %v", err)
+-	}
+-	if !bytes.Equal(s0, s1) {
+-		t.Errorf("Marshal:")
+-		diff(t, s0, s1)
+-	}
+-}
+-
+-type Xint struct {
+-	X int
+-}
+-
+-func TestUnmarshalInterface(t *testing.T) {
+-	var xint Xint
+-	var i any = &xint
+-	if err := Unmarshal([]byte(`{"X":1}`), &i); err != nil {
+-		t.Fatalf("Unmarshal error: %v", err)
+-	}
+-	if xint.X != 1 {
+-		t.Fatalf("xint.X = %d, want 1", xint.X)
+-	}
+-}
+-
+-func TestUnmarshalPtrPtr(t *testing.T) {
+-	var xint Xint
+-	pxint := &xint
+-	if err := Unmarshal([]byte(`{"X":1}`), &pxint); err != nil {
+-		t.Fatalf("Unmarshal: %v", err)
+-	}
+-	if xint.X != 1 {
+-		t.Fatalf("xint.X = %d, want 1", xint.X)
+-	}
+-}
+-
+-func TestEscape(t *testing.T) {
+-	const input = `"foobar"<html>` + " [\u2028 \u2029]"
+-	const want = `"\"foobar\"\u003chtml\u003e [\u2028 \u2029]"`
+-	got, err := Marshal(input)
+-	if err != nil {
+-		t.Fatalf("Marshal error: %v", err)
+-	}
+-	if string(got) != want {
+-		t.Errorf("Marshal(%#q):\n\tgot:  %s\n\twant: %s", input, got, want)
+-	}
+-}
+-
+-// If people misuse the ,string modifier, the error message should be
+-// helpful, telling the user that they're doing it wrong.
+-func TestErrorMessageFromMisusedString(t *testing.T) {
+-	// WrongString is a struct that's misusing the ,string modifier.
+-	type WrongString struct {
+-		Message string `json:"result,string"`
+-	}
+-	tests := []struct {
+-		CaseName
+-		in, err string
+-	}{
+-		{Name(""), `{"result":"x"}`, `json: cannot unmarshal string into Go struct field WrongString.result of type string: invalid character 'x' looking for beginning of object key string`},
+-		{Name(""), `{"result":"foo"}`, `json: cannot unmarshal string into Go struct field WrongString.result of type string: invalid character 'f' looking for beginning of object key string`},
+-		{Name(""), `{"result":"123"}`, `json: cannot unmarshal string into Go struct field WrongString.result of type string: invalid character '1' looking for beginning of object key string`},
+-		{Name(""), `{"result":123}`, `json: cannot unmarshal number into Go struct field WrongString.result of type string`},
+-		{Name(""), `{"result":"\""}`, `json: cannot unmarshal string into Go struct field WrongString.result of type string: unexpected end of JSON input`},
+-		{Name(""), `{"result":"\"foo"}`, `json: cannot unmarshal string into Go struct field WrongString.result of type string: unexpected end of JSON input`},
+-	}
+-	for _, tt := range tests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			r := strings.NewReader(tt.in)
+-			var s WrongString
+-			err := NewDecoder(r).Decode(&s)
+-			got := fmt.Sprintf("%v", err)
+-			if got != tt.err {
+-				t.Errorf("%s: Decode error:\n\tgot:  %s\n\twant: %s", tt.Where, got, tt.err)
+-			}
+-		})
+-	}
+-}
+-
+-type All struct {
+-	Bool    bool
+-	Int     int
+-	Int8    int8
+-	Int16   int16
+-	Int32   int32
+-	Int64   int64
+-	Uint    uint
+-	Uint8   uint8
+-	Uint16  uint16
+-	Uint32  uint32
+-	Uint64  uint64
+-	Uintptr uintptr
+-	Float32 float32
+-	Float64 float64
+-
+-	Foo  string `json:"bar"`
+-	Foo2 string `json:"bar2,dummyopt"`
+-
+-	IntStr     int64   `json:",string"`
+-	UintptrStr uintptr `json:",string"`
+-
+-	PBool    *bool
+-	PInt     *int
+-	PInt8    *int8
+-	PInt16   *int16
+-	PInt32   *int32
+-	PInt64   *int64
+-	PUint    *uint
+-	PUint8   *uint8
+-	PUint16  *uint16
+-	PUint32  *uint32
+-	PUint64  *uint64
+-	PUintptr *uintptr
+-	PFloat32 *float32
+-	PFloat64 *float64
+-
+-	String  string
+-	PString *string
+-
+-	Map   map[string]Small
+-	MapP  map[string]*Small
+-	PMap  *map[string]Small
+-	PMapP *map[string]*Small
+-
+-	EmptyMap map[string]Small
+-	NilMap   map[string]Small
+-
+-	Slice   []Small
+-	SliceP  []*Small
+-	PSlice  *[]Small
+-	PSliceP *[]*Small
+-
+-	EmptySlice []Small
+-	NilSlice   []Small
+-
+-	StringSlice []string
+-	ByteSlice   []byte
+-
+-	Small   Small
+-	PSmall  *Small
+-	PPSmall **Small
+-
+-	Interface  any
+-	PInterface *any
+-
+-	unexported int
+-}
+-
+-type Small struct {
+-	Tag string
+-}
+-
+-var allValue = All{
+-	Bool:       true,
+-	Int:        2,
+-	Int8:       3,
+-	Int16:      4,
+-	Int32:      5,
+-	Int64:      6,
+-	Uint:       7,
+-	Uint8:      8,
+-	Uint16:     9,
+-	Uint32:     10,
+-	Uint64:     11,
+-	Uintptr:    12,
+-	Float32:    14.1,
+-	Float64:    15.1,
+-	Foo:        "foo",
+-	Foo2:       "foo2",
+-	IntStr:     42,
+-	UintptrStr: 44,
+-	String:     "16",
+-	Map: map[string]Small{
+-		"17": {Tag: "tag17"},
+-		"18": {Tag: "tag18"},
+-	},
+-	MapP: map[string]*Small{
+-		"19": {Tag: "tag19"},
+-		"20": nil,
+-	},
+-	EmptyMap:    map[string]Small{},
+-	Slice:       []Small{{Tag: "tag20"}, {Tag: "tag21"}},
+-	SliceP:      []*Small{{Tag: "tag22"}, nil, {Tag: "tag23"}},
+-	EmptySlice:  []Small{},
+-	StringSlice: []string{"str24", "str25", "str26"},
+-	ByteSlice:   []byte{27, 28, 29},
+-	Small:       Small{Tag: "tag30"},
+-	PSmall:      &Small{Tag: "tag31"},
+-	Interface:   5.2,
+-}
+-
+-var pallValue = All{
+-	PBool:      &allValue.Bool,
+-	PInt:       &allValue.Int,
+-	PInt8:      &allValue.Int8,
+-	PInt16:     &allValue.Int16,
+-	PInt32:     &allValue.Int32,
+-	PInt64:     &allValue.Int64,
+-	PUint:      &allValue.Uint,
+-	PUint8:     &allValue.Uint8,
+-	PUint16:    &allValue.Uint16,
+-	PUint32:    &allValue.Uint32,
+-	PUint64:    &allValue.Uint64,
+-	PUintptr:   &allValue.Uintptr,
+-	PFloat32:   &allValue.Float32,
+-	PFloat64:   &allValue.Float64,
+-	PString:    &allValue.String,
+-	PMap:       &allValue.Map,
+-	PMapP:      &allValue.MapP,
+-	PSlice:     &allValue.Slice,
+-	PSliceP:    &allValue.SliceP,
+-	PPSmall:    &allValue.PSmall,
+-	PInterface: &allValue.Interface,
+-}
+-
+-var allValueIndent = `{
+-	"Bool": true,
+-	"Int": 2,
+-	"Int8": 3,
+-	"Int16": 4,
+-	"Int32": 5,
+-	"Int64": 6,
+-	"Uint": 7,
+-	"Uint8": 8,
+-	"Uint16": 9,
+-	"Uint32": 10,
+-	"Uint64": 11,
+-	"Uintptr": 12,
+-	"Float32": 14.1,
+-	"Float64": 15.1,
+-	"bar": "foo",
+-	"bar2": "foo2",
+-	"IntStr": "42",
+-	"UintptrStr": "44",
+-	"PBool": null,
+-	"PInt": null,
+-	"PInt8": null,
+-	"PInt16": null,
+-	"PInt32": null,
+-	"PInt64": null,
+-	"PUint": null,
+-	"PUint8": null,
+-	"PUint16": null,
+-	"PUint32": null,
+-	"PUint64": null,
+-	"PUintptr": null,
+-	"PFloat32": null,
+-	"PFloat64": null,
+-	"String": "16",
+-	"PString": null,
+-	"Map": {
+-		"17": {
+-			"Tag": "tag17"
+-		},
+-		"18": {
+-			"Tag": "tag18"
+-		}
+-	},
+-	"MapP": {
+-		"19": {
+-			"Tag": "tag19"
+-		},
+-		"20": null
+-	},
+-	"PMap": null,
+-	"PMapP": null,
+-	"EmptyMap": {},
+-	"NilMap": null,
+-	"Slice": [
+-		{
+-			"Tag": "tag20"
+-		},
+-		{
+-			"Tag": "tag21"
+-		}
+-	],
+-	"SliceP": [
+-		{
+-			"Tag": "tag22"
+-		},
+-		null,
+-		{
+-			"Tag": "tag23"
+-		}
+-	],
+-	"PSlice": null,
+-	"PSliceP": null,
+-	"EmptySlice": [],
+-	"NilSlice": null,
+-	"StringSlice": [
+-		"str24",
+-		"str25",
+-		"str26"
+-	],
+-	"ByteSlice": "Gxwd",
+-	"Small": {
+-		"Tag": "tag30"
+-	},
+-	"PSmall": {
+-		"Tag": "tag31"
+-	},
+-	"PPSmall": null,
+-	"Interface": 5.2,
+-	"PInterface": null
+-}`
+-
+-var allValueCompact = stripWhitespace(allValueIndent)
+-
+-var pallValueIndent = `{
+-	"Bool": false,
+-	"Int": 0,
+-	"Int8": 0,
+-	"Int16": 0,
+-	"Int32": 0,
+-	"Int64": 0,
+-	"Uint": 0,
+-	"Uint8": 0,
+-	"Uint16": 0,
+-	"Uint32": 0,
+-	"Uint64": 0,
+-	"Uintptr": 0,
+-	"Float32": 0,
+-	"Float64": 0,
+-	"bar": "",
+-	"bar2": "",
+-        "IntStr": "0",
+-	"UintptrStr": "0",
+-	"PBool": true,
+-	"PInt": 2,
+-	"PInt8": 3,
+-	"PInt16": 4,
+-	"PInt32": 5,
+-	"PInt64": 6,
+-	"PUint": 7,
+-	"PUint8": 8,
+-	"PUint16": 9,
+-	"PUint32": 10,
+-	"PUint64": 11,
+-	"PUintptr": 12,
+-	"PFloat32": 14.1,
+-	"PFloat64": 15.1,
+-	"String": "",
+-	"PString": "16",
+-	"Map": null,
+-	"MapP": null,
+-	"PMap": {
+-		"17": {
+-			"Tag": "tag17"
+-		},
+-		"18": {
+-			"Tag": "tag18"
+-		}
+-	},
+-	"PMapP": {
+-		"19": {
+-			"Tag": "tag19"
+-		},
+-		"20": null
+-	},
+-	"EmptyMap": null,
+-	"NilMap": null,
+-	"Slice": null,
+-	"SliceP": null,
+-	"PSlice": [
+-		{
+-			"Tag": "tag20"
+-		},
+-		{
+-			"Tag": "tag21"
+-		}
+-	],
+-	"PSliceP": [
+-		{
+-			"Tag": "tag22"
+-		},
+-		null,
+-		{
+-			"Tag": "tag23"
+-		}
+-	],
+-	"EmptySlice": null,
+-	"NilSlice": null,
+-	"StringSlice": null,
+-	"ByteSlice": null,
+-	"Small": {
+-		"Tag": ""
+-	},
+-	"PSmall": null,
+-	"PPSmall": {
+-		"Tag": "tag31"
+-	},
+-	"Interface": null,
+-	"PInterface": 5.2
+-}`
+-
+-var pallValueCompact = stripWhitespace(pallValueIndent)
+-
+-func TestRefUnmarshal(t *testing.T) {
+-	type S struct {
+-		// Ref is defined in encode_test.go.
+-		R0 Ref
+-		R1 *Ref
+-		R2 RefText
+-		R3 *RefText
+-	}
+-	want := S{
+-		R0: 12,
+-		R1: new(Ref),
+-		R2: 13,
+-		R3: new(RefText),
+-	}
+-	*want.R1 = 12
+-	*want.R3 = 13
+-
+-	var got S
+-	if err := Unmarshal([]byte(`{"R0":"ref","R1":"ref","R2":"ref","R3":"ref"}`), &got); err != nil {
+-		t.Fatalf("Unmarshal error: %v", err)
+-	}
+-	if !reflect.DeepEqual(got, want) {
+-		t.Errorf("Unmarsha:\n\tgot:  %+v\n\twant: %+v", got, want)
+-	}
+-}
+-
+-// Test that the empty string doesn't panic decoding when ,string is specified
+-// Issue 3450
+-func TestEmptyString(t *testing.T) {
+-	type T2 struct {
+-		Number1 int `json:",string"`
+-		Number2 int `json:",string"`
+-	}
+-	data := `{"Number1":"1", "Number2":""}`
+-	dec := NewDecoder(strings.NewReader(data))
+-	var got T2
+-	switch err := dec.Decode(&got); {
+-	case err == nil:
+-		t.Fatalf("Decode error: got nil, want non-nil")
+-	case got.Number1 != 1:
+-		t.Fatalf("Decode: got.Number1 = %d, want 1", got.Number1)
+-	}
+-}
+-
+-// Test that a null for ,string is not replaced with the previous quoted string (issue 7046).
+-// It should also not be an error (issue 2540, issue 8587).
+-func TestNullString(t *testing.T) {
+-	type T struct {
+-		A int  `json:",string"`
+-		B int  `json:",string"`
+-		C *int `json:",string"`
+-	}
+-	data := []byte(`{"A": "1", "B": null, "C": null}`)
+-	var s T
+-	s.B = 1
+-	s.C = new(int)
+-	*s.C = 2
+-	switch err := Unmarshal(data, &s); {
+-	case err != nil:
+-		t.Fatalf("Unmarshal error: %v", err)
+-	case s.B != 1:
+-		t.Fatalf("Unmarshal: s.B = %d, want 1", s.B)
+-	case s.C != nil:
+-		t.Fatalf("Unmarshal: s.C = %d, want non-nil", s.C)
+-	}
+-}
+-
+-func addr[T any](v T) *T {
+-	return &v
+-}
+-
+-func TestInterfaceSet(t *testing.T) {
+-	errUnmarshal := &UnmarshalTypeError{Value: "object", Offset: 5, Type: reflect.TypeFor[int](), Field: "X"}
+-	tests := []struct {
+-		CaseName
+-		pre  any
+-		json string
+-		post any
+-	}{
+-		{Name(""), "foo", `"bar"`, "bar"},
+-		{Name(""), "foo", `2`, 2.0},
+-		{Name(""), "foo", `true`, true},
+-		{Name(""), "foo", `null`, nil},
+-		{Name(""), map[string]any{}, `true`, true},
+-		{Name(""), []string{}, `true`, true},
+-
+-		{Name(""), any(nil), `null`, any(nil)},
+-		{Name(""), (*int)(nil), `null`, any(nil)},
+-		{Name(""), (*int)(addr(0)), `null`, any(nil)},
+-		{Name(""), (*int)(addr(1)), `null`, any(nil)},
+-		{Name(""), (**int)(nil), `null`, any(nil)},
+-		{Name(""), (**int)(addr[*int](nil)), `null`, (**int)(addr[*int](nil))},
+-		{Name(""), (**int)(addr(addr(1))), `null`, (**int)(addr[*int](nil))},
+-		{Name(""), (***int)(nil), `null`, any(nil)},
+-		{Name(""), (***int)(addr[**int](nil)), `null`, (***int)(addr[**int](nil))},
+-		{Name(""), (***int)(addr(addr[*int](nil))), `null`, (***int)(addr[**int](nil))},
+-		{Name(""), (***int)(addr(addr(addr(1)))), `null`, (***int)(addr[**int](nil))},
+-
+-		{Name(""), any(nil), `2`, float64(2)},
+-		{Name(""), (int)(1), `2`, float64(2)},
+-		{Name(""), (*int)(nil), `2`, float64(2)},
+-		{Name(""), (*int)(addr(0)), `2`, (*int)(addr(2))},
+-		{Name(""), (*int)(addr(1)), `2`, (*int)(addr(2))},
+-		{Name(""), (**int)(nil), `2`, float64(2)},
+-		{Name(""), (**int)(addr[*int](nil)), `2`, (**int)(addr(addr(2)))},
+-		{Name(""), (**int)(addr(addr(1))), `2`, (**int)(addr(addr(2)))},
+-		{Name(""), (***int)(nil), `2`, float64(2)},
+-		{Name(""), (***int)(addr[**int](nil)), `2`, (***int)(addr(addr(addr(2))))},
+-		{Name(""), (***int)(addr(addr[*int](nil))), `2`, (***int)(addr(addr(addr(2))))},
+-		{Name(""), (***int)(addr(addr(addr(1)))), `2`, (***int)(addr(addr(addr(2))))},
+-
+-		{Name(""), any(nil), `{}`, map[string]any{}},
+-		{Name(""), (int)(1), `{}`, map[string]any{}},
+-		{Name(""), (*int)(nil), `{}`, map[string]any{}},
+-		{Name(""), (*int)(addr(0)), `{}`, errUnmarshal},
+-		{Name(""), (*int)(addr(1)), `{}`, errUnmarshal},
+-		{Name(""), (**int)(nil), `{}`, map[string]any{}},
+-		{Name(""), (**int)(addr[*int](nil)), `{}`, errUnmarshal},
+-		{Name(""), (**int)(addr(addr(1))), `{}`, errUnmarshal},
+-		{Name(""), (***int)(nil), `{}`, map[string]any{}},
+-		{Name(""), (***int)(addr[**int](nil)), `{}`, errUnmarshal},
+-		{Name(""), (***int)(addr(addr[*int](nil))), `{}`, errUnmarshal},
+-		{Name(""), (***int)(addr(addr(addr(1)))), `{}`, errUnmarshal},
+-	}
+-	for _, tt := range tests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			b := struct{ X any }{tt.pre}
+-			blob := `{"X":` + tt.json + `}`
+-			if err := Unmarshal([]byte(blob), &b); err != nil {
+-				if wantErr, _ := tt.post.(error); equalError(err, wantErr) {
+-					return
+-				}
+-				t.Fatalf("%s: Unmarshal(%#q) error: %v", tt.Where, blob, err)
+-			}
+-			if !reflect.DeepEqual(b.X, tt.post) {
+-				t.Errorf("%s: Unmarshal(%#q):\n\tpre.X:  %#v\n\tgot.X:  %#v\n\twant.X: %#v", tt.Where, blob, tt.pre, b.X, tt.post)
+-			}
+-		})
+-	}
+-}
+-
+-type NullTest struct {
+-	Bool      bool
+-	Int       int
+-	Int8      int8
+-	Int16     int16
+-	Int32     int32
+-	Int64     int64
+-	Uint      uint
+-	Uint8     uint8
+-	Uint16    uint16
+-	Uint32    uint32
+-	Uint64    uint64
+-	Float32   float32
+-	Float64   float64
+-	String    string
+-	PBool     *bool
+-	Map       map[string]string
+-	Slice     []string
+-	Interface any
+-
+-	PRaw    *RawMessage
+-	PTime   *time.Time
+-	PBigInt *big.Int
+-	PText   *MustNotUnmarshalText
+-	PBuffer *bytes.Buffer // has methods, just not relevant ones
+-	PStruct *struct{}
+-
+-	Raw    RawMessage
+-	Time   time.Time
+-	BigInt big.Int
+-	Text   MustNotUnmarshalText
+-	Buffer bytes.Buffer
+-	Struct struct{}
+-}
+-
+-// JSON null values should be ignored for primitives and string values instead of resulting in an error.
+-// Issue 2540
+-func TestUnmarshalNulls(t *testing.T) {
+-	// Unmarshal docs:
+-	// The JSON null value unmarshals into an interface, map, pointer, or slice
+-	// by setting that Go value to nil. Because null is often used in JSON to mean
+-	// ``not present,'' unmarshaling a JSON null into any other Go type has no effect
+-	// on the value and produces no error.
+-
+-	jsonData := []byte(`{
+-				"Bool"    : null,
+-				"Int"     : null,
+-				"Int8"    : null,
+-				"Int16"   : null,
+-				"Int32"   : null,
+-				"Int64"   : null,
+-				"Uint"    : null,
+-				"Uint8"   : null,
+-				"Uint16"  : null,
+-				"Uint32"  : null,
+-				"Uint64"  : null,
+-				"Float32" : null,
+-				"Float64" : null,
+-				"String"  : null,
+-				"PBool": null,
+-				"Map": null,
+-				"Slice": null,
+-				"Interface": null,
+-				"PRaw": null,
+-				"PTime": null,
+-				"PBigInt": null,
+-				"PText": null,
+-				"PBuffer": null,
+-				"PStruct": null,
+-				"Raw": null,
+-				"Time": null,
+-				"BigInt": null,
+-				"Text": null,
+-				"Buffer": null,
+-				"Struct": null
+-			}`)
+-	nulls := NullTest{
+-		Bool:      true,
+-		Int:       2,
+-		Int8:      3,
+-		Int16:     4,
+-		Int32:     5,
+-		Int64:     6,
+-		Uint:      7,
+-		Uint8:     8,
+-		Uint16:    9,
+-		Uint32:    10,
+-		Uint64:    11,
+-		Float32:   12.1,
+-		Float64:   13.1,
+-		String:    "14",
+-		PBool:     new(bool),
+-		Map:       map[string]string{},
+-		Slice:     []string{},
+-		Interface: new(MustNotUnmarshalJSON),
+-		PRaw:      new(RawMessage),
+-		PTime:     new(time.Time),
+-		PBigInt:   new(big.Int),
+-		PText:     new(MustNotUnmarshalText),
+-		PStruct:   new(struct{}),
+-		PBuffer:   new(bytes.Buffer),
+-		Raw:       RawMessage("123"),
+-		Time:      time.Unix(123456789, 0),
+-		BigInt:    *big.NewInt(123),
+-	}
+-
+-	before := nulls.Time.String()
+-
+-	err := Unmarshal(jsonData, &nulls)
+-	if err != nil {
+-		t.Errorf("Unmarshal of null values failed: %v", err)
+-	}
+-	if !nulls.Bool || nulls.Int != 2 || nulls.Int8 != 3 || nulls.Int16 != 4 || nulls.Int32 != 5 || nulls.Int64 != 6 ||
+-		nulls.Uint != 7 || nulls.Uint8 != 8 || nulls.Uint16 != 9 || nulls.Uint32 != 10 || nulls.Uint64 != 11 ||
+-		nulls.Float32 != 12.1 || nulls.Float64 != 13.1 || nulls.String != "14" {
+-		t.Errorf("Unmarshal of null values affected primitives")
+-	}
+-
+-	if nulls.PBool != nil {
+-		t.Errorf("Unmarshal of null did not clear nulls.PBool")
+-	}
+-	if nulls.Map != nil {
+-		t.Errorf("Unmarshal of null did not clear nulls.Map")
+-	}
+-	if nulls.Slice != nil {
+-		t.Errorf("Unmarshal of null did not clear nulls.Slice")
+-	}
+-	if nulls.Interface != nil {
+-		t.Errorf("Unmarshal of null did not clear nulls.Interface")
+-	}
+-	if nulls.PRaw != nil {
+-		t.Errorf("Unmarshal of null did not clear nulls.PRaw")
+-	}
+-	if nulls.PTime != nil {
+-		t.Errorf("Unmarshal of null did not clear nulls.PTime")
+-	}
+-	if nulls.PBigInt != nil {
+-		t.Errorf("Unmarshal of null did not clear nulls.PBigInt")
+-	}
+-	if nulls.PText != nil {
+-		t.Errorf("Unmarshal of null did not clear nulls.PText")
+-	}
+-	if nulls.PBuffer != nil {
+-		t.Errorf("Unmarshal of null did not clear nulls.PBuffer")
+-	}
+-	if nulls.PStruct != nil {
+-		t.Errorf("Unmarshal of null did not clear nulls.PStruct")
+-	}
+-
+-	if string(nulls.Raw) != "null" {
+-		t.Errorf("Unmarshal of RawMessage null did not record null: %v", string(nulls.Raw))
+-	}
+-	if nulls.Time.String() != before {
+-		t.Errorf("Unmarshal of time.Time null set time to %v", nulls.Time.String())
+-	}
+-	if nulls.BigInt.String() != "123" {
+-		t.Errorf("Unmarshal of big.Int null set int to %v", nulls.BigInt.String())
+-	}
+-}
+-
+-type MustNotUnmarshalJSON struct{}
+-
+-func (x MustNotUnmarshalJSON) UnmarshalJSON(data []byte) error {
+-	return errors.New("MustNotUnmarshalJSON was used")
+-}
+-
+-type MustNotUnmarshalText struct{}
+-
+-func (x MustNotUnmarshalText) UnmarshalText(text []byte) error {
+-	return errors.New("MustNotUnmarshalText was used")
+-}
+-
+-func TestStringKind(t *testing.T) {
+-	type stringKind string
+-	want := map[stringKind]int{"foo": 42}
+-	data, err := Marshal(want)
+-	if err != nil {
+-		t.Fatalf("Marshal error: %v", err)
+-	}
+-	var got map[stringKind]int
+-	err = Unmarshal(data, &got)
+-	if err != nil {
+-		t.Fatalf("Unmarshal error: %v", err)
+-	}
+-	if !maps.Equal(got, want) {
+-		t.Fatalf("Marshal/Unmarshal mismatch:\n\tgot:  %v\n\twant: %v", got, want)
+-	}
+-}
+-
+-// Custom types with []byte as underlying type could not be marshaled
+-// and then unmarshaled.
+-// Issue 8962.
+-func TestByteKind(t *testing.T) {
+-	type byteKind []byte
+-	want := byteKind("hello")
+-	data, err := Marshal(want)
+-	if err != nil {
+-		t.Fatalf("Marshal error: %v", err)
+-	}
+-	var got byteKind
+-	err = Unmarshal(data, &got)
+-	if err != nil {
+-		t.Fatalf("Unmarshal error: %v", err)
+-	}
+-	if !slices.Equal(got, want) {
+-		t.Fatalf("Marshal/Unmarshal mismatch:\n\tgot:  %v\n\twant: %v", got, want)
+-	}
+-}
+-
+-// The fix for issue 8962 introduced a regression.
+-// Issue 12921.
+-func TestSliceOfCustomByte(t *testing.T) {
+-	type Uint8 uint8
+-	want := []Uint8("hello")
+-	data, err := Marshal(want)
+-	if err != nil {
+-		t.Fatalf("Marshal error: %v", err)
+-	}
+-	var got []Uint8
+-	err = Unmarshal(data, &got)
+-	if err != nil {
+-		t.Fatalf("Unmarshal error: %v", err)
+-	}
+-	if !slices.Equal(got, want) {
+-		t.Fatalf("Marshal/Unmarshal mismatch:\n\tgot:  %v\n\twant: %v", got, want)
+-	}
+-}
+-
+-func TestUnmarshalTypeError(t *testing.T) {
+-	tests := []struct {
+-		CaseName
+-		dest any
+-		in   string
+-	}{
+-		{Name(""), new(string), `{"user": "name"}`}, // issue 4628.
+-		{Name(""), new(error), `{}`},                // issue 4222
+-		{Name(""), new(error), `[]`},
+-		{Name(""), new(error), `""`},
+-		{Name(""), new(error), `123`},
+-		{Name(""), new(error), `true`},
+-	}
+-	for _, tt := range tests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			err := Unmarshal([]byte(tt.in), tt.dest)
+-			if _, ok := err.(*UnmarshalTypeError); !ok {
+-				t.Errorf("%s: Unmarshal(%#q, %T):\n\tgot:  %T\n\twant: %T",
+-					tt.Where, tt.in, tt.dest, err, new(UnmarshalTypeError))
+-			}
+-		})
+-	}
+-}
+-
+-func TestUnmarshalSyntax(t *testing.T) {
+-	var x any
+-	tests := []struct {
+-		CaseName
+-		in string
+-	}{
+-		{Name(""), "tru"},
+-		{Name(""), "fals"},
+-		{Name(""), "nul"},
+-		{Name(""), "123e"},
+-		{Name(""), `"hello`},
+-		{Name(""), `[1,2,3`},
+-		{Name(""), `{"key":1`},
+-		{Name(""), `{"key":1,`},
+-	}
+-	for _, tt := range tests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			err := Unmarshal([]byte(tt.in), &x)
+-			if _, ok := err.(*SyntaxError); !ok {
+-				t.Errorf("%s: Unmarshal(%#q, any):\n\tgot:  %T\n\twant: %T",
+-					tt.Where, tt.in, err, new(SyntaxError))
+-			}
+-		})
+-	}
+-}
+-
+-// Test handling of unexported fields that should be ignored.
+-// Issue 4660
+-type unexportedFields struct {
+-	Name string
+-	m    map[string]any `json:"-"`
+-	m2   map[string]any `json:"abcd"`
+-
+-	s []int `json:"-"`
+-}
+-
+-func TestUnmarshalUnexported(t *testing.T) {
+-	input := `{"Name": "Bob", "m": {"x": 123}, "m2": {"y": 456}, "abcd": {"z": 789}, "s": [2, 3]}`
+-	want := &unexportedFields{Name: "Bob"}
+-
+-	out := &unexportedFields{}
+-	err := Unmarshal([]byte(input), out)
+-	if err != nil {
+-		t.Errorf("Unmarshal error: %v", err)
+-	}
+-	if !reflect.DeepEqual(out, want) {
+-		t.Errorf("Unmarshal:\n\tgot:  %+v\n\twant: %+v", out, want)
+-	}
+-}
+-
+-// Time3339 is a time.Time which encodes to and from JSON
+-// as an RFC 3339 time in UTC.
+-type Time3339 time.Time
+-
+-func (t *Time3339) UnmarshalJSON(b []byte) error {
+-	if len(b) < 2 || b[0] != '"' || b[len(b)-1] != '"' {
+-		return fmt.Errorf("types: failed to unmarshal non-string value %q as an RFC 3339 time", b)
+-	}
+-	tm, err := time.Parse(time.RFC3339, string(b[1:len(b)-1]))
+-	if err != nil {
+-		return err
+-	}
+-	*t = Time3339(tm)
+-	return nil
+-}
+-
+-func TestUnmarshalJSONLiteralError(t *testing.T) {
+-	var t3 Time3339
+-	switch err := Unmarshal([]byte(`"0000-00-00T00:00:00Z"`), &t3); {
+-	case err == nil:
+-		t.Fatalf("Unmarshal error: got nil, want non-nil")
+-	case !strings.Contains(err.Error(), "range"):
+-		t.Errorf("Unmarshal error:\n\tgot:  %v\n\twant: out of range", err)
+-	}
+-}
+-
+-// Test that extra object elements in an array do not result in a
+-// "data changing underfoot" error.
+-// Issue 3717
+-func TestSkipArrayObjects(t *testing.T) {
+-	json := `[{}]`
+-	var dest [0]any
+-
+-	err := Unmarshal([]byte(json), &dest)
+-	if err != nil {
+-		t.Errorf("Unmarshal error: %v", err)
+-	}
+-}
+-
+-// Test semantics of pre-filled data, such as struct fields, map elements,
+-// slices, and arrays.
+-// Issues 4900 and 8837, among others.
+-func TestPrefilled(t *testing.T) {
+-	// Values here change, cannot reuse table across runs.
+-	tests := []struct {
+-		CaseName
+-		in  string
+-		ptr any
+-		out any
+-	}{{
+-		CaseName: Name(""),
+-		in:       `{"X": 1, "Y": 2}`,
+-		ptr:      &XYZ{X: float32(3), Y: int16(4), Z: 1.5},
+-		out:      &XYZ{X: float64(1), Y: float64(2), Z: 1.5},
+-	}, {
+-		CaseName: Name(""),
+-		in:       `{"X": 1, "Y": 2}`,
+-		ptr:      &map[string]any{"X": float32(3), "Y": int16(4), "Z": 1.5},
+-		out:      &map[string]any{"X": float64(1), "Y": float64(2), "Z": 1.5},
+-	}, {
+-		CaseName: Name(""),
+-		in:       `[2]`,
+-		ptr:      &[]int{1},
+-		out:      &[]int{2},
+-	}, {
+-		CaseName: Name(""),
+-		in:       `[2, 3]`,
+-		ptr:      &[]int{1},
+-		out:      &[]int{2, 3},
+-	}, {
+-		CaseName: Name(""),
+-		in:       `[2, 3]`,
+-		ptr:      &[...]int{1},
+-		out:      &[...]int{2},
+-	}, {
+-		CaseName: Name(""),
+-		in:       `[3]`,
+-		ptr:      &[...]int{1, 2},
+-		out:      &[...]int{3, 0},
+-	}}
+-	for _, tt := range tests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			ptrstr := fmt.Sprintf("%v", tt.ptr)
+-			err := Unmarshal([]byte(tt.in), tt.ptr) // tt.ptr edited here
+-			if err != nil {
+-				t.Errorf("%s: Unmarshal error: %v", tt.Where, err)
+-			}
+-			if !reflect.DeepEqual(tt.ptr, tt.out) {
+-				t.Errorf("%s: Unmarshal(%#q, %T):\n\tgot:  %v\n\twant: %v", tt.Where, tt.in, ptrstr, tt.ptr, tt.out)
+-			}
+-		})
+-	}
+-}
+-
+-func TestInvalidUnmarshal(t *testing.T) {
+-	tests := []struct {
+-		CaseName
+-		in      string
+-		v       any
+-		wantErr error
+-	}{
+-		{Name(""), `{"a":"1"}`, nil, &InvalidUnmarshalError{}},
+-		{Name(""), `{"a":"1"}`, struct{}{}, &InvalidUnmarshalError{reflect.TypeFor[struct{}]()}},
+-		{Name(""), `{"a":"1"}`, (*int)(nil), &InvalidUnmarshalError{reflect.TypeFor[*int]()}},
+-		{Name(""), `123`, nil, &InvalidUnmarshalError{}},
+-		{Name(""), `123`, struct{}{}, &InvalidUnmarshalError{reflect.TypeFor[struct{}]()}},
+-		{Name(""), `123`, (*int)(nil), &InvalidUnmarshalError{reflect.TypeFor[*int]()}},
+-		{Name(""), `123`, new(net.IP), &UnmarshalTypeError{Value: "number", Type: reflect.TypeFor[net.IP](), Offset: len64(``), Err: errors.New("JSON value must be string type")}},
+-	}
+-	for _, tt := range tests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			switch gotErr := Unmarshal([]byte(tt.in), tt.v); {
+-			case gotErr == nil:
+-				t.Fatalf("%s: Unmarshal error: got nil, want non-nil", tt.Where)
+-			case !reflect.DeepEqual(gotErr, tt.wantErr):
+-				t.Errorf("%s: Unmarshal error:\n\tgot:  %#v\n\twant: %#v", tt.Where, gotErr, tt.wantErr)
+-			}
+-		})
+-	}
+-}
+-
+-// Test that string option is ignored for invalid types.
+-// Issue 9812.
+-func TestInvalidStringOption(t *testing.T) {
+-	num := 0
+-	item := struct {
+-		T time.Time         `json:",string"`
+-		M map[string]string `json:",string"`
+-		S []string          `json:",string"`
+-		A [1]string         `json:",string"`
+-		I any               `json:",string"`
+-		P *int              `json:",string"`
+-	}{M: make(map[string]string), S: make([]string, 0), I: num, P: &num}
+-
+-	data, err := Marshal(item)
+-	if err != nil {
+-		t.Fatalf("Marshal error: %v", err)
+-	}
+-
+-	err = Unmarshal(data, &item)
+-	if err != nil {
+-		t.Fatalf("Unmarshal error: %v", err)
+-	}
+-}
+-
+-// Test unmarshal behavior with regards to embedded unexported structs.
+-//
+-// (Issue 21357) If the embedded struct is a pointer and is unallocated,
+-// this returns an error because unmarshal cannot set the field.
+-//
+-// (Issue 24152) If the embedded struct is given an explicit name,
+-// ensure that the normal unmarshal logic does not panic in reflect.
+-//
+-// (Issue 28145) If the embedded struct is given an explicit name and has
+-// exported methods, don't cause a panic trying to get its value.
+-func TestUnmarshalEmbeddedUnexported(t *testing.T) {
+-	type (
+-		embed1 struct{ Q int }
+-		embed2 struct{ Q int }
+-		embed3 struct {
+-			Q int64 `json:",string"`
+-		}
+-		S1 struct {
+-			*embed1
+-			R int
+-		}
+-		S2 struct {
+-			*embed1
+-			Q int
+-		}
+-		S3 struct {
+-			embed1
+-			R int
+-		}
+-		S4 struct {
+-			*embed1
+-			embed2
+-		}
+-		S5 struct {
+-			*embed3
+-			R int
+-		}
+-		S6 struct {
+-			embed1 `json:"embed1"`
+-		}
+-		S7 struct {
+-			embed1 `json:"embed1"`
+-			embed2
+-		}
+-		S8 struct {
+-			embed1 `json:"embed1"`
+-			embed2 `json:"embed2"`
+-			Q      int
+-		}
+-		S9 struct {
+-			unexportedWithMethods `json:"embed"`
+-		}
+-	)
+-
+-	tests := []struct {
+-		CaseName
+-		in  string
+-		ptr any
+-		out any
+-		err error
+-	}{{
+-		// Error since we cannot set S1.embed1, but still able to set S1.R.
+-		CaseName: Name(""),
+-		in:       `{"R":2,"Q":1}`,
+-		ptr:      new(S1),
+-		out:      &S1{R: 2},
+-		err: &UnmarshalTypeError{
+-			Value:  "number",
+-			Type:   reflect.TypeFor[S1](),
+-			Offset: len64(`{"R":2,"Q":`),
+-			Struct: "S1",
+-			Field:  "Q",
+-			Err:    errors.New("cannot set embedded pointer to unexported struct type"),
+-		},
+-	}, {
+-		// The top level Q field takes precedence.
+-		CaseName: Name(""),
+-		in:       `{"Q":1}`,
+-		ptr:      new(S2),
+-		out:      &S2{Q: 1},
+-	}, {
+-		// No issue with non-pointer variant.
+-		CaseName: Name(""),
+-		in:       `{"R":2,"Q":1}`,
+-		ptr:      new(S3),
+-		out:      &S3{embed1: embed1{Q: 1}, R: 2},
+-	}, {
+-		// No error since both embedded structs have field R, which annihilate each other.
+-		// Thus, no attempt is made at setting S4.embed1.
+-		CaseName: Name(""),
+-		in:       `{"R":2}`,
+-		ptr:      new(S4),
+-		out:      new(S4),
+-	}, {
+-		// Error since we cannot set S5.embed1, but still able to set S5.R.
+-		CaseName: Name(""),
+-		in:       `{"R":2,"Q":1}`,
+-		ptr:      new(S5),
+-		out:      &S5{R: 2},
+-		err: &UnmarshalTypeError{
+-			Value:  "number",
+-			Type:   reflect.TypeFor[S5](),
+-			Offset: len64(`{"R":2,"Q":`),
+-			Struct: "S5",
+-			Field:  "Q",
+-			Err:    errors.New("cannot set embedded pointer to unexported struct type"),
+-		},
+-	}, {
+-		// Issue 24152, ensure decodeState.indirect does not panic.
+-		CaseName: Name(""),
+-		in:       `{"embed1": {"Q": 1}}`,
+-		ptr:      new(S6),
+-		out:      &S6{embed1{1}},
+-	}, {
+-		// Issue 24153, check that we can still set forwarded fields even in
+-		// the presence of a name conflict.
+-		//
+-		// This relies on obscure behavior of reflect where it is possible
+-		// to set a forwarded exported field on an unexported embedded struct
+-		// even though there is a name conflict, even when it would have been
+-		// impossible to do so according to Go visibility rules.
+-		// Go forbids this because it is ambiguous whether S7.Q refers to
+-		// S7.embed1.Q or S7.embed2.Q. Since embed1 and embed2 are unexported,
+-		// it should be impossible for an external package to set either Q.
+-		//
+-		// It is probably okay for a future reflect change to break this.
+-		CaseName: Name(""),
+-		in:       `{"embed1": {"Q": 1}, "Q": 2}`,
+-		ptr:      new(S7),
+-		out:      &S7{embed1{1}, embed2{2}},
+-	}, {
+-		// Issue 24153, similar to the S7 case.
+-		CaseName: Name(""),
+-		in:       `{"embed1": {"Q": 1}, "embed2": {"Q": 2}, "Q": 3}`,
+-		ptr:      new(S8),
+-		out:      &S8{embed1{1}, embed2{2}, 3},
+-	}, {
+-		// Issue 228145, similar to the cases above.
+-		CaseName: Name(""),
+-		in:       `{"embed": {}}`,
+-		ptr:      new(S9),
+-		out:      &S9{},
+-	}}
+-	for _, tt := range tests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			err := Unmarshal([]byte(tt.in), tt.ptr)
+-			if !equalError(err, tt.err) {
+-				t.Errorf("%s: Unmarshal error:\n\tgot:  %v\n\twant: %v", tt.Where, err, tt.err)
+-			}
+-			if !reflect.DeepEqual(tt.ptr, tt.out) {
+-				t.Errorf("%s: Unmarshal:\n\tgot:  %#+v\n\twant: %#+v", tt.Where, tt.ptr, tt.out)
+-			}
+-		})
+-	}
+-}
+-
+-func TestUnmarshalErrorAfterMultipleJSON(t *testing.T) {
+-	tests := []struct {
+-		CaseName
+-		in  string
+-		err error
+-	}{{
+-		CaseName: Name(""),
+-		in:       `1 false null :`,
+-		err:      &SyntaxError{"invalid character ':' looking for beginning of value", len64(`1 false null `)},
+-	}, {
+-		CaseName: Name(""),
+-		in:       `1 [] [,]`,
+-		err:      &SyntaxError{"invalid character ',' looking for beginning of value", len64(`1 [] [`)},
+-	}, {
+-		CaseName: Name(""),
+-		in:       `1 [] [true:]`,
+-		err:      &SyntaxError{"invalid character ':' after array element", len64(`1 [] [true`)},
+-	}, {
+-		CaseName: Name(""),
+-		in:       `1  {}    {"x"=}`,
+-		err:      &SyntaxError{"invalid character '=' after object key", len64(`1  {}    {"x"`)},
+-	}, {
+-		CaseName: Name(""),
+-		in:       `falsetruenul#`,
+-		err:      &SyntaxError{"invalid character '#' in literal null (expecting 'l')", len64(`falsetruenul`)},
+-	}}
+-	for _, tt := range tests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			dec := NewDecoder(strings.NewReader(tt.in))
+-			var err error
+-			for err == nil {
+-				var v any
+-				err = dec.Decode(&v)
+-			}
+-			if !reflect.DeepEqual(err, tt.err) {
+-				t.Errorf("%s: Decode error:\n\tgot:  %v\n\twant: %v", tt.Where, err, tt.err)
+-			}
+-		})
+-	}
+-}
+-
+-type unmarshalPanic struct{}
+-
+-func (unmarshalPanic) UnmarshalJSON([]byte) error { panic(0xdead) }
+-
+-func TestUnmarshalPanic(t *testing.T) {
+-	defer func() {
+-		if got := recover(); !reflect.DeepEqual(got, 0xdead) {
+-			t.Errorf("panic() = (%T)(%v), want 0xdead", got, got)
+-		}
+-	}()
+-	Unmarshal([]byte("{}"), &unmarshalPanic{})
+-	t.Fatalf("Unmarshal should have panicked")
+-}
+-
+-type textUnmarshalerString string
+-
+-func (m *textUnmarshalerString) UnmarshalText(text []byte) error {
+-	*m = textUnmarshalerString(strings.ToLower(string(text)))
+-	return nil
+-}
+-
+-// Test unmarshal to a map, where the map key is a user defined type.
+-// See golang.org/issues/34437.
+-func TestUnmarshalMapWithTextUnmarshalerStringKey(t *testing.T) {
+-	var p map[textUnmarshalerString]string
+-	if err := Unmarshal([]byte(`{"FOO": "1"}`), &p); err != nil {
+-		t.Fatalf("Unmarshal error: %v", err)
+-	}
+-
+-	if _, ok := p["foo"]; !ok {
+-		t.Errorf(`key "foo" missing in map: %v`, p)
+-	}
+-}
+-
+-func TestUnmarshalRescanLiteralMangledUnquote(t *testing.T) {
+-	// See golang.org/issues/38105.
+-	var p map[textUnmarshalerString]string
+-	if err := Unmarshal([]byte(`{"开源":"12345开源"}`), &p); err != nil {
+-		t.Fatalf("Unmarshal error: %v", err)
+-	}
+-	if _, ok := p["开源"]; !ok {
+-		t.Errorf(`key "开源" missing in map: %v`, p)
+-	}
+-
+-	// See golang.org/issues/38126.
+-	type T struct {
+-		F1 string `json:"F1,string"`
+-	}
+-	wantT := T{"aaa\tbbb"}
+-
+-	b, err := Marshal(wantT)
+-	if err != nil {
+-		t.Fatalf("Marshal error: %v", err)
+-	}
+-	var gotT T
+-	if err := Unmarshal(b, &gotT); err != nil {
+-		t.Fatalf("Unmarshal error: %v", err)
+-	}
+-	if gotT != wantT {
+-		t.Errorf("Marshal/Unmarshal roundtrip:\n\tgot:  %q\n\twant: %q", gotT, wantT)
+-	}
+-
+-	// See golang.org/issues/39555.
+-	input := map[textUnmarshalerString]string{"FOO": "", `"`: ""}
+-
+-	encoded, err := Marshal(input)
+-	if err != nil {
+-		t.Fatalf("Marshal error: %v", err)
+-	}
+-	var got map[textUnmarshalerString]string
+-	if err := Unmarshal(encoded, &got); err != nil {
+-		t.Fatalf("Unmarshal error: %v", err)
+-	}
+-	want := map[textUnmarshalerString]string{"foo": "", `"`: ""}
+-	if !maps.Equal(got, want) {
+-		t.Errorf("Marshal/Unmarshal roundtrip:\n\tgot:  %q\n\twant: %q", gotT, wantT)
+-	}
+-}
+-
+-func TestUnmarshalMaxDepth(t *testing.T) {
+-	tests := []struct {
+-		CaseName
+-		data        string
+-		errMaxDepth bool
+-	}{{
+-		CaseName:    Name("ArrayUnderMaxNestingDepth"),
+-		data:        `{"a":` + strings.Repeat(`[`, 10000-1) + strings.Repeat(`]`, 10000-1) + `}`,
+-		errMaxDepth: false,
+-	}, {
+-		CaseName:    Name("ArrayOverMaxNestingDepth"),
+-		data:        `{"a":` + strings.Repeat(`[`, 10000) + strings.Repeat(`]`, 10000) + `}`,
+-		errMaxDepth: true,
+-	}, {
+-		CaseName:    Name("ArrayOverStackDepth"),
+-		data:        `{"a":` + strings.Repeat(`[`, 3000000) + strings.Repeat(`]`, 3000000) + `}`,
+-		errMaxDepth: true,
+-	}, {
+-		CaseName:    Name("ObjectUnderMaxNestingDepth"),
+-		data:        `{"a":` + strings.Repeat(`{"a":`, 10000-1) + `0` + strings.Repeat(`}`, 10000-1) + `}`,
+-		errMaxDepth: false,
+-	}, {
+-		CaseName:    Name("ObjectOverMaxNestingDepth"),
+-		data:        `{"a":` + strings.Repeat(`{"a":`, 10000) + `0` + strings.Repeat(`}`, 10000) + `}`,
+-		errMaxDepth: true,
+-	}, {
+-		CaseName:    Name("ObjectOverStackDepth"),
+-		data:        `{"a":` + strings.Repeat(`{"a":`, 3000000) + `0` + strings.Repeat(`}`, 3000000) + `}`,
+-		errMaxDepth: true,
+-	}}
+-
+-	targets := []struct {
+-		CaseName
+-		newValue func() any
+-	}{{
+-		CaseName: Name("unstructured"),
+-		newValue: func() any {
+-			var v any
+-			return &v
+-		},
+-	}, {
+-		CaseName: Name("typed named field"),
+-		newValue: func() any {
+-			v := struct {
+-				A any `json:"a"`
+-			}{}
+-			return &v
+-		},
+-	}, {
+-		CaseName: Name("typed missing field"),
+-		newValue: func() any {
+-			v := struct {
+-				B any `json:"b"`
+-			}{}
+-			return &v
+-		},
+-	}, {
+-		CaseName: Name("custom unmarshaler"),
+-		newValue: func() any {
+-			v := unmarshaler{}
+-			return &v
+-		},
+-	}}
+-
+-	for _, tt := range tests {
+-		for _, target := range targets {
+-			t.Run(target.Name+"-"+tt.Name, func(t *testing.T) {
+-				err := Unmarshal([]byte(tt.data), target.newValue())
+-				if !tt.errMaxDepth {
+-					if err != nil {
+-						t.Errorf("%s: %s: Unmarshal error: %v", tt.Where, target.Where, err)
+-					}
+-				} else {
+-					if err == nil || !strings.Contains(err.Error(), "exceeded max depth") {
+-						t.Errorf("%s: %s: Unmarshal error:\n\tgot:  %v\n\twant: exceeded max depth", tt.Where, target.Where, err)
+-					}
+-				}
+-			})
+-		}
+-	}
+-}
+diff --git a/pkg/internal/third_party/go-json-experiment/json/v1/diff_test.go b/pkg/internal/third_party/go-json-experiment/json/v1/diff_test.go
+deleted file mode 100644
+index 185c33003..000000000
+--- a/pkg/internal/third_party/go-json-experiment/json/v1/diff_test.go
++++ /dev/null
+@@ -1,1130 +0,0 @@
+-// Copyright 2020 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+-package json_test
+-
+-import (
+-	"errors"
+-	"path"
+-	"reflect"
+-	"strings"
+-	"testing"
+-	"time"
+-
+-	jsonv2 "k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json"
+-	"k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json/jsontext"
+-	jsonv1 "k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json/v1"
+-)
+-
+-// NOTE: This file serves as a list of semantic differences between v1 and v2.
+-// Each test explains how v1 behaves, how v2 behaves, and
+-// a rationale for why the behavior was changed.
+-
+-var jsonPackages = []struct {
+-	Version   string
+-	Marshal   func(any) ([]byte, error)
+-	Unmarshal func([]byte, any) error
+-}{
+-	{"v1", jsonv1.Marshal, jsonv1.Unmarshal},
+-	{"v2",
+-		func(in any) ([]byte, error) { return jsonv2.Marshal(in) },
+-		func(in []byte, out any) error { return jsonv2.Unmarshal(in, out) }},
+-}
+-
+-// In v1, unmarshal matches struct fields using a case-insensitive match.
+-// In v2, unmarshal matches struct fields using a case-sensitive match.
+-//
+-// Case-insensitive matching is a surprising default and
+-// incurs significant performance cost when unmarshaling unknown fields.
+-// In v2, we can opt into v1-like behavior with the `case:ignore` tag option.
+-// The case-insensitive matching performed by v2 is looser than that of v1
+-// where it also ignores dashes and underscores.
+-// This allows v2 to match fields regardless of whether the name is in
+-// snake_case, camelCase, or kebab-case.
+-//
+-// Related issue:
+-//
+-//	https://go.dev/issue/14750
+-func TestCaseSensitivity(t *testing.T) {
+-	type Fields struct {
+-		FieldA bool
+-		FieldB bool `json:"fooBar"`
+-		FieldC bool `json:"fizzBuzz,case:ignore"` // `case:ignore` is used by v2 to explicitly enable case-insensitive matching
+-	}
+-
+-	for _, json := range jsonPackages {
+-		t.Run(path.Join("Unmarshal", json.Version), func(t *testing.T) {
+-			// This is a mapping from Go field names to JSON member names to
+-			// whether the JSON member name would match the Go field name.
+-			type goName = string
+-			type jsonName = string
+-			onlyV1 := json.Version == "v1"
+-			onlyV2 := json.Version == "v2"
+-			allMatches := map[goName]map[jsonName]bool{
+-				"FieldA": {
+-					"FieldA": true,   // exact match
+-					"fielda": onlyV1, // v1 is case-insensitive by default
+-					"fieldA": onlyV1, // v1 is case-insensitive by default
+-					"FIELDA": onlyV1, // v1 is case-insensitive by default
+-					"FieldB": false,
+-					"FieldC": false,
+-				},
+-				"FieldB": {
+-					"fooBar":   true,   // exact match for explicitly specified JSON name
+-					"FooBar":   onlyV1, // v1 is case-insensitive even if an explicit JSON name is provided
+-					"foobar":   onlyV1, // v1 is case-insensitive even if an explicit JSON name is provided
+-					"FOOBAR":   onlyV1, // v1 is case-insensitive even if an explicit JSON name is provided
+-					"fizzBuzz": false,
+-					"FieldA":   false,
+-					"FieldB":   false, // explicit JSON name means that the Go field name is not used for matching
+-					"FieldC":   false,
+-				},
+-				"FieldC": {
+-					"fizzBuzz":  true,   // exact match for explicitly specified JSON name
+-					"fizzbuzz":  true,   // v2 is case-insensitive due to `case:ignore` tag
+-					"FIZZBUZZ":  true,   // v2 is case-insensitive due to `case:ignore` tag
+-					"fizz_buzz": onlyV2, // case-insensitivity in v2 ignores dashes and underscores
+-					"fizz-buzz": onlyV2, // case-insensitivity in v2 ignores dashes and underscores
+-					"fooBar":    false,
+-					"FieldA":    false,
+-					"FieldC":    false, // explicit JSON name means that the Go field name is not used for matching
+-					"FieldB":    false,
+-				},
+-			}
+-
+-			for goFieldName, matches := range allMatches {
+-				for jsonMemberName, wantMatch := range matches {
+-					in := `{"` + jsonMemberName + `":true}`
+-					var s Fields
+-					if err := json.Unmarshal([]byte(in), &s); err != nil {
+-						t.Fatalf("json.Unmarshal error: %v", err)
+-					}
+-					gotMatch := reflect.ValueOf(s).FieldByName(goFieldName).Bool()
+-					if gotMatch != wantMatch {
+-						t.Fatalf("%T.%s = %v, want %v", s, goFieldName, gotMatch, wantMatch)
+-					}
+-				}
+-			}
+-		})
+-	}
+-}
+-
+-// In v1, the "omitempty" option specifies that a struct field is omitted
+-// when marshaling if it is an empty Go value, which is defined as
+-// false, 0, a nil pointer, a nil interface value, and
+-// any empty array, slice, map, or string.
+-//
+-// In v2, the "omitempty" option specifies that a struct field is omitted
+-// when marshaling if it is an empty JSON value, which is defined as
+-// a JSON null or empty JSON string, object, or array.
+-//
+-// In v2, we also provide the "omitzero" option which specifies that a field
+-// is omitted if it is the zero Go value or if it implements an "IsZero() bool"
+-// method that reports true. Together, "omitzero" and "omitempty" can cover
+-// all the prior use cases of the v1 definition of "omitempty".
+-// Note that "omitempty" is defined in terms of the Go type system in v1,
+-// but now defined in terms of the JSON type system in v2.
+-//
+-// Related issues:
+-//
+-//	https://go.dev/issue/11939
+-//	https://go.dev/issue/22480
+-//	https://go.dev/issue/29310
+-//	https://go.dev/issue/32675
+-//	https://go.dev/issue/45669
+-//	https://go.dev/issue/45787
+-//	https://go.dev/issue/50480
+-//	https://go.dev/issue/52803
+-func TestOmitEmptyOption(t *testing.T) {
+-	type Struct struct {
+-		Foo string  `json:",omitempty"`
+-		Bar []int   `json:",omitempty"`
+-		Baz *Struct `json:",omitempty"`
+-	}
+-	type Types struct {
+-		Bool       bool              `json:",omitempty"`
+-		StringA    string            `json:",omitempty"`
+-		StringB    string            `json:",omitempty"`
+-		BytesA     []byte            `json:",omitempty"`
+-		BytesB     []byte            `json:",omitempty"`
+-		BytesC     []byte            `json:",omitempty"`
+-		Int        int               `json:",omitempty"`
+-		MapA       map[string]string `json:",omitempty"`
+-		MapB       map[string]string `json:",omitempty"`
+-		MapC       map[string]string `json:",omitempty"`
+-		StructA    Struct            `json:",omitempty"`
+-		StructB    Struct            `json:",omitempty"`
+-		StructC    Struct            `json:",omitempty"`
+-		SliceA     []string          `json:",omitempty"`
+-		SliceB     []string          `json:",omitempty"`
+-		SliceC     []string          `json:",omitempty"`
+-		Array      [1]string         `json:",omitempty"`
+-		PointerA   *string           `json:",omitempty"`
+-		PointerB   *string           `json:",omitempty"`
+-		PointerC   *string           `json:",omitempty"`
+-		InterfaceA any               `json:",omitempty"`
+-		InterfaceB any               `json:",omitempty"`
+-		InterfaceC any               `json:",omitempty"`
+-		InterfaceD any               `json:",omitempty"`
+-	}
+-
+-	something := "something"
+-	for _, json := range jsonPackages {
+-		t.Run(path.Join("Marshal", json.Version), func(t *testing.T) {
+-			in := Types{
+-				Bool:       false,
+-				StringA:    "",
+-				StringB:    something,
+-				BytesA:     nil,
+-				BytesB:     []byte{},
+-				BytesC:     []byte(something),
+-				Int:        0,
+-				MapA:       nil,
+-				MapB:       map[string]string{},
+-				MapC:       map[string]string{something: something},
+-				StructA:    Struct{},
+-				StructB:    Struct{Bar: []int{}, Baz: new(Struct)},
+-				StructC:    Struct{Foo: something},
+-				SliceA:     nil,
+-				SliceB:     []string{},
+-				SliceC:     []string{something},
+-				Array:      [1]string{something},
+-				PointerA:   nil,
+-				PointerB:   new(string),
+-				PointerC:   &something,
+-				InterfaceA: nil,
+-				InterfaceB: (*string)(nil),
+-				InterfaceC: new(string),
+-				InterfaceD: &something,
+-			}
+-			b, err := json.Marshal(in)
+-			if err != nil {
+-				t.Fatalf("json.Marshal error: %v", err)
+-			}
+-			var out map[string]any
+-			if err := json.Unmarshal(b, &out); err != nil {
+-				t.Fatalf("json.Unmarshal error: %v", err)
+-			}
+-
+-			onlyV1 := json.Version == "v1"
+-			onlyV2 := json.Version == "v2"
+-			wantPresent := map[string]bool{
+-				"Bool":       onlyV2, // false is an empty Go bool, but is NOT an empty JSON value
+-				"StringA":    false,
+-				"StringB":    true,
+-				"BytesA":     false,
+-				"BytesB":     false,
+-				"BytesC":     true,
+-				"Int":        onlyV2, // 0 is an empty Go integer, but NOT an empty JSON value
+-				"MapA":       false,
+-				"MapB":       false,
+-				"MapC":       true,
+-				"StructA":    onlyV1, // Struct{} is NOT an empty Go value, but {} is an empty JSON value
+-				"StructB":    onlyV1, // Struct{...} is NOT an empty Go value, but {} is an empty JSON value
+-				"StructC":    true,
+-				"SliceA":     false,
+-				"SliceB":     false,
+-				"SliceC":     true,
+-				"Array":      true,
+-				"PointerA":   false,
+-				"PointerB":   onlyV1, // new(string) is NOT a nil Go pointer, but "" is an empty JSON value
+-				"PointerC":   true,
+-				"InterfaceA": false,
+-				"InterfaceB": onlyV1, // (*string)(nil) is NOT a nil Go interface, but null is an empty JSON value
+-				"InterfaceC": onlyV1, // new(string) is NOT a nil Go interface, but "" is an empty JSON value
+-				"InterfaceD": true,
+-			}
+-			for field, want := range wantPresent {
+-				_, got := out[field]
+-				if got != want {
+-					t.Fatalf("%T.%s = %v, want %v", in, field, got, want)
+-				}
+-			}
+-		})
+-	}
+-}
+-
+-func addr[T any](v T) *T {
+-	return &v
+-}
+-
+-// In v1, the "string" option specifies that Go strings, bools, and numeric
+-// values are encoded within a JSON string when marshaling and
+-// are unmarshaled from its native representation escaped within a JSON string.
+-// The "string" option is not applied recursively, and so does not affect
+-// strings, bools, and numeric values within a Go slice or map, but
+-// does have special handling to affect the underlying value within a pointer.
+-// When unmarshaling, the "string" option permits decoding from a JSON null
+-// escaped within a JSON string in some inconsistent cases.
+-//
+-// In v2, the "string" option specifies that only numeric values are encoded as
+-// a JSON number within a JSON string when marshaling and are unmarshaled
+-// from either a JSON number or a JSON string containing a JSON number.
+-// The "string" option is applied recursively to all numeric sub-values,
+-// and thus affects numeric values within a Go slice or map.
+-// There is no support for escaped JSON nulls within a JSON string.
+-//
+-// The main utility for stringifying JSON numbers is because JSON parsers
+-// often represents numbers as IEEE 754 floating-point numbers.
+-// This results in a loss of precision representing 64-bit integer values.
+-// Consequently, many JSON-based APIs actually requires that such values
+-// be encoded within a JSON string. Since the main utility of stringification
+-// is for numeric values, v2 limits the effect of the "string" option
+-// to just numeric Go types. According to all code known by the Go module proxy,
+-// there are close to zero usages of the "string" option on a Go string or bool.
+-//
+-// Regarding the recursive application of the "string" option,
+-// there have been a number of issues filed about users being surprised that
+-// the "string" option does not recursively affect numeric values
+-// within a composite type like a Go map, slice, or interface value.
+-// In v1, specifying the "string" option on composite type has no effect
+-// and so this would be a largely backwards compatible change.
+-//
+-// The ability to decode from a JSON null wrapped within a JSON string
+-// is removed in v2 because this behavior was surprising and inconsistent in v1.
+-//
+-// Related issues:
+-//
+-//	https://go.dev/issue/15624
+-//	https://go.dev/issue/20651
+-//	https://go.dev/issue/22177
+-//	https://go.dev/issue/32055
+-//	https://go.dev/issue/32117
+-//	https://go.dev/issue/50997
+-func TestStringOption(t *testing.T) {
+-	type Types struct {
+-		String     string              `json:",string"`
+-		Bool       bool                `json:",string"`
+-		Int        int                 `json:",string"`
+-		Float      float64             `json:",string"`
+-		Map        map[string]int      `json:",string"`
+-		Struct     struct{ Field int } `json:",string"`
+-		Slice      []int               `json:",string"`
+-		Array      [1]int              `json:",string"`
+-		PointerA   *int                `json:",string"`
+-		PointerB   *int                `json:",string"`
+-		PointerC   **int               `json:",string"`
+-		InterfaceA any                 `json:",string"`
+-		InterfaceB any                 `json:",string"`
+-	}
+-
+-	for _, json := range jsonPackages {
+-		t.Run(path.Join("Marshal", json.Version), func(t *testing.T) {
+-			in := Types{
+-				String:     "string",
+-				Bool:       true,
+-				Int:        1,
+-				Float:      1,
+-				Map:        map[string]int{"Name": 1},
+-				Struct:     struct{ Field int }{1},
+-				Slice:      []int{1},
+-				Array:      [1]int{1},
+-				PointerA:   nil,
+-				PointerB:   addr(1),
+-				PointerC:   addr(addr(1)),
+-				InterfaceA: nil,
+-				InterfaceB: 1,
+-			}
+-			quote := func(s string) string {
+-				b, _ := jsontext.AppendQuote(nil, s)
+-				return string(b)
+-			}
+-			quoteOnlyV1 := func(s string) string {
+-				if json.Version == "v1" {
+-					s = quote(s)
+-				}
+-				return s
+-			}
+-			quoteOnlyV2 := func(s string) string {
+-				if json.Version == "v2" {
+-					s = quote(s)
+-				}
+-				return s
+-			}
+-			want := strings.Join([]string{
+-				`{`,
+-				`"String":` + quoteOnlyV1(`"string"`) + `,`, // in v1, Go strings are also stringified
+-				`"Bool":` + quoteOnlyV1("true") + `,`,       // in v1, Go bools are also stringified
+-				`"Int":` + quote("1") + `,`,
+-				`"Float":` + quote("1") + `,`,
+-				`"Map":{"Name":` + quoteOnlyV2("1") + `},`,     // in v2, numbers are recursively stringified
+-				`"Struct":{"Field":` + quoteOnlyV2("1") + `},`, // in v2, numbers are recursively stringified
+-				`"Slice":[` + quoteOnlyV2("1") + `],`,          // in v2, numbers are recursively stringified
+-				`"Array":[` + quoteOnlyV2("1") + `],`,          // in v2, numbers are recursively stringified
+-				`"PointerA":null,`,
+-				`"PointerB":` + quote("1") + `,`,       // in v1, numbers are stringified after a single pointer indirection
+-				`"PointerC":` + quoteOnlyV2("1") + `,`, // in v2, numbers are recursively stringified
+-				`"InterfaceA":null,`,
+-				`"InterfaceB":` + quoteOnlyV2("1") + ``, // in v2, numbers are recursively stringified
+-				`}`}, "")
+-			got, err := json.Marshal(in)
+-			if err != nil {
+-				t.Fatalf("json.Marshal error: %v", err)
+-			}
+-			if string(got) != want {
+-				t.Fatalf("json.Marshal = %s, want %s", got, want)
+-			}
+-		})
+-	}
+-
+-	for _, json := range jsonPackages {
+-		t.Run(path.Join("Unmarshal/Null", json.Version), func(t *testing.T) {
+-			var got Types
+-			err := json.Unmarshal([]byte(`{
+-				"Bool":     "null",
+-				"Int":      "null",
+-				"PointerA": "null"
+-			}`), &got)
+-			switch {
+-			case !reflect.DeepEqual(got, Types{}):
+-				t.Fatalf("json.Unmarshal = %v, want %v", got, Types{})
+-			case json.Version == "v1" && err != nil:
+-				t.Fatalf("json.Unmarshal error: %v", err)
+-			case json.Version == "v2" && err == nil:
+-				t.Fatal("json.Unmarshal error is nil, want non-nil")
+-			}
+-		})
+-
+-		t.Run(path.Join("Unmarshal/Bool", json.Version), func(t *testing.T) {
+-			var got Types
+-			want := map[string]Types{
+-				"v1": {Bool: true},
+-				"v2": {Bool: false},
+-			}[json.Version]
+-			err := json.Unmarshal([]byte(`{"Bool": "true"}`), &got)
+-			switch {
+-			case !reflect.DeepEqual(got, want):
+-				t.Fatalf("json.Unmarshal = %v, want %v", got, want)
+-			case json.Version == "v1" && err != nil:
+-				t.Fatalf("json.Unmarshal error: %v", err)
+-			case json.Version == "v2" && err == nil:
+-				t.Fatal("json.Unmarshal error is nil, want non-nil")
+-			}
+-		})
+-
+-		t.Run(path.Join("Unmarshal/Shallow", json.Version), func(t *testing.T) {
+-			var got Types
+-			want := Types{Int: 1, PointerB: addr(1)}
+-			err := json.Unmarshal([]byte(`{
+-				"Int":      "1",
+-				"PointerB": "1"
+-			}`), &got)
+-			switch {
+-			case !reflect.DeepEqual(got, want):
+-				t.Fatalf("json.Unmarshal = %v, want %v", got, want)
+-			case err != nil:
+-				t.Fatalf("json.Unmarshal error: %v", err)
+-			}
+-		})
+-
+-		t.Run(path.Join("Unmarshal/Deep", json.Version), func(t *testing.T) {
+-			var got Types
+-			want := map[string]Types{
+-				"v1": {
+-					Map:      map[string]int{"Name": 0},
+-					Slice:    []int{0},
+-					PointerC: addr(addr(0)),
+-				},
+-				"v2": {
+-					Map:      map[string]int{"Name": 1},
+-					Struct:   struct{ Field int }{1},
+-					Slice:    []int{1},
+-					Array:    [1]int{1},
+-					PointerC: addr(addr(1)),
+-				},
+-			}[json.Version]
+-			err := json.Unmarshal([]byte(`{
+-				"Map":      {"Name":"1"},
+-				"Struct":   {"Field":"1"},
+-				"Slice":    ["1"],
+-				"Array":    ["1"],
+-				"PointerC": "1"
+-			}`), &got)
+-			switch {
+-			case !reflect.DeepEqual(got, want):
+-				t.Fatalf("json.Unmarshal =\n%v, want\n%v", got, want)
+-			case json.Version == "v1" && err == nil:
+-				t.Fatal("json.Unmarshal error is nil, want non-nil")
+-			case json.Version == "v2" && err != nil:
+-				t.Fatalf("json.Unmarshal error: %v", err)
+-			}
+-		})
+-	}
+-}
+-
+-// In v1, nil slices and maps are marshaled as a JSON null.
+-// In v2, nil slices and maps are marshaled as an empty JSON object or array.
+-//
+-// Users of v2 can opt into the v1 behavior by setting
+-// the "format:emitnull" option in the `json` struct field tag:
+-//
+-//	struct {
+-//		S []string          `json:",format:emitnull"`
+-//		M map[string]string `json:",format:emitnull"`
+-//	}
+-//
+-// JSON is a language-agnostic data interchange format.
+-// The fact that maps and slices are nil-able in Go is a semantic detail of the
+-// Go language. We should avoid leaking such details to the JSON representation.
+-// When JSON implementations leak language-specific details,
+-// it complicates transition to/from languages with different type systems.
+-//
+-// Furthermore, consider two related Go types: string and []byte.
+-// It's an asymmetric oddity of v1 that zero values of string and []byte marshal
+-// as an empty JSON string for the former, while the latter as a JSON null.
+-// The non-zero values of those types always marshal as JSON strings.
+-//
+-// Related issues:
+-//
+-//	https://go.dev/issue/27589
+-//	https://go.dev/issue/37711
+-func TestNilSlicesAndMaps(t *testing.T) {
+-	type Composites struct {
+-		B []byte            // always encoded in v2 as a JSON string
+-		S []string          // always encoded in v2 as a JSON array
+-		M map[string]string // always encoded in v2 as a JSON object
+-	}
+-
+-	for _, json := range jsonPackages {
+-		t.Run(path.Join("Marshal", json.Version), func(t *testing.T) {
+-			in := []Composites{
+-				{B: []byte(nil), S: []string(nil), M: map[string]string(nil)},
+-				{B: []byte{}, S: []string{}, M: map[string]string{}},
+-			}
+-			want := map[string]string{
+-				"v1": `[{"B":null,"S":null,"M":null},{"B":"","S":[],"M":{}}]`,
+-				"v2": `[{"B":"","S":[],"M":{}},{"B":"","S":[],"M":{}}]`, // v2 emits nil slices and maps as empty JSON objects and arrays
+-			}[json.Version]
+-			got, err := json.Marshal(in)
+-			if err != nil {
+-				t.Fatalf("json.Marshal error: %v", err)
+-			}
+-			if string(got) != want {
+-				t.Fatalf("json.Marshal = %s, want %s", got, want)
+-			}
+-		})
+-	}
+-}
+-
+-// In v1, unmarshaling into a Go array permits JSON arrays with any length.
+-// In v2, unmarshaling into a Go array requires that the JSON array
+-// have the exact same number of elements as the Go array.
+-//
+-// Go arrays are often used because the exact length has significant meaning.
+-// Ignoring this detail seems like a mistake. Also, the v1 behavior leads to
+-// silent data loss when excess JSON array elements are discarded.
+-func TestArrays(t *testing.T) {
+-	for _, json := range jsonPackages {
+-		t.Run(path.Join("Unmarshal/TooFew", json.Version), func(t *testing.T) {
+-			var got [2]int
+-			err := json.Unmarshal([]byte(`[1]`), &got)
+-			switch {
+-			case got != [2]int{1, 0}:
+-				t.Fatalf(`json.Unmarshal = %v, want [1 0]`, got)
+-			case json.Version == "v1" && err != nil:
+-				t.Fatalf("json.Unmarshal error: %v", err)
+-			case json.Version == "v2" && err == nil:
+-				t.Fatal("json.Unmarshal error is nil, want non-nil")
+-			}
+-		})
+-	}
+-
+-	for _, json := range jsonPackages {
+-		t.Run(path.Join("Unmarshal/TooMany", json.Version), func(t *testing.T) {
+-			var got [2]int
+-			err := json.Unmarshal([]byte(`[1,2,3]`), &got)
+-			switch {
+-			case got != [2]int{1, 2}:
+-				t.Fatalf(`json.Unmarshal = %v, want [1 2]`, got)
+-			case json.Version == "v1" && err != nil:
+-				t.Fatalf("json.Unmarshal error: %v", err)
+-			case json.Version == "v2" && err == nil:
+-				t.Fatal("json.Unmarshal error is nil, want non-nil")
+-			}
+-		})
+-	}
+-}
+-
+-// In v1, byte arrays are treated as arrays of unsigned integers.
+-// In v2, byte arrays are treated as binary values (similar to []byte).
+-// This is to make the behavior of [N]byte and []byte more consistent.
+-//
+-// Users of v2 can opt into the v1 behavior by setting
+-// the "format:array" option in the `json` struct field tag:
+-//
+-//	struct {
+-//		B [32]byte `json:",format:array"`
+-//	}
+-func TestByteArrays(t *testing.T) {
+-	for _, json := range jsonPackages {
+-		t.Run(path.Join("Marshal", json.Version), func(t *testing.T) {
+-			in := [4]byte{1, 2, 3, 4}
+-			got, err := json.Marshal(in)
+-			if err != nil {
+-				t.Fatalf("json.Marshal error: %v", err)
+-			}
+-			want := map[string]string{
+-				"v1": `[1,2,3,4]`,
+-				"v2": `"AQIDBA=="`,
+-			}[json.Version]
+-			if string(got) != want {
+-				t.Fatalf("json.Marshal = %s, want %s", got, want)
+-			}
+-		})
+-	}
+-
+-	for _, json := range jsonPackages {
+-		t.Run(path.Join("Unmarshal", json.Version), func(t *testing.T) {
+-			in := map[string]string{
+-				"v1": `[1,2,3,4]`,
+-				"v2": `"AQIDBA=="`,
+-			}[json.Version]
+-			var got [4]byte
+-			err := json.Unmarshal([]byte(in), &got)
+-			switch {
+-			case err != nil:
+-				t.Fatalf("json.Unmarshal error: %v", err)
+-			case got != [4]byte{1, 2, 3, 4}:
+-				t.Fatalf("json.Unmarshal = %v, want [1 2 3 4]", got)
+-			}
+-		})
+-	}
+-}
+-
+-// CallCheck implements json.{Marshaler,Unmarshaler} on a pointer receiver.
+-type CallCheck string
+-
+-// MarshalJSON always returns a JSON string with the literal "CALLED".
+-func (*CallCheck) MarshalJSON() ([]byte, error) {
+-	return []byte(`"CALLED"`), nil
+-}
+-
+-// UnmarshalJSON always stores a string with the literal "CALLED".
+-func (v *CallCheck) UnmarshalJSON([]byte) error {
+-	*v = `CALLED`
+-	return nil
+-}
+-
+-// In v1, the implementation is inconsistent about whether it calls
+-// MarshalJSON and UnmarshalJSON methods declared on pointer receivers
+-// when it has an unaddressable value (per reflect.Value.CanAddr) on hand.
+-// When marshaling, it never boxes the value on the heap to make it addressable,
+-// while it sometimes boxes values (e.g., for map entries) when unmarshaling.
+-//
+-// In v2, the implementation always calls MarshalJSON and UnmarshalJSON methods
+-// by boxing the value on the heap if necessary.
+-//
+-// The v1 behavior is surprising at best and buggy at worst.
+-// Unfortunately, it cannot be changed without breaking existing usages.
+-//
+-// Related issues:
+-//
+-//	https://go.dev/issue/27722
+-//	https://go.dev/issue/33993
+-//	https://go.dev/issue/42508
+-func TestPointerReceiver(t *testing.T) {
+-	type Values struct {
+-		S []CallCheck
+-		A [1]CallCheck
+-		M map[string]CallCheck
+-		V CallCheck
+-		I any
+-	}
+-
+-	for _, json := range jsonPackages {
+-		t.Run(path.Join("Marshal", json.Version), func(t *testing.T) {
+-			var cc CallCheck
+-			in := Values{
+-				S: []CallCheck{cc},
+-				A: [1]CallCheck{cc},             // MarshalJSON not called on v1
+-				M: map[string]CallCheck{"": cc}, // MarshalJSON not called on v1
+-				V: cc,                           // MarshalJSON not called on v1
+-				I: cc,                           // MarshalJSON not called on v1
+-			}
+-			want := map[string]string{
+-				"v1": `{"S":["CALLED"],"A":[""],"M":{"":""},"V":"","I":""}`,
+-				"v2": `{"S":["CALLED"],"A":["CALLED"],"M":{"":"CALLED"},"V":"CALLED","I":"CALLED"}`,
+-			}[json.Version]
+-			got, err := json.Marshal(in)
+-			if err != nil {
+-				t.Fatalf("json.Marshal error: %v", err)
+-			}
+-			if string(got) != want {
+-				t.Fatalf("json.Marshal = %s, want %s", got, want)
+-			}
+-		})
+-	}
+-
+-	for _, json := range jsonPackages {
+-		t.Run(path.Join("Unmarshal", json.Version), func(t *testing.T) {
+-			in := `{"S":[""],"A":[""],"M":{"":""},"V":"","I":""}`
+-			called := CallCheck("CALLED") // resulting state if UnmarshalJSON is called
+-			want := map[string]Values{
+-				"v1": {
+-					S: []CallCheck{called},
+-					A: [1]CallCheck{called},
+-					M: map[string]CallCheck{"": called},
+-					V: called,
+-					I: "", // UnmarshalJSON not called on v1; replaced with Go string
+-				},
+-				"v2": {
+-					S: []CallCheck{called},
+-					A: [1]CallCheck{called},
+-					M: map[string]CallCheck{"": called},
+-					V: called,
+-					I: called,
+-				},
+-			}[json.Version]
+-			got := Values{
+-				A: [1]CallCheck{CallCheck("")},
+-				S: []CallCheck{CallCheck("")},
+-				M: map[string]CallCheck{"": CallCheck("")},
+-				V: CallCheck(""),
+-				I: CallCheck(""),
+-			}
+-			if err := json.Unmarshal([]byte(in), &got); err != nil {
+-				t.Fatalf("json.Unmarshal error: %v", err)
+-			}
+-			if !reflect.DeepEqual(got, want) {
+-				t.Fatalf("json.Unmarshal = %v, want %v", got, want)
+-			}
+-		})
+-	}
+-}
+-
+-// In v1, maps are marshaled in a deterministic order.
+-// In v2, maps are marshaled in a non-deterministic order.
+-//
+-// The reason for the change is that v2 prioritizes performance and
+-// the guarantee that marshaling operates primarily in a streaming manner.
+-//
+-// The v2 API provides jsontext.Value.Canonicalize if stability is needed:
+-//
+-//	(*jsontext.Value)(&b).Canonicalize()
+-//
+-// Related issue:
+-//
+-//	https://go.dev/issue/7872
+-//	https://go.dev/issue/33714
+-func TestMapDeterminism(t *testing.T) {
+-	const iterations = 10
+-	in := map[int]int{0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9}
+-
+-	for _, json := range jsonPackages {
+-		t.Run(path.Join("Marshal", json.Version), func(t *testing.T) {
+-			outs := make(map[string]bool)
+-			for range iterations {
+-				b, err := json.Marshal(in)
+-				if err != nil {
+-					t.Fatalf("json.Marshal error: %v", err)
+-				}
+-				outs[string(b)] = true
+-			}
+-			switch {
+-			case json.Version == "v1" && len(outs) != 1:
+-				t.Fatalf("json.Marshal encoded to %d unique forms, expected 1", len(outs))
+-			case json.Version == "v2" && len(outs) == 1:
+-				t.Logf("json.Marshal encoded to 1 unique form by chance; are you feeling lucky?")
+-			}
+-		})
+-	}
+-}
+-
+-// In v1, JSON string encoding escapes special characters related to HTML.
+-// In v2, JSON string encoding uses a normalized representation (per RFC 8785).
+-//
+-// Users of v2 can opt into the v1 behavior by setting EscapeForHTML and EscapeForJS.
+-//
+-// Escaping HTML-specific characters in a JSON library is a layering violation.
+-// It presumes that JSON is always used with HTML and ignores other
+-// similar classes of injection attacks (e.g., SQL injection).
+-// Users of JSON with HTML should either manually ensure that embedded JSON is
+-// properly escaped or be relying on a module like "github.com/google/safehtml"
+-// to handle safe interoperability of JSON and HTML.
+-func TestEscapeHTML(t *testing.T) {
+-	for _, json := range jsonPackages {
+-		t.Run(path.Join("Marshal", json.Version), func(t *testing.T) {
+-			const in = `<script> console.log("Hello, world!"); </script>`
+-			got, err := json.Marshal(in)
+-			if err != nil {
+-				t.Fatalf("json.Marshal error: %v", err)
+-			}
+-			want := map[string]string{
+-				"v1": `"\u003cscript\u003e console.log(\"Hello, world!\"); \u003c/script\u003e"`,
+-				"v2": `"<script> console.log(\"Hello, world!\"); </script>"`,
+-			}[json.Version]
+-			if string(got) != want {
+-				t.Fatalf("json.Marshal = %s, want %s", got, want)
+-			}
+-		})
+-	}
+-}
+-
+-// In v1, JSON serialization silently ignored invalid UTF-8 by
+-// replacing such bytes with the Unicode replacement character.
+-// In v2, JSON serialization reports an error if invalid UTF-8 is encountered.
+-//
+-// Users of v2 can opt into the v1 behavior by setting [AllowInvalidUTF8].
+-//
+-// Silently allowing invalid UTF-8 causes data corruption that can be difficult
+-// to detect until it is too late. Once it has been discovered, strict UTF-8
+-// behavior sometimes cannot be enabled since other logic may be depending
+-// on the current behavior due to Hyrum's Law.
+-//
+-// Tim Bray, the author of RFC 8259 recommends that implementations should
+-// go beyond RFC 8259 and instead target compliance with RFC 7493,
+-// which makes strict decisions about behavior left undefined in RFC 8259.
+-// In particular, RFC 7493 rejects the presence of invalid UTF-8.
+-// See https://www.tbray.org/ongoing/When/201x/2017/12/14/RFC-8259-STD-90
+-func TestInvalidUTF8(t *testing.T) {
+-	for _, json := range jsonPackages {
+-		t.Run(path.Join("Marshal", json.Version), func(t *testing.T) {
+-			got, err := json.Marshal("\xff")
+-			switch {
+-			case json.Version == "v1" && err != nil:
+-				t.Fatalf("json.Marshal error: %v", err)
+-			case json.Version == "v1" && string(got) != "\"\ufffd\"":
+-				t.Fatalf(`json.Marshal = %s, want %q`, got, "\ufffd")
+-			case json.Version == "v2" && err == nil:
+-				t.Fatal("json.Marshal error is nil, want non-nil")
+-			}
+-		})
+-	}
+-
+-	for _, json := range jsonPackages {
+-		t.Run(path.Join("Unmarshal", json.Version), func(t *testing.T) {
+-			const in = "\"\xff\""
+-			var got string
+-			err := json.Unmarshal([]byte(in), &got)
+-			switch {
+-			case json.Version == "v1" && err != nil:
+-				t.Fatalf("json.Unmarshal error: %v", err)
+-			case json.Version == "v1" && got != "\ufffd":
+-				t.Fatalf(`json.Unmarshal = %q, want "\ufffd"`, got)
+-			case json.Version == "v2" && err == nil:
+-				t.Fatal("json.Unmarshal error is nil, want non-nil")
+-			}
+-		})
+-	}
+-}
+-
+-// In v1, duplicate JSON object names are permitted by default where
+-// they follow the inconsistent and difficult-to-explain merge semantics of v1.
+-// In v2, duplicate JSON object names are rejected by default where
+-// they follow the merge semantics of v2 based on RFC 7396.
+-//
+-// Users of v2 can opt into the v1 behavior by setting [AllowDuplicateNames].
+-//
+-// Per RFC 8259, the handling of duplicate names is left as undefined behavior.
+-// Rejecting such inputs is within the realm of valid behavior.
+-// Tim Bray, the author of RFC 8259 recommends that implementations should
+-// go beyond RFC 8259 and instead target compliance with RFC 7493,
+-// which makes strict decisions about behavior left undefined in RFC 8259.
+-// In particular, RFC 7493 rejects the presence of duplicate object names.
+-// See https://www.tbray.org/ongoing/When/201x/2017/12/14/RFC-8259-STD-90
+-//
+-// The lack of duplicate name rejection has correctness implications where
+-// roundtrip unmarshal/marshal do not result in semantically equivalent JSON.
+-// This is surprising behavior for users when they accidentally
+-// send JSON objects with duplicate names.
+-//
+-// The lack of duplicate name rejection may have security implications since it
+-// becomes difficult for a security tool to validate the semantic meaning of a
+-// JSON object since meaning is undefined in the presence of duplicate names.
+-// See https://labs.bishopfox.com/tech-blog/an-exploration-of-json-interoperability-vulnerabilities
+-//
+-// Related issue:
+-//
+-//	https://go.dev/issue/48298
+-func TestDuplicateNames(t *testing.T) {
+-	for _, json := range jsonPackages {
+-		t.Run(path.Join("Unmarshal", json.Version), func(t *testing.T) {
+-			const in = `{"Name":1,"Name":2}`
+-			var got struct{ Name int }
+-			err := json.Unmarshal([]byte(in), &got)
+-			switch {
+-			case json.Version == "v1" && err != nil:
+-				t.Fatalf("json.Unmarshal error: %v", err)
+-			case json.Version == "v1" && got != struct{ Name int }{2}:
+-				t.Fatalf(`json.Unmarshal = %v, want {2}`, got)
+-			case json.Version == "v2" && err == nil:
+-				t.Fatal("json.Unmarshal error is nil, want non-nil")
+-			}
+-		})
+-	}
+-}
+-
+-// In v1, unmarshaling a JSON null into a non-empty value was inconsistent
+-// in that sometimes it would be ignored and other times clear the value.
+-// In v2, unmarshaling a JSON null into a non-empty value would consistently
+-// always clear the value regardless of the value's type.
+-//
+-// The purpose of this change is to have consistent behavior with how JSON nulls
+-// are handled during Unmarshal. This semantic detail has no effect
+-// when Unmarshaling into a empty value.
+-//
+-// Related issues:
+-//
+-//	https://go.dev/issue/22177
+-//	https://go.dev/issue/33835
+-func TestMergeNull(t *testing.T) {
+-	type Types struct {
+-		Bool      bool
+-		String    string
+-		Bytes     []byte
+-		Int       int
+-		Map       map[string]string
+-		Struct    struct{ Field string }
+-		Slice     []string
+-		Array     [1]string
+-		Pointer   *string
+-		Interface any
+-	}
+-
+-	for _, json := range jsonPackages {
+-		t.Run(path.Join("Unmarshal", json.Version), func(t *testing.T) {
+-			// Start with a non-empty value where all fields are populated.
+-			in := Types{
+-				Bool:      true,
+-				String:    "old",
+-				Bytes:     []byte("old"),
+-				Int:       1234,
+-				Map:       map[string]string{"old": "old"},
+-				Struct:    struct{ Field string }{"old"},
+-				Slice:     []string{"old"},
+-				Array:     [1]string{"old"},
+-				Pointer:   new(string),
+-				Interface: "old",
+-			}
+-
+-			// Unmarshal a JSON null into every field.
+-			if err := json.Unmarshal([]byte(`{
+-				"Bool":      null,
+-				"String":    null,
+-				"Bytes":     null,
+-				"Int":       null,
+-				"Map":       null,
+-				"Struct":    null,
+-				"Slice":     null,
+-				"Array":     null,
+-				"Pointer":   null,
+-				"Interface": null
+-			}`), &in); err != nil {
+-				t.Fatalf("json.Unmarshal error: %v", err)
+-			}
+-
+-			want := map[string]Types{
+-				"v1": {
+-					Bool:   true,
+-					String: "old",
+-					Int:    1234,
+-					Struct: struct{ Field string }{"old"},
+-					Array:  [1]string{"old"},
+-				},
+-				"v2": {}, // all fields are zeroed
+-			}[json.Version]
+-			if !reflect.DeepEqual(in, want) {
+-				t.Fatalf("json.Unmarshal = %+v, want %+v", in, want)
+-			}
+-		})
+-	}
+-}
+-
+-// In v1, merge semantics are inconsistent and difficult to explain.
+-// In v2, merge semantics replaces the destination value for anything
+-// other than a JSON object, and recursively merges JSON objects.
+-//
+-// Merge semantics in v1 are inconsistent and difficult to explain
+-// largely because the behavior came about organically, rather than
+-// having a principled approach to how the semantics should operate.
+-// In v2, merging follows behavior based on RFC 7396.
+-//
+-// Related issues:
+-//
+-//	https://go.dev/issue/21092
+-//	https://go.dev/issue/26946
+-//	https://go.dev/issue/27172
+-//	https://go.dev/issue/30701
+-//	https://go.dev/issue/31924
+-//	https://go.dev/issue/43664
+-func TestMergeComposite(t *testing.T) {
+-	type Tuple struct{ Old, New bool }
+-	type Composites struct {
+-		Slice            []Tuple
+-		Array            [1]Tuple
+-		Map              map[string]Tuple
+-		MapPointer       map[string]*Tuple
+-		Struct           struct{ Tuple Tuple }
+-		StructPointer    *struct{ Tuple Tuple }
+-		Interface        any
+-		InterfacePointer any
+-	}
+-
+-	for _, json := range jsonPackages {
+-		t.Run(path.Join("Unmarshal", json.Version), func(t *testing.T) {
+-			// Start with a non-empty value where all fields are populated.
+-			in := Composites{
+-				Slice:            []Tuple{{Old: true}, {Old: true}}[:1],
+-				Array:            [1]Tuple{{Old: true}},
+-				Map:              map[string]Tuple{"Tuple": {Old: true}},
+-				MapPointer:       map[string]*Tuple{"Tuple": {Old: true}},
+-				Struct:           struct{ Tuple Tuple }{Tuple{Old: true}},
+-				StructPointer:    &struct{ Tuple Tuple }{Tuple{Old: true}},
+-				Interface:        Tuple{Old: true},
+-				InterfacePointer: &Tuple{Old: true},
+-			}
+-
+-			// Unmarshal into every pre-populated field.
+-			if err := json.Unmarshal([]byte(`{
+-				"Slice":            [{"New":true}, {"New":true}],
+-				"Array":            [{"New":true}],
+-				"Map":              {"Tuple": {"New":true}},
+-				"MapPointer":       {"Tuple": {"New":true}},
+-				"Struct":           {"Tuple": {"New":true}},
+-				"StructPointer":    {"Tuple": {"New":true}},
+-				"Interface":        {"New":true},
+-				"InterfacePointer": {"New":true}
+-			}`), &in); err != nil {
+-				t.Fatalf("json.Unmarshal error: %v", err)
+-			}
+-
+-			merged := Tuple{Old: true, New: true}
+-			replaced := Tuple{Old: false, New: true}
+-			want := map[string]Composites{
+-				"v1": {
+-					Slice:            []Tuple{merged, merged},               // merged
+-					Array:            [1]Tuple{merged},                      // merged
+-					Map:              map[string]Tuple{"Tuple": replaced},   // replaced
+-					MapPointer:       map[string]*Tuple{"Tuple": &replaced}, // replaced
+-					Struct:           struct{ Tuple Tuple }{merged},         // merged (same as v2)
+-					StructPointer:    &struct{ Tuple Tuple }{merged},        // merged (same as v2)
+-					Interface:        map[string]any{"New": true},           // replaced
+-					InterfacePointer: &merged,                               // merged (same as v2)
+-				},
+-				"v2": {
+-					Slice:            []Tuple{replaced, replaced},         // replaced
+-					Array:            [1]Tuple{replaced},                  // replaced
+-					Map:              map[string]Tuple{"Tuple": merged},   // merged
+-					MapPointer:       map[string]*Tuple{"Tuple": &merged}, // merged
+-					Struct:           struct{ Tuple Tuple }{merged},       // merged (same as v1)
+-					StructPointer:    &struct{ Tuple Tuple }{merged},      // merged (same as v1)
+-					Interface:        merged,                              // merged
+-					InterfacePointer: &merged,                             // merged (same as v1)
+-				},
+-			}[json.Version]
+-			if !reflect.DeepEqual(in, want) {
+-				t.Fatalf("json.Unmarshal = %+v, want %+v", in, want)
+-			}
+-		})
+-	}
+-}
+-
+-// In v1, there was no special support for time.Duration,
+-// which resulted in that type simply being treated as a signed integer.
+-// In v2, there is now first-class support for time.Duration, where the type is
+-// formatted and parsed using time.Duration.String and time.ParseDuration.
+-//
+-// Users of v2 can opt into the v1 behavior by setting
+-// the "format:nano" option in the `json` struct field tag:
+-//
+-//	struct {
+-//		Duration time.Duration `json:",format:nano"`
+-//	}
+-//
+-// Related issue:
+-//
+-//	https://go.dev/issue/10275
+-func TestTimeDurations(t *testing.T) {
+-	t.SkipNow() // TODO(https://go.dev/issue/71631): The default representation of time.Duration is still undecided.
+-	for _, json := range jsonPackages {
+-		t.Run(path.Join("Marshal", json.Version), func(t *testing.T) {
+-			got, err := json.Marshal(time.Minute)
+-			switch {
+-			case err != nil:
+-				t.Fatalf("json.Marshal error: %v", err)
+-			case json.Version == "v1" && string(got) != "60000000000":
+-				t.Fatalf("json.Marshal = %s, want 60000000000", got)
+-			case json.Version == "v2" && string(got) != `"1m0s"`:
+-				t.Fatalf(`json.Marshal = %s, want "1m0s"`, got)
+-			}
+-		})
+-	}
+-
+-	for _, json := range jsonPackages {
+-		t.Run(path.Join("Unmarshal", json.Version), func(t *testing.T) {
+-			in := map[string]string{
+-				"v1": "60000000000",
+-				"v2": `"1m0s"`,
+-			}[json.Version]
+-			var got time.Duration
+-			err := json.Unmarshal([]byte(in), &got)
+-			switch {
+-			case err != nil:
+-				t.Fatalf("json.Unmarshal error: %v", err)
+-			case got != time.Minute:
+-				t.Fatalf("json.Unmarshal = %v, want 1m0s", got)
+-			}
+-		})
+-	}
+-}
+-
+-// In v1, non-empty structs without any JSON serializable fields are permitted.
+-// In v2, non-empty structs without any JSON serializable fields are rejected.
+-//
+-// The purpose of this change is to avoid a common pitfall for new users
+-// where they expect JSON serialization to handle unexported fields.
+-// However, this does not work since Go reflection does not
+-// provide the package the ability to mutate such fields.
+-// Rejecting unserializable structs in v2 is intended to be a clear signal
+-// that the type is not supposed to be serialized.
+-func TestEmptyStructs(t *testing.T) {
+-	never := func(string) bool { return false }
+-	onlyV2 := func(v string) bool { return v == "v2" }
+-	values := []struct {
+-		in        any
+-		wantError func(string) bool
+-	}{
+-		// It is okay to marshal a truly empty struct in v1 and v2.
+-		{in: addr(struct{}{}), wantError: never},
+-		// In v1, a non-empty struct without exported fields
+-		// is equivalent to an empty struct, but is rejected in v2.
+-		// Note that errors.errorString type has only unexported fields.
+-		{in: errors.New("error"), wantError: onlyV2},
+-		// A mix of exported and unexported fields is permitted.
+-		{in: addr(struct{ Exported, unexported int }{}), wantError: never},
+-	}
+-
+-	for _, json := range jsonPackages {
+-		t.Run("Marshal", func(t *testing.T) {
+-			for _, value := range values {
+-				wantError := value.wantError(json.Version)
+-				_, err := json.Marshal(value.in)
+-				switch {
+-				case (err == nil) && wantError:
+-					t.Fatalf("json.Marshal error is nil, want non-nil")
+-				case (err != nil) && !wantError:
+-					t.Fatalf("json.Marshal error: %v", err)
+-				}
+-			}
+-		})
+-	}
+-
+-	for _, json := range jsonPackages {
+-		t.Run("Unmarshal", func(t *testing.T) {
+-			for _, value := range values {
+-				wantError := value.wantError(json.Version)
+-				out := reflect.New(reflect.TypeOf(value.in).Elem()).Interface()
+-				err := json.Unmarshal([]byte("{}"), out)
+-				switch {
+-				case (err == nil) && wantError:
+-					t.Fatalf("json.Unmarshal error is nil, want non-nil")
+-				case (err != nil) && !wantError:
+-					t.Fatalf("json.Unmarshal error: %v", err)
+-				}
+-			}
+-		})
+-	}
+-}
+diff --git a/pkg/internal/third_party/go-json-experiment/json/v1/encode.go b/pkg/internal/third_party/go-json-experiment/json/v1/encode.go
+deleted file mode 100644
+index 052dc06fd..000000000
+--- a/pkg/internal/third_party/go-json-experiment/json/v1/encode.go
++++ /dev/null
+@@ -1,251 +0,0 @@
+-// Copyright 2010 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+-// Package json implements encoding and decoding of JSON as defined in
+-// RFC 7159. The mapping between JSON and Go values is described
+-// in the documentation for the Marshal and Unmarshal functions.
+-//
+-// See "JSON and Go" for an introduction to this package:
+-// https://golang.org/doc/articles/json_and_go.html
+-//
+-// # Security Considerations
+-//
+-// See the "Security Considerations" section in [encoding/json/v2].
+-//
+-// For historical reasons, the default behavior of v1 [encoding/json]
+-// unfortunately operates with less secure defaults.
+-// New usages of JSON in Go are encouraged to use [encoding/json/v2] instead.
+-package json
+-
+-import (
+-	"reflect"
+-	"strconv"
+-
+-	jsonv2 "k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json"
+-)
+-
+-// Marshal returns the JSON encoding of v.
+-//
+-// Marshal traverses the value v recursively.
+-// If an encountered value implements [Marshaler]
+-// and is not a nil pointer, Marshal calls [Marshaler.MarshalJSON]
+-// to produce JSON. If no [Marshaler.MarshalJSON] method is present but the
+-// value implements [encoding.TextMarshaler] instead, Marshal calls
+-// [encoding.TextMarshaler.MarshalText] and encodes the result as a JSON string.
+-// The nil pointer exception is not strictly necessary
+-// but mimics a similar, necessary exception in the behavior of
+-// [Unmarshaler.UnmarshalJSON].
+-//
+-// Otherwise, Marshal uses the following type-dependent default encodings:
+-//
+-// Boolean values encode as JSON booleans.
+-//
+-// Floating point, integer, and [Number] values encode as JSON numbers.
+-// NaN and +/-Inf values will return an [UnsupportedValueError].
+-//
+-// String values encode as JSON strings coerced to valid UTF-8,
+-// replacing invalid bytes with the Unicode replacement rune.
+-// So that the JSON will be safe to embed inside HTML <script> tags,
+-// the string is encoded using [HTMLEscape],
+-// which replaces "<", ">", "&", U+2028, and U+2029 are escaped
+-// to "\u003c","\u003e", "\u0026", "\u2028", and "\u2029".
+-// This replacement can be disabled when using an [Encoder],
+-// by calling [Encoder.SetEscapeHTML](false).
+-//
+-// Array and slice values encode as JSON arrays, except that
+-// []byte encodes as a base64-encoded string, and a nil slice
+-// encodes as the null JSON value.
+-//
+-// Struct values encode as JSON objects.
+-// Each exported struct field becomes a member of the object, using the
+-// field name as the object key, unless the field is omitted for one of the
+-// reasons given below.
+-//
+-// The encoding of each struct field can be customized by the format string
+-// stored under the "json" key in the struct field's tag.
+-// The format string gives the name of the field, possibly followed by a
+-// comma-separated list of options. The name may be empty in order to
+-// specify options without overriding the default field name.
+-//
+-// The "omitempty" option specifies that the field should be omitted
+-// from the encoding if the field has an empty value, defined as
+-// false, 0, a nil pointer, a nil interface value, and any array,
+-// slice, map, or string of length zero.
+-//
+-// As a special case, if the field tag is "-", the field is always omitted.
+-// JSON names containing commas or quotes, or names identical to "" or "-",
+-// can be specified using a single-quoted string literal, where the syntax
+-// is identical to the Go grammar for a double-quoted string literal,
+-// but instead uses single quotes as the delimiters.
+-//
+-// Examples of struct field tags and their meanings:
+-//
+-//	// Field appears in JSON as key "myName".
+-//	Field int `json:"myName"`
+-//
+-//	// Field appears in JSON as key "myName" and
+-//	// the field is omitted from the object if its value is empty,
+-//	// as defined above.
+-//	Field int `json:"myName,omitempty"`
+-//
+-//	// Field appears in JSON as key "Field" (the default), but
+-//	// the field is skipped if empty.
+-//	// Note the leading comma.
+-//	Field int `json:",omitempty"`
+-//
+-//	// Field is ignored by this package.
+-//	Field int `json:"-"`
+-//
+-//	// Field appears in JSON as key "-".
+-//	Field int `json:"'-'"`
+-//
+-// The "omitzero" option specifies that the field should be omitted
+-// from the encoding if the field has a zero value, according to rules:
+-//
+-// 1) If the field type has an "IsZero() bool" method, that will be used to
+-// determine whether the value is zero.
+-//
+-// 2) Otherwise, the value is zero if it is the zero value for its type.
+-//
+-// If both "omitempty" and "omitzero" are specified, the field will be omitted
+-// if the value is either empty or zero (or both).
+-//
+-// The "string" option signals that a field is stored as JSON inside a
+-// JSON-encoded string. It applies only to fields of string, floating point,
+-// integer, or boolean types. This extra level of encoding is sometimes used
+-// when communicating with JavaScript programs:
+-//
+-//	Int64String int64 `json:",string"`
+-//
+-// The key name will be used if it's a non-empty string consisting of
+-// only Unicode letters, digits, and ASCII punctuation except quotation
+-// marks, backslash, and comma.
+-//
+-// Embedded struct fields are usually marshaled as if their inner exported fields
+-// were fields in the outer struct, subject to the usual Go visibility rules amended
+-// as described in the next paragraph.
+-// An anonymous struct field with a name given in its JSON tag is treated as
+-// having that name, rather than being anonymous.
+-// An anonymous struct field of interface type is treated the same as having
+-// that type as its name, rather than being anonymous.
+-//
+-// The Go visibility rules for struct fields are amended for JSON when
+-// deciding which field to marshal or unmarshal. If there are
+-// multiple fields at the same level, and that level is the least
+-// nested (and would therefore be the nesting level selected by the
+-// usual Go rules), the following extra rules apply:
+-//
+-// 1) Of those fields, if any are JSON-tagged, only tagged fields are considered,
+-// even if there are multiple untagged fields that would otherwise conflict.
+-//
+-// 2) If there is exactly one field (tagged or not according to the first rule), that is selected.
+-//
+-// 3) Otherwise there are multiple fields, and all are ignored; no error occurs.
+-//
+-// Handling of anonymous struct fields is new in Go 1.1.
+-// Prior to Go 1.1, anonymous struct fields were ignored. To force ignoring of
+-// an anonymous struct field in both current and earlier versions, give the field
+-// a JSON tag of "-".
+-//
+-// Map values encode as JSON objects. The map's key type must either be a
+-// string, an integer type, or implement [encoding.TextMarshaler]. The map keys
+-// are sorted and used as JSON object keys by applying the following rules,
+-// subject to the UTF-8 coercion described for string values above:
+-//   - keys of any string type are used directly
+-//   - keys that implement [encoding.TextMarshaler] are marshaled
+-//   - integer keys are converted to strings
+-//
+-// Pointer values encode as the value pointed to.
+-// A nil pointer encodes as the null JSON value.
+-//
+-// Interface values encode as the value contained in the interface.
+-// A nil interface value encodes as the null JSON value.
+-//
+-// Channel, complex, and function values cannot be encoded in JSON.
+-// Attempting to encode such a value causes Marshal to return
+-// an [UnsupportedTypeError].
+-//
+-// JSON cannot represent cyclic data structures and Marshal does not
+-// handle them. Passing cyclic structures to Marshal will result in
+-// an error.
+-func Marshal(v any) ([]byte, error) {
+-	return jsonv2.Marshal(v, DefaultOptionsV1())
+-}
+-
+-// MarshalIndent is like [Marshal] but applies [Indent] to format the output.
+-// Each JSON element in the output will begin on a new line beginning with prefix
+-// followed by one or more copies of indent according to the indentation nesting.
+-func MarshalIndent(v any, prefix, indent string) ([]byte, error) {
+-	b, err := Marshal(v)
+-	if err != nil {
+-		return nil, err
+-	}
+-	b, err = appendIndent(nil, b, prefix, indent)
+-	if err != nil {
+-		return nil, err
+-	}
+-	return b, nil
+-}
+-
+-// Marshaler is the interface implemented by types that
+-// can marshal themselves into valid JSON.
+-type Marshaler = jsonv2.Marshaler
+-
+-// An UnsupportedTypeError is returned by [Marshal] when attempting
+-// to encode an unsupported value type.
+-type UnsupportedTypeError struct {
+-	Type reflect.Type
+-}
+-
+-func (e *UnsupportedTypeError) Error() string {
+-	return "json: unsupported type: " + e.Type.String()
+-}
+-
+-// An UnsupportedValueError is returned by [Marshal] when attempting
+-// to encode an unsupported value.
+-type UnsupportedValueError struct {
+-	Value reflect.Value
+-	Str   string
+-}
+-
+-func (e *UnsupportedValueError) Error() string {
+-	return "json: unsupported value: " + e.Str
+-}
+-
+-// Before Go 1.2, an InvalidUTF8Error was returned by [Marshal] when
+-// attempting to encode a string value with invalid UTF-8 sequences.
+-// As of Go 1.2, [Marshal] instead coerces the string to valid UTF-8 by
+-// replacing invalid bytes with the Unicode replacement rune U+FFFD.
+-//
+-// Deprecated: No longer used; kept for compatibility.
+-type InvalidUTF8Error struct {
+-	S string // the whole string value that caused the error
+-}
+-
+-func (e *InvalidUTF8Error) Error() string {
+-	return "json: invalid UTF-8 in string: " + strconv.Quote(e.S)
+-}
+-
+-// A MarshalerError represents an error from calling a
+-// [Marshaler.MarshalJSON] or [encoding.TextMarshaler.MarshalText] method.
+-type MarshalerError struct {
+-	Type       reflect.Type
+-	Err        error
+-	sourceFunc string
+-}
+-
+-func (e *MarshalerError) Error() string {
+-	srcFunc := e.sourceFunc
+-	if srcFunc == "" {
+-		srcFunc = "MarshalJSON"
+-	}
+-	return "json: error calling " + srcFunc +
+-		" for type " + e.Type.String() +
+-		": " + e.Err.Error()
+-}
+-
+-// Unwrap returns the underlying error.
+-func (e *MarshalerError) Unwrap() error { return e.Err }
+diff --git a/pkg/internal/third_party/go-json-experiment/json/v1/encode_test.go b/pkg/internal/third_party/go-json-experiment/json/v1/encode_test.go
+deleted file mode 100644
+index cb929e1eb..000000000
+--- a/pkg/internal/third_party/go-json-experiment/json/v1/encode_test.go
++++ /dev/null
+@@ -1,1410 +0,0 @@
+-// Copyright 2011 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+-package json
+-
+-import (
+-	"bytes"
+-	"encoding"
+-	"fmt"
+-	"log"
+-	"math"
+-	"reflect"
+-	"regexp"
+-	"runtime/debug"
+-	"strconv"
+-	"testing"
+-	"time"
+-)
+-
+-type OptionalsEmpty struct {
+-	Sr string `json:"sr"`
+-	So string `json:"so,omitempty"`
+-	Sw string `json:"-"`
+-
+-	Ir int `json:"omitempty"` // actually named omitempty, not an option
+-	Io int `json:"io,omitempty"`
+-
+-	Slr []string `json:"slr,random"`
+-	Slo []string `json:"slo,omitempty"`
+-
+-	Mr map[string]any `json:"mr"`
+-	Mo map[string]any `json:",omitempty"`
+-
+-	Fr float64 `json:"fr"`
+-	Fo float64 `json:"fo,omitempty"`
+-
+-	Br bool `json:"br"`
+-	Bo bool `json:"bo,omitempty"`
+-
+-	Ur uint `json:"ur"`
+-	Uo uint `json:"uo,omitempty"`
+-
+-	Str struct{} `json:"str"`
+-	Sto struct{} `json:"sto,omitempty"`
+-}
+-
+-func TestOmitEmpty(t *testing.T) {
+-	const want = `{
+- "sr": "",
+- "omitempty": 0,
+- "slr": null,
+- "mr": {},
+- "fr": 0,
+- "br": false,
+- "ur": 0,
+- "str": {},
+- "sto": {}
+-}`
+-	var o OptionalsEmpty
+-	o.Sw = "something"
+-	o.Mr = map[string]any{}
+-	o.Mo = map[string]any{}
+-
+-	got, err := MarshalIndent(&o, "", " ")
+-	if err != nil {
+-		t.Fatalf("MarshalIndent error: %v", err)
+-	}
+-	if got := string(got); got != want {
+-		t.Errorf("MarshalIndent:\n\tgot:  %s\n\twant: %s\n", indentNewlines(got), indentNewlines(want))
+-	}
+-}
+-
+-type NonZeroStruct struct{}
+-
+-func (nzs NonZeroStruct) IsZero() bool {
+-	return false
+-}
+-
+-type NoPanicStruct struct {
+-	Int int `json:"int,omitzero"`
+-}
+-
+-func (nps *NoPanicStruct) IsZero() bool {
+-	return nps.Int != 0
+-}
+-
+-type isZeroer interface {
+-	IsZero() bool
+-}
+-
+-type OptionalsZero struct {
+-	Sr string `json:"sr"`
+-	So string `json:"so,omitzero"`
+-	Sw string `json:"-"`
+-
+-	Ir int `json:"omitzero"` // actually named omitzero, not an option
+-	Io int `json:"io,omitzero"`
+-
+-	Slr       []string `json:"slr,random"`
+-	Slo       []string `json:"slo,omitzero"`
+-	SloNonNil []string `json:"slononnil,omitzero"`
+-
+-	Mr  map[string]any `json:"mr"`
+-	Mo  map[string]any `json:",omitzero"`
+-	Moo map[string]any `json:"moo,omitzero"`
+-
+-	Fr   float64    `json:"fr"`
+-	Fo   float64    `json:"fo,omitzero"`
+-	Foo  float64    `json:"foo,omitzero"`
+-	Foo2 [2]float64 `json:"foo2,omitzero"`
+-
+-	Br bool `json:"br"`
+-	Bo bool `json:"bo,omitzero"`
+-
+-	Ur uint `json:"ur"`
+-	Uo uint `json:"uo,omitzero"`
+-
+-	Str struct{} `json:"str"`
+-	Sto struct{} `json:"sto,omitzero"`
+-
+-	Time      time.Time     `json:"time,omitzero"`
+-	TimeLocal time.Time     `json:"timelocal,omitzero"`
+-	Nzs       NonZeroStruct `json:"nzs,omitzero"`
+-
+-	NilIsZeroer    isZeroer       `json:"niliszeroer,omitzero"`    // nil interface
+-	NonNilIsZeroer isZeroer       `json:"nonniliszeroer,omitzero"` // non-nil interface
+-	NoPanicStruct0 isZeroer       `json:"nps0,omitzero"`           // non-nil interface with nil pointer
+-	NoPanicStruct1 isZeroer       `json:"nps1,omitzero"`           // non-nil interface with non-nil pointer
+-	NoPanicStruct2 *NoPanicStruct `json:"nps2,omitzero"`           // nil pointer
+-	NoPanicStruct3 *NoPanicStruct `json:"nps3,omitzero"`           // non-nil pointer
+-	NoPanicStruct4 NoPanicStruct  `json:"nps4,omitzero"`           // concrete type
+-}
+-
+-func TestOmitZero(t *testing.T) {
+-	const want = `{
+- "sr": "",
+- "omitzero": 0,
+- "slr": null,
+- "slononnil": [],
+- "mr": {},
+- "Mo": {},
+- "fr": 0,
+- "br": false,
+- "ur": 0,
+- "str": {},
+- "nzs": {},
+- "nps1": {},
+- "nps3": {},
+- "nps4": {}
+-}`
+-	var o OptionalsZero
+-	o.Sw = "something"
+-	o.SloNonNil = make([]string, 0)
+-	o.Mr = map[string]any{}
+-	o.Mo = map[string]any{}
+-
+-	o.Foo = -0
+-	o.Foo2 = [2]float64{+0, -0}
+-
+-	o.TimeLocal = time.Time{}.Local()
+-
+-	o.NonNilIsZeroer = time.Time{}
+-	o.NoPanicStruct0 = (*NoPanicStruct)(nil)
+-	o.NoPanicStruct1 = &NoPanicStruct{}
+-	o.NoPanicStruct3 = &NoPanicStruct{}
+-
+-	got, err := MarshalIndent(&o, "", " ")
+-	if err != nil {
+-		t.Fatalf("MarshalIndent error: %v", err)
+-	}
+-	if got := string(got); got != want {
+-		t.Errorf("MarshalIndent:\n\tgot:  %s\n\twant: %s\n", indentNewlines(got), indentNewlines(want))
+-	}
+-}
+-
+-func TestOmitZeroMap(t *testing.T) {
+-	const want = `{
+- "foo": {
+-  "sr": "",
+-  "omitzero": 0,
+-  "slr": null,
+-  "mr": null,
+-  "fr": 0,
+-  "br": false,
+-  "ur": 0,
+-  "str": {},
+-  "nzs": {},
+-  "nps4": {}
+- }
+-}`
+-	m := map[string]OptionalsZero{"foo": {}}
+-	got, err := MarshalIndent(m, "", " ")
+-	if err != nil {
+-		t.Fatalf("MarshalIndent error: %v", err)
+-	}
+-	if got := string(got); got != want {
+-		fmt.Println(got)
+-		t.Errorf("MarshalIndent:\n\tgot:  %s\n\twant: %s\n", indentNewlines(got), indentNewlines(want))
+-	}
+-}
+-
+-type OptionalsEmptyZero struct {
+-	Sr string `json:"sr"`
+-	So string `json:"so,omitempty,omitzero"`
+-	Sw string `json:"-"`
+-
+-	Io int `json:"io,omitempty,omitzero"`
+-
+-	Slr       []string `json:"slr,random"`
+-	Slo       []string `json:"slo,omitempty,omitzero"`
+-	SloNonNil []string `json:"slononnil,omitempty,omitzero"`
+-
+-	Mr map[string]any `json:"mr"`
+-	Mo map[string]any `json:",omitempty,omitzero"`
+-
+-	Fr float64 `json:"fr"`
+-	Fo float64 `json:"fo,omitempty,omitzero"`
+-
+-	Br bool `json:"br"`
+-	Bo bool `json:"bo,omitempty,omitzero"`
+-
+-	Ur uint `json:"ur"`
+-	Uo uint `json:"uo,omitempty,omitzero"`
+-
+-	Str struct{} `json:"str"`
+-	Sto struct{} `json:"sto,omitempty,omitzero"`
+-
+-	Time time.Time     `json:"time,omitempty,omitzero"`
+-	Nzs  NonZeroStruct `json:"nzs,omitempty,omitzero"`
+-}
+-
+-func TestOmitEmptyZero(t *testing.T) {
+-	const want = `{
+- "sr": "",
+- "slr": null,
+- "mr": {},
+- "fr": 0,
+- "br": false,
+- "ur": 0,
+- "str": {},
+- "nzs": {}
+-}`
+-	var o OptionalsEmptyZero
+-	o.Sw = "something"
+-	o.SloNonNil = make([]string, 0)
+-	o.Mr = map[string]any{}
+-	o.Mo = map[string]any{}
+-
+-	got, err := MarshalIndent(&o, "", " ")
+-	if err != nil {
+-		t.Fatalf("MarshalIndent error: %v", err)
+-	}
+-	if got := string(got); got != want {
+-		t.Errorf("MarshalIndent:\n\tgot:  %s\n\twant: %s\n", indentNewlines(got), indentNewlines(want))
+-	}
+-}
+-
+-type StringTag struct {
+-	BoolStr    bool    `json:",string"`
+-	IntStr     int64   `json:",string"`
+-	UintptrStr uintptr `json:",string"`
+-	StrStr     string  `json:",string"`
+-	NumberStr  Number  `json:",string"`
+-}
+-
+-func TestRoundtripStringTag(t *testing.T) {
+-	tests := []struct {
+-		CaseName
+-		in   StringTag
+-		want string // empty to just test that we roundtrip
+-	}{{
+-		CaseName: Name("AllTypes"),
+-		in: StringTag{
+-			BoolStr:    true,
+-			IntStr:     42,
+-			UintptrStr: 44,
+-			StrStr:     "xzbit",
+-			NumberStr:  "46",
+-		},
+-		want: `{
+-	"BoolStr": "true",
+-	"IntStr": "42",
+-	"UintptrStr": "44",
+-	"StrStr": "\"xzbit\"",
+-	"NumberStr": "46"
+-}`,
+-	}, {
+-		// See golang.org/issues/38173.
+-		CaseName: Name("StringDoubleEscapes"),
+-		in: StringTag{
+-			StrStr:    "\b\f\n\r\t\"\\",
+-			NumberStr: "0", // just to satisfy the roundtrip
+-		},
+-		want: `{
+-	"BoolStr": "false",
+-	"IntStr": "0",
+-	"UintptrStr": "0",
+-	"StrStr": "\"\\b\\f\\n\\r\\t\\\"\\\\\"",
+-	"NumberStr": "0"
+-}`,
+-	}}
+-	for _, tt := range tests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			got, err := MarshalIndent(&tt.in, "", "\t")
+-			if err != nil {
+-				t.Fatalf("%s: MarshalIndent error: %v", tt.Where, err)
+-			}
+-			if got := string(got); got != tt.want {
+-				t.Fatalf("%s: MarshalIndent:\n\tgot:  %s\n\twant: %s", tt.Where, stripWhitespace(got), stripWhitespace(tt.want))
+-			}
+-
+-			// Verify that it round-trips.
+-			var s2 StringTag
+-			if err := Unmarshal(got, &s2); err != nil {
+-				t.Fatalf("%s: Decode error: %v", tt.Where, err)
+-			}
+-			if !reflect.DeepEqual(s2, tt.in) {
+-				t.Fatalf("%s: Decode:\n\tinput: %s\n\tgot:  %#v\n\twant: %#v", tt.Where, indentNewlines(string(got)), s2, tt.in)
+-			}
+-		})
+-	}
+-}
+-
+-// byte slices are special even if they're renamed types.
+-type renamedByte byte
+-type renamedByteSlice []byte
+-type renamedRenamedByteSlice []renamedByte
+-
+-func TestEncodeRenamedByteSlice(t *testing.T) {
+-	s := renamedByteSlice("abc")
+-	got, err := Marshal(s)
+-	if err != nil {
+-		t.Fatalf("Marshal error: %v", err)
+-	}
+-	want := `"YWJj"`
+-	if string(got) != want {
+-		t.Errorf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
+-	}
+-	r := renamedRenamedByteSlice("abc")
+-	got, err = Marshal(r)
+-	if err != nil {
+-		t.Fatalf("Marshal error: %v", err)
+-	}
+-	if string(got) != want {
+-		t.Errorf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
+-	}
+-}
+-
+-type SamePointerNoCycle struct {
+-	Ptr1, Ptr2 *SamePointerNoCycle
+-}
+-
+-var samePointerNoCycle = &SamePointerNoCycle{}
+-
+-type PointerCycle struct {
+-	Ptr *PointerCycle
+-}
+-
+-var pointerCycle = &PointerCycle{}
+-
+-type PointerCycleIndirect struct {
+-	Ptrs []any
+-}
+-
+-type RecursiveSlice []RecursiveSlice
+-
+-var (
+-	pointerCycleIndirect = &PointerCycleIndirect{}
+-	mapCycle             = make(map[string]any)
+-	sliceCycle           = []any{nil}
+-	sliceNoCycle         = []any{nil, nil}
+-	recursiveSliceCycle  = []RecursiveSlice{nil}
+-)
+-
+-func init() {
+-	ptr := &SamePointerNoCycle{}
+-	samePointerNoCycle.Ptr1 = ptr
+-	samePointerNoCycle.Ptr2 = ptr
+-
+-	pointerCycle.Ptr = pointerCycle
+-	pointerCycleIndirect.Ptrs = []any{pointerCycleIndirect}
+-
+-	mapCycle["x"] = mapCycle
+-	sliceCycle[0] = sliceCycle
+-	sliceNoCycle[1] = sliceNoCycle[:1]
+-	const startDetectingCyclesAfter = 1e3
+-	for i := startDetectingCyclesAfter; i > 0; i-- {
+-		sliceNoCycle = []any{sliceNoCycle}
+-	}
+-	recursiveSliceCycle[0] = recursiveSliceCycle
+-}
+-
+-func TestSamePointerNoCycle(t *testing.T) {
+-	if _, err := Marshal(samePointerNoCycle); err != nil {
+-		t.Fatalf("Marshal error: %v", err)
+-	}
+-}
+-
+-func TestSliceNoCycle(t *testing.T) {
+-	if _, err := Marshal(sliceNoCycle); err != nil {
+-		t.Fatalf("Marshal error: %v", err)
+-	}
+-}
+-
+-func TestUnsupportedValues(t *testing.T) {
+-	tests := []struct {
+-		CaseName
+-		in any
+-	}{
+-		{Name(""), math.NaN()},
+-		{Name(""), math.Inf(-1)},
+-		{Name(""), math.Inf(1)},
+-		{Name(""), pointerCycle},
+-		{Name(""), pointerCycleIndirect},
+-		{Name(""), mapCycle},
+-		{Name(""), sliceCycle},
+-		{Name(""), recursiveSliceCycle},
+-	}
+-	for _, tt := range tests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			if _, err := Marshal(tt.in); err != nil {
+-				if _, ok := err.(*UnsupportedValueError); !ok {
+-					t.Errorf("%s: Marshal error:\n\tgot:  %T\n\twant: %T", tt.Where, err, new(UnsupportedValueError))
+-				}
+-			} else {
+-				t.Errorf("%s: Marshal error: got nil, want non-nil", tt.Where)
+-			}
+-		})
+-	}
+-}
+-
+-// Issue 43207
+-func TestMarshalTextFloatMap(t *testing.T) {
+-	m := map[textfloat]string{
+-		textfloat(math.NaN()): "1",
+-		textfloat(math.NaN()): "1",
+-	}
+-	got, err := Marshal(m)
+-	if err != nil {
+-		t.Errorf("Marshal error: %v", err)
+-	}
+-	want := `{"TF:NaN":"1","TF:NaN":"1"}`
+-	if string(got) != want {
+-		t.Errorf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
+-	}
+-}
+-
+-// Ref has Marshaler and Unmarshaler methods with pointer receiver.
+-type Ref int
+-
+-func (*Ref) MarshalJSON() ([]byte, error) {
+-	return []byte(`"ref"`), nil
+-}
+-
+-func (r *Ref) UnmarshalJSON([]byte) error {
+-	*r = 12
+-	return nil
+-}
+-
+-// Val has Marshaler methods with value receiver.
+-type Val int
+-
+-func (Val) MarshalJSON() ([]byte, error) {
+-	return []byte(`"val"`), nil
+-}
+-
+-// RefText has Marshaler and Unmarshaler methods with pointer receiver.
+-type RefText int
+-
+-func (*RefText) MarshalText() ([]byte, error) {
+-	return []byte(`"ref"`), nil
+-}
+-
+-func (r *RefText) UnmarshalText([]byte) error {
+-	*r = 13
+-	return nil
+-}
+-
+-// ValText has Marshaler methods with value receiver.
+-type ValText int
+-
+-func (ValText) MarshalText() ([]byte, error) {
+-	return []byte(`"val"`), nil
+-}
+-
+-func TestRefValMarshal(t *testing.T) {
+-	var s = struct {
+-		R0 Ref
+-		R1 *Ref
+-		R2 RefText
+-		R3 *RefText
+-		V0 Val
+-		V1 *Val
+-		V2 ValText
+-		V3 *ValText
+-	}{
+-		R0: 12,
+-		R1: new(Ref),
+-		R2: 14,
+-		R3: new(RefText),
+-		V0: 13,
+-		V1: new(Val),
+-		V2: 15,
+-		V3: new(ValText),
+-	}
+-	const want = `{"R0":"ref","R1":"ref","R2":"\"ref\"","R3":"\"ref\"","V0":"val","V1":"val","V2":"\"val\"","V3":"\"val\""}`
+-	b, err := Marshal(&s)
+-	if err != nil {
+-		t.Fatalf("Marshal error: %v", err)
+-	}
+-	if got := string(b); got != want {
+-		t.Errorf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
+-	}
+-}
+-
+-// C implements Marshaler and returns unescaped JSON.
+-type C int
+-
+-func (C) MarshalJSON() ([]byte, error) {
+-	return []byte(`"<&>"`), nil
+-}
+-
+-// CText implements Marshaler and returns unescaped text.
+-type CText int
+-
+-func (CText) MarshalText() ([]byte, error) {
+-	return []byte(`"<&>"`), nil
+-}
+-
+-func TestMarshalerEscaping(t *testing.T) {
+-	var c C
+-	want := `"\u003c\u0026\u003e"`
+-	b, err := Marshal(c)
+-	if err != nil {
+-		t.Fatalf("Marshal error: %v", err)
+-	}
+-	if got := string(b); got != want {
+-		t.Errorf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
+-	}
+-
+-	var ct CText
+-	want = `"\"\u003c\u0026\u003e\""`
+-	b, err = Marshal(ct)
+-	if err != nil {
+-		t.Fatalf("Marshal error: %v", err)
+-	}
+-	if got := string(b); got != want {
+-		t.Errorf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
+-	}
+-}
+-
+-func TestAnonymousFields(t *testing.T) {
+-	tests := []struct {
+-		CaseName
+-		makeInput func() any // Function to create input value
+-		want      string     // Expected JSON output
+-	}{{
+-		// Both S1 and S2 have a field named X. From the perspective of S,
+-		// it is ambiguous which one X refers to.
+-		// This should not serialize either field.
+-		CaseName: Name("AmbiguousField"),
+-		makeInput: func() any {
+-			type (
+-				S1 struct{ x, X int }
+-				S2 struct{ x, X int }
+-				S  struct {
+-					S1
+-					S2
+-				}
+-			)
+-			return S{S1{1, 2}, S2{3, 4}}
+-		},
+-		want: `{}`,
+-	}, {
+-		CaseName: Name("DominantField"),
+-		// Both S1 and S2 have a field named X, but since S has an X field as
+-		// well, it takes precedence over S1.X and S2.X.
+-		makeInput: func() any {
+-			type (
+-				S1 struct{ x, X int }
+-				S2 struct{ x, X int }
+-				S  struct {
+-					S1
+-					S2
+-					x, X int
+-				}
+-			)
+-			return S{S1{1, 2}, S2{3, 4}, 5, 6}
+-		},
+-		want: `{"X":6}`,
+-	}, {
+-		// Unexported embedded field of non-struct type should not be serialized.
+-		CaseName: Name("UnexportedEmbeddedInt"),
+-		makeInput: func() any {
+-			type (
+-				myInt int
+-				S     struct{ myInt }
+-			)
+-			return S{5}
+-		},
+-		want: `{}`,
+-	}, {
+-		// Exported embedded field of non-struct type should be serialized.
+-		CaseName: Name("ExportedEmbeddedInt"),
+-		makeInput: func() any {
+-			type (
+-				MyInt int
+-				S     struct{ MyInt }
+-			)
+-			return S{5}
+-		},
+-		want: `{"MyInt":5}`,
+-	}, {
+-		// Unexported embedded field of pointer to non-struct type
+-		// should not be serialized.
+-		CaseName: Name("UnexportedEmbeddedIntPointer"),
+-		makeInput: func() any {
+-			type (
+-				myInt int
+-				S     struct{ *myInt }
+-			)
+-			s := S{new(myInt)}
+-			*s.myInt = 5
+-			return s
+-		},
+-		want: `{}`,
+-	}, {
+-		// Exported embedded field of pointer to non-struct type
+-		// should be serialized.
+-		CaseName: Name("ExportedEmbeddedIntPointer"),
+-		makeInput: func() any {
+-			type (
+-				MyInt int
+-				S     struct{ *MyInt }
+-			)
+-			s := S{new(MyInt)}
+-			*s.MyInt = 5
+-			return s
+-		},
+-		want: `{"MyInt":5}`,
+-	}, {
+-		// Exported fields of embedded structs should have their
+-		// exported fields be serialized regardless of whether the struct types
+-		// themselves are exported.
+-		CaseName: Name("EmbeddedStruct"),
+-		makeInput: func() any {
+-			type (
+-				s1 struct{ x, X int }
+-				S2 struct{ y, Y int }
+-				S  struct {
+-					s1
+-					S2
+-				}
+-			)
+-			return S{s1{1, 2}, S2{3, 4}}
+-		},
+-		want: `{"X":2,"Y":4}`,
+-	}, {
+-		// Exported fields of pointers to embedded structs should have their
+-		// exported fields be serialized regardless of whether the struct types
+-		// themselves are exported.
+-		CaseName: Name("EmbeddedStructPointer"),
+-		makeInput: func() any {
+-			type (
+-				s1 struct{ x, X int }
+-				S2 struct{ y, Y int }
+-				S  struct {
+-					*s1
+-					*S2
+-				}
+-			)
+-			return S{&s1{1, 2}, &S2{3, 4}}
+-		},
+-		want: `{"X":2,"Y":4}`,
+-	}, {
+-		// Exported fields on embedded unexported structs at multiple levels
+-		// of nesting should still be serialized.
+-		CaseName: Name("NestedStructAndInts"),
+-		makeInput: func() any {
+-			type (
+-				MyInt1 int
+-				MyInt2 int
+-				myInt  int
+-				s2     struct {
+-					MyInt2
+-					myInt
+-				}
+-				s1 struct {
+-					MyInt1
+-					myInt
+-					s2
+-				}
+-				S struct {
+-					s1
+-					myInt
+-				}
+-			)
+-			return S{s1{1, 2, s2{3, 4}}, 6}
+-		},
+-		want: `{"MyInt1":1,"MyInt2":3}`,
+-	}, {
+-		// If an anonymous struct pointer field is nil, we should ignore
+-		// the embedded fields behind it. Not properly doing so may
+-		// result in the wrong output or reflect panics.
+-		CaseName: Name("EmbeddedFieldBehindNilPointer"),
+-		makeInput: func() any {
+-			type (
+-				S2 struct{ Field string }
+-				S  struct{ *S2 }
+-			)
+-			return S{}
+-		},
+-		want: `{}`,
+-	}}
+-
+-	for _, tt := range tests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			b, err := Marshal(tt.makeInput())
+-			if err != nil {
+-				t.Fatalf("%s: Marshal error: %v", tt.Where, err)
+-			}
+-			if string(b) != tt.want {
+-				t.Fatalf("%s: Marshal:\n\tgot:  %s\n\twant: %s", tt.Where, b, tt.want)
+-			}
+-		})
+-	}
+-}
+-
+-type BugA struct {
+-	S string
+-}
+-
+-type BugB struct {
+-	BugA
+-	S string
+-}
+-
+-type BugC struct {
+-	S string
+-}
+-
+-// Legal Go: We never use the repeated embedded field (S).
+-type BugX struct {
+-	A int
+-	BugA
+-	BugB
+-}
+-
+-// golang.org/issue/16042.
+-// Even if a nil interface value is passed in, as long as
+-// it implements Marshaler, it should be marshaled.
+-type nilJSONMarshaler string
+-
+-func (nm *nilJSONMarshaler) MarshalJSON() ([]byte, error) {
+-	if nm == nil {
+-		return Marshal("0zenil0")
+-	}
+-	return Marshal("zenil:" + string(*nm))
+-}
+-
+-// golang.org/issue/34235.
+-// Even if a nil interface value is passed in, as long as
+-// it implements encoding.TextMarshaler, it should be marshaled.
+-type nilTextMarshaler string
+-
+-func (nm *nilTextMarshaler) MarshalText() ([]byte, error) {
+-	if nm == nil {
+-		return []byte("0zenil0"), nil
+-	}
+-	return []byte("zenil:" + string(*nm)), nil
+-}
+-
+-// See golang.org/issue/16042 and golang.org/issue/34235.
+-func TestNilMarshal(t *testing.T) {
+-	tests := []struct {
+-		CaseName
+-		in   any
+-		want string
+-	}{
+-		{Name(""), nil, `null`},
+-		{Name(""), new(float64), `0`},
+-		{Name(""), []any(nil), `null`},
+-		{Name(""), []string(nil), `null`},
+-		{Name(""), map[string]string(nil), `null`},
+-		{Name(""), []byte(nil), `null`},
+-		{Name(""), struct{ M string }{"gopher"}, `{"M":"gopher"}`},
+-		{Name(""), struct{ M Marshaler }{}, `{"M":null}`},
+-		{Name(""), struct{ M Marshaler }{(*nilJSONMarshaler)(nil)}, `{"M":"0zenil0"}`},
+-		{Name(""), struct{ M any }{(*nilJSONMarshaler)(nil)}, `{"M":null}`},
+-		{Name(""), struct{ M encoding.TextMarshaler }{}, `{"M":null}`},
+-		{Name(""), struct{ M encoding.TextMarshaler }{(*nilTextMarshaler)(nil)}, `{"M":"0zenil0"}`},
+-		{Name(""), struct{ M any }{(*nilTextMarshaler)(nil)}, `{"M":null}`},
+-	}
+-	for _, tt := range tests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			switch got, err := Marshal(tt.in); {
+-			case err != nil:
+-				t.Fatalf("%s: Marshal error: %v", tt.Where, err)
+-			case string(got) != tt.want:
+-				t.Fatalf("%s: Marshal:\n\tgot:  %s\n\twant: %s", tt.Where, got, tt.want)
+-			}
+-		})
+-	}
+-}
+-
+-// Issue 5245.
+-func TestEmbeddedBug(t *testing.T) {
+-	v := BugB{
+-		BugA{"A"},
+-		"B",
+-	}
+-	b, err := Marshal(v)
+-	if err != nil {
+-		t.Fatal("Marshal error:", err)
+-	}
+-	want := `{"S":"B"}`
+-	got := string(b)
+-	if got != want {
+-		t.Fatalf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
+-	}
+-	// Now check that the duplicate field, S, does not appear.
+-	x := BugX{
+-		A: 23,
+-	}
+-	b, err = Marshal(x)
+-	if err != nil {
+-		t.Fatal("Marshal error:", err)
+-	}
+-	want = `{"A":23}`
+-	got = string(b)
+-	if got != want {
+-		t.Fatalf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
+-	}
+-}
+-
+-type BugD struct { // Same as BugA after tagging.
+-	XXX string `json:"S"`
+-}
+-
+-// BugD's tagged S field should dominate BugA's.
+-type BugY struct {
+-	BugA
+-	BugD
+-}
+-
+-// Test that a field with a tag dominates untagged fields.
+-func TestTaggedFieldDominates(t *testing.T) {
+-	v := BugY{
+-		BugA{"BugA"},
+-		BugD{"BugD"},
+-	}
+-	b, err := Marshal(v)
+-	if err != nil {
+-		t.Fatal("Marshal error:", err)
+-	}
+-	want := `{"S":"BugD"}`
+-	got := string(b)
+-	if got != want {
+-		t.Fatalf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
+-	}
+-}
+-
+-// There are no tags here, so S should not appear.
+-type BugZ struct {
+-	BugA
+-	BugC
+-	BugY // Contains a tagged S field through BugD; should not dominate.
+-}
+-
+-func TestDuplicatedFieldDisappears(t *testing.T) {
+-	v := BugZ{
+-		BugA{"BugA"},
+-		BugC{"BugC"},
+-		BugY{
+-			BugA{"nested BugA"},
+-			BugD{"nested BugD"},
+-		},
+-	}
+-	b, err := Marshal(v)
+-	if err != nil {
+-		t.Fatal("Marshal error:", err)
+-	}
+-	want := `{}`
+-	got := string(b)
+-	if got != want {
+-		t.Fatalf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
+-	}
+-}
+-
+-func TestIssue10281(t *testing.T) {
+-	type Foo struct {
+-		N Number
+-	}
+-	x := Foo{Number(`invalid`)}
+-
+-	if _, err := Marshal(&x); err == nil {
+-		t.Fatalf("Marshal error: got nil, want non-nil")
+-	}
+-}
+-
+-func TestMarshalErrorAndReuseEncodeState(t *testing.T) {
+-	// Disable the GC temporarily to prevent encodeState's in Pool being cleaned away during the test.
+-	percent := debug.SetGCPercent(-1)
+-	defer debug.SetGCPercent(percent)
+-
+-	// Trigger an error in Marshal with cyclic data.
+-	type Dummy struct {
+-		Name string
+-		Next *Dummy
+-	}
+-	dummy := Dummy{Name: "Dummy"}
+-	dummy.Next = &dummy
+-	if _, err := Marshal(dummy); err == nil {
+-		t.Errorf("Marshal error: got nil, want non-nil")
+-	}
+-
+-	type Data struct {
+-		A string
+-		I int
+-	}
+-	want := Data{A: "a", I: 1}
+-	b, err := Marshal(want)
+-	if err != nil {
+-		t.Errorf("Marshal error: %v", err)
+-	}
+-
+-	var got Data
+-	if err := Unmarshal(b, &got); err != nil {
+-		t.Errorf("Unmarshal error: %v", err)
+-	}
+-	if got != want {
+-		t.Errorf("Unmarshal:\n\tgot:  %v\n\twant: %v", got, want)
+-	}
+-}
+-
+-func TestHTMLEscape(t *testing.T) {
+-	var b, want bytes.Buffer
+-	m := `{"M":"<html>foo &` + "\xe2\x80\xa8 \xe2\x80\xa9" + `</html>"}`
+-	want.Write([]byte(`{"M":"\u003chtml\u003efoo \u0026\u2028 \u2029\u003c/html\u003e"}`))
+-	HTMLEscape(&b, []byte(m))
+-	if !bytes.Equal(b.Bytes(), want.Bytes()) {
+-		t.Errorf("HTMLEscape:\n\tgot:  %s\n\twant: %s", b.Bytes(), want.Bytes())
+-	}
+-}
+-
+-// golang.org/issue/8582
+-func TestEncodePointerString(t *testing.T) {
+-	type stringPointer struct {
+-		N *int64 `json:"n,string"`
+-	}
+-	var n int64 = 42
+-	b, err := Marshal(stringPointer{N: &n})
+-	if err != nil {
+-		t.Fatalf("Marshal error: %v", err)
+-	}
+-	if got, want := string(b), `{"n":"42"}`; got != want {
+-		t.Fatalf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
+-	}
+-	var back stringPointer
+-	switch err = Unmarshal(b, &back); {
+-	case err != nil:
+-		t.Fatalf("Unmarshal error: %v", err)
+-	case back.N == nil:
+-		t.Fatalf("Unmarshal: back.N = nil, want non-nil")
+-	case *back.N != 42:
+-		t.Fatalf("Unmarshal: *back.N = %d, want 42", *back.N)
+-	}
+-}
+-
+-var encodeStringTests = []struct {
+-	in  string
+-	out string
+-}{
+-	{"\x00", `"\u0000"`},
+-	{"\x01", `"\u0001"`},
+-	{"\x02", `"\u0002"`},
+-	{"\x03", `"\u0003"`},
+-	{"\x04", `"\u0004"`},
+-	{"\x05", `"\u0005"`},
+-	{"\x06", `"\u0006"`},
+-	{"\x07", `"\u0007"`},
+-	{"\x08", `"\b"`},
+-	{"\x09", `"\t"`},
+-	{"\x0a", `"\n"`},
+-	{"\x0b", `"\u000b"`},
+-	{"\x0c", `"\f"`},
+-	{"\x0d", `"\r"`},
+-	{"\x0e", `"\u000e"`},
+-	{"\x0f", `"\u000f"`},
+-	{"\x10", `"\u0010"`},
+-	{"\x11", `"\u0011"`},
+-	{"\x12", `"\u0012"`},
+-	{"\x13", `"\u0013"`},
+-	{"\x14", `"\u0014"`},
+-	{"\x15", `"\u0015"`},
+-	{"\x16", `"\u0016"`},
+-	{"\x17", `"\u0017"`},
+-	{"\x18", `"\u0018"`},
+-	{"\x19", `"\u0019"`},
+-	{"\x1a", `"\u001a"`},
+-	{"\x1b", `"\u001b"`},
+-	{"\x1c", `"\u001c"`},
+-	{"\x1d", `"\u001d"`},
+-	{"\x1e", `"\u001e"`},
+-	{"\x1f", `"\u001f"`},
+-}
+-
+-func TestEncodeString(t *testing.T) {
+-	for _, tt := range encodeStringTests {
+-		b, err := Marshal(tt.in)
+-		if err != nil {
+-			t.Errorf("Marshal(%q) error: %v", tt.in, err)
+-			continue
+-		}
+-		out := string(b)
+-		if out != tt.out {
+-			t.Errorf("Marshal(%q) = %#q, want %#q", tt.in, out, tt.out)
+-		}
+-	}
+-}
+-
+-type jsonbyte byte
+-
+-func (b jsonbyte) MarshalJSON() ([]byte, error) { return tenc(`{"JB":%d}`, b) }
+-
+-type textbyte byte
+-
+-func (b textbyte) MarshalText() ([]byte, error) { return tenc(`TB:%d`, b) }
+-
+-type jsonint int
+-
+-func (i jsonint) MarshalJSON() ([]byte, error) { return tenc(`{"JI":%d}`, i) }
+-
+-type textint int
+-
+-func (i textint) MarshalText() ([]byte, error) { return tenc(`TI:%d`, i) }
+-
+-func tenc(format string, a ...any) ([]byte, error) {
+-	var buf bytes.Buffer
+-	fmt.Fprintf(&buf, format, a...)
+-	return buf.Bytes(), nil
+-}
+-
+-type textfloat float64
+-
+-func (f textfloat) MarshalText() ([]byte, error) { return tenc(`TF:%0.2f`, f) }
+-
+-// Issue 13783
+-func TestEncodeBytekind(t *testing.T) {
+-	tests := []struct {
+-		CaseName
+-		in   any
+-		want string
+-	}{
+-		{Name(""), byte(7), "7"},
+-		{Name(""), jsonbyte(7), `{"JB":7}`},
+-		{Name(""), textbyte(4), `"TB:4"`},
+-		{Name(""), jsonint(5), `{"JI":5}`},
+-		{Name(""), textint(1), `"TI:1"`},
+-		{Name(""), []byte{0, 1}, `"AAE="`},
+-		{Name(""), []jsonbyte{0, 1}, `[{"JB":0},{"JB":1}]`},
+-		{Name(""), [][]jsonbyte{{0, 1}, {3}}, `[[{"JB":0},{"JB":1}],[{"JB":3}]]`},
+-		{Name(""), []textbyte{2, 3}, `["TB:2","TB:3"]`},
+-		{Name(""), []jsonint{5, 4}, `[{"JI":5},{"JI":4}]`},
+-		{Name(""), []textint{9, 3}, `["TI:9","TI:3"]`},
+-		{Name(""), []int{9, 3}, `[9,3]`},
+-		{Name(""), []textfloat{12, 3}, `["TF:12.00","TF:3.00"]`},
+-	}
+-	for _, tt := range tests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			b, err := Marshal(tt.in)
+-			if err != nil {
+-				t.Errorf("%s: Marshal error: %v", tt.Where, err)
+-			}
+-			got, want := string(b), tt.want
+-			if got != want {
+-				t.Errorf("%s: Marshal:\n\tgot:  %s\n\twant: %s", tt.Where, got, want)
+-			}
+-		})
+-	}
+-}
+-
+-func TestTextMarshalerMapKeysAreSorted(t *testing.T) {
+-	got, err := Marshal(map[unmarshalerText]int{
+-		{"x", "y"}: 1,
+-		{"y", "x"}: 2,
+-		{"a", "z"}: 3,
+-		{"z", "a"}: 4,
+-	})
+-	if err != nil {
+-		t.Fatalf("Marshal error: %v", err)
+-	}
+-	const want = `{"a:z":3,"x:y":1,"y:x":2,"z:a":4}`
+-	if string(got) != want {
+-		t.Errorf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
+-	}
+-}
+-
+-// https://golang.org/issue/33675
+-func TestNilMarshalerTextMapKey(t *testing.T) {
+-	got, err := Marshal(map[*unmarshalerText]int{
+-		(*unmarshalerText)(nil): 1,
+-		{"A", "B"}:              2,
+-	})
+-	if err != nil {
+-		t.Fatalf("Marshal error: %v", err)
+-	}
+-	const want = `{"":1,"A:B":2}`
+-	if string(got) != want {
+-		t.Errorf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
+-	}
+-}
+-
+-var re = regexp.MustCompile
+-
+-// syntactic checks on form of marshaled floating point numbers.
+-var badFloatREs = []*regexp.Regexp{
+-	re(`p`),                     // no binary exponential notation
+-	re(`^\+`),                   // no leading + sign
+-	re(`^-?0[^.]`),              // no unnecessary leading zeros
+-	re(`^-?\.`),                 // leading zero required before decimal point
+-	re(`\.(e|$)`),               // no trailing decimal
+-	re(`\.[0-9]+0(e|$)`),        // no trailing zero in fraction
+-	re(`^-?(0|[0-9]{2,})\..*e`), // exponential notation must have normalized mantissa
+-	re(`e[0-9]`),                // positive exponent must be signed
+-	re(`e[+-]0`),                // exponent must not have leading zeros
+-	re(`e-[1-6]$`),              // not tiny enough for exponential notation
+-	re(`e+(.|1.|20)$`),          // not big enough for exponential notation
+-	re(`^-?0\.0000000`),         // too tiny, should use exponential notation
+-	re(`^-?[0-9]{22}`),          // too big, should use exponential notation
+-	re(`[1-9][0-9]{16}[1-9]`),   // too many significant digits in integer
+-	re(`[1-9][0-9.]{17}[1-9]`),  // too many significant digits in decimal
+-	// below here for float32 only
+-	re(`[1-9][0-9]{8}[1-9]`),  // too many significant digits in integer
+-	re(`[1-9][0-9.]{9}[1-9]`), // too many significant digits in decimal
+-}
+-
+-func TestMarshalFloat(t *testing.T) {
+-	t.Parallel()
+-	nfail := 0
+-	test := func(f float64, bits int) {
+-		vf := any(f)
+-		if bits == 32 {
+-			f = float64(float32(f)) // round
+-			vf = float32(f)
+-		}
+-		bout, err := Marshal(vf)
+-		if err != nil {
+-			t.Errorf("Marshal(%T(%g)) error: %v", vf, vf, err)
+-			nfail++
+-			return
+-		}
+-		out := string(bout)
+-
+-		// result must convert back to the same float
+-		g, err := strconv.ParseFloat(out, bits)
+-		if err != nil {
+-			t.Errorf("ParseFloat(%q) error: %v", out, err)
+-			nfail++
+-			return
+-		}
+-		if f != g || fmt.Sprint(f) != fmt.Sprint(g) { // fmt.Sprint handles ±0
+-			t.Errorf("ParseFloat(%q):\n\tgot:  %g\n\twant: %g", out, float32(g), vf)
+-			nfail++
+-			return
+-		}
+-
+-		bad := badFloatREs
+-		if bits == 64 {
+-			bad = bad[:len(bad)-2]
+-		}
+-		for _, re := range bad {
+-			if re.MatchString(out) {
+-				t.Errorf("Marshal(%T(%g)) = %q; must not match /%s/", vf, vf, out, re)
+-				nfail++
+-				return
+-			}
+-		}
+-	}
+-
+-	var (
+-		bigger  = math.Inf(+1)
+-		smaller = math.Inf(-1)
+-	)
+-
+-	var digits = "1.2345678901234567890123"
+-	for i := len(digits); i >= 2; i-- {
+-		if testing.Short() && i < len(digits)-4 {
+-			break
+-		}
+-		for exp := -30; exp <= 30; exp++ {
+-			for _, sign := range "+-" {
+-				for bits := 32; bits <= 64; bits += 32 {
+-					s := fmt.Sprintf("%c%se%d", sign, digits[:i], exp)
+-					f, err := strconv.ParseFloat(s, bits)
+-					if err != nil {
+-						log.Fatal(err)
+-					}
+-					next := math.Nextafter
+-					if bits == 32 {
+-						next = func(g, h float64) float64 {
+-							return float64(math.Nextafter32(float32(g), float32(h)))
+-						}
+-					}
+-					test(f, bits)
+-					test(next(f, bigger), bits)
+-					test(next(f, smaller), bits)
+-					if nfail > 50 {
+-						t.Fatalf("stopping test early")
+-					}
+-				}
+-			}
+-		}
+-	}
+-	test(0, 64)
+-	test(math.Copysign(0, -1), 64)
+-	test(0, 32)
+-	test(math.Copysign(0, -1), 32)
+-}
+-
+-func TestMarshalRawMessageValue(t *testing.T) {
+-	type (
+-		T1 struct {
+-			M RawMessage `json:",omitempty"`
+-		}
+-		T2 struct {
+-			M *RawMessage `json:",omitempty"`
+-		}
+-	)
+-
+-	var (
+-		rawNil   = RawMessage(nil)
+-		rawEmpty = RawMessage([]byte{})
+-		rawText  = RawMessage([]byte(`"foo"`))
+-	)
+-
+-	tests := []struct {
+-		CaseName
+-		in   any
+-		want string
+-		ok   bool
+-	}{
+-		// Test with nil RawMessage.
+-		{Name(""), rawNil, "null", true},
+-		{Name(""), &rawNil, "null", true},
+-		{Name(""), []any{rawNil}, "[null]", true},
+-		{Name(""), &[]any{rawNil}, "[null]", true},
+-		{Name(""), []any{&rawNil}, "[null]", true},
+-		{Name(""), &[]any{&rawNil}, "[null]", true},
+-		{Name(""), struct{ M RawMessage }{rawNil}, `{"M":null}`, true},
+-		{Name(""), &struct{ M RawMessage }{rawNil}, `{"M":null}`, true},
+-		{Name(""), struct{ M *RawMessage }{&rawNil}, `{"M":null}`, true},
+-		{Name(""), &struct{ M *RawMessage }{&rawNil}, `{"M":null}`, true},
+-		{Name(""), map[string]any{"M": rawNil}, `{"M":null}`, true},
+-		{Name(""), &map[string]any{"M": rawNil}, `{"M":null}`, true},
+-		{Name(""), map[string]any{"M": &rawNil}, `{"M":null}`, true},
+-		{Name(""), &map[string]any{"M": &rawNil}, `{"M":null}`, true},
+-		{Name(""), T1{rawNil}, "{}", true},
+-		{Name(""), T2{&rawNil}, `{"M":null}`, true},
+-		{Name(""), &T1{rawNil}, "{}", true},
+-		{Name(""), &T2{&rawNil}, `{"M":null}`, true},
+-
+-		// Test with empty, but non-nil, RawMessage.
+-		{Name(""), rawEmpty, "", false},
+-		{Name(""), &rawEmpty, "", false},
+-		{Name(""), []any{rawEmpty}, "", false},
+-		{Name(""), &[]any{rawEmpty}, "", false},
+-		{Name(""), []any{&rawEmpty}, "", false},
+-		{Name(""), &[]any{&rawEmpty}, "", false},
+-		{Name(""), struct{ X RawMessage }{rawEmpty}, "", false},
+-		{Name(""), &struct{ X RawMessage }{rawEmpty}, "", false},
+-		{Name(""), struct{ X *RawMessage }{&rawEmpty}, "", false},
+-		{Name(""), &struct{ X *RawMessage }{&rawEmpty}, "", false},
+-		{Name(""), map[string]any{"nil": rawEmpty}, "", false},
+-		{Name(""), &map[string]any{"nil": rawEmpty}, "", false},
+-		{Name(""), map[string]any{"nil": &rawEmpty}, "", false},
+-		{Name(""), &map[string]any{"nil": &rawEmpty}, "", false},
+-		{Name(""), T1{rawEmpty}, "{}", true},
+-		{Name(""), T2{&rawEmpty}, "", false},
+-		{Name(""), &T1{rawEmpty}, "{}", true},
+-		{Name(""), &T2{&rawEmpty}, "", false},
+-
+-		// Test with RawMessage with some text.
+-		//
+-		// The tests below marked with Issue6458 used to generate "ImZvbyI=" instead "foo".
+-		// This behavior was intentionally changed in Go 1.8.
+-		// See https://golang.org/issues/14493#issuecomment-255857318
+-		{Name(""), rawText, `"foo"`, true}, // Issue6458
+-		{Name(""), &rawText, `"foo"`, true},
+-		{Name(""), []any{rawText}, `["foo"]`, true},  // Issue6458
+-		{Name(""), &[]any{rawText}, `["foo"]`, true}, // Issue6458
+-		{Name(""), []any{&rawText}, `["foo"]`, true},
+-		{Name(""), &[]any{&rawText}, `["foo"]`, true},
+-		{Name(""), struct{ M RawMessage }{rawText}, `{"M":"foo"}`, true}, // Issue6458
+-		{Name(""), &struct{ M RawMessage }{rawText}, `{"M":"foo"}`, true},
+-		{Name(""), struct{ M *RawMessage }{&rawText}, `{"M":"foo"}`, true},
+-		{Name(""), &struct{ M *RawMessage }{&rawText}, `{"M":"foo"}`, true},
+-		{Name(""), map[string]any{"M": rawText}, `{"M":"foo"}`, true},  // Issue6458
+-		{Name(""), &map[string]any{"M": rawText}, `{"M":"foo"}`, true}, // Issue6458
+-		{Name(""), map[string]any{"M": &rawText}, `{"M":"foo"}`, true},
+-		{Name(""), &map[string]any{"M": &rawText}, `{"M":"foo"}`, true},
+-		{Name(""), T1{rawText}, `{"M":"foo"}`, true}, // Issue6458
+-		{Name(""), T2{&rawText}, `{"M":"foo"}`, true},
+-		{Name(""), &T1{rawText}, `{"M":"foo"}`, true},
+-		{Name(""), &T2{&rawText}, `{"M":"foo"}`, true},
+-	}
+-
+-	for _, tt := range tests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			b, err := Marshal(tt.in)
+-			if ok := (err == nil); ok != tt.ok {
+-				if err != nil {
+-					t.Errorf("%s: Marshal error: %v", tt.Where, err)
+-				} else {
+-					t.Errorf("%s: Marshal error: got nil, want non-nil", tt.Where)
+-				}
+-			}
+-			if got := string(b); got != tt.want {
+-				t.Errorf("%s: Marshal:\n\tinput: %#v\n\tgot:  %s\n\twant: %s", tt.Where, tt.in, got, tt.want)
+-			}
+-		})
+-	}
+-}
+-
+-type marshalPanic struct{}
+-
+-func (marshalPanic) MarshalJSON() ([]byte, error) { panic(0xdead) }
+-
+-func TestMarshalPanic(t *testing.T) {
+-	defer func() {
+-		if got := recover(); !reflect.DeepEqual(got, 0xdead) {
+-			t.Errorf("panic() = (%T)(%v), want 0xdead", got, got)
+-		}
+-	}()
+-	Marshal(&marshalPanic{})
+-	t.Error("Marshal should have panicked")
+-}
+-
+-func TestMarshalUncommonFieldNames(t *testing.T) {
+-	v := struct {
+-		A0, À, Aβ int
+-	}{}
+-	b, err := Marshal(v)
+-	if err != nil {
+-		t.Fatal("Marshal error:", err)
+-	}
+-	want := `{"A0":0,"À":0,"Aβ":0}`
+-	got := string(b)
+-	if got != want {
+-		t.Fatalf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
+-	}
+-}
+-
+-func TestMarshalerError(t *testing.T) {
+-	s := "test variable"
+-	st := reflect.TypeOf(s)
+-	const errText = "json: test error"
+-
+-	tests := []struct {
+-		CaseName
+-		err  *MarshalerError
+-		want string
+-	}{{
+-		Name(""),
+-		&MarshalerError{st, fmt.Errorf(errText), ""},
+-		"json: error calling MarshalJSON for type " + st.String() + ": " + errText,
+-	}, {
+-		Name(""),
+-		&MarshalerError{st, fmt.Errorf(errText), "TestMarshalerError"},
+-		"json: error calling TestMarshalerError for type " + st.String() + ": " + errText,
+-	}}
+-
+-	for _, tt := range tests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			got := tt.err.Error()
+-			if got != tt.want {
+-				t.Errorf("%s: Error:\n\tgot:  %s\n\twant: %s", tt.Where, got, tt.want)
+-			}
+-		})
+-	}
+-}
+-
+-type marshaledValue string
+-
+-func (v marshaledValue) MarshalJSON() ([]byte, error) {
+-	return []byte(v), nil
+-}
+-
+-func TestIssue63379(t *testing.T) {
+-	for _, v := range []string{
+-		"[]<",
+-		"[]>",
+-		"[]&",
+-		"[]\u2028",
+-		"[]\u2029",
+-		"{}<",
+-		"{}>",
+-		"{}&",
+-		"{}\u2028",
+-		"{}\u2029",
+-	} {
+-		_, err := Marshal(marshaledValue(v))
+-		if err == nil {
+-			t.Errorf("expected error for %q", v)
+-		}
+-	}
+-}
+diff --git a/pkg/internal/third_party/go-json-experiment/json/v1/example_marshaling_test.go b/pkg/internal/third_party/go-json-experiment/json/v1/example_marshaling_test.go
+deleted file mode 100644
+index 0e23878a6..000000000
+--- a/pkg/internal/third_party/go-json-experiment/json/v1/example_marshaling_test.go
++++ /dev/null
+@@ -1,76 +0,0 @@
+-// Copyright 2016 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+-package json_test
+-
+-import (
+-	"fmt"
+-	"log"
+-	"strings"
+-
+-	"k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json/v1"
+-)
+-
+-type Animal int
+-
+-const (
+-	Unknown Animal = iota
+-	Gopher
+-	Zebra
+-)
+-
+-func (a *Animal) UnmarshalJSON(b []byte) error {
+-	var s string
+-	if err := json.Unmarshal(b, &s); err != nil {
+-		return err
+-	}
+-	switch strings.ToLower(s) {
+-	default:
+-		*a = Unknown
+-	case "gopher":
+-		*a = Gopher
+-	case "zebra":
+-		*a = Zebra
+-	}
+-
+-	return nil
+-}
+-
+-func (a Animal) MarshalJSON() ([]byte, error) {
+-	var s string
+-	switch a {
+-	default:
+-		s = "unknown"
+-	case Gopher:
+-		s = "gopher"
+-	case Zebra:
+-		s = "zebra"
+-	}
+-
+-	return json.Marshal(s)
+-}
+-
+-func Example_customMarshalJSON() {
+-	blob := `["gopher","armadillo","zebra","unknown","gopher","bee","gopher","zebra"]`
+-	var zoo []Animal
+-	if err := json.Unmarshal([]byte(blob), &zoo); err != nil {
+-		log.Fatal(err)
+-	}
+-
+-	census := make(map[Animal]int)
+-	for _, animal := range zoo {
+-		census[animal] += 1
+-	}
+-
+-	fmt.Printf("Zoo Census:\n* Gophers: %d\n* Zebras:  %d\n* Unknown: %d\n",
+-		census[Gopher], census[Zebra], census[Unknown])
+-
+-	// Output:
+-	// Zoo Census:
+-	// * Gophers: 3
+-	// * Zebras:  2
+-	// * Unknown: 3
+-}
+diff --git a/pkg/internal/third_party/go-json-experiment/json/v1/example_test.go b/pkg/internal/third_party/go-json-experiment/json/v1/example_test.go
+deleted file mode 100644
+index 4567adfd4..000000000
+--- a/pkg/internal/third_party/go-json-experiment/json/v1/example_test.go
++++ /dev/null
+@@ -1,313 +0,0 @@
+-// Copyright 2011 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+-package json_test
+-
+-import (
+-	"bytes"
+-	"fmt"
+-	"io"
+-	"log"
+-	"os"
+-	"strings"
+-
+-	"k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json/v1"
+-)
+-
+-func ExampleMarshal() {
+-	type ColorGroup struct {
+-		ID     int
+-		Name   string
+-		Colors []string
+-	}
+-	group := ColorGroup{
+-		ID:     1,
+-		Name:   "Reds",
+-		Colors: []string{"Crimson", "Red", "Ruby", "Maroon"},
+-	}
+-	b, err := json.Marshal(group)
+-	if err != nil {
+-		fmt.Println("error:", err)
+-	}
+-	os.Stdout.Write(b)
+-	// Output:
+-	// {"ID":1,"Name":"Reds","Colors":["Crimson","Red","Ruby","Maroon"]}
+-}
+-
+-func ExampleUnmarshal() {
+-	var jsonBlob = []byte(`[
+-	{"Name": "Platypus", "Order": "Monotremata"},
+-	{"Name": "Quoll",    "Order": "Dasyuromorphia"}
+-]`)
+-	type Animal struct {
+-		Name  string
+-		Order string
+-	}
+-	var animals []Animal
+-	err := json.Unmarshal(jsonBlob, &animals)
+-	if err != nil {
+-		fmt.Println("error:", err)
+-	}
+-	fmt.Printf("%+v", animals)
+-	// Output:
+-	// [{Name:Platypus Order:Monotremata} {Name:Quoll Order:Dasyuromorphia}]
+-}
+-
+-// This example uses a Decoder to decode a stream of distinct JSON values.
+-func ExampleDecoder() {
+-	const jsonStream = `
+-	{"Name": "Ed", "Text": "Knock knock."}
+-	{"Name": "Sam", "Text": "Who's there?"}
+-	{"Name": "Ed", "Text": "Go fmt."}
+-	{"Name": "Sam", "Text": "Go fmt who?"}
+-	{"Name": "Ed", "Text": "Go fmt yourself!"}
+-`
+-	type Message struct {
+-		Name, Text string
+-	}
+-	dec := json.NewDecoder(strings.NewReader(jsonStream))
+-	for {
+-		var m Message
+-		if err := dec.Decode(&m); err == io.EOF {
+-			break
+-		} else if err != nil {
+-			log.Fatal(err)
+-		}
+-		fmt.Printf("%s: %s\n", m.Name, m.Text)
+-	}
+-	// Output:
+-	// Ed: Knock knock.
+-	// Sam: Who's there?
+-	// Ed: Go fmt.
+-	// Sam: Go fmt who?
+-	// Ed: Go fmt yourself!
+-}
+-
+-// This example uses a Decoder to decode a stream of distinct JSON values.
+-func ExampleDecoder_Token() {
+-	const jsonStream = `
+-	{"Message": "Hello", "Array": [1, 2, 3], "Null": null, "Number": 1.234}
+-`
+-	dec := json.NewDecoder(strings.NewReader(jsonStream))
+-	for {
+-		t, err := dec.Token()
+-		if err == io.EOF {
+-			break
+-		}
+-		if err != nil {
+-			log.Fatal(err)
+-		}
+-		fmt.Printf("%T: %v", t, t)
+-		if dec.More() {
+-			fmt.Printf(" (more)")
+-		}
+-		fmt.Printf("\n")
+-	}
+-	// Output:
+-	// json.Delim: { (more)
+-	// string: Message (more)
+-	// string: Hello (more)
+-	// string: Array (more)
+-	// json.Delim: [ (more)
+-	// float64: 1 (more)
+-	// float64: 2 (more)
+-	// float64: 3
+-	// json.Delim: ] (more)
+-	// string: Null (more)
+-	// <nil>: <nil> (more)
+-	// string: Number (more)
+-	// float64: 1.234
+-	// json.Delim: }
+-}
+-
+-// This example uses a Decoder to decode a streaming array of JSON objects.
+-func ExampleDecoder_Decode_stream() {
+-	const jsonStream = `
+-	[
+-		{"Name": "Ed", "Text": "Knock knock."},
+-		{"Name": "Sam", "Text": "Who's there?"},
+-		{"Name": "Ed", "Text": "Go fmt."},
+-		{"Name": "Sam", "Text": "Go fmt who?"},
+-		{"Name": "Ed", "Text": "Go fmt yourself!"}
+-	]
+-`
+-	type Message struct {
+-		Name, Text string
+-	}
+-	dec := json.NewDecoder(strings.NewReader(jsonStream))
+-
+-	// read open bracket
+-	t, err := dec.Token()
+-	if err != nil {
+-		log.Fatal(err)
+-	}
+-	fmt.Printf("%T: %v\n", t, t)
+-
+-	// while the array contains values
+-	for dec.More() {
+-		var m Message
+-		// decode an array value (Message)
+-		err := dec.Decode(&m)
+-		if err != nil {
+-			log.Fatal(err)
+-		}
+-
+-		fmt.Printf("%v: %v\n", m.Name, m.Text)
+-	}
+-
+-	// read closing bracket
+-	t, err = dec.Token()
+-	if err != nil {
+-		log.Fatal(err)
+-	}
+-	fmt.Printf("%T: %v\n", t, t)
+-
+-	// Output:
+-	// json.Delim: [
+-	// Ed: Knock knock.
+-	// Sam: Who's there?
+-	// Ed: Go fmt.
+-	// Sam: Go fmt who?
+-	// Ed: Go fmt yourself!
+-	// json.Delim: ]
+-}
+-
+-// This example uses RawMessage to delay parsing part of a JSON message.
+-func ExampleRawMessage_unmarshal() {
+-	type Color struct {
+-		Space string
+-		Point json.RawMessage // delay parsing until we know the color space
+-	}
+-	type RGB struct {
+-		R uint8
+-		G uint8
+-		B uint8
+-	}
+-	type YCbCr struct {
+-		Y  uint8
+-		Cb int8
+-		Cr int8
+-	}
+-
+-	var j = []byte(`[
+-	{"Space": "YCbCr", "Point": {"Y": 255, "Cb": 0, "Cr": -10}},
+-	{"Space": "RGB",   "Point": {"R": 98, "G": 218, "B": 255}}
+-]`)
+-	var colors []Color
+-	err := json.Unmarshal(j, &colors)
+-	if err != nil {
+-		log.Fatalln("error:", err)
+-	}
+-
+-	for _, c := range colors {
+-		var dst any
+-		switch c.Space {
+-		case "RGB":
+-			dst = new(RGB)
+-		case "YCbCr":
+-			dst = new(YCbCr)
+-		}
+-		err := json.Unmarshal(c.Point, dst)
+-		if err != nil {
+-			log.Fatalln("error:", err)
+-		}
+-		fmt.Println(c.Space, dst)
+-	}
+-	// Output:
+-	// YCbCr &{255 0 -10}
+-	// RGB &{98 218 255}
+-}
+-
+-// This example uses RawMessage to use a precomputed JSON during marshal.
+-func ExampleRawMessage_marshal() {
+-	h := json.RawMessage(`{"precomputed": true}`)
+-
+-	c := struct {
+-		Header *json.RawMessage `json:"header"`
+-		Body   string           `json:"body"`
+-	}{Header: &h, Body: "Hello Gophers!"}
+-
+-	b, err := json.MarshalIndent(&c, "", "\t")
+-	if err != nil {
+-		fmt.Println("error:", err)
+-	}
+-	os.Stdout.Write(b)
+-
+-	// Output:
+-	// {
+-	// 	"header": {
+-	// 		"precomputed": true
+-	// 	},
+-	// 	"body": "Hello Gophers!"
+-	// }
+-}
+-
+-func ExampleIndent() {
+-	type Road struct {
+-		Name   string
+-		Number int
+-	}
+-	roads := []Road{
+-		{"Diamond Fork", 29},
+-		{"Sheep Creek", 51},
+-	}
+-
+-	b, err := json.Marshal(roads)
+-	if err != nil {
+-		log.Fatal(err)
+-	}
+-
+-	var out bytes.Buffer
+-	json.Indent(&out, b, "=", "\t")
+-	out.WriteTo(os.Stdout)
+-	// Output:
+-	// [
+-	// =	{
+-	// =		"Name": "Diamond Fork",
+-	// =		"Number": 29
+-	// =	},
+-	// =	{
+-	// =		"Name": "Sheep Creek",
+-	// =		"Number": 51
+-	// =	}
+-	// =]
+-}
+-
+-func ExampleMarshalIndent() {
+-	data := map[string]int{
+-		"a": 1,
+-		"b": 2,
+-	}
+-
+-	b, err := json.MarshalIndent(data, "<prefix>", "<indent>")
+-	if err != nil {
+-		log.Fatal(err)
+-	}
+-
+-	fmt.Println(string(b))
+-	// Output:
+-	// {
+-	// <prefix><indent>"a": 1,
+-	// <prefix><indent>"b": 2
+-	// <prefix>}
+-}
+-
+-func ExampleValid() {
+-	goodJSON := `{"example": 1}`
+-	badJSON := `{"example":2:]}}`
+-
+-	fmt.Println(json.Valid([]byte(goodJSON)), json.Valid([]byte(badJSON)))
+-	// Output:
+-	// true false
+-}
+-
+-func ExampleHTMLEscape() {
+-	var out bytes.Buffer
+-	json.HTMLEscape(&out, []byte(`{"Name":"<b>HTML content</b>"}`))
+-	out.WriteTo(os.Stdout)
+-	// Output:
+-	//{"Name":"\u003cb\u003eHTML content\u003c/b\u003e"}
+-}
+diff --git a/pkg/internal/third_party/go-json-experiment/json/v1/example_text_marshaling_test.go b/pkg/internal/third_party/go-json-experiment/json/v1/example_text_marshaling_test.go
+deleted file mode 100644
+index a7a153946..000000000
+--- a/pkg/internal/third_party/go-json-experiment/json/v1/example_text_marshaling_test.go
++++ /dev/null
+@@ -1,70 +0,0 @@
+-// Copyright 2018 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+-package json_test
+-
+-import (
+-	"fmt"
+-	"log"
+-	"strings"
+-
+-	"k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json/v1"
+-)
+-
+-type Size int
+-
+-const (
+-	Unrecognized Size = iota
+-	Small
+-	Large
+-)
+-
+-func (s *Size) UnmarshalText(text []byte) error {
+-	switch strings.ToLower(string(text)) {
+-	default:
+-		*s = Unrecognized
+-	case "small":
+-		*s = Small
+-	case "large":
+-		*s = Large
+-	}
+-	return nil
+-}
+-
+-func (s Size) MarshalText() ([]byte, error) {
+-	var name string
+-	switch s {
+-	default:
+-		name = "unrecognized"
+-	case Small:
+-		name = "small"
+-	case Large:
+-		name = "large"
+-	}
+-	return []byte(name), nil
+-}
+-
+-func Example_textMarshalJSON() {
+-	blob := `["small","regular","large","unrecognized","small","normal","small","large"]`
+-	var inventory []Size
+-	if err := json.Unmarshal([]byte(blob), &inventory); err != nil {
+-		log.Fatal(err)
+-	}
+-
+-	counts := make(map[Size]int)
+-	for _, size := range inventory {
+-		counts[size] += 1
+-	}
+-
+-	fmt.Printf("Inventory Counts:\n* Small:        %d\n* Large:        %d\n* Unrecognized: %d\n",
+-		counts[Small], counts[Large], counts[Unrecognized])
+-
+-	// Output:
+-	// Inventory Counts:
+-	// * Small:        3
+-	// * Large:        2
+-	// * Unrecognized: 3
+-}
+diff --git a/pkg/internal/third_party/go-json-experiment/json/v1/fuzz_test.go b/pkg/internal/third_party/go-json-experiment/json/v1/fuzz_test.go
+deleted file mode 100644
+index 2e0c93837..000000000
+--- a/pkg/internal/third_party/go-json-experiment/json/v1/fuzz_test.go
++++ /dev/null
+@@ -1,85 +0,0 @@
+-// Copyright 2021 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+-package json
+-
+-import (
+-	"bytes"
+-	"io"
+-	"testing"
+-)
+-
+-func FuzzUnmarshalJSON(f *testing.F) {
+-	f.Add([]byte(`{
+-"object": {
+-	"slice": [
+-		1,
+-		2.0,
+-		"3",
+-		[4],
+-		{5: {}}
+-	]
+-},
+-"slice": [[]],
+-"string": ":)",
+-"int": 1e5,
+-"float": 3e-9"
+-}`))
+-
+-	f.Fuzz(func(t *testing.T, b []byte) {
+-		for _, typ := range []func() any{
+-			func() any { return new(any) },
+-			func() any { return new(map[string]any) },
+-			func() any { return new([]any) },
+-		} {
+-			i := typ()
+-			if err := Unmarshal(b, i); err != nil {
+-				return
+-			}
+-
+-			encoded, err := Marshal(i)
+-			if err != nil {
+-				t.Fatalf("failed to marshal: %s", err)
+-			}
+-
+-			if err := Unmarshal(encoded, i); err != nil {
+-				t.Fatalf("failed to roundtrip: %s", err)
+-			}
+-		}
+-	})
+-}
+-
+-func FuzzDecoderToken(f *testing.F) {
+-	f.Add([]byte(`{
+-"object": {
+-	"slice": [
+-		1,
+-		2.0,
+-		"3",
+-		[4],
+-		{5: {}}
+-	]
+-},
+-"slice": [[]],
+-"string": ":)",
+-"int": 1e5,
+-"float": 3e-9"
+-}`))
+-
+-	f.Fuzz(func(t *testing.T, b []byte) {
+-		r := bytes.NewReader(b)
+-		d := NewDecoder(r)
+-		for {
+-			_, err := d.Token()
+-			if err != nil {
+-				if err == io.EOF {
+-					break
+-				}
+-				return
+-			}
+-		}
+-	})
+-}
+diff --git a/pkg/internal/third_party/go-json-experiment/json/v1/indent.go b/pkg/internal/third_party/go-json-experiment/json/v1/indent.go
+deleted file mode 100644
+index 19d90b9ea..000000000
+--- a/pkg/internal/third_party/go-json-experiment/json/v1/indent.go
++++ /dev/null
+@@ -1,129 +0,0 @@
+-// Copyright 2010 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+-package json
+-
+-import (
+-	"bytes"
+-	"strings"
+-
+-	"k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json/jsontext"
+-)
+-
+-// HTMLEscape appends to dst the JSON-encoded src with <, >, &, U+2028 and U+2029
+-// characters inside string literals changed to \u003c, \u003e, \u0026, \u2028, \u2029
+-// so that the JSON will be safe to embed inside HTML <script> tags.
+-// For historical reasons, web browsers don't honor standard HTML
+-// escaping within <script> tags, so an alternative JSON encoding must be used.
+-func HTMLEscape(dst *bytes.Buffer, src []byte) {
+-	dst.Grow(len(src))
+-	dst.Write(appendHTMLEscape(dst.AvailableBuffer(), src))
+-}
+-
+-func appendHTMLEscape(dst, src []byte) []byte {
+-	const hex = "0123456789abcdef"
+-	// The characters can only appear in string literals,
+-	// so just scan the string one byte at a time.
+-	start := 0
+-	for i, c := range src {
+-		if c == '<' || c == '>' || c == '&' {
+-			dst = append(dst, src[start:i]...)
+-			dst = append(dst, '\\', 'u', '0', '0', hex[c>>4], hex[c&0xF])
+-			start = i + 1
+-		}
+-		// Convert U+2028 and U+2029 (E2 80 A8 and E2 80 A9).
+-		if c == 0xE2 && i+2 < len(src) && src[i+1] == 0x80 && src[i+2]&^1 == 0xA8 {
+-			dst = append(dst, src[start:i]...)
+-			dst = append(dst, '\\', 'u', '2', '0', '2', hex[src[i+2]&0xF])
+-			start = i + len("\u2029")
+-		}
+-	}
+-	return append(dst, src[start:]...)
+-}
+-
+-// Compact appends to dst the JSON-encoded src with
+-// insignificant space characters elided.
+-func Compact(dst *bytes.Buffer, src []byte) error {
+-	dst.Grow(len(src))
+-	b := dst.AvailableBuffer()
+-	b, err := jsontext.AppendFormat(b, src,
+-		jsontext.AllowDuplicateNames(true),
+-		jsontext.AllowInvalidUTF8(true),
+-		jsontext.PreserveRawStrings(true))
+-	if err != nil {
+-		return transformSyntacticError(err)
+-	}
+-	dst.Write(b)
+-	return nil
+-}
+-
+-// indentGrowthFactor specifies the growth factor of indenting JSON input.
+-// Empirically, the growth factor was measured to be between 1.4x to 1.8x
+-// for some set of compacted JSON with the indent being a single tab.
+-// Specify a growth factor slightly larger than what is observed
+-// to reduce probability of allocation in appendIndent.
+-// A factor no higher than 2 ensures that wasted space never exceeds 50%.
+-const indentGrowthFactor = 2
+-
+-// Indent appends to dst an indented form of the JSON-encoded src.
+-// Each element in a JSON object or array begins on a new,
+-// indented line beginning with prefix followed by one or more
+-// copies of indent according to the indentation nesting.
+-// The data appended to dst does not begin with the prefix nor
+-// any indentation, to make it easier to embed inside other formatted JSON data.
+-// Although leading space characters (space, tab, carriage return, newline)
+-// at the beginning of src are dropped, trailing space characters
+-// at the end of src are preserved and copied to dst.
+-// For example, if src has no trailing spaces, neither will dst;
+-// if src ends in a trailing newline, so will dst.
+-func Indent(dst *bytes.Buffer, src []byte, prefix, indent string) error {
+-	dst.Grow(indentGrowthFactor * len(src))
+-	b := dst.AvailableBuffer()
+-	b, err := appendIndent(b, src, prefix, indent)
+-	dst.Write(b)
+-	return err
+-}
+-
+-func appendIndent(dst, src []byte, prefix, indent string) ([]byte, error) {
+-	// In v2, only spaces and tabs are allowed, while v1 allowed any character.
+-	dstLen := len(dst)
+-	if len(strings.Trim(prefix, " \t"))+len(strings.Trim(indent, " \t")) > 0 {
+-		// Use placeholder spaces of correct length, and replace afterwards.
+-		invalidPrefix, invalidIndent := prefix, indent
+-		prefix = strings.Repeat(" ", len(prefix))
+-		indent = strings.Repeat(" ", len(indent))
+-		defer func() {
+-			b := dst[dstLen:]
+-			for i := bytes.IndexByte(b, '\n'); i >= 0; i = bytes.IndexByte(b, '\n') {
+-				b = b[i+len("\n"):]
+-				n := len(b) - len(bytes.TrimLeft(b, " ")) // len(prefix)+n*len(indent)
+-				spaces := b[:n]
+-				spaces = spaces[copy(spaces, invalidPrefix):]
+-				for len(spaces) > 0 {
+-					spaces = spaces[copy(spaces, invalidIndent):]
+-				}
+-				b = b[n:]
+-			}
+-		}()
+-	}
+-
+-	dst, err := jsontext.AppendFormat(dst, src,
+-		jsontext.AllowDuplicateNames(true),
+-		jsontext.AllowInvalidUTF8(true),
+-		jsontext.PreserveRawStrings(true),
+-		jsontext.Multiline(true),
+-		jsontext.WithIndentPrefix(prefix),
+-		jsontext.WithIndent(indent))
+-	if err != nil {
+-		return dst[:dstLen], transformSyntacticError(err)
+-	}
+-
+-	// In v2, trailing whitespace is discarded, while v1 preserved it.
+-	if n := len(src) - len(bytes.TrimRight(src, " \n\r\t")); n > 0 {
+-		dst = append(dst, src[len(src)-n:]...)
+-	}
+-	return dst, nil
+-}
+diff --git a/pkg/internal/third_party/go-json-experiment/json/v1/inject.go b/pkg/internal/third_party/go-json-experiment/json/v1/inject.go
+deleted file mode 100644
+index bd780c803..000000000
+--- a/pkg/internal/third_party/go-json-experiment/json/v1/inject.go
++++ /dev/null
+@@ -1,156 +0,0 @@
+-// Copyright 2024 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+-package json
+-
+-import (
+-	"fmt"
+-	"reflect"
+-	"strconv"
+-	"strings"
+-
+-	jsonv2 "k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json"
+-	"k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json/internal"
+-	"k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json/jsontext"
+-)
+-
+-// Inject functionality into v2 to properly handle v1 types.
+-func init() {
+-	internal.TransformMarshalError = transformMarshalError
+-	internal.TransformUnmarshalError = transformUnmarshalError
+-	internal.NewMarshalerError = func(val any, err error, funcName string) error {
+-		return &MarshalerError{reflect.TypeOf(val), err, funcName}
+-	}
+-
+-	internal.NewRawNumber = func() any { return new(Number) }
+-	internal.RawNumberOf = func(b []byte) any { return Number(b) }
+-}
+-
+-func transformMarshalError(root any, err error) error {
+-	// Historically, errors returned from Marshal methods were wrapped
+-	// in a [MarshalerError]. This is directly performed by the v2 package
+-	// via the injected [internal.NewMarshalerError] constructor
+-	// while operating under [ReportErrorsWithLegacySemantics].
+-	// Note that errors from a Marshal method were always wrapped,
+-	// even if wrapped for multiple layers.
+-	if err, ok := err.(*jsonv2.SemanticError); err != nil {
+-		if err.Err == nil {
+-			// Historically, this was only reported for unserializable types
+-			// like complex numbers, channels, functions, and unsafe.Pointers.
+-			return &UnsupportedTypeError{Type: err.GoType}
+-		} else {
+-			// Historically, this was only reported for NaN or ±Inf values
+-			// and cycles detected in the value.
+-			// The Val used to be populated with the reflect.Value,
+-			// but this is no longer supported.
+-			errStr := err.Err.Error()
+-			if err.Err == internal.ErrCycle && err.GoType != nil {
+-				errStr += " via " + err.GoType.String()
+-			}
+-			errStr = strings.TrimPrefix(errStr, "unsupported value: ")
+-			return &UnsupportedValueError{Str: errStr}
+-		}
+-	} else if ok {
+-		return (*UnsupportedValueError)(nil)
+-	}
+-	if err, _ := err.(*MarshalerError); err != nil {
+-		err.Err = transformSyntacticError(err.Err)
+-		return err
+-	}
+-	return transformSyntacticError(err)
+-}
+-
+-func transformUnmarshalError(root any, err error) error {
+-	// Historically, errors from Unmarshal methods were never wrapped and
+-	// returned verbatim while operating under [ReportErrorsWithLegacySemantics].
+-	if err, ok := err.(*jsonv2.SemanticError); err != nil {
+-		if err.Err == internal.ErrNonNilReference {
+-			return &InvalidUnmarshalError{err.GoType}
+-		}
+-		if err.Err == jsonv2.ErrUnknownName {
+-			return fmt.Errorf("json: unknown field %q", err.JSONPointer.LastToken())
+-		}
+-		if err.Err == internal.ErrNilInterface {
+-			err.Err = nil // non-descriptive for historical reasons
+-		}
+-
+-		// Historically, UnmarshalTypeError has always been inconsistent
+-		// about how it reported position information.
+-		//
+-		// The Struct field now points to the root type,
+-		// rather than some intermediate struct in the path.
+-		// This better matches the original intent of the field based
+-		// on how the Error message was formatted.
+-		//
+-		// For a representation closer to the historical representation,
+-		// we switch the '/'-delimited representation of a JSON pointer
+-		// to use a '.'-delimited representation. This may be ambiguous,
+-		// but the prior representation was always ambiguous as well.
+-		// Users that care about precise positions should use v2 errors
+-		// by disabling [ReportErrorsWithLegacySemantics].
+-		//
+-		// The introduction of a Err field is new to the v1-to-v2 migration
+-		// and allows us to preserve stronger error information
+-		// that may be surfaced by the v2 package.
+-		//
+-		// See https://go.dev/issue/43126
+-		var value string
+-		switch err.JSONKind {
+-		case 'n', '"', '0':
+-			value = err.JSONKind.String()
+-		case 'f', 't':
+-			value = "bool"
+-		case '[', ']':
+-			value = "array"
+-		case '{', '}':
+-			value = "object"
+-		}
+-		if len(err.JSONValue) > 0 {
+-			isStrconvError := err.Err == strconv.ErrRange || err.Err == strconv.ErrSyntax
+-			isNumericKind := func(t reflect.Type) bool {
+-				if t == nil {
+-					return false
+-				}
+-				switch t.Kind() {
+-				case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+-					reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+-					reflect.Float32, reflect.Float64:
+-					return true
+-				}
+-				return false
+-			}
+-			if isStrconvError && isNumericKind(err.GoType) {
+-				value = "number"
+-				if err.JSONKind == '"' {
+-					err.JSONValue, _ = jsontext.AppendUnquote(nil, err.JSONValue)
+-				}
+-				err.Err = nil
+-			}
+-			value += " " + string(err.JSONValue)
+-		}
+-		var rootName string
+-		if t := reflect.TypeOf(root); t != nil && err.JSONPointer != "" {
+-			if t.Kind() == reflect.Pointer {
+-				t = t.Elem()
+-			}
+-			rootName = t.Name()
+-		}
+-		fieldPath := string(err.JSONPointer)
+-		fieldPath = strings.TrimPrefix(fieldPath, "/")
+-		fieldPath = strings.ReplaceAll(fieldPath, "/", ".")
+-		return &UnmarshalTypeError{
+-			Value:  value,
+-			Type:   err.GoType,
+-			Offset: err.ByteOffset,
+-			Struct: rootName,
+-			Field:  fieldPath,
+-			Err:    transformSyntacticError(err.Err),
+-		}
+-	} else if ok {
+-		return (*UnmarshalTypeError)(nil)
+-	}
+-	return transformSyntacticError(err)
+-}
+diff --git a/pkg/internal/third_party/go-json-experiment/json/v1/options.go b/pkg/internal/third_party/go-json-experiment/json/v1/options.go
+deleted file mode 100644
+index fa10afd91..000000000
+--- a/pkg/internal/third_party/go-json-experiment/json/v1/options.go
++++ /dev/null
+@@ -1,546 +0,0 @@
+-// Copyright 2023 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+-// Migrating to v2
+-//
+-// This package (i.e., [encoding/json]) is now formally known as the v1 package
+-// since a v2 package now exists at [encoding/json/v2].
+-// All the behavior of the v1 package is implemented in terms of
+-// the v2 package with the appropriate set of options specified that
+-// preserve the historical behavior of v1.
+-//
+-// The [jsonv2.Marshal] function is the newer equivalent of v1 [Marshal].
+-// The [jsonv2.Unmarshal] function is the newer equivalent of v1 [Unmarshal].
+-// The v2 functions have the same calling signature as the v1 equivalent
+-// except that they take in variadic [Options] arguments that can be specified
+-// to alter the behavior of marshal or unmarshal. Both v1 and v2 generally
+-// behave in similar ways, but there are some notable differences.
+-//
+-// The following is a list of differences between v1 and v2:
+-//
+-//   - In v1, JSON object members are unmarshaled into a Go struct using a
+-//     case-insensitive name match with the JSON name of the fields.
+-//     In contrast, v2 matches fields using an exact, case-sensitive match.
+-//     The [jsonv2.MatchCaseInsensitiveNames] and [MatchCaseSensitiveDelimiter]
+-//     options control this behavior difference. To explicitly specify a Go struct
+-//     field to use a particular name matching scheme, either the `case:ignore`
+-//     or the `case:strict` field option can be specified.
+-//     Field-specified options take precedence over caller-specified options.
+-//
+-//   - In v1, when marshaling a Go struct, a field marked as `omitempty`
+-//     is omitted if the field value is an "empty" Go value, which is defined as
+-//     false, 0, a nil pointer, a nil interface value, and
+-//     any empty array, slice, map, or string. In contrast, v2 redefines
+-//     `omitempty` to omit a field if it encodes as an "empty" JSON value,
+-//     which is defined as a JSON null, or an empty JSON string, object, or array.
+-//     The [OmitEmptyWithLegacySemantics] option controls this behavior difference.
+-//     Note that `omitempty` behaves identically in both v1 and v2 for a
+-//     Go array, slice, map, or string (assuming no user-defined MarshalJSON method
+-//     overrides the default representation). Existing usages of `omitempty` on a
+-//     Go bool, number, pointer, or interface value should migrate to specifying
+-//     `omitzero` instead (which is identically supported in both v1 and v2).
+-//
+-//   - In v1, a Go struct field marked as `string` can be used to quote a
+-//     Go string, bool, or number as a JSON string. It does not recursively
+-//     take effect on composite Go types. In contrast, v2 restricts
+-//     the `string` option to only quote a Go number as a JSON string.
+-//     It does recursively take effect on Go numbers within a composite Go type.
+-//     The [StringifyWithLegacySemantics] option controls this behavior difference.
+-//
+-//   - In v1, a nil Go slice or Go map is marshaled as a JSON null.
+-//     In contrast, v2 marshals a nil Go slice or Go map as
+-//     an empty JSON array or JSON object, respectively.
+-//     The [jsonv2.FormatNilSliceAsNull] and [jsonv2.FormatNilMapAsNull] options
+-//     control this behavior difference. To explicitly specify a Go struct field
+-//     to use a particular representation for nil, either the `format:emitempty`
+-//     or `format:emitnull` field option can be specified.
+-//     Field-specified options take precedence over caller-specified options.
+-//
+-//   - In v1, a Go array may be unmarshaled from a JSON array of any length.
+-//     In contrast, in v2 a Go array must be unmarshaled from a JSON array
+-//     of the same length, otherwise it results in an error.
+-//     The [UnmarshalArrayFromAnyLength] option controls this behavior difference.
+-//
+-//   - In v1, a Go byte array is represented as a JSON array of JSON numbers.
+-//     In contrast, in v2 a Go byte array is represented as a Base64-encoded JSON string.
+-//     The [FormatByteArrayAsArray] option controls this behavior difference.
+-//     To explicitly specify a Go struct field to use a particular representation,
+-//     either the `format:array` or `format:base64` field option can be specified.
+-//     Field-specified options take precedence over caller-specified options.
+-//
+-//   - In v1, MarshalJSON methods declared on a pointer receiver are only called
+-//     if the Go value is addressable. In contrast, in v2 a MarshalJSON method
+-//     is always callable regardless of addressability.
+-//     The [CallMethodsWithLegacySemantics] option controls this behavior difference.
+-//
+-//   - In v1, MarshalJSON and UnmarshalJSON methods are never called for Go map keys.
+-//     In contrast, in v2 a MarshalJSON or UnmarshalJSON method is eligible for
+-//     being called for Go map keys.
+-//     The [CallMethodsWithLegacySemantics] option controls this behavior difference.
+-//
+-//   - In v1, a Go map is marshaled in a deterministic order.
+-//     In contrast, in v2 a Go map is marshaled in a non-deterministic order.
+-//     The [jsonv2.Deterministic] option controls this behavior difference.
+-//
+-//   - In v1, JSON strings are encoded with HTML-specific or JavaScript-specific
+-//     characters being escaped. In contrast, in v2 JSON strings use the minimal
+-//     encoding and only escape if required by the JSON grammar.
+-//     The [jsontext.EscapeForHTML] and [jsontext.EscapeForJS] options
+-//     control this behavior difference.
+-//
+-//   - In v1, bytes of invalid UTF-8 within a string are silently replaced with
+-//     the Unicode replacement character. In contrast, in v2 the presence of
+-//     invalid UTF-8 results in an error. The [jsontext.AllowInvalidUTF8] option
+-//     controls this behavior difference.
+-//
+-//   - In v1, a JSON object with duplicate names is permitted.
+-//     In contrast, in v2 a JSON object with duplicate names results in an error.
+-//     The [jsontext.AllowDuplicateNames] option controls this behavior difference.
+-//
+-//   - In v1, when unmarshaling a JSON null into a non-empty Go value it will
+-//     inconsistently either zero out the value or do nothing.
+-//     In contrast, in v2 unmarshaling a JSON null will consistently and always
+-//     zero out the underlying Go value. The [MergeWithLegacySemantics] option
+-//     controls this behavior difference.
+-//
+-//   - In v1, when unmarshaling a JSON value into a non-zero Go value,
+-//     it merges into the original Go value for array elements, slice elements,
+-//     struct fields (but not map values),
+-//     pointer values, and interface values (only if a non-nil pointer).
+-//     In contrast, in v2 unmarshal merges into the Go value
+-//     for struct fields, map values, pointer values, and interface values.
+-//     In general, the v2 semantic merges when unmarshaling a JSON object,
+-//     otherwise it replaces the value. The [MergeWithLegacySemantics] option
+-//     controls this behavior difference.
+-//
+-//   - In v1, a [time.Duration] is represented as a JSON number containing
+-//     the decimal number of nanoseconds. In contrast, in v2 a [time.Duration]
+-//     has no default representation and results in a runtime error.
+-//     The [FormatDurationAsNano] option controls this behavior difference.
+-//     To explicitly specify a Go struct field to use a particular representation,
+-//     either the `format:nano` or `format:units` field option can be specified.
+-//     Field-specified options take precedence over caller-specified options.
+-//
+-//   - In v1, errors are never reported at runtime for Go struct types
+-//     that have some form of structural error (e.g., a malformed tag option).
+-//     In contrast, v2 reports a runtime error for Go types that are invalid
+-//     as they relate to JSON serialization. For example, a Go struct
+-//     with only unexported fields cannot be serialized.
+-//     The [ReportErrorsWithLegacySemantics] option controls this behavior difference.
+-//
+-// As mentioned, the entirety of v1 is implemented in terms of v2,
+-// where options are implicitly specified to opt into legacy behavior.
+-// For example, [Marshal] directly calls [jsonv2.Marshal] with [DefaultOptionsV1].
+-// Similarly, [Unmarshal] directly calls [jsonv2.Unmarshal] with [DefaultOptionsV1].
+-// The [DefaultOptionsV1] option represents the set of all options that specify
+-// default v1 behavior.
+-//
+-// For many of the behavior differences, there are Go struct field options
+-// that the author of a Go type can specify to control the behavior such that
+-// the type is represented identically in JSON under either v1 or v2 semantics.
+-//
+-// The availability of [DefaultOptionsV1] and [jsonv2.DefaultOptionsV2],
+-// where later options take precedence over former options allows for
+-// a gradual migration from v1 to v2. For example:
+-//
+-//   - jsonv1.Marshal(v)
+-//     uses default v1 semantics.
+-//
+-//   - jsonv2.Marshal(v, jsonv1.DefaultOptionsV1())
+-//     is semantically equivalent to jsonv1.Marshal
+-//     and thus uses default v1 semantics.
+-//
+-//   - jsonv2.Marshal(v, jsonv1.DefaultOptionsV1(), jsontext.AllowDuplicateNames(false))
+-//     uses mostly v1 semantics, but opts into one particular v2-specific behavior.
+-//
+-//   - jsonv2.Marshal(v, jsonv1.CallMethodsWithLegacySemantics(true))
+-//     uses mostly v2 semantics, but opts into one particular v1-specific behavior.
+-//
+-//   - jsonv2.Marshal(v, ..., jsonv2.DefaultOptionsV2())
+-//     is semantically equivalent to jsonv2.Marshal since
+-//     jsonv2.DefaultOptionsV2 overrides any options specified earlier
+-//     and thus uses default v2 semantics.
+-//
+-//   - jsonv2.Marshal(v)
+-//     uses default v2 semantics.
+-//
+-// All new usages of "json" in Go should use the v2 package,
+-// but the v1 package will forever remain supported.
+-package json
+-
+-// TODO(https://go.dev/issue/71631): Update the "Migrating to v2" documentation
+-// with default v2 behavior for [time.Duration].
+-
+-import (
+-	"encoding"
+-
+-	jsonv2 "k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json"
+-	"k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json/internal/jsonflags"
+-	"k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json/internal/jsonopts"
+-	"k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json/jsontext"
+-)
+-
+-// Reference encoding, jsonv2, and jsontext packages to assist pkgsite
+-// in being able to hotlink references to those packages.
+-var (
+-	_ encoding.TextMarshaler
+-	_ encoding.TextUnmarshaler
+-	_ jsonv2.Options
+-	_ jsontext.Options
+-)
+-
+-// Options are a set of options to configure the v2 "json" package
+-// to operate with v1 semantics for particular features.
+-// Values of this type can be passed to v2 functions like
+-// [jsonv2.Marshal] or [jsonv2.Unmarshal].
+-// Instead of referencing this type, use [jsonv2.Options].
+-//
+-// See the "Migrating to v2" section for guidance on how to migrate usage
+-// of "json" from using v1 to using v2 instead.
+-type Options = jsonopts.Options
+-
+-// DefaultOptionsV1 is the full set of all options that define v1 semantics.
+-// It is equivalent to the following boolean options being set to true:
+-//
+-//   - [CallMethodsWithLegacySemantics]
+-//   - [FormatByteArrayAsArray]
+-//   - [FormatBytesWithLegacySemantics]
+-//   - [FormatDurationAsNano]
+-//   - [MatchCaseSensitiveDelimiter]
+-//   - [MergeWithLegacySemantics]
+-//   - [OmitEmptyWithLegacySemantics]
+-//   - [ParseBytesWithLooseRFC4648]
+-//   - [ParseTimeWithLooseRFC3339]
+-//   - [ReportErrorsWithLegacySemantics]
+-//   - [StringifyWithLegacySemantics]
+-//   - [UnmarshalArrayFromAnyLength]
+-//   - [jsonv2.Deterministic]
+-//   - [jsonv2.FormatNilMapAsNull]
+-//   - [jsonv2.FormatNilSliceAsNull]
+-//   - [jsonv2.MatchCaseInsensitiveNames]
+-//   - [jsontext.AllowDuplicateNames]
+-//   - [jsontext.AllowInvalidUTF8]
+-//   - [jsontext.EscapeForHTML]
+-//   - [jsontext.EscapeForJS]
+-//   - [jsontext.PreserveRawStrings]
+-//
+-// All other boolean options are set to false.
+-// All non-boolean options are set to the zero value,
+-// except for [jsontext.WithIndent], which defaults to "\t".
+-//
+-// The [Marshal] and [Unmarshal] functions in this package are
+-// semantically identical to calling the v2 equivalents with this option:
+-//
+-//	jsonv2.Marshal(v, jsonv1.DefaultOptionsV1())
+-//	jsonv2.Unmarshal(b, v, jsonv1.DefaultOptionsV1())
+-func DefaultOptionsV1() Options {
+-	return &jsonopts.DefaultOptionsV1
+-}
+-
+-// CallMethodsWithLegacySemantics specifies that calling of type-provided
+-// marshal and unmarshal methods follow legacy semantics:
+-//
+-//   - When marshaling, a marshal method declared on a pointer receiver
+-//     is only called if the Go value is addressable.
+-//     Values obtained from an interface or map element are not addressable.
+-//     Values obtained from a pointer or slice element are addressable.
+-//     Values obtained from an array element or struct field inherit
+-//     the addressability of the parent. In contrast, the v2 semantic
+-//     is to always call marshal methods regardless of addressability.
+-//
+-//   - When marshaling or unmarshaling, the [Marshaler] or [Unmarshaler]
+-//     methods are ignored for map keys. However, [encoding.TextMarshaler]
+-//     or [encoding.TextUnmarshaler] are still callable.
+-//     In contrast, the v2 semantic is to serialize map keys
+-//     like any other value (with regard to calling methods),
+-//     which may include calling [Marshaler] or [Unmarshaler] methods,
+-//     where it is the implementation's responsibility to represent the
+-//     Go value as a JSON string (as required for JSON object names).
+-//
+-//   - When marshaling, if a map key value implements a marshal method
+-//     and is a nil pointer, then it is serialized as an empty JSON string.
+-//     In contrast, the v2 semantic is to report an error.
+-//
+-//   - When marshaling, if an interface type implements a marshal method
+-//     and the interface value is a nil pointer to a concrete type,
+-//     then the marshal method is always called.
+-//     In contrast, the v2 semantic is to never directly call methods
+-//     on interface values and to instead defer evaluation based upon
+-//     the underlying concrete value. Similar to non-interface values,
+-//     marshal methods are not called on nil pointers and
+-//     are instead serialized as a JSON null.
+-//
+-// This affects either marshaling or unmarshaling.
+-// The v1 default is true.
+-func CallMethodsWithLegacySemantics(v bool) Options {
+-	if v {
+-		return jsonflags.CallMethodsWithLegacySemantics | 1
+-	} else {
+-		return jsonflags.CallMethodsWithLegacySemantics | 0
+-	}
+-}
+-
+-// FormatByteArrayAsArray specifies that a Go [N]byte is
+-// formatted as as a normal Go array in contrast to the v2 default of
+-// formatting [N]byte as using binary data encoding (RFC 4648).
+-// If a struct field has a `format` tag option,
+-// then the specified formatting takes precedence.
+-//
+-// This affects either marshaling or unmarshaling.
+-// The v1 default is true.
+-func FormatByteArrayAsArray(v bool) Options {
+-	if v {
+-		return jsonflags.FormatByteArrayAsArray | 1
+-	} else {
+-		return jsonflags.FormatByteArrayAsArray | 0
+-	}
+-}
+-
+-// FormatBytesWithLegacySemantics specifies that handling of
+-// []~byte and [N]~byte types follow legacy semantics:
+-//
+-//   - A Go []~byte is to be treated as using some form of
+-//     binary data encoding (RFC 4648) in contrast to the v2 default
+-//     of only treating []byte as such. In particular, v2 does not
+-//     treat slices of named byte types as representing binary data.
+-//
+-//   - When marshaling, if a named byte implements a marshal method,
+-//     then the slice is serialized as a JSON array of elements,
+-//     each of which call the marshal method.
+-//
+-//   - When unmarshaling, if the input is a JSON array,
+-//     then unmarshal into the []~byte as if it were a normal Go slice.
+-//     In contrast, the v2 default is to report an error unmarshaling
+-//     a JSON array when expecting some form of binary data encoding.
+-//
+-// This affects either marshaling or unmarshaling.
+-// The v1 default is true.
+-func FormatBytesWithLegacySemantics(v bool) Options {
+-	if v {
+-		return jsonflags.FormatBytesWithLegacySemantics | 1
+-	} else {
+-		return jsonflags.FormatBytesWithLegacySemantics | 0
+-	}
+-}
+-
+-// FormatDurationAsNano specifies that a [time.Duration] is
+-// formatted as a JSON number representing the number of nanoseconds
+-// in contrast to the v2 default of reporting an error.
+-// If a duration field has a `format` tag option,
+-// then the specified formatting takes precedence.
+-//
+-// This affects either marshaling or unmarshaling.
+-// The v1 default is true.
+-func FormatDurationAsNano(v bool) Options {
+-	// TODO(https://go.dev/issue/71631): Update documentation with v2 behavior.
+-	if v {
+-		return jsonflags.FormatDurationAsNano | 1
+-	} else {
+-		return jsonflags.FormatDurationAsNano | 0
+-	}
+-}
+-
+-// MatchCaseSensitiveDelimiter specifies that underscores and dashes are
+-// not to be ignored when performing case-insensitive name matching which
+-// occurs under [jsonv2.MatchCaseInsensitiveNames] or the `case:ignore` tag option.
+-// Thus, case-insensitive name matching is identical to [strings.EqualFold].
+-// Use of this option diminishes the ability of case-insensitive matching
+-// to be able to match common case variants (e.g, "foo_bar" with "fooBar").
+-//
+-// This affects either marshaling or unmarshaling.
+-// The v1 default is true.
+-func MatchCaseSensitiveDelimiter(v bool) Options {
+-	if v {
+-		return jsonflags.MatchCaseSensitiveDelimiter | 1
+-	} else {
+-		return jsonflags.MatchCaseSensitiveDelimiter | 0
+-	}
+-}
+-
+-// MergeWithLegacySemantics specifies that unmarshaling into a non-zero
+-// Go value follows legacy semantics:
+-//
+-//   - When unmarshaling a JSON null, this preserves the original Go value
+-//     if the kind is a bool, int, uint, float, string, array, or struct.
+-//     Otherwise, it zeros the Go value.
+-//     In contrast, the default v2 behavior is to consistently and always
+-//     zero the Go value when unmarshaling a JSON null into it.
+-//
+-//   - When unmarshaling a JSON value other than null, this merges into
+-//     the original Go value for array elements, slice elements,
+-//     struct fields (but not map values),
+-//     pointer values, and interface values (only if a non-nil pointer).
+-//     In contrast, the default v2 behavior is to merge into the Go value
+-//     for struct fields, map values, pointer values, and interface values.
+-//     In general, the v2 semantic merges when unmarshaling a JSON object,
+-//     otherwise it replaces the original value.
+-//
+-// This only affects unmarshaling and is ignored when marshaling.
+-// The v1 default is true.
+-func MergeWithLegacySemantics(v bool) Options {
+-	if v {
+-		return jsonflags.MergeWithLegacySemantics | 1
+-	} else {
+-		return jsonflags.MergeWithLegacySemantics | 0
+-	}
+-}
+-
+-// OmitEmptyWithLegacySemantics specifies that the `omitempty` tag option
+-// follows a definition of empty where a field is omitted if the Go value is
+-// false, 0, a nil pointer, a nil interface value,
+-// or any empty array, slice, map, or string.
+-// This overrides the v2 semantic where a field is empty if the value
+-// marshals as a JSON null or an empty JSON string, object, or array.
+-//
+-// The v1 and v2 definitions of `omitempty` are practically the same for
+-// Go strings, slices, arrays, and maps. Usages of `omitempty` on
+-// Go bools, ints, uints floats, pointers, and interfaces should migrate to use
+-// the `omitzero` tag option, which omits a field if it is the zero Go value.
+-//
+-// This only affects marshaling and is ignored when unmarshaling.
+-// The v1 default is true.
+-func OmitEmptyWithLegacySemantics(v bool) Options {
+-	if v {
+-		return jsonflags.OmitEmptyWithLegacySemantics | 1
+-	} else {
+-		return jsonflags.OmitEmptyWithLegacySemantics | 0
+-	}
+-}
+-
+-// ParseBytesWithLooseRFC4648 specifies that when parsing
+-// binary data encoded as "base32" or "base64",
+-// to ignore the presence of '\r' and '\n' characters.
+-// In contrast, the v2 default is to report an error in order to be
+-// strictly compliant with RFC 4648, section 3.3,
+-// which specifies that non-alphabet characters must be rejected.
+-//
+-// This only affects unmarshaling and is ignored when marshaling.
+-// The v1 default is true.
+-func ParseBytesWithLooseRFC4648(v bool) Options {
+-	if v {
+-		return jsonflags.ParseBytesWithLooseRFC4648 | 1
+-	} else {
+-		return jsonflags.ParseBytesWithLooseRFC4648 | 0
+-	}
+-}
+-
+-// ParseTimeWithLooseRFC3339 specifies that a [time.Time]
+-// parses according to loose adherence to RFC 3339.
+-// In particular, it permits historically incorrect representations,
+-// allowing for deviations in hour format, sub-second separator,
+-// and timezone representation. In contrast, the default v2 behavior
+-// is to strictly comply with the grammar specified in RFC 3339.
+-//
+-// This only affects unmarshaling and is ignored when marshaling.
+-// The v1 default is true.
+-func ParseTimeWithLooseRFC3339(v bool) Options {
+-	if v {
+-		return jsonflags.ParseTimeWithLooseRFC3339 | 1
+-	} else {
+-		return jsonflags.ParseTimeWithLooseRFC3339 | 0
+-	}
+-}
+-
+-// ReportErrorsWithLegacySemantics specifies that Marshal and Unmarshal
+-// should report errors with legacy semantics:
+-//
+-//   - When marshaling or unmarshaling, the returned error values are
+-//     usually of types such as [SyntaxError], [MarshalerError],
+-//     [UnsupportedTypeError], [UnsupportedValueError],
+-//     [InvalidUnmarshalError], or [UnmarshalTypeError].
+-//     In contrast, the v2 semantic is to always return errors as either
+-//     [jsonv2.SemanticError] or [jsontext.SyntacticError].
+-//
+-//   - When marshaling, if a user-defined marshal method reports an error,
+-//     it is always wrapped in a [MarshalerError], even if the error itself
+-//     is already a [MarshalerError], which may lead to multiple redundant
+-//     layers of wrapping. In contrast, the v2 semantic is to
+-//     always wrap an error within [jsonv2.SemanticError]
+-//     unless it is already a semantic error.
+-//
+-//   - When unmarshaling, if a user-defined unmarshal method reports an error,
+-//     it is never wrapped and reported verbatim. In contrast, the v2 semantic
+-//     is to always wrap an error within [jsonv2.SemanticError]
+-//     unless it is already a semantic error.
+-//
+-//   - When marshaling or unmarshaling, if a Go struct contains type errors
+-//     (e.g., conflicting names or malformed field tags), then such errors
+-//     are ignored and the Go struct uses a best-effort representation.
+-//     In contrast, the v2 semantic is to report a runtime error.
+-//
+-//   - When unmarshaling, the syntactic structure of the JSON input
+-//     is fully validated before performing the semantic unmarshaling
+-//     of the JSON data into the Go value. Practically speaking,
+-//     this means that JSON input with syntactic errors do not result
+-//     in any mutations of the target Go value. In contrast, the v2 semantic
+-//     is to perform a streaming decode and gradually unmarshal the JSON input
+-//     into the target Go value, which means that the Go value may be
+-//     partially mutated when a syntactic error is encountered.
+-//
+-//   - When unmarshaling, a semantic error does not immediately terminate the
+-//     unmarshal procedure, but rather evaluation continues.
+-//     When unmarshal returns, only the first semantic error is reported.
+-//     In contrast, the v2 semantic is to terminate unmarshal the moment
+-//     an error is encountered.
+-//
+-// This affects either marshaling or unmarshaling.
+-// The v1 default is true.
+-func ReportErrorsWithLegacySemantics(v bool) Options {
+-	if v {
+-		return jsonflags.ReportErrorsWithLegacySemantics | 1
+-	} else {
+-		return jsonflags.ReportErrorsWithLegacySemantics | 0
+-	}
+-}
+-
+-// StringifyWithLegacySemantics specifies that the `string` tag option
+-// may stringify bools and string values. It only takes effect on fields
+-// where the top-level type is a bool, string, numeric kind, or a pointer to
+-// such a kind. Specifically, `string` will not stringify bool, string,
+-// or numeric kinds within a composite data type
+-// (e.g., array, slice, struct, map, or interface).
+-//
+-// When marshaling, such Go values are serialized as their usual
+-// JSON representation, but quoted within a JSON string.
+-// When unmarshaling, such Go values must be deserialized from
+-// a JSON string containing their usual JSON representation.
+-// A JSON null quoted in a JSON string is a valid substitute for JSON null
+-// while unmarshaling into a Go value that `string` takes effect on.
+-//
+-// This affects either marshaling or unmarshaling.
+-// The v1 default is true.
+-func StringifyWithLegacySemantics(v bool) Options {
+-	if v {
+-		return jsonflags.StringifyWithLegacySemantics | 1
+-	} else {
+-		return jsonflags.StringifyWithLegacySemantics | 0
+-	}
+-}
+-
+-// UnmarshalArrayFromAnyLength specifies that Go arrays can be unmarshaled
+-// from input JSON arrays of any length. If the JSON array is too short,
+-// then the remaining Go array elements are zeroed. If the JSON array
+-// is too long, then the excess JSON array elements are skipped over.
+-//
+-// This only affects unmarshaling and is ignored when marshaling.
+-// The v1 default is true.
+-func UnmarshalArrayFromAnyLength(v bool) Options {
+-	if v {
+-		return jsonflags.UnmarshalArrayFromAnyLength | 1
+-	} else {
+-		return jsonflags.UnmarshalArrayFromAnyLength | 0
+-	}
+-}
+-
+-// unmarshalAnyWithRawNumber specifies that unmarshaling a JSON number into
+-// an empty Go interface should use the Number type instead of a float64.
+-func unmarshalAnyWithRawNumber(v bool) Options {
+-	if v {
+-		return jsonflags.UnmarshalAnyWithRawNumber | 1
+-	} else {
+-		return jsonflags.UnmarshalAnyWithRawNumber | 0
+-	}
+-}
+diff --git a/pkg/internal/third_party/go-json-experiment/json/v1/scanner.go b/pkg/internal/third_party/go-json-experiment/json/v1/scanner.go
+deleted file mode 100644
+index 59c360384..000000000
+--- a/pkg/internal/third_party/go-json-experiment/json/v1/scanner.go
++++ /dev/null
+@@ -1,86 +0,0 @@
+-// Copyright 2010 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+-package json
+-
+-import (
+-	"errors"
+-	"io"
+-	"strings"
+-
+-	"k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json/internal"
+-	"k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json/internal/jsonflags"
+-	"k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json/jsontext"
+-)
+-
+-// export exposes internal functionality of the "jsontext" package.
+-var export = jsontext.Internal.Export(&internal.AllowInternalUse)
+-
+-// Valid reports whether data is a valid JSON encoding.
+-func Valid(data []byte) bool {
+-	return checkValid(data) == nil
+-}
+-
+-func checkValid(data []byte) error {
+-	d := export.GetBufferedDecoder(data)
+-	defer export.PutBufferedDecoder(d)
+-	xd := export.Decoder(d)
+-	xd.Struct.Flags.Set(jsonflags.AllowDuplicateNames | jsonflags.AllowInvalidUTF8 | 1)
+-	if _, err := d.ReadValue(); err != nil {
+-		if err == io.EOF {
+-			offset := d.InputOffset() + int64(len(d.UnreadBuffer()))
+-			err = &jsontext.SyntacticError{ByteOffset: offset, Err: io.ErrUnexpectedEOF}
+-		}
+-		return transformSyntacticError(err)
+-	}
+-	if err := xd.CheckEOF(); err != nil {
+-		return transformSyntacticError(err)
+-	}
+-	return nil
+-}
+-
+-// A SyntaxError is a description of a JSON syntax error.
+-// [Unmarshal] will return a SyntaxError if the JSON can't be parsed.
+-type SyntaxError struct {
+-	msg    string // description of error
+-	Offset int64  // error occurred after reading Offset bytes
+-}
+-
+-func (e *SyntaxError) Error() string { return e.msg }
+-
+-var errUnexpectedEnd = errors.New("unexpected end of JSON input")
+-
+-func transformSyntacticError(err error) error {
+-	switch serr, ok := err.(*jsontext.SyntacticError); {
+-	case serr != nil:
+-		if serr.Err == io.ErrUnexpectedEOF {
+-			serr.Err = errUnexpectedEnd
+-		}
+-		msg := serr.Err.Error()
+-		if i := strings.Index(msg, " (expecting"); i >= 0 && !strings.Contains(msg, " in literal") {
+-			msg = msg[:i]
+-		}
+-		return &SyntaxError{Offset: serr.ByteOffset, msg: syntaxErrorReplacer.Replace(msg)}
+-	case ok:
+-		return (*SyntaxError)(nil)
+-	case export.IsIOError(err):
+-		return errors.Unwrap(err) // v1 historically did not wrap IO errors
+-	default:
+-		return err
+-	}
+-}
+-
+-// syntaxErrorReplacer replaces certain string literals in the v2 error
+-// to better match the historical string rendering of syntax errors.
+-// In particular, v2 uses the terminology "object name" to match RFC 8259,
+-// while v1 uses "object key", which is not a term found in JSON literature.
+-var syntaxErrorReplacer = strings.NewReplacer(
+-	"object name", "object key",
+-	"at start of value", "looking for beginning of value",
+-	"at start of string", "looking for beginning of object key string",
+-	"after object value", "after object key:value pair",
+-	"in number", "in numeric literal",
+-)
+diff --git a/pkg/internal/third_party/go-json-experiment/json/v1/scanner_test.go b/pkg/internal/third_party/go-json-experiment/json/v1/scanner_test.go
+deleted file mode 100644
+index 4864193ee..000000000
+--- a/pkg/internal/third_party/go-json-experiment/json/v1/scanner_test.go
++++ /dev/null
+@@ -1,307 +0,0 @@
+-// Copyright 2010 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+-package json
+-
+-import (
+-	"bytes"
+-	"math"
+-	"math/rand"
+-	"reflect"
+-	"strings"
+-	"testing"
+-)
+-
+-func indentNewlines(s string) string {
+-	return strings.Join(strings.Split(s, "\n"), "\n\t")
+-}
+-
+-func stripWhitespace(s string) string {
+-	return strings.Map(func(r rune) rune {
+-		if r == ' ' || r == '\n' || r == '\r' || r == '\t' {
+-			return -1
+-		}
+-		return r
+-	}, s)
+-}
+-
+-func TestValid(t *testing.T) {
+-	tests := []struct {
+-		CaseName
+-		data string
+-		ok   bool
+-	}{
+-		{Name(""), `foo`, false},
+-		{Name(""), `}{`, false},
+-		{Name(""), `{]`, false},
+-		{Name(""), `{}`, true},
+-		{Name(""), `{"foo":"bar"}`, true},
+-		{Name(""), `{"foo":"bar","bar":{"baz":["qux"]}}`, true},
+-	}
+-	for _, tt := range tests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			if ok := Valid([]byte(tt.data)); ok != tt.ok {
+-				t.Errorf("%s: Valid(`%s`) = %v, want %v", tt.Where, tt.data, ok, tt.ok)
+-			}
+-		})
+-	}
+-}
+-
+-func TestCompactAndIndent(t *testing.T) {
+-	tests := []struct {
+-		CaseName
+-		compact string
+-		indent  string
+-	}{
+-		{Name(""), `1`, `1`},
+-		{Name(""), `{}`, `{}`},
+-		{Name(""), `[]`, `[]`},
+-		{Name(""), `{"":2}`, "{\n\t\"\": 2\n}"},
+-		{Name(""), `[3]`, "[\n\t3\n]"},
+-		{Name(""), `[1,2,3]`, "[\n\t1,\n\t2,\n\t3\n]"},
+-		{Name(""), `{"x":1}`, "{\n\t\"x\": 1\n}"},
+-		{Name(""), `[true,false,null,"x",1,1.5,0,-5e+2]`, `[
+-	true,
+-	false,
+-	null,
+-	"x",
+-	1,
+-	1.5,
+-	0,
+-	-5e+2
+-]`},
+-		{Name(""), "{\"\":\"<>&\u2028\u2029\"}", "{\n\t\"\": \"<>&\u2028\u2029\"\n}"}, // See golang.org/issue/34070
+-		{Name(""), `null`, "null \n\r\t"},                                             // See golang.org/issue/13520 and golang.org/issue/74806
+-	}
+-	var buf bytes.Buffer
+-	for _, tt := range tests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			buf.Reset()
+-			if err := Compact(&buf, []byte(tt.compact)); err != nil {
+-				t.Errorf("%s: Compact error: %v", tt.Where, err)
+-			} else if got := buf.String(); got != tt.compact {
+-				t.Errorf("%s: Compact:\n\tgot:  %s\n\twant: %s", tt.Where, indentNewlines(got), indentNewlines(tt.compact))
+-			}
+-
+-			buf.Reset()
+-			if err := Compact(&buf, []byte(tt.indent)); err != nil {
+-				t.Errorf("%s: Compact error: %v", tt.Where, err)
+-			} else if got := buf.String(); got != tt.compact {
+-				t.Errorf("%s: Compact:\n\tgot:  %s\n\twant: %s", tt.Where, indentNewlines(got), indentNewlines(tt.compact))
+-			}
+-
+-			buf.Reset()
+-			if err := Indent(&buf, []byte(tt.indent), "", "\t"); err != nil {
+-				t.Errorf("%s: Indent error: %v", tt.Where, err)
+-			} else if got := buf.String(); got != tt.indent {
+-				t.Errorf("%s: Compact:\n\tgot:  %s\n\twant: %s", tt.Where, indentNewlines(got), indentNewlines(tt.indent))
+-			}
+-
+-			buf.Reset()
+-			if err := Indent(&buf, []byte(tt.compact), "", "\t"); err != nil {
+-				t.Errorf("%s: Indent error: %v", tt.Where, err)
+-			} else if got := buf.String(); got != strings.TrimRight(tt.indent, " \n\r\t") {
+-				t.Errorf("%s: Compact:\n\tgot:  %s\n\twant: %s", tt.Where, indentNewlines(got), indentNewlines(tt.indent))
+-			}
+-		})
+-	}
+-}
+-
+-func TestCompactSeparators(t *testing.T) {
+-	// U+2028 and U+2029 should be escaped inside strings.
+-	// They should not appear outside strings.
+-	tests := []struct {
+-		CaseName
+-		in, compact string
+-	}{
+-		{Name(""), "{\"\u2028\": 1}", "{\"\u2028\":1}"},
+-		{Name(""), "{\"\u2029\" :2}", "{\"\u2029\":2}"},
+-	}
+-	for _, tt := range tests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			var buf bytes.Buffer
+-			if err := Compact(&buf, []byte(tt.in)); err != nil {
+-				t.Errorf("%s: Compact error: %v", tt.Where, err)
+-			} else if got := buf.String(); got != tt.compact {
+-				t.Errorf("%s: Compact:\n\tgot:  %s\n\twant: %s", tt.Where, indentNewlines(got), indentNewlines(tt.compact))
+-			}
+-		})
+-	}
+-}
+-
+-// Tests of a large random structure.
+-
+-func TestCompactBig(t *testing.T) {
+-	initBig()
+-	var buf bytes.Buffer
+-	if err := Compact(&buf, jsonBig); err != nil {
+-		t.Fatalf("Compact error: %v", err)
+-	}
+-	b := buf.Bytes()
+-	if !bytes.Equal(b, jsonBig) {
+-		t.Error("Compact:")
+-		diff(t, b, jsonBig)
+-		return
+-	}
+-}
+-
+-func TestIndentBig(t *testing.T) {
+-	t.Parallel()
+-	initBig()
+-	var buf bytes.Buffer
+-	if err := Indent(&buf, jsonBig, "", "\t"); err != nil {
+-		t.Fatalf("Indent error: %v", err)
+-	}
+-	b := buf.Bytes()
+-	if len(b) == len(jsonBig) {
+-		// jsonBig is compact (no unnecessary spaces);
+-		// indenting should make it bigger
+-		t.Fatalf("Indent did not expand the input")
+-	}
+-
+-	// should be idempotent
+-	var buf1 bytes.Buffer
+-	if err := Indent(&buf1, b, "", "\t"); err != nil {
+-		t.Fatalf("Indent error: %v", err)
+-	}
+-	b1 := buf1.Bytes()
+-	if !bytes.Equal(b1, b) {
+-		t.Error("Indent(Indent(jsonBig)) != Indent(jsonBig):")
+-		diff(t, b1, b)
+-		return
+-	}
+-
+-	// should get back to original
+-	buf1.Reset()
+-	if err := Compact(&buf1, b); err != nil {
+-		t.Fatalf("Compact error: %v", err)
+-	}
+-	b1 = buf1.Bytes()
+-	if !bytes.Equal(b1, jsonBig) {
+-		t.Error("Compact(Indent(jsonBig)) != jsonBig:")
+-		diff(t, b1, jsonBig)
+-		return
+-	}
+-}
+-
+-func TestIndentErrors(t *testing.T) {
+-	tests := []struct {
+-		CaseName
+-		in  string
+-		err error
+-	}{
+-		{Name(""), `{"X": "foo", "Y"}`, &SyntaxError{"invalid character '}' after object key", len64(`{"X": "foo", "Y"`)}},
+-		{Name(""), `{"X": "foo" "Y": "bar"}`, &SyntaxError{"invalid character '\"' after object key:value pair", len64(`{"X": "foo" `)}},
+-	}
+-	for _, tt := range tests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			slice := make([]uint8, 0)
+-			buf := bytes.NewBuffer(slice)
+-			if err := Indent(buf, []uint8(tt.in), "", ""); err != nil {
+-				if !reflect.DeepEqual(err, tt.err) {
+-					t.Fatalf("%s: Indent error:\n\tgot:  %v\n\twant: %v", tt.Where, err, tt.err)
+-				}
+-			}
+-		})
+-	}
+-}
+-
+-func diff(t *testing.T, a, b []byte) {
+-	t.Helper()
+-	for i := 0; ; i++ {
+-		if i >= len(a) || i >= len(b) || a[i] != b[i] {
+-			j := i - 10
+-			if j < 0 {
+-				j = 0
+-			}
+-			t.Errorf("diverge at %d: «%s» vs «%s»", i, trim(a[j:]), trim(b[j:]))
+-			return
+-		}
+-	}
+-}
+-
+-func trim(b []byte) []byte {
+-	return b[:min(len(b), 20)]
+-}
+-
+-// Generate a random JSON object.
+-
+-var jsonBig []byte
+-
+-func initBig() {
+-	n := 10000
+-	if testing.Short() {
+-		n = 100
+-	}
+-	b, err := Marshal(genValue(n))
+-	if err != nil {
+-		panic(err)
+-	}
+-	jsonBig = b
+-}
+-
+-func genValue(n int) any {
+-	if n > 1 {
+-		switch rand.Intn(2) {
+-		case 0:
+-			return genArray(n)
+-		case 1:
+-			return genMap(n)
+-		}
+-	}
+-	switch rand.Intn(3) {
+-	case 0:
+-		return rand.Intn(2) == 0
+-	case 1:
+-		return rand.NormFloat64()
+-	case 2:
+-		return genString(30)
+-	}
+-	panic("unreachable")
+-}
+-
+-func genString(stddev float64) string {
+-	n := int(math.Abs(rand.NormFloat64()*stddev + stddev/2))
+-	c := make([]rune, n)
+-	for i := range c {
+-		f := math.Abs(rand.NormFloat64()*64 + 32)
+-		if f > 0x10ffff {
+-			f = 0x10ffff
+-		}
+-		c[i] = rune(f)
+-	}
+-	return string(c)
+-}
+-
+-func genArray(n int) []any {
+-	f := int(math.Abs(rand.NormFloat64()) * math.Min(10, float64(n/2)))
+-	if f > n {
+-		f = n
+-	}
+-	if f < 1 {
+-		f = 1
+-	}
+-	x := make([]any, f)
+-	for i := range x {
+-		x[i] = genValue(((i+1)*n)/f - (i*n)/f)
+-	}
+-	return x
+-}
+-
+-func genMap(n int) map[string]any {
+-	f := int(math.Abs(rand.NormFloat64()) * math.Min(10, float64(n/2)))
+-	if f > n {
+-		f = n
+-	}
+-	if n > 0 && f == 0 {
+-		f = 1
+-	}
+-	x := make(map[string]any)
+-	for i := 0; i < f; i++ {
+-		x[genString(10)] = genValue(((i+1)*n)/f - (i*n)/f)
+-	}
+-	return x
+-}
+diff --git a/pkg/internal/third_party/go-json-experiment/json/v1/stream.go b/pkg/internal/third_party/go-json-experiment/json/v1/stream.go
+deleted file mode 100644
+index 82e648589..000000000
+--- a/pkg/internal/third_party/go-json-experiment/json/v1/stream.go
++++ /dev/null
+@@ -1,242 +0,0 @@
+-// Copyright 2010 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+-package json
+-
+-import (
+-	"bytes"
+-	"errors"
+-	"io"
+-
+-	jsonv2 "k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json"
+-	"k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json/jsontext"
+-)
+-
+-// A Decoder reads and decodes JSON values from an input stream.
+-type Decoder struct {
+-	dec  *jsontext.Decoder
+-	opts jsonv2.Options
+-	err  error
+-}
+-
+-// NewDecoder returns a new decoder that reads from r.
+-//
+-// The decoder introduces its own buffering and may
+-// read data from r beyond the JSON values requested.
+-func NewDecoder(r io.Reader) *Decoder {
+-	// Hide bytes.Buffer from jsontext since it implements optimizations that
+-	// also limits certain ways it could be used. For example, one cannot write
+-	// to the bytes.Buffer while it is in use by jsontext.Decoder.
+-	if _, ok := r.(*bytes.Buffer); ok {
+-		r = struct{ io.Reader }{r}
+-	}
+-
+-	dec := new(Decoder)
+-	dec.opts = DefaultOptionsV1()
+-	dec.dec = jsontext.NewDecoder(r, dec.opts)
+-	return dec
+-}
+-
+-// UseNumber causes the Decoder to unmarshal a number into an
+-// interface value as a [Number] instead of as a float64.
+-func (dec *Decoder) UseNumber() {
+-	if useNumber, _ := jsonv2.GetOption(dec.opts, unmarshalAnyWithRawNumber); !useNumber {
+-		dec.opts = jsonv2.JoinOptions(dec.opts, unmarshalAnyWithRawNumber(true))
+-	}
+-}
+-
+-// DisallowUnknownFields causes the Decoder to return an error when the destination
+-// is a struct and the input contains object keys which do not match any
+-// non-ignored, exported fields in the destination.
+-func (dec *Decoder) DisallowUnknownFields() {
+-	if reject, _ := jsonv2.GetOption(dec.opts, jsonv2.RejectUnknownMembers); !reject {
+-		dec.opts = jsonv2.JoinOptions(dec.opts, jsonv2.RejectUnknownMembers(true))
+-	}
+-}
+-
+-// Decode reads the next JSON-encoded value from its
+-// input and stores it in the value pointed to by v.
+-//
+-// See the documentation for [Unmarshal] for details about
+-// the conversion of JSON into a Go value.
+-func (dec *Decoder) Decode(v any) error {
+-	if dec.err != nil {
+-		return dec.err
+-	}
+-	b, err := dec.dec.ReadValue()
+-	if err != nil {
+-		dec.err = transformSyntacticError(err)
+-		if dec.err.Error() == errUnexpectedEnd.Error() {
+-			// NOTE: Decode has always been inconsistent with Unmarshal
+-			// with regard to the exact error value for truncated input.
+-			dec.err = io.ErrUnexpectedEOF
+-		}
+-		return dec.err
+-	}
+-	return jsonv2.Unmarshal(b, v, dec.opts)
+-}
+-
+-// Buffered returns a reader of the data remaining in the Decoder's
+-// buffer. The reader is valid until the next call to [Decoder.Decode].
+-func (dec *Decoder) Buffered() io.Reader {
+-	return bytes.NewReader(dec.dec.UnreadBuffer())
+-}
+-
+-// An Encoder writes JSON values to an output stream.
+-type Encoder struct {
+-	w    io.Writer
+-	opts jsonv2.Options
+-	err  error
+-
+-	buf       bytes.Buffer
+-	indentBuf bytes.Buffer
+-
+-	indentPrefix string
+-	indentValue  string
+-}
+-
+-// NewEncoder returns a new encoder that writes to w.
+-func NewEncoder(w io.Writer) *Encoder {
+-	enc := new(Encoder)
+-	enc.w = w
+-	enc.opts = DefaultOptionsV1()
+-	return enc
+-}
+-
+-// Encode writes the JSON encoding of v to the stream,
+-// followed by a newline character.
+-//
+-// See the documentation for [Marshal] for details about the
+-// conversion of Go values to JSON.
+-func (enc *Encoder) Encode(v any) error {
+-	if enc.err != nil {
+-		return enc.err
+-	}
+-
+-	buf := &enc.buf
+-	buf.Reset()
+-	if err := jsonv2.MarshalWrite(buf, v, enc.opts); err != nil {
+-		return err
+-	}
+-	if len(enc.indentPrefix)+len(enc.indentValue) > 0 {
+-		enc.indentBuf.Reset()
+-		if err := Indent(&enc.indentBuf, buf.Bytes(), enc.indentPrefix, enc.indentValue); err != nil {
+-			return err
+-		}
+-		buf = &enc.indentBuf
+-	}
+-	buf.WriteByte('\n')
+-
+-	if _, err := enc.w.Write(buf.Bytes()); err != nil {
+-		enc.err = err
+-		return err
+-	}
+-	return nil
+-}
+-
+-// SetIndent instructs the encoder to format each subsequent encoded
+-// value as if indented by the package-level function Indent(dst, src, prefix, indent).
+-// Calling SetIndent("", "") disables indentation.
+-func (enc *Encoder) SetIndent(prefix, indent string) {
+-	enc.indentPrefix = prefix
+-	enc.indentValue = indent
+-}
+-
+-// SetEscapeHTML specifies whether problematic HTML characters
+-// should be escaped inside JSON quoted strings.
+-// The default behavior is to escape &, <, and > to \u0026, \u003c, and \u003e
+-// to avoid certain safety problems that can arise when embedding JSON in HTML.
+-//
+-// In non-HTML settings where the escaping interferes with the readability
+-// of the output, SetEscapeHTML(false) disables this behavior.
+-func (enc *Encoder) SetEscapeHTML(on bool) {
+-	if escape, _ := jsonv2.GetOption(enc.opts, jsontext.EscapeForHTML); escape != on {
+-		enc.opts = jsonv2.JoinOptions(enc.opts, jsontext.EscapeForHTML(on))
+-	}
+-}
+-
+-// RawMessage is a raw encoded JSON value.
+-// It implements [Marshaler] and [Unmarshaler] and can
+-// be used to delay JSON decoding or precompute a JSON encoding.
+-type RawMessage = jsontext.Value
+-
+-// A Token holds a value of one of these types:
+-//
+-//   - [Delim], for the four JSON delimiters [ ] { }
+-//   - bool, for JSON booleans
+-//   - float64, for JSON numbers
+-//   - [Number], for JSON numbers
+-//   - string, for JSON string literals
+-//   - nil, for JSON null
+-type Token any
+-
+-// A Delim is a JSON array or object delimiter, one of [ ] { or }.
+-type Delim rune
+-
+-func (d Delim) String() string {
+-	return string(d)
+-}
+-
+-// Token returns the next JSON token in the input stream.
+-// At the end of the input stream, Token returns nil, [io.EOF].
+-//
+-// Token guarantees that the delimiters [ ] { } it returns are
+-// properly nested and matched: if Token encounters an unexpected
+-// delimiter in the input, it will return an error.
+-//
+-// The input stream consists of basic JSON values—bool, string,
+-// number, and null—along with delimiters [ ] { } of type [Delim]
+-// to mark the start and end of arrays and objects.
+-// Commas and colons are elided.
+-func (dec *Decoder) Token() (Token, error) {
+-	tok, err := dec.dec.ReadToken()
+-	if err != nil {
+-		// Historically, v1 would report just [io.EOF] if
+-		// the stream is a prefix of a valid JSON value.
+-		// It reports an unwrapped [io.ErrUnexpectedEOF] if
+-		// truncated within a JSON token such as a literal, number, or string.
+-		if errors.Is(err, io.ErrUnexpectedEOF) {
+-			if len(bytes.Trim(dec.dec.UnreadBuffer(), " \r\n\t,:")) == 0 {
+-				return nil, io.EOF
+-			}
+-			return nil, io.ErrUnexpectedEOF
+-		}
+-		return nil, transformSyntacticError(err)
+-	}
+-	switch k := tok.Kind(); k {
+-	case 'n':
+-		return nil, nil
+-	case 'f':
+-		return false, nil
+-	case 't':
+-		return true, nil
+-	case '"':
+-		return tok.String(), nil
+-	case '0':
+-		if useNumber, _ := jsonv2.GetOption(dec.opts, unmarshalAnyWithRawNumber); useNumber {
+-			return Number(tok.String()), nil
+-		}
+-		return tok.Float(), nil
+-	case '{', '}', '[', ']':
+-		return Delim(k), nil
+-	default:
+-		panic("unreachable")
+-	}
+-}
+-
+-// More reports whether there is another element in the
+-// current array or object being parsed.
+-func (dec *Decoder) More() bool {
+-	k := dec.dec.PeekKind()
+-	return k > 0 && k != ']' && k != '}'
+-}
+-
+-// InputOffset returns the input stream byte offset of the current decoder position.
+-// The offset gives the location of the end of the most recently returned token
+-// and the beginning of the next token.
+-func (dec *Decoder) InputOffset() int64 {
+-	return dec.dec.InputOffset()
+-}
+diff --git a/pkg/internal/third_party/go-json-experiment/json/v1/stream_test.go b/pkg/internal/third_party/go-json-experiment/json/v1/stream_test.go
+deleted file mode 100644
+index 08011f1bd..000000000
+--- a/pkg/internal/third_party/go-json-experiment/json/v1/stream_test.go
++++ /dev/null
+@@ -1,539 +0,0 @@
+-// Copyright 2010 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+-package json
+-
+-import (
+-	"bytes"
+-	"io"
+-	"log"
+-	"net"
+-	"net/http"
+-	"net/http/httptest"
+-	"reflect"
+-	"runtime/debug"
+-	"strings"
+-	"testing"
+-
+-	"k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json/internal/jsontest"
+-)
+-
+-type CaseName = jsontest.CaseName
+-type CasePos = jsontest.CasePos
+-
+-var Name = jsontest.Name
+-
+-// Test values for the stream test.
+-// One of each JSON kind.
+-var streamTest = []any{
+-	0.1,
+-	"hello",
+-	nil,
+-	true,
+-	false,
+-	[]any{"a", "b", "c"},
+-	map[string]any{"K": "Kelvin", "ß": "long s"},
+-	3.14, // another value to make sure something can follow map
+-}
+-
+-var streamEncoded = `0.1
+-"hello"
+-null
+-true
+-false
+-["a","b","c"]
+-{"ß":"long s","K":"Kelvin"}
+-3.14
+-`
+-
+-func TestEncoder(t *testing.T) {
+-	for i := 0; i <= len(streamTest); i++ {
+-		var buf strings.Builder
+-		enc := NewEncoder(&buf)
+-		// Check that enc.SetIndent("", "") turns off indentation.
+-		enc.SetIndent(">", ".")
+-		enc.SetIndent("", "")
+-		for j, v := range streamTest[0:i] {
+-			if err := enc.Encode(v); err != nil {
+-				t.Fatalf("#%d.%d Encode error: %v", i, j, err)
+-			}
+-		}
+-		if got, want := buf.String(), nlines(streamEncoded, i); got != want {
+-			t.Errorf("encoding %d items: mismatch:", i)
+-			diff(t, []byte(got), []byte(want))
+-			break
+-		}
+-	}
+-}
+-
+-func TestEncoderErrorAndReuseEncodeState(t *testing.T) {
+-	// Disable the GC temporarily to prevent encodeState's in Pool being cleaned away during the test.
+-	percent := debug.SetGCPercent(-1)
+-	defer debug.SetGCPercent(percent)
+-
+-	// Trigger an error in Marshal with cyclic data.
+-	type Dummy struct {
+-		Name string
+-		Next *Dummy
+-	}
+-	dummy := Dummy{Name: "Dummy"}
+-	dummy.Next = &dummy
+-
+-	var buf bytes.Buffer
+-	enc := NewEncoder(&buf)
+-	if err := enc.Encode(dummy); err == nil {
+-		t.Errorf("Encode(dummy) error: got nil, want non-nil")
+-	}
+-
+-	type Data struct {
+-		A string
+-		I int
+-	}
+-	want := Data{A: "a", I: 1}
+-	if err := enc.Encode(want); err != nil {
+-		t.Errorf("Marshal error: %v", err)
+-	}
+-
+-	var got Data
+-	if err := Unmarshal(buf.Bytes(), &got); err != nil {
+-		t.Errorf("Unmarshal error: %v", err)
+-	}
+-	if got != want {
+-		t.Errorf("Marshal/Unmarshal roundtrip:\n\tgot:  %v\n\twant: %v", got, want)
+-	}
+-}
+-
+-var streamEncodedIndent = `0.1
+-"hello"
+-null
+-true
+-false
+-[
+->."a",
+->."b",
+->."c"
+->]
+-{
+->."ß": "long s",
+->."K": "Kelvin"
+->}
+-3.14
+-`
+-
+-func TestEncoderIndent(t *testing.T) {
+-	var buf strings.Builder
+-	enc := NewEncoder(&buf)
+-	enc.SetIndent(">", ".")
+-	for _, v := range streamTest {
+-		enc.Encode(v)
+-	}
+-	if got, want := buf.String(), streamEncodedIndent; got != want {
+-		t.Errorf("Encode mismatch:\ngot:\n%s\n\nwant:\n%s", got, want)
+-		diff(t, []byte(got), []byte(want))
+-	}
+-}
+-
+-type strMarshaler string
+-
+-func (s strMarshaler) MarshalJSON() ([]byte, error) {
+-	return []byte(s), nil
+-}
+-
+-type strPtrMarshaler string
+-
+-func (s *strPtrMarshaler) MarshalJSON() ([]byte, error) {
+-	return []byte(*s), nil
+-}
+-
+-func TestEncoderSetEscapeHTML(t *testing.T) {
+-	var c C
+-	var ct CText
+-	var tagStruct struct {
+-		Valid   int `json:"<>&#! "`
+-		Invalid int `json:"\\"`
+-	}
+-
+-	// This case is particularly interesting, as we force the encoder to
+-	// take the address of the Ptr field to use its MarshalJSON method. This
+-	// is why the '&' is important.
+-	marshalerStruct := &struct {
+-		NonPtr strMarshaler
+-		Ptr    strPtrMarshaler
+-	}{`"<str>"`, `"<str>"`}
+-
+-	// https://golang.org/issue/34154
+-	stringOption := struct {
+-		Bar string `json:"bar,string"`
+-	}{`<html>foobar</html>`}
+-
+-	tests := []struct {
+-		CaseName
+-		v          any
+-		wantEscape string
+-		want       string
+-	}{
+-		{Name("c"), c, `"\u003c\u0026\u003e"`, `"<&>"`},
+-		{Name("ct"), ct, `"\"\u003c\u0026\u003e\""`, `"\"<&>\""`},
+-		{Name(`"<&>"`), "<&>", `"\u003c\u0026\u003e"`, `"<&>"`},
+-		{
+-			Name("tagStruct"), tagStruct,
+-			`{"\u003c\u003e\u0026#! ":0,"Invalid":0}`,
+-			`{"<>&#! ":0,"Invalid":0}`,
+-		},
+-		{
+-			Name(`"<str>"`), marshalerStruct,
+-			`{"NonPtr":"\u003cstr\u003e","Ptr":"\u003cstr\u003e"}`,
+-			`{"NonPtr":"<str>","Ptr":"<str>"}`,
+-		},
+-		{
+-			Name("stringOption"), stringOption,
+-			`{"bar":"\"\\u003chtml\\u003efoobar\\u003c/html\\u003e\""}`,
+-			`{"bar":"\"<html>foobar</html>\""}`,
+-		},
+-	}
+-	for _, tt := range tests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			var buf strings.Builder
+-			enc := NewEncoder(&buf)
+-			if err := enc.Encode(tt.v); err != nil {
+-				t.Fatalf("%s: Encode(%s) error: %s", tt.Where, tt.Name, err)
+-			}
+-			if got := strings.TrimSpace(buf.String()); got != tt.wantEscape {
+-				t.Errorf("%s: Encode(%s):\n\tgot:  %s\n\twant: %s", tt.Where, tt.Name, got, tt.wantEscape)
+-			}
+-			buf.Reset()
+-			enc.SetEscapeHTML(false)
+-			if err := enc.Encode(tt.v); err != nil {
+-				t.Fatalf("%s: SetEscapeHTML(false) Encode(%s) error: %s", tt.Where, tt.Name, err)
+-			}
+-			if got := strings.TrimSpace(buf.String()); got != tt.want {
+-				t.Errorf("%s: SetEscapeHTML(false) Encode(%s):\n\tgot:  %s\n\twant: %s",
+-					tt.Where, tt.Name, got, tt.want)
+-			}
+-		})
+-	}
+-}
+-
+-func TestDecoder(t *testing.T) {
+-	for i := 0; i <= len(streamTest); i++ {
+-		// Use stream without newlines as input,
+-		// just to stress the decoder even more.
+-		// Our test input does not include back-to-back numbers.
+-		// Otherwise stripping the newlines would
+-		// merge two adjacent JSON values.
+-		var buf bytes.Buffer
+-		for _, c := range nlines(streamEncoded, i) {
+-			if c != '\n' {
+-				buf.WriteRune(c)
+-			}
+-		}
+-		out := make([]any, i)
+-		dec := NewDecoder(&buf)
+-		for j := range out {
+-			if err := dec.Decode(&out[j]); err != nil {
+-				t.Fatalf("decode #%d/%d error: %v", j, i, err)
+-			}
+-		}
+-		if !reflect.DeepEqual(out, streamTest[0:i]) {
+-			t.Errorf("decoding %d items: mismatch:", i)
+-			for j := range out {
+-				if !reflect.DeepEqual(out[j], streamTest[j]) {
+-					t.Errorf("#%d:\n\tgot:  %v\n\twant: %v", j, out[j], streamTest[j])
+-				}
+-			}
+-			break
+-		}
+-	}
+-}
+-
+-func TestDecoderBuffered(t *testing.T) {
+-	r := strings.NewReader(`{"Name": "Gopher"} extra `)
+-	var m struct {
+-		Name string
+-	}
+-	d := NewDecoder(r)
+-	err := d.Decode(&m)
+-	if err != nil {
+-		t.Fatal(err)
+-	}
+-	if m.Name != "Gopher" {
+-		t.Errorf("Name = %s, want Gopher", m.Name)
+-	}
+-	rest, err := io.ReadAll(d.Buffered())
+-	if err != nil {
+-		t.Fatal(err)
+-	}
+-	if got, want := string(rest), " extra "; got != want {
+-		t.Errorf("Remaining = %s, want %s", got, want)
+-	}
+-}
+-
+-func nlines(s string, n int) string {
+-	if n <= 0 {
+-		return ""
+-	}
+-	for i, c := range s {
+-		if c == '\n' {
+-			if n--; n == 0 {
+-				return s[0 : i+1]
+-			}
+-		}
+-	}
+-	return s
+-}
+-
+-func TestRawMessage(t *testing.T) {
+-	var data struct {
+-		X  float64
+-		Id RawMessage
+-		Y  float32
+-	}
+-	const raw = `["\u0056",null]`
+-	const want = `{"X":0.1,"Id":["\u0056",null],"Y":0.2}`
+-	err := Unmarshal([]byte(want), &data)
+-	if err != nil {
+-		t.Fatalf("Unmarshal error: %v", err)
+-	}
+-	if string([]byte(data.Id)) != raw {
+-		t.Fatalf("Unmarshal:\n\tgot:  %s\n\twant: %s", []byte(data.Id), raw)
+-	}
+-	got, err := Marshal(&data)
+-	if err != nil {
+-		t.Fatalf("Marshal error: %v", err)
+-	}
+-	if string(got) != want {
+-		t.Fatalf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
+-	}
+-}
+-
+-func TestNullRawMessage(t *testing.T) {
+-	var data struct {
+-		X     float64
+-		Id    RawMessage
+-		IdPtr *RawMessage
+-		Y     float32
+-	}
+-	const want = `{"X":0.1,"Id":null,"IdPtr":null,"Y":0.2}`
+-	err := Unmarshal([]byte(want), &data)
+-	if err != nil {
+-		t.Fatalf("Unmarshal error: %v", err)
+-	}
+-	if want, got := "null", string(data.Id); want != got {
+-		t.Fatalf("Unmarshal:\n\tgot:  %s\n\twant: %s", got, want)
+-	}
+-	if data.IdPtr != nil {
+-		t.Fatalf("pointer mismatch: got non-nil, want nil")
+-	}
+-	got, err := Marshal(&data)
+-	if err != nil {
+-		t.Fatalf("Marshal error: %v", err)
+-	}
+-	if string(got) != want {
+-		t.Fatalf("Marshal:\n\tgot:  %s\n\twant: %s", got, want)
+-	}
+-}
+-
+-func TestBlocking(t *testing.T) {
+-	tests := []struct {
+-		CaseName
+-		in string
+-	}{
+-		{Name(""), `{"x": 1}`},
+-		{Name(""), `[1, 2, 3]`},
+-	}
+-	for _, tt := range tests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			r, w := net.Pipe()
+-			go w.Write([]byte(tt.in))
+-			var val any
+-
+-			// If Decode reads beyond what w.Write writes above,
+-			// it will block, and the test will deadlock.
+-			if err := NewDecoder(r).Decode(&val); err != nil {
+-				t.Errorf("%s: NewDecoder(%s).Decode error: %v", tt.Where, tt.in, err)
+-			}
+-			r.Close()
+-			w.Close()
+-		})
+-	}
+-}
+-
+-type decodeThis struct {
+-	v any
+-}
+-
+-func TestDecodeInStream(t *testing.T) {
+-	tests := []struct {
+-		CaseName
+-		json      string
+-		expTokens []any
+-	}{
+-		// streaming token cases
+-		{CaseName: Name(""), json: `10`, expTokens: []any{float64(10)}},
+-		{CaseName: Name(""), json: ` [10] `, expTokens: []any{
+-			Delim('['), float64(10), Delim(']')}},
+-		{CaseName: Name(""), json: ` [false,10,"b"] `, expTokens: []any{
+-			Delim('['), false, float64(10), "b", Delim(']')}},
+-		{CaseName: Name(""), json: `{ "a": 1 }`, expTokens: []any{
+-			Delim('{'), "a", float64(1), Delim('}')}},
+-		{CaseName: Name(""), json: `{"a": 1, "b":"3"}`, expTokens: []any{
+-			Delim('{'), "a", float64(1), "b", "3", Delim('}')}},
+-		{CaseName: Name(""), json: ` [{"a": 1},{"a": 2}] `, expTokens: []any{
+-			Delim('['),
+-			Delim('{'), "a", float64(1), Delim('}'),
+-			Delim('{'), "a", float64(2), Delim('}'),
+-			Delim(']')}},
+-		{CaseName: Name(""), json: `{"obj": {"a": 1}}`, expTokens: []any{
+-			Delim('{'), "obj", Delim('{'), "a", float64(1), Delim('}'),
+-			Delim('}')}},
+-		{CaseName: Name(""), json: `{"obj": [{"a": 1}]}`, expTokens: []any{
+-			Delim('{'), "obj", Delim('['),
+-			Delim('{'), "a", float64(1), Delim('}'),
+-			Delim(']'), Delim('}')}},
+-
+-		// streaming tokens with intermittent Decode()
+-		{CaseName: Name(""), json: `{ "a": 1 }`, expTokens: []any{
+-			Delim('{'), "a",
+-			decodeThis{float64(1)},
+-			Delim('}')}},
+-		{CaseName: Name(""), json: ` [ { "a" : 1 } ] `, expTokens: []any{
+-			Delim('['),
+-			decodeThis{map[string]any{"a": float64(1)}},
+-			Delim(']')}},
+-		{CaseName: Name(""), json: ` [{"a": 1},{"a": 2}] `, expTokens: []any{
+-			Delim('['),
+-			decodeThis{map[string]any{"a": float64(1)}},
+-			decodeThis{map[string]any{"a": float64(2)}},
+-			Delim(']')}},
+-		{CaseName: Name(""), json: `{ "obj" : [ { "a" : 1 } ] }`, expTokens: []any{
+-			Delim('{'), "obj", Delim('['),
+-			decodeThis{map[string]any{"a": float64(1)}},
+-			Delim(']'), Delim('}')}},
+-
+-		{CaseName: Name(""), json: `{"obj": {"a": 1}}`, expTokens: []any{
+-			Delim('{'), "obj",
+-			decodeThis{map[string]any{"a": float64(1)}},
+-			Delim('}')}},
+-		{CaseName: Name(""), json: `{"obj": [{"a": 1}]}`, expTokens: []any{
+-			Delim('{'), "obj",
+-			decodeThis{[]any{
+-				map[string]any{"a": float64(1)},
+-			}},
+-			Delim('}')}},
+-		{CaseName: Name(""), json: ` [{"a": 1} {"a": 2}] `, expTokens: []any{
+-			Delim('['),
+-			decodeThis{map[string]any{"a": float64(1)}},
+-			decodeThis{&SyntaxError{"invalid character '{' after array element", len64(` [{"a": 1} `)}},
+-		}},
+-		{CaseName: Name(""), json: `{ "` + strings.Repeat("a", 513) + `" 1 }`, expTokens: []any{
+-			Delim('{'), strings.Repeat("a", 513),
+-			decodeThis{&SyntaxError{"invalid character '1' after object key", len64(`{ "` + strings.Repeat("a", 513) + `" `)}},
+-		}},
+-		{CaseName: Name(""), json: `{ "\a" }`, expTokens: []any{
+-			Delim('{'),
+-			&SyntaxError{"invalid escape sequence `\\a` in string", len64(`{ "`)},
+-		}},
+-		{CaseName: Name(""), json: ` \a`, expTokens: []any{
+-			&SyntaxError{"invalid character '\\\\' looking for beginning of value", len64(` `)},
+-		}},
+-	}
+-	for _, tt := range tests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			dec := NewDecoder(strings.NewReader(tt.json))
+-			for i, want := range tt.expTokens {
+-				var got any
+-				var err error
+-
+-				if dt, ok := want.(decodeThis); ok {
+-					want = dt.v
+-					err = dec.Decode(&got)
+-				} else {
+-					got, err = dec.Token()
+-				}
+-				if errWant, ok := want.(error); ok {
+-					if err == nil || !reflect.DeepEqual(err, errWant) {
+-						t.Fatalf("%s:\n\tinput: %s\n\tgot error:  %v\n\twant error: %v", tt.Where, tt.json, err, errWant)
+-					}
+-					break
+-				} else if err != nil {
+-					t.Fatalf("%s:\n\tinput: %s\n\tgot error:  %v\n\twant error: nil", tt.Where, tt.json, err)
+-				}
+-				if !reflect.DeepEqual(got, want) {
+-					t.Fatalf("%s: token %d:\n\tinput: %s\n\tgot:  %T(%v)\n\twant: %T(%v)", tt.Where, i, tt.json, got, got, want, want)
+-				}
+-			}
+-		})
+-	}
+-}
+-
+-// Test from golang.org/issue/11893
+-func TestHTTPDecoding(t *testing.T) {
+-	const raw = `{ "foo": "bar" }`
+-
+-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+-		w.Write([]byte(raw))
+-	}))
+-	defer ts.Close()
+-	res, err := http.Get(ts.URL)
+-	if err != nil {
+-		log.Fatalf("http.Get error: %v", err)
+-	}
+-	defer res.Body.Close()
+-
+-	foo := struct {
+-		Foo string
+-	}{}
+-
+-	d := NewDecoder(res.Body)
+-	err = d.Decode(&foo)
+-	if err != nil {
+-		t.Fatalf("Decode error: %v", err)
+-	}
+-	if foo.Foo != "bar" {
+-		t.Errorf(`Decode: got %q, want "bar"`, foo.Foo)
+-	}
+-
+-	// make sure we get the EOF the second time
+-	err = d.Decode(&foo)
+-	if err != io.EOF {
+-		t.Errorf("Decode error:\n\tgot:  %v\n\twant: io.EOF", err)
+-	}
+-}
+-
+-func TestTokenTruncation(t *testing.T) {
+-	tests := []struct {
+-		in  string
+-		err error
+-	}{
+-		{in: ``, err: io.EOF},
+-		{in: `{`, err: io.EOF},
+-		{in: `{"`, err: io.ErrUnexpectedEOF},
+-		{in: `{"k"`, err: io.EOF},
+-		{in: `{"k":`, err: io.EOF},
+-		{in: `{"k",`, err: &SyntaxError{"invalid character ',' after object key", int64(len(`{"k"`))}},
+-		{in: `{"k"}`, err: &SyntaxError{"invalid character '}' after object key", int64(len(`{"k"`))}},
+-		{in: ` [0`, err: io.EOF},
+-		{in: `[0.`, err: io.ErrUnexpectedEOF},
+-		{in: `[0. `, err: &SyntaxError{"invalid character ' ' in numeric literal", int64(len(`[0.`))}},
+-		{in: `[0,`, err: io.EOF},
+-		{in: `[0:`, err: &SyntaxError{"invalid character ':' after array element", int64(len(`[0`))}},
+-		{in: `n`, err: io.ErrUnexpectedEOF},
+-		{in: `nul`, err: io.ErrUnexpectedEOF},
+-		{in: `fal `, err: &SyntaxError{"invalid character ' ' in literal false (expecting 's')", int64(len(`fal`))}},
+-		{in: `false`, err: io.EOF},
+-	}
+-	for _, tt := range tests {
+-		d := NewDecoder(strings.NewReader(tt.in))
+-		for i := 0; true; i++ {
+-			if _, err := d.Token(); err != nil {
+-				if !reflect.DeepEqual(err, tt.err) {
+-					t.Errorf("`%s`: %d.Token error = %#v, want %v", tt.in, i, err, tt.err)
+-				}
+-				break
+-			}
+-		}
+-	}
+-}
+diff --git a/pkg/internal/third_party/go-json-experiment/json/v1/tagkey_test.go b/pkg/internal/third_party/go-json-experiment/json/v1/tagkey_test.go
+deleted file mode 100644
+index 5fa81ea20..000000000
+--- a/pkg/internal/third_party/go-json-experiment/json/v1/tagkey_test.go
++++ /dev/null
+@@ -1,121 +0,0 @@
+-// Copyright 2011 The Go Authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style
+-// license that can be found in the LICENSE file.
+-
+-//go:build !goexperiment.jsonv2 || !go1.25
+-
+-package json
+-
+-import "testing"
+-
+-type basicLatin2xTag struct {
+-	V string `json:"$%-/"`
+-}
+-
+-type basicLatin3xTag struct {
+-	V string `json:"0123456789"`
+-}
+-
+-type basicLatin4xTag struct {
+-	V string `json:"ABCDEFGHIJKLMO"`
+-}
+-
+-type basicLatin5xTag struct {
+-	V string `json:"PQRSTUVWXYZ_"`
+-}
+-
+-type basicLatin6xTag struct {
+-	V string `json:"abcdefghijklmno"`
+-}
+-
+-type basicLatin7xTag struct {
+-	V string `json:"pqrstuvwxyz"`
+-}
+-
+-type miscPlaneTag struct {
+-	V string `json:"色は匂へど"`
+-}
+-
+-type percentSlashTag struct {
+-	V string `json:"text/html%"` // https://golang.org/issue/2718
+-}
+-
+-type punctuationTag struct {
+-	V string `json:"!#$%&()*+-./:;<=>?@[]^_{|}~ "` // https://golang.org/issue/3546
+-}
+-
+-type dashTag struct {
+-	V string `json:"-,"`
+-}
+-
+-type emptyTag struct {
+-	W string
+-}
+-
+-type misnamedTag struct {
+-	X string `jsom:"Misnamed"`
+-}
+-
+-type badFormatTag struct {
+-	Y string `:"BadFormat"`
+-}
+-
+-type badCodeTag struct {
+-	Z string `json:" !\"#&'()*+,."`
+-}
+-
+-type spaceTag struct {
+-	Q string `json:"With space"`
+-}
+-
+-type unicodeTag struct {
+-	W string `json:"Ελλάδα"`
+-}
+-
+-func TestStructTagObjectKey(t *testing.T) {
+-	tests := []struct {
+-		CaseName
+-		raw   any
+-		value string
+-		key   string
+-	}{
+-		{Name(""), basicLatin2xTag{"2x"}, "2x", "$%-/"},
+-		{Name(""), basicLatin3xTag{"3x"}, "3x", "0123456789"},
+-		{Name(""), basicLatin4xTag{"4x"}, "4x", "ABCDEFGHIJKLMO"},
+-		{Name(""), basicLatin5xTag{"5x"}, "5x", "PQRSTUVWXYZ_"},
+-		{Name(""), basicLatin6xTag{"6x"}, "6x", "abcdefghijklmno"},
+-		{Name(""), basicLatin7xTag{"7x"}, "7x", "pqrstuvwxyz"},
+-		{Name(""), miscPlaneTag{"いろはにほへと"}, "いろはにほへと", "色は匂へど"},
+-		{Name(""), dashTag{"foo"}, "foo", "-"},
+-		{Name(""), emptyTag{"Pour Moi"}, "Pour Moi", "W"},
+-		{Name(""), misnamedTag{"Animal Kingdom"}, "Animal Kingdom", "X"},
+-		{Name(""), badFormatTag{"Orfevre"}, "Orfevre", "Y"},
+-		{Name(""), badCodeTag{"Reliable Man"}, "Reliable Man", "Z"},
+-		{Name(""), percentSlashTag{"brut"}, "brut", "text/html%"},
+-		{Name(""), punctuationTag{"Union Rags"}, "Union Rags", "!#$%&()*+-./:;<=>?@[]^_{|}~ "},
+-		{Name(""), spaceTag{"Perreddu"}, "Perreddu", "With space"},
+-		{Name(""), unicodeTag{"Loukanikos"}, "Loukanikos", "Ελλάδα"},
+-	}
+-	for _, tt := range tests {
+-		t.Run(tt.Name, func(t *testing.T) {
+-			b, err := Marshal(tt.raw)
+-			if err != nil {
+-				t.Fatalf("%s: Marshal error: %v", tt.Where, err)
+-			}
+-			var f any
+-			err = Unmarshal(b, &f)
+-			if err != nil {
+-				t.Fatalf("%s: Unmarshal error: %v", tt.Where, err)
+-			}
+-			for k, v := range f.(map[string]any) {
+-				if k == tt.key {
+-					if s, ok := v.(string); !ok || s != tt.value {
+-						t.Fatalf("%s: Unmarshal(%#q) value:\n\tgot:  %q\n\twant: %q", tt.Where, b, s, tt.value)
+-					}
+-				} else {
+-					t.Fatalf("%s: Unmarshal(%#q): unexpected key: %q", tt.Where, b, k)
+-				}
+-			}
+-		})
+-	}
+-}

--- a/SPECS/go-k8s-kube-openapi/go-k8s-kube-openapi.spec
+++ b/SPECS/go-k8s-kube-openapi/go-k8s-kube-openapi.spec
@@ -32,6 +32,9 @@ Source0:        https://github.com/kubernetes/kube-openapi/archive/%{commit_id}.
 BuildArch:      noarch
 BuildSystem:    golangmodules
 
+# https://github.com/kubernetes/kube-openapi/pull/616
+Patch0:         0001-Insulate-go-json-experiment-from-stdlib.patch
+
 BuildRequires:  go
 BuildRequires:  go-rpm-macros
 BuildRequires:  go(github.com/davecgh/go-spew)

--- a/SPECS/go-k8s-sigs-json/0001-Fix-UnmarshalTypeError-test-literals-with-Go-1.27.patch
+++ b/SPECS/go-k8s-sigs-json/0001-Fix-UnmarshalTypeError-test-literals-with-Go-1.27.patch
@@ -1,0 +1,38 @@
+From 8bf1f0ac81a8c55b3c130dcad9582bbabf7a948e Mon Sep 17 00:00:00 2001
+From: Arthur Diniz <arthurbd@debian.org>
+Date: Wed, 9 Sep 2026 12:48:12 +0100
+Subject: [PATCH] Use keyed struct literals for UnmarshalTypeError in
+ decode_test.go
+
+UnmarshalTypeError is a type alias to encoding/json.UnmarshalTypeError.
+Go 1.27 reimplements encoding/json on top of encoding/json/v2 and adds
+an Err field to UnmarshalTypeError, so the positional struct literals in
+decode_test.go fail to compile with "too few values in struct literal".
+
+Signed-off-by: Arthur Diniz <arthurbd@debian.org>
+---
+ internal/golang/encoding/json/decode_test.go | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/internal/golang/encoding/json/decode_test.go b/internal/golang/encoding/json/decode_test.go
+index aa355c1..efb7342 100644
+--- a/internal/golang/encoding/json/decode_test.go
++++ b/internal/golang/encoding/json/decode_test.go
+@@ -437,13 +437,13 @@ var unmarshalTests = []struct {
+ 	{CaseName: Name(""), in: `"g-clef: \uD834\uDD1E"`, ptr: new(string), out: "g-clef: \U0001D11E"},
+ 	{CaseName: Name(""), in: `"invalid: \uD834x\uDD1E"`, ptr: new(string), out: "invalid: \uFFFDx\uFFFD"},
+ 	{CaseName: Name(""), in: "null", ptr: new(any), out: nil},
+-	{CaseName: Name(""), in: `{"X": [1,2,3], "Y": 4}`, ptr: new(T), out: T{Y: 4}, err: &UnmarshalTypeError{"array", reflect.TypeFor[string](), 7, "T", "X"}},
+-	{CaseName: Name(""), in: `{"X": 23}`, ptr: new(T), out: T{}, err: &UnmarshalTypeError{"number", reflect.TypeFor[string](), 8, "T", "X"}},
++	{CaseName: Name(""), in: `{"X": [1,2,3], "Y": 4}`, ptr: new(T), out: T{Y: 4}, err: &UnmarshalTypeError{Value: "array", Type: reflect.TypeFor[string](), Offset: 7, Struct: "T", Field: "X"}},
++	{CaseName: Name(""), in: `{"X": 23}`, ptr: new(T), out: T{}, err: &UnmarshalTypeError{Value: "number", Type: reflect.TypeFor[string](), Offset: 8, Struct: "T", Field: "X"}},
+ 	{CaseName: Name(""), in: `{"x": 1}`, ptr: new(tx), out: tx{}},
+ 	{CaseName: Name(""), in: `{"x": 1}`, ptr: new(tx), out: tx{}},
+ 	{CaseName: Name(""), in: `{"x": 1}`, ptr: new(tx), err: fmt.Errorf("json: unknown field \"x\""), disallowUnknownFields: true},
+-	{CaseName: Name(""), in: `{"S": 23}`, ptr: new(W), out: W{}, err: &UnmarshalTypeError{"number", reflect.TypeFor[SS](), 0, "W", "S"}},
+-	{CaseName: Name(""), in: `{"T": {"X": 23}}`, ptr: new(TOuter), out: TOuter{}, err: &UnmarshalTypeError{"number", reflect.TypeFor[string](), 8, "TOuter", "T.X"}},
++	{CaseName: Name(""), in: `{"S": 23}`, ptr: new(W), out: W{}, err: &UnmarshalTypeError{Value: "number", Type: reflect.TypeFor[SS](), Offset: 0, Struct: "W", Field: "S"}},
++	{CaseName: Name(""), in: `{"T": {"X": 23}}`, ptr: new(TOuter), out: TOuter{}, err: &UnmarshalTypeError{Value: "number", Type: reflect.TypeFor[string](), Offset: 8, Struct: "TOuter", Field: "T.X"}},
+ 	{CaseName: Name(""), in: `{"F1":1,"F2":2,"F3":3}`, ptr: new(V), out: V{F1: float64(1), F2: int32(2), F3: Number("3")}},
+ 	{CaseName: Name(""), in: `{"F1":1,"F2":2,"F3":3}`, ptr: new(V), out: V{F1: Number("1"), F2: int32(2), F3: Number("3")}, useNumber: true},
+ 	{CaseName: Name(""), in: `{"k1":1,"k2":"s","k3":[1,2.0,3e-3],"k4":{"kk1":"s","kk2":2}}`, ptr: new(any), out: ifaceNumAsFloat64},

--- a/SPECS/go-k8s-sigs-json/go-k8s-sigs-json.spec
+++ b/SPECS/go-k8s-sigs-json/go-k8s-sigs-json.spec
@@ -9,15 +9,18 @@
 %define commit_id 2d320260d730f3842fef7b08d9a807bdbc617824
 
 Name:           go-k8s-sigs-json
-Version:        0+git20250730.2d32026
+Version:        0+git20260909.2d32026
 Release:        %autorelease
 Summary:        Golang JSON decoder supporting case-sensitive, number-preserving, and strict decoding use cases
 License:        Apache-2.0
 URL:            https://github.com/kubernetes-sigs/json
-#!RemoteAsset
+#!RemoteAsset:  sha256:f2e10ac812a98639cca58f38ac3b729a76e91426a9b538cd05c574e02ddca4e4
 Source0:        https://github.com/kubernetes-sigs/json/archive/%{commit_id}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
+
+# Use keyed UnmarshalTypeError literals for Go 1.27 compatibility.
+Patch0:         0001-Fix-UnmarshalTypeError-test-literals-with-Go-1.27.patch
 
 BuildRequires:  go
 BuildRequires:  go-rpm-macros
@@ -31,9 +34,9 @@ machinery#json). It provides case-sensitive, integer-preserving JSON
 unmarshaling functions based on encoding/json Unmarshal().
 
 %files
-%license LICENSE*
 %doc README*
+%license LICENSE*
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog
-%{?autochangelog}
+%autochangelog

--- a/SPECS/go-k8s-sigs-yaml/2000-Update-binary-JSON-test-for-Go-1.27.patch
+++ b/SPECS/go-k8s-sigs-yaml/2000-Update-binary-JSON-test-for-Go-1.27.patch
@@ -1,0 +1,25 @@
+From 72965f6285f9590f3cb729fabfc762735a8a3e7d Mon Sep 17 00:00:00 2001
+From: misaka00251 <liuxin@iscas.ac.cn>
+Date: Wed, 9 Sep 2026 23:02:08 +0800
+Subject: [PATCH] Update binary JSON test for Go 1.27
+
+---
+ yaml_test.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/yaml_test.go b/yaml_test.go
+index 4ab50f0..4d1608f 100644
+--- a/yaml_test.go
++++ b/yaml_test.go
+@@ -723,7 +723,7 @@ func TestYAMLToJSON(t *testing.T) {
+ 		},
+ 		"binary data": {
+ 			yaml:                 "a: !!binary gIGC",
+-			json:                 `{"a":"\ufffd\ufffd\ufffd"}`,
++			json:                 `{"a":"���"}`,
+ 			yamlReverseOverwrite: strPtr("a: \ufffd\ufffd\ufffd\n"),
+ 		},
+ 
+-- 
+2.55.0
+

--- a/SPECS/go-k8s-sigs-yaml/go-k8s-sigs-yaml.spec
+++ b/SPECS/go-k8s-sigs-yaml/go-k8s-sigs-yaml.spec
@@ -18,6 +18,10 @@ Source0:        https://github.com/kubernetes-sigs/yaml/archive/v%{version}.tar.
 BuildArch:      noarch
 BuildSystem:    golangmodules
 
+# Update binary JSON test output for Go 1.27 encoding/json.
+# Remove this once upstream resolves the issue.
+Patch2000:      2000-Update-binary-JSON-test-for-Go-1.27.patch
+
 BuildRequires:  go
 BuildRequires:  go-rpm-macros
 BuildRequires:  go(github.com/google/go-cmp)

--- a/SPECS/go-pgregory-rapid/2000-Update-string-examples-for-Go-1.27-Unicode-tables.patch
+++ b/SPECS/go-pgregory-rapid/2000-Update-string-examples-for-Go-1.27-Unicode-tables.patch
@@ -1,0 +1,49 @@
+From 5c68c3ade50777588439b3263754ec8292d7eb86 Mon Sep 17 00:00:00 2001
+From: misaka00251 <liuxin@iscas.ac.cn>
+Date: Wed, 9 Sep 2026 22:37:58 +0800
+Subject: [PATCH] Update string examples for Go 1.27 Unicode tables
+
+---
+ strings_example_test.go | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/strings_example_test.go b/strings_example_test.go
+index bb5e048..e8818ab 100644
+--- a/strings_example_test.go
++++ b/strings_example_test.go
+@@ -28,8 +28,8 @@ func ExampleRune() {
+ 	// '\n' '\x1b' 'A' 'a' '*'
+ 	// '0' '@' '?' '\'' '\ue05d'
+ 	// '<' '%' '!' '\u0604' 'A'
+-	// '%' '╷' '~' '!' '/'
+-	// '\u00ad' '𝅾' '@' '҈' ' '
++	// '%' '╴' '~' '!' '/'
++	// '\u00ad' 'ૼ' '@' '҈' ' '
+ }
+ 
+ func ExampleRuneFrom() {
+@@ -64,8 +64,8 @@ func ExampleString() {
+ 	}
+ 	// Output:
+ 	// "\n߾⃝?\rA�֍"
+-	// "\u2006𑨳"
+-	// "A＄\u0603ᾢ"
++	// "\u2006𝨠#`\x1b�\u00a0?˄~ס"
++	// "A﹩\u0603ᾢ"
+ 	// "+^#.[#৲"
+ 	// ""
+ }
+@@ -92,8 +92,8 @@ func ExampleStringN() {
+ 	}
+ 	// Output:
+ 	// "\n߾⃝?\r"
+-	// "\u2006𑨳#`\x1b"
+-	// "A＄\u0603ᾢÉ"
++	// "\u2006𝨠#`\x1b"
++	// "A﹩\u0603ᾢÉ"
+ 	// "+^#.["
+ 	// ".A<a¤"
+ }
+-- 
+2.55.0
+

--- a/SPECS/go-pgregory-rapid/go-pgregory-rapid.spec
+++ b/SPECS/go-pgregory-rapid/go-pgregory-rapid.spec
@@ -18,6 +18,10 @@ Source0:        https://github.com/flyingmutant/rapid/archive/v%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
 
+# Update string examples for Go 1.27 Unicode 17 tables.
+# Remove this once upstream resolves the issue.
+Patch2000:      2000-Update-string-examples-for-Go-1.27-Unicode-tables.patch
+
 BuildRequires:  go
 BuildRequires:  go-rpm-macros
 

--- a/SPECS/go-sourcehut-sbinet-cmpimg/2000-Fix-TestDiff-for-Go-1.27-PNG-encoding-changes.patch
+++ b/SPECS/go-sourcehut-sbinet-cmpimg/2000-Fix-TestDiff-for-Go-1.27-PNG-encoding-changes.patch
@@ -1,0 +1,36 @@
+From 510b447f4f2217d97e07ccb4394c79f49b14da09 Mon Sep 17 00:00:00 2001
+From: misaka00251 <liuxin@iscas.ac.cn>
+Date: Wed, 9 Sep 2026 22:00:44 +0800
+Subject: [PATCH] Fix TestDiff for Go 1.27 PNG encoding changes
+
+---
+ cmpimg_test.go | 13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/cmpimg_test.go b/cmpimg_test.go
+index 3a1798c..b4aa666 100644
+--- a/cmpimg_test.go
++++ b/cmpimg_test.go
+@@ -49,9 +49,16 @@ func TestDiff(t *testing.T) {
+ 	if err != nil {
+ 		t.Fatalf("failed to encode difference png: %v", err)
+ 	}
+-	gotDiff := base64.StdEncoding.EncodeToString(buf.Bytes())
+-	if gotDiff != wantDiffEncoded {
+-		t.Errorf("unexpected encoded diff value:\ngot:%s\nwant:%s", gotDiff, wantDiffEncoded)
++	wantDiff, err := base64.StdEncoding.DecodeString(wantDiffEncoded)
++	if err != nil {
++		t.Fatalf("failed to decode expected difference png: %v", err)
++	}
++	equal, err := Equal("png", buf.Bytes(), wantDiff)
++	if err != nil {
++		t.Fatalf("failed to compare difference png: %v", err)
++	}
++	if !equal {
++		t.Error("unexpected diff image")
+ 	}
+ }
+ 
+-- 
+2.55.0
+

--- a/SPECS/go-sourcehut-sbinet-cmpimg/go-sourcehut-sbinet-cmpimg.spec
+++ b/SPECS/go-sourcehut-sbinet-cmpimg/go-sourcehut-sbinet-cmpimg.spec
@@ -13,10 +13,13 @@ Release:        %autorelease
 Summary:        simple package to compare images
 License:        BSD-3-Clause
 URL:            https://git.sr.ht/~sbinet/cmpimg
-#!RemoteAsset
+#!RemoteAsset:  sha256:fb13ae7a19cde0a2f4a85e1691db457cbb1d568915ed93e2349d5dd2efad834c
 Source0:        https://git.sr.ht/~sbinet/cmpimg/archive/v%{version}.tar.gz#/%{_name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildSystem:    golangmodules
+
+# Avoid relying on exact PNG encoding output changed by Go 1.27.
+Patch2000:      2000-Fix-TestDiff-for-Go-1.27-PNG-encoding-changes.patch
 
 BuildOption(prep):  -n %{_name}-%{version}
 
@@ -35,9 +38,9 @@ cmpimg is a simple package (extracted from Gonum/plot) to
 compare images (PNG, JPEG, PDF, ...)
 
 %files
-%license LICENSE*
 %doc README*
+%license LICENSE*
 %{go_sys_gopath}/%{go_import_path}
 
 %changelog
-%{?autochangelog}
+%autochangelog


### PR DESCRIPTION
## Summary

This Pull Request fixes several Go modules, and afterwards, we need to manually rebuild `go-k8s-client-go`. Some of the test fix patches are assisted by AI, while others have been backported or rebased.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: ChatGPT 5.6:Sol

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy
