### PR TITLE
SPECS: aflplusplus: Drop undefined gcc_version macro

### DIFF
--- a/SPECS/aflplusplus/aflplusplus.spec
+++ b/SPECS/aflplusplus/aflplusplus.spec
@@ -5,8 +5,8 @@
 # SPDX-License-Identifier: MulanPSL-2.0
 
 %global llvm_config /usr/bin/llvm-config
-%global gcc /usr/bin/gcc-%{gcc_version}
-%global gxx /usr/bin/g++-%{gcc_version}
+%global gcc /usr/bin/gcc
+%global gxx /usr/bin/g++
 %global clang /usr/bin/clang
 %global lld /usr/bin/ld.lld
 %global afl_helper_path %{_libdir}/af
@@ -52,8 +52,8 @@ BuildOption(install):  MAN_PATH="%{_mandir}/man8"
 BuildOption(install):  MISC_PATH="%{_pkgdocdir}"
 
 BuildRequires:  clang
-BuildRequires:  gcc%{gcc_version}-c++
-BuildRequires:  gcc%{gcc_version}-devel
+BuildRequires:  gcc-c++
+BuildRequires:  gcc-devel
 BuildRequires:  llvm-devel
 %ifarch x86_64
 BuildRequires:  lld


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why the change is needed.
For package updates, link to the upstream changelog or summarize the notable changes.
For new packages, briefly describe the package and provide its homepage or upstream repository.
-->

Remove references to the undefined `%{gcc_version}` macro from the
aflplusplus spec. Use the default GCC compiler paths and unversioned
GCC package dependencies instead.

## Related Issue

<!--
Link related issues if applicable.
Example: Resolves #123
-->

- Resolves #1168

## Checklist

- [x] I have read the [openRuyi Code of Conduct] and agree to abide by it.

<!--
If this PR includes non-trivial AI-assisted content, check the box below and add attribution
using the `AGENT_NAME:MODEL_VERSION` format.
Example: Assisted-by: ChatGPT:GPT-5.5 Thinking
-->

- [x] I have read the [AI-Assisted Contribution Policy], and this Pull Request includes non-trivial AI-assisted content.

Assisted-by: Codex:GPT-5

[openRuyi Code of Conduct]: https://openruyi.cn/governance/legal/code-of-conduct
[AI-Assisted Contribution Policy]:https://openruyi.cn/governance/policy/ai-contribution-policy